### PR TITLE
fix(task): resolve PWA offline startup redirect loop and false offlin…

### DIFF
--- a/apps/reborn-notes/src/app.html
+++ b/apps/reborn-notes/src/app.html
@@ -83,7 +83,13 @@
 				var el=document.getElementById('app-loading');
 				if(!el)return;
 				var offline=typeof navigator!=='undefined'&&!navigator.onLine;
-				var noSW=typeof navigator!=='undefined'&&!navigator.serviceWorker?.controller;
+				// On iOS Safari PWA cold starts `navigator.serviceWorker.controller` is
+				// transiently null even when a service worker is registered and will
+				// soon take control, so the previous `!controller` probe produced a
+				// false "Brak połączenia" screen. Only fail fast when the browser has
+				// no Service Worker API at all — otherwise let the 15s stall timeout
+				// below decide.
+				var noSW=typeof navigator!=='undefined'&&!('serviceWorker' in navigator);
 				if(offline&&noSW){
 					el.querySelector('.app-loading__spinner').style.display='none';
 					el.querySelector('p').textContent='Brak połączenia z siecią. Połącz się i spróbuj ponownie.';

--- a/apps/reborn-task/src/app.html
+++ b/apps/reborn-task/src/app.html
@@ -83,7 +83,13 @@
 				var el=document.getElementById('app-loading');
 				if(!el)return;
 				var offline=typeof navigator!=='undefined'&&!navigator.onLine;
-				var noSW=typeof navigator!=='undefined'&&!navigator.serviceWorker?.controller;
+				// On iOS Safari PWA cold starts `navigator.serviceWorker.controller` is
+				// transiently null even when a service worker is registered and will
+				// soon take control, so the previous `!controller` probe produced a
+				// false "Brak połączenia" screen. Only fail fast when the browser has
+				// no Service Worker API at all — otherwise let the 15s stall timeout
+				// below decide.
+				var noSW=typeof navigator!=='undefined'&&!('serviceWorker' in navigator);
 				if(offline&&noSW){
 					el.querySelector('.app-loading__spinner').style.display='none';
 					el.querySelector('p').textContent='Brak połączenia z siecią. Połącz się i spróbuj ponownie.';

--- a/apps/reborn-task/src/hooks.client.ts
+++ b/apps/reborn-task/src/hooks.client.ts
@@ -8,6 +8,7 @@ if (import.meta.hot) {
 }
 import { cryptoManager } from '@reborn/crypto';
 import { base } from '$app/paths';
+import { authOperationsService } from '$lib/services/auth-operations.service';
 import { trashManagementService } from '$lib/services/trash-management.service';
 import { recurrenceService } from '$lib/services/recurrence.service';
 import { pushNotificationService } from '$lib/services/push-notification.service';
@@ -15,6 +16,15 @@ import { startSwUpdateWatcher } from '$lib/services/sw-update.service';
 import { startPwaInstallPrompt } from '$lib/services/pwa-install.service';
 
 const logger = createLogger('hooks.client');
+
+// Eagerly construct the session manager singleton at module load time so that
+// `auth.store.ts` (which retries on a short interval) can attach immediately
+// instead of racing `initializeAuth()` behind the 5s i18n timeout in +layout.ts.
+try {
+	authOperationsService.getSessionManager();
+} catch (error: unknown) {
+	logger.error('Failed to eagerly initialize session manager:', error);
+}
 
 // ---------------------------------------------------------------------------
 // Client-side error handler — detect offline chunk-loading failures

--- a/apps/reborn-task/src/routes/+layout.ts
+++ b/apps/reborn-task/src/routes/+layout.ts
@@ -56,7 +56,17 @@ export const load: LayoutLoad = async ({ data }) => {
 			});
 		}
 
-		await authBootstrapPromise;
+		// Cap the wait so offline cold starts don't stack i18n (5s) + auth
+		// bootstrap (another 3–5s of IndexedDB + store refreshes) on top of
+		// each other and push total load past the 15s app.html stall timer.
+		// hooks.client.ts eagerly constructs the SessionManager, and
+		// initializeAuth() sets {isInitialized,isAuthenticated} before any
+		// slow IO, so routes can make redirect decisions even if bootstrap
+		// continues in the background.
+		await Promise.race([
+			authBootstrapPromise,
+			new Promise<void>((resolve) => setTimeout(resolve, 3000))
+		]);
 
 		// Mark as initialized to prevent re-runs
 		isInitialized = true;

--- a/apps/reborn-task/src/routes/+page.ts
+++ b/apps/reborn-task/src/routes/+page.ts
@@ -25,22 +25,22 @@ export const load: PageLoad = async ({ parent }) => {
 
 	// Client-side only redirect
 	if (browser) {
+		// NOTE: `redirect()` throws a `Redirect` sentinel that SvelteKit catches
+		// upstream — it MUST NOT be wrapped in try/catch here or the happy path
+		// gets swallowed and every visit falls through to /auth/unlock.
+		let currentSession: Awaited<ReturnType<typeof waitForSessionReady>>;
 		try {
-			const currentSession = await waitForSessionReady();
-
-			if (currentSession.isAuthenticated) {
-				if (currentSession.hasE2E) {
-					redirect(303, `${base}/all`);
-				}
-				redirect(303, `${base}/auth/unlock`);
-			}
-
-			redirect(303, `${base}/auth/login`);
+			currentSession = await waitForSessionReady();
 		} catch {
-			// Fallback path if auth bootstrap fails unexpectedly
 			const hasTokens = !!localStorage.getItem('access_token');
 			redirect(303, hasTokens ? `${base}/auth/unlock` : `${base}/auth/login`);
 		}
+
+		if (currentSession.isAuthenticated) {
+			redirect(303, currentSession.hasE2E ? `${base}/all` : `${base}/auth/unlock`);
+		}
+
+		redirect(303, `${base}/auth/login`);
 	}
 
 	// Server-side: just return empty object

--- a/apps/reborn-task/src/routes/auth/unlock/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/unlock/+page.svelte
@@ -40,6 +40,14 @@
 
 		const currentSession = $session;
 
+		// Wait until the session store has finished bootstrapping. Without this
+		// guard the first reactive pass sees {isInitialized:false, isAuthenticated:false}
+		// and bounces to /auth/login before initializeAuth() has even populated
+		// the store — producing the offline redirect loop.
+		if (!currentSession.isInitialized || currentSession.isLoading) {
+			return;
+		}
+
 		// If user is not authenticated, redirect to login
 		if (!currentSession.isAuthenticated) {
 			logger.debug('User not authenticated, redirecting to login');


### PR DESCRIPTION
…e screen

Eagerly construct the SessionManager singleton in hooks.client.ts so auth.store.ts attaches before its retry window expires, move redirect() calls out of the try/catch in +page.ts that was swallowing the happy path, guard unlock page's checkAuthState against an uninitialized session, cap authBootstrapPromise at 3s to keep total cold-start under the 15s stall banner, and stop treating a transiently-null serviceWorker.controller (iOS PWA cold start) as "no service worker" in both apps.