### PR TITLE
fix: prevent ghost tasks after user switch in Task app

### DIFF
--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { goto } from '$lib/utils/navigation';
+import { base } from '$app/paths';
 import {
 	initializeAuthService,
 	getAuthService,
@@ -37,6 +37,18 @@ export class AuthOperationsService {
 		try {
 			// Database is now initialized in @reborn/storage package
 			logger.info('Using @reborn/storage for data management');
+
+			// Clear any previous user's data from IndexedDB before starting new session.
+			// Prevents ghost tasks when switching users or after account deletion + re-register.
+			const { clearAllUserData, isDatabaseInitialized } = await import('@reborn/storage');
+			if (isDatabaseInitialized()) {
+				try {
+					await clearAllUserData();
+					logger.info('Cleared previous user data from IndexedDB before login');
+				} catch (err) {
+					logger.error('Failed to clear IndexedDB before login:', err);
+				}
+			}
 
 			// Import only stores used by Reborn Task app
 			const {
@@ -243,8 +255,9 @@ export class AuthOperationsService {
 				// Don't interrupt logout process on error
 			}
 
-			// Redirect to login
-			await goto('/auth/login');
+			// Hard redirect to login — guarantees ALL in-memory state
+			// (Svelte stores, module singletons, $state) is cleared.
+			window.location.href = `${base}/auth/login`;
 		}
 	}
 
@@ -302,7 +315,9 @@ export class AuthOperationsService {
 			logger.error('Failed to clear user data:', error);
 		}
 
-		await goto('/auth/login');
+		// Hard redirect to login — guarantees ALL in-memory state
+		// (Svelte stores, module singletons, $state) is cleared.
+		window.location.href = `${base}/auth/login`;
 	}
 
 	/**

--- a/apps/reborn-task/src/lib/services/task-title-index.svelte.ts
+++ b/apps/reborn-task/src/lib/services/task-title-index.svelte.ts
@@ -76,12 +76,15 @@ const BATCH_SIZE = 100;
 
 async function decryptTaskEntry(
 	enc: TaskEncryptedBooleans
-): Promise<{ id: string } & TaskIndexEntry> {
+): Promise<({ id: string } & TaskIndexEntry) | null> {
 	let title = '';
 	try {
 		title = await cryptoManager.decryptText(enc.title_encrypted);
 	} catch {
-		title = '';
+		// Decryption failed — likely stale data from another user's session.
+		// Return null so build() can filter this entry out instead of showing
+		// a blank task card in the UI.
+		return null;
 	}
 
 	// Decrypt metadata bundle for fields not available as shadow indexes
@@ -170,6 +173,7 @@ class TaskIndex {
 				const batch = allEncrypted.slice(i, i + BATCH_SIZE);
 				const entries = await Promise.all(batch.map(decryptTaskEntry));
 				for (const e of entries) {
+					if (!e) continue; // Skip undecryptable entries (stale cross-user data)
 					const { id, ...entry } = e;
 					map.set(id, entry);
 				}

--- a/apps/reborn-task/src/routes/+layout.svelte
+++ b/apps/reborn-task/src/routes/+layout.svelte
@@ -36,6 +36,15 @@
 		}
 	});
 
+	// Reset sync flag when user logs out — allows re-sync for next login.
+	// Defensive: even though logout now uses hard redirect (which clears all
+	// in-memory state), this handles edge cases like internal navigation.
+	$effect(() => {
+		if (browser && $session?.isInitialized && !$session?.isAuthenticated) {
+			hasTriggeredInitialSync = false;
+		}
+	});
+
 	// Re-decrypt stores and pull from server when E2E key becomes available.
 	// Covers cross-app login (storage event → /auth/unlock → E2E unlocked) and
 	// any other path where hasE2E flips to true after layout already mounted.

--- a/apps/reborn-task/src/routes/settings/security/delete-account/+page.svelte
+++ b/apps/reborn-task/src/routes/settings/security/delete-account/+page.svelte
@@ -15,7 +15,7 @@
 	} from '@reborn/ui';
 	import { AlertTriangle, Trash2 } from '@lucide/svelte';
 	import { t } from '$lib/stores/i18n.store';
-	import { goto } from '$lib/utils/navigation';
+	import { base } from '$app/paths';
 	import { createLogger } from '@reborn/utils';
 	import { logout as authLogout } from '$lib/auth';
 
@@ -66,9 +66,15 @@
 				return;
 			}
 
-			// Clear local data and redirect to login
+			// Clear local data: auth state + IndexedDB + hard redirect
 			await authLogout(true);
-			await goto('/auth/login');
+			try {
+				const { clearAllUserData } = await import('@reborn/storage');
+				await clearAllUserData();
+			} catch {
+				// Best-effort — pre-login clear will catch any remnants
+			}
+			window.location.href = `${base}/auth/login`;
 		} catch (err: unknown) {
 			logger.error('Failed to delete account:', err);
 			error = $t('settings.delete_account.error_generic');


### PR DESCRIPTION
Clear IndexedDB before loading stores on login (onStorageInit) to prevent stale encrypted data from a previous user appearing as blank task cards.

Changes:
- Add pre-login clearAllUserData() in auth-operations.service.ts
- Switch logout/logoutAllDevices to hard redirect (window.location.href) to ensure all in-memory state is cleared
- Reset hasTriggeredInitialSync flag when session becomes unauthenticated
- Filter out undecryptable tasks in task-title-index (return null instead of empty title) as defense-in-depth
- Harden delete-account flow with explicit IndexedDB clear + hard redirect

Notes app already protected by pre-login clear, hard redirect on logout, and full store clear before server pull — no changes needed.