### PR TITLE
fix: prevent offline data loss in IndexedDB on key restore and notes …

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression tests for BUG-2/3/4 (fix/offline-data-loss).
+ *
+ * These are intentionally source-level checks: the sync service pulls in
+ * browser-only modules ($env/static/public, IndexedDB, cryptoManager) that are
+ * impractical to wire up in a Node test env. A source-level assertion is the
+ * cheapest way to guarantee we never re-introduce the clear-before-pull
+ * pattern that caused offline data loss.
+ */
+
+function readSource(relative: string): string {
+  return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+describe('notes-sync — regression (offline data loss)', () => {
+  it('pullFromServer does NOT clear local stores before fetching (BUG-2)', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const pullFn = src.slice(
+      src.indexOf('export async function pullFromServer'),
+      src.indexOf('async function pullFolders')
+    );
+    expect(pullFn).not.toMatch(/noteStore\.clear\(\)/);
+    expect(pullFn).not.toMatch(/folderStore\.clear\(\)/);
+    expect(pullFn).not.toMatch(/tagStore\.clear\(\)/);
+    expect(pullFn).not.toMatch(/noteHistoryStore\.clear\(\)/);
+  });
+
+  it('online handler pushes pending items BEFORE pulling (BUG-3)', () => {
+    const src = readSource('../stores/sync-status.store.ts');
+    const onlineHandler = src.slice(
+      src.indexOf("addEventListener('online'"),
+      src.indexOf("addEventListener('offline'")
+    );
+    // Look only at CALL sites, not the destructuring import (which lists names
+    // in arbitrary order).
+    const pushCallIdx = onlineHandler.search(/pushPendingItems\s*\(/);
+    const pullCallIdx = onlineHandler.search(/pullFromServer\s*\(/);
+    expect(pushCallIdx).toBeGreaterThan(-1);
+    expect(pullCallIdx).toBeGreaterThan(-1);
+    expect(pushCallIdx).toBeLessThan(pullCallIdx);
+    // Both calls must be awaited (sequential), not parallel fire-and-forget.
+    expect(onlineHandler).toMatch(/await\s+pushPendingItems/);
+    expect(onlineHandler).toMatch(/await\s+pullFromServer/);
+  });
+
+  it('layout initial sync pushes pending items BEFORE pulling (BUG-4)', () => {
+    const src = readSource('../../routes/+layout.svelte');
+    // Skip past the import statement on L18 that lists both names.
+    const bodyStart = src.indexOf('<script');
+    const afterImports = src.indexOf('onMount', bodyStart);
+    const body = src.slice(afterImports);
+
+    // Two sync paths exist: the $effect runSync() and the onMount block.
+    // Each must call pushPendingItems before pullFromServer.
+    const pushCalls = [...body.matchAll(/pushPendingItems\s*\(/g)];
+    expect(pushCalls.length).toBeGreaterThanOrEqual(2);
+
+    // First pushPendingItems call must precede first pullFromServer call.
+    const firstPushCall = body.search(/pushPendingItems\s*\(/);
+    const firstPullCall = body.search(/pullFromServer\s*\(/);
+    expect(firstPushCall).toBeGreaterThan(-1);
+    expect(firstPullCall).toBeGreaterThan(-1);
+    expect(firstPushCall).toBeLessThan(firstPullCall);
+  });
+
+  it('pull helpers remove ghost items (synced locally but deleted on server)', () => {
+    const src = readSource('./notes-sync.service.ts');
+
+    // pullFolders must clean up orphaned synced folders
+    const pullFolders = src.slice(
+      src.indexOf('async function pullFolders'),
+      src.indexOf('async function pullTags')
+    );
+    expect(pullFolders).toMatch(/folderStore\.deleteMany/);
+    expect(pullFolders).toMatch(/sync_status.*===.*'synced'/);
+
+    // pullTags must clean up orphaned synced tags
+    const pullTags = src.slice(
+      src.indexOf('async function pullTags'),
+      src.indexOf('async function pullNotes')
+    );
+    expect(pullTags).toMatch(/tagStore\.deleteMany/);
+    expect(pullTags).toMatch(/sync_status.*===.*'synced'/);
+
+    // pullNotes must clean up orphaned synced notes
+    const pullNotes = src.slice(
+      src.indexOf('async function pullNotes'),
+      src.indexOf('// ── Push helpers')
+    );
+    expect(pullNotes).toMatch(/noteStore\.deleteMany/);
+    expect(pullNotes).toMatch(/sync_status.*===.*'synced'/);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -15,7 +15,6 @@ import {
   noteStore,
   folderStore,
   tagStore,
-  noteTagStore,
   noteTagOperations,
   noteTagQueries,
   noteHistoryStore,
@@ -107,16 +106,11 @@ export async function pullFromServer(): Promise<boolean> {
   let success = true;
   let gotUnauthorized = false;
   try {
-    // Clear stale data before pulling — prevents phantom notes from a previous
-    // user session (different master key → decryption errors).
-    await Promise.all([
-      noteStore.clear(),
-      folderStore.clear(),
-      tagStore.clear(),
-      noteTagStore.clear(),
-      noteHistoryStore.clear()
-    ]);
-
+    // NOTE: We intentionally do NOT clear local stores before pulling.
+    // Each pull* helper merges by sync_version and skips items with
+    // sync_status='pending' — clearing would wipe offline edits that haven't
+    // been pushed yet (observed data loss in offline → online transitions).
+    // Cross-user cleanup is handled by clearAllUserData() during login/logout.
     await Promise.all([
       pullFolders().catch((e) => {
         if (isUnauthorizedError(e)) gotUnauthorized = true;
@@ -213,6 +207,18 @@ async function pullFolders(): Promise<void> {
       await folderStore.save(folder);
     })
   );
+
+  // Remove local folders that no longer exist on the server (deleted on another device).
+  // Only remove 'synced' items — 'pending' items were created/edited locally and not yet pushed.
+  const serverFolderIds = new Set((data as Array<{ id: string }>).map((f) => f.id));
+  const allLocalFolders = (await folderStore.getAll()) as FolderEncrypted[];
+  const orphanIds = allLocalFolders
+    .filter((f) => f.sync_status === 'synced' && !serverFolderIds.has(f.id))
+    .map((f) => f.id);
+  if (orphanIds.length > 0) {
+    await folderStore.deleteMany(orphanIds);
+    logger.debug(`Removed ${orphanIds.length} locally-synced folders no longer on server`);
+  }
 }
 
 async function pullTags(): Promise<void> {
@@ -257,6 +263,17 @@ async function pullTags(): Promise<void> {
       });
     })
   );
+
+  // Remove local tags that no longer exist on the server (hard-deleted on another device).
+  const serverTagIds = new Set((data as Array<{ id: string }>).map((t) => t.id));
+  const allLocalTags = (await tagStore.getAll()) as TagEncrypted[];
+  const orphanTagIds = allLocalTags
+    .filter((t) => t.sync_status === 'synced' && !serverTagIds.has(t.id))
+    .map((t) => t.id);
+  if (orphanTagIds.length > 0) {
+    await tagStore.deleteMany(orphanTagIds);
+    logger.debug(`Removed ${orphanTagIds.length} locally-synced tags no longer on server`);
+  }
 }
 
 async function pullNotes(): Promise<void> {
@@ -352,6 +369,21 @@ async function pullNotes(): Promise<void> {
       }
     })
   );
+
+  // Remove local notes that no longer exist on the server (permanently deleted on another device).
+  // We use include_archived=true above, so the server returns soft-deleted notes too.
+  // If a note is missing from the response entirely, it was permanently deleted.
+  const serverNoteIds = new Set(
+    (data as Array<{ id: string }>).map((n) => n.id)
+  );
+  const allLocalNotes = (await noteStore.getAll()) as NoteStoredLocal[];
+  const orphanNoteIds = allLocalNotes
+    .filter((n) => n.sync_status === 'synced' && !serverNoteIds.has(n.id))
+    .map((n) => n.id);
+  if (orphanNoteIds.length > 0) {
+    await noteStore.deleteMany(orphanNoteIds);
+    logger.debug(`Removed ${orphanNoteIds.length} locally-synced notes no longer on server`);
+  }
 }
 
 // ── Push helpers — IndexedDB → server ────────────────────────────

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -27,17 +27,22 @@ function createOnlineStore() {
   if (browser) {
     window.addEventListener('online', () => {
       set(true);
-      // Trigger sync when coming back online (lazy import to avoid circular deps)
-      import('$lib/services/notes-sync.service').then(({ pullFromServer, pushPendingItems, refreshStoresAfterPull }) => {
-        // fire-and-forget: background sync, errors handled internally
-        pushPendingItems().catch(() => {});
-        // fire-and-forget: background sync, errors handled internally
-        pullFromServer()
-          .then(async (synced) => {
+      // Trigger sync when coming back online (lazy import to avoid circular deps).
+      // CRITICAL: push BEFORE pull — running them in parallel risks pull reaching
+      // the server before push completes, so items still 'pending' locally would
+      // be re-fetched as already-synced versions and subsequent push attempts
+      // would conflict.
+      import('$lib/services/notes-sync.service').then(
+        async ({ pullFromServer, pushPendingItems, refreshStoresAfterPull }) => {
+          try {
+            await pushPendingItems();
+            const synced = await pullFromServer();
             if (synced) await refreshStoresAfterPull();
-          })
-          .catch(() => {});
-      });
+          } catch {
+            // fire-and-forget: background sync, errors handled internally
+          }
+        }
+      );
     });
     window.addEventListener('offline', () => set(false));
   }

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -79,6 +79,9 @@
       // Build NoteIndex FIRST (in parallel with folders/tags), then refresh notesStore
       await Promise.all([foldersStore.refresh(), tagsStore.refresh(), noteIndex.build()]);
       notesStore.refresh();
+      // Push pending offline edits BEFORE pull — otherwise pullFromServer's
+      // version checks could mask unsynced local changes on the next write.
+      await pushPendingItems().catch(() => {});
       const synced = await pullFromServer();
       if (synced) {
         await refreshStoresAfterPull();
@@ -129,7 +132,11 @@
         // Build NoteIndex in parallel with folders/tags (data already in IndexedDB from init above)
         await noteIndex.build();
         notesStore.refresh();
-        pullFromServer()
+        // Push pending offline edits BEFORE pull — guarantees local unsynced
+        // changes reach the server before we merge the remote state in.
+        pushPendingItems()
+          .catch(() => {})
+          .then(() => pullFromServer())
           .then(async (synced) => {
             if (synced) {
               await refreshStoresAfterPull();

--- a/apps/reborn-task/src/lib/auth/authService.ts
+++ b/apps/reborn-task/src/lib/auth/authService.ts
@@ -22,7 +22,10 @@ let sessionManager: SessionManager | null = globalThis.__sessionManagerInstance 
  * Initialize the auth service (should be called once on app start)
  */
 export function initializeAuthService(
-	onStorageInit?: (cryptoManager: CryptoManager) => Promise<void>,
+	onStorageInit?: (
+		cryptoManager: CryptoManager,
+		context: 'login' | 'restore'
+	) => Promise<void>,
 	onLanguageChange?: (language: string) => void
 ): { authService: AuthService; sessionManager: SessionManager } {
 	if (!browser) {

--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -29,24 +29,36 @@ declare global {
 export class AuthOperationsService {
 	/**
 	 * Initialize storage callback
-	 * This is called from AuthService after successful login/unlock
+	 * This is called from AuthService after successful login/unlock.
+	 *
+	 * `context` distinguishes user-switching flows (login) from same-user key
+	 * restore on app start (restore). Clearing IndexedDB is only correct for
+	 * login — on restore it would wipe offline changes that haven't been synced.
 	 */
-	private async onStorageInit(cryptoManager: CryptoManager, authToken?: string) {
-		logger.info('Initializing storage with E2E encryption');
+	private async onStorageInit(
+		cryptoManager: CryptoManager,
+		context: 'login' | 'restore' = 'login',
+		authToken?: string
+	) {
+		logger.info(`Initializing storage with E2E encryption (context=${context})`);
 
 		try {
 			// Database is now initialized in @reborn/storage package
 			logger.info('Using @reborn/storage for data management');
 
-			// Clear any previous user's data from IndexedDB before starting new session.
-			// Prevents ghost tasks when switching users or after account deletion + re-register.
-			const { clearAllUserData, isDatabaseInitialized } = await import('@reborn/storage');
-			if (isDatabaseInitialized()) {
-				try {
-					await clearAllUserData();
-					logger.info('Cleared previous user data from IndexedDB before login');
-				} catch (err) {
-					logger.error('Failed to clear IndexedDB before login:', err);
+			// Clear any previous user's data from IndexedDB ONLY on login — prevents
+			// ghost tasks when switching users or after account deletion + re-register.
+			// On 'restore' (same user, master key loaded from IndexedDB on app start)
+			// we MUST preserve local data, otherwise offline edits are lost.
+			if (context === 'login') {
+				const { clearAllUserData, isDatabaseInitialized } = await import('@reborn/storage');
+				if (isDatabaseInitialized()) {
+					try {
+						await clearAllUserData();
+						logger.info('Cleared previous user data from IndexedDB before login');
+					} catch (err) {
+						logger.error('Failed to clear IndexedDB before login:', err);
+					}
 				}
 			}
 
@@ -457,8 +469,9 @@ export class AuthOperationsService {
 			if (cryptoManager.isInitialized()) {
 				logger.info('E2E initialized (master key restored from IndexedDB)');
 
-				// Trigger onStorageInit to ensure stores are initialized
-				await this.onStorageInit(cryptoManager);
+				// Trigger onStorageInit to ensure stores are initialized.
+				// 'restore' context — same user, key loaded from IndexedDB. Do NOT clear data.
+				await this.onStorageInit(cryptoManager, 'restore');
 
 				// Update session to reflect E2E status
 				const sessionManager = this.getSessionManager();

--- a/packages/auth/src/__tests__/AuthService.onStorageInit.spec.ts
+++ b/packages/auth/src/__tests__/AuthService.onStorageInit.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthService } from '../services/AuthService';
+import { SessionManager } from '../services/SessionManager';
+import type { IAuthStorage, IAuthApiClient } from '../services/AuthService';
+import type { CryptoManager } from '@reborn/crypto';
+import type { LoginResult, AuthCredentials } from '../types';
+
+/**
+ * Regression tests for BUG-1: `onStorageInit` callback must receive a `context`
+ * argument so consumers can distinguish user-switch (login) from same-user key
+ * restore. Clearing IndexedDB on 'restore' causes offline data loss.
+ */
+
+const VALID_USER = {
+  id: 'user-1',
+  username: 'alice',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z'
+};
+
+function makeCryptoManager(initialized = true): CryptoManager {
+  return {
+    loadUserMasterKey: vi.fn().mockResolvedValue(true),
+    isInitialized: vi.fn().mockReturnValue(initialized),
+    clearMasterKey: vi.fn()
+  } as unknown as CryptoManager;
+}
+
+function makeStorage(existingCreds?: AuthCredentials): IAuthStorage {
+  let creds: AuthCredentials | null = existingCreds ?? null;
+  return {
+    getCredentials: vi.fn(async () => creds),
+    saveCredentials: vi.fn(async (c: AuthCredentials) => {
+      creds = c;
+    }),
+    clearCredentials: vi.fn(async () => {
+      creds = null;
+    }),
+    getUserSettings: vi.fn(async () => null),
+    saveUserSettings: vi.fn(async () => {})
+  };
+}
+
+function makeApiClient(loginResult: LoginResult): IAuthApiClient {
+  return {
+    login: vi.fn().mockResolvedValue(loginResult),
+    register: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    verifyTwoFactor: vi.fn(),
+    refreshToken: vi.fn()
+  } as unknown as IAuthApiClient;
+}
+
+describe('AuthService onStorageInit context', () => {
+  let onStorageInit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onStorageInit = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('passes context="login" on completeLogin (user-switch path)', async () => {
+    const loginResult: LoginResult = {
+      success: true,
+      user: VALID_USER,
+      encryptedMasterKey: 'enc',
+      masterKeySalt: 'salt'
+    };
+    const service = new AuthService(
+      makeCryptoManager(),
+      new SessionManager(),
+      makeStorage(),
+      makeApiClient(loginResult),
+      onStorageInit
+    );
+
+    await service.login('alice', 'password');
+
+    expect(onStorageInit).toHaveBeenCalledTimes(1);
+    expect(onStorageInit).toHaveBeenCalledWith(expect.anything(), 'login');
+  });
+
+  it('passes context="login" on tryOfflineLogin', async () => {
+    const credentials: AuthCredentials = {
+      id: 'currentUser',
+      encrypted_master_key: 'enc',
+      master_key_salt: 'salt',
+      user_profile: VALID_USER
+    };
+    const service = new AuthService(
+      makeCryptoManager(),
+      new SessionManager(),
+      makeStorage(credentials),
+      makeApiClient({ success: true }),
+      onStorageInit
+    );
+
+    const ok = await service.tryOfflineLogin('password');
+
+    expect(ok).toBe(true);
+    expect(onStorageInit).toHaveBeenCalledWith(expect.anything(), 'login');
+  });
+
+  it('passes context="restore" on unlockE2E (same user, preserve local data)', async () => {
+    const credentials: AuthCredentials = {
+      id: 'currentUser',
+      encrypted_master_key: 'enc',
+      master_key_salt: 'salt',
+      user_profile: VALID_USER
+    };
+    const sessionManager = new SessionManager();
+    // Simulate an existing session (required for unlockE2E)
+    sessionManager.setAuthenticated(VALID_USER, false);
+
+    const service = new AuthService(
+      makeCryptoManager(),
+      sessionManager,
+      makeStorage(credentials),
+      makeApiClient({ success: true }),
+      onStorageInit
+    );
+
+    const result = await service.unlockE2E('password');
+
+    expect(result.success).toBe(true);
+    expect(onStorageInit).toHaveBeenCalledWith(expect.anything(), 'restore');
+  });
+
+  it('does NOT call onStorageInit with a missing context argument', async () => {
+    // Regression guard — earlier implementation called onStorageInit(cryptoManager)
+    // without a context, which made consumers default to clearing IndexedDB.
+    const loginResult: LoginResult = {
+      success: true,
+      user: VALID_USER,
+      encryptedMasterKey: 'enc',
+      masterKeySalt: 'salt'
+    };
+    const service = new AuthService(
+      makeCryptoManager(),
+      new SessionManager(),
+      makeStorage(),
+      makeApiClient(loginResult),
+      onStorageInit
+    );
+
+    await service.login('alice', 'password');
+
+    const call = onStorageInit.mock.calls[0];
+    expect(call.length).toBeGreaterThanOrEqual(2);
+    expect(['login', 'restore']).toContain(call[1]);
+  });
+});

--- a/packages/auth/src/services/AuthService.ts
+++ b/packages/auth/src/services/AuthService.ts
@@ -52,7 +52,10 @@ export class AuthService implements IAuthService {
     private sessionManager: SessionManager,
     private storage: IAuthStorage,
     private apiClient: IAuthApiClient,
-    private onStorageInit?: (cryptoManager: CryptoManager) => Promise<void>,
+    private onStorageInit?: (
+      cryptoManager: CryptoManager,
+      context: 'login' | 'restore'
+    ) => Promise<void>,
     private onLanguageChange?: (language: string) => void
   ) {}
 
@@ -309,7 +312,7 @@ export class AuthService implements IAuthService {
       // Initialize storage with E2E
       if (this.onStorageInit) {
         try {
-          await this.onStorageInit(this.cryptoManager);
+          await this.onStorageInit(this.cryptoManager, 'login');
           logger.info('Storage initialized with E2E after login');
         } catch (storageError) {
           logger.error('Failed to initialize storage after login:', storageError);
@@ -365,7 +368,7 @@ export class AuthService implements IAuthService {
       // Initialize storage with E2E
       if (this.onStorageInit) {
         try {
-          await this.onStorageInit(this.cryptoManager);
+          await this.onStorageInit(this.cryptoManager, 'login');
           logger.info('E2E storage initialized after 2FA login');
         } catch (storageError) {
           logger.error('Failed to initialize storage after 2FA login:', storageError);
@@ -482,7 +485,7 @@ export class AuthService implements IAuthService {
 
       // Initialize storage with E2E
       if (this.onStorageInit) {
-        await this.onStorageInit(this.cryptoManager);
+        await this.onStorageInit(this.cryptoManager, 'login');
       }
 
       logger.info('Offline login successful');
@@ -580,7 +583,7 @@ export class AuthService implements IAuthService {
       // Initialize storage with E2E if callback provided
       if (this.onStorageInit) {
         try {
-          await this.onStorageInit(this.cryptoManager);
+          await this.onStorageInit(this.cryptoManager, 'restore');
           logger.info('Storage re-initialized with E2E after unlock');
         } catch (storageError) {
           logger.error('Failed to re-initialize storage after E2E unlock:', storageError);


### PR DESCRIPTION
…sync

Four bugs caused user data loss and app hangs in offline mode:

- BUG-1: onStorageInit cleared the entire IndexedDB on every app start, even when the master key was being restored for the same user (not only on login). Added context: 'login' | 'restore' — clearAllUserData() runs only on login. checkE2EStatus now passes 'restore'.

- BUG-2: reborn-notes pullFromServer cleared noteStore/folderStore/tagStore BEFORE fetching — if the pull failed, local offline edits were wiped. The existing sync_status='pending' guards ran on already-emptied stores. Clear removed; merge-by-sync_version is sufficient.

- BUG-3: The notes online-event handler ran pushPendingItems and pullFromServer in parallel; the pull could win the race and mask unsynced local changes. Now awaited sequentially push → pull.

- BUG-4: Notes initial sync (+layout.svelte) called pullFromServer without first pushing pending offline edits. Added pushPendingItems() before both the onMount and $effect pull paths.

Regression tests cover onStorageInit context propagation and the clear-before-pull / push-first patterns.