### PR TITLE
fix(task): eliminate offline cold-start race that redirected to login

### DIFF
--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -540,10 +540,13 @@ export class AuthOperationsService {
 				logger.debug('Auth token restored to sync service from localStorage');
 			}
 
-			// Mark session as initialized. If we have tokens, also set isLoading=true
-			// so that (app) layout guard waits for the background auth check to complete.
-			sessionManager.setSession({ isInitialized: true, isLoading: hasTokens });
-			logger.debug('Session marked as initialized', { isLoading: hasTokens });
+			// Mark session as initialized but keep isLoading=true until we've
+			// finished reading persisted credentials. Flipping isLoading=false here
+			// would let `+page.ts` waitForSessionReady() return on {isAuthenticated:false}
+			// and bounce an offline cold start to /auth/login before setAuthenticated()
+			// has had a chance to run.
+			sessionManager.setSession({ isInitialized: true, isLoading: true });
+			logger.debug('Session marked as initialized (isLoading=true until auth resolves)');
 
 			// Check if we're offline
 			if (!navigator.onLine) {
@@ -555,7 +558,7 @@ export class AuthOperationsService {
 				// and wrapped master key — mirrors the pattern used by reborn-notes.
 				const storage = new AuthStorageAdapter();
 				const credentials = await storage.getCredentials();
-				if (credentials) {
+				if (credentials?.user_profile) {
 					logger.info('Offline credentials available, marking session authenticated');
 					// Populate both isAuthenticated AND user so layout guards don't
 					// redirect to /auth/login while we still have a valid profile.
@@ -610,6 +613,11 @@ export class AuthOperationsService {
 				if (hasOffline) {
 					logger.info('Offline credentials available');
 				}
+
+				// Release the isLoading=true we set at the top of this try{} —
+				// without this flip, waitForSessionReady() would never return and
+				// +page.ts would stall until its 1.5s polling timeout.
+				sessionManager.setLoading(false);
 			}
 		} catch (error: unknown) {
 			logger.error('Auth initialization failed:', error);

--- a/apps/reborn-task/src/routes/+page.ts
+++ b/apps/reborn-task/src/routes/+page.ts
@@ -28,6 +28,26 @@ export const load: PageLoad = async ({ parent }) => {
 		// NOTE: `redirect()` throws a `Redirect` sentinel that SvelteKit catches
 		// upstream — it MUST NOT be wrapped in try/catch here or the happy path
 		// gets swallowed and every visit falls through to /auth/unlock.
+
+		// Offline cold start: decide the redirect target from persisted
+		// credentials directly. The session store may still be mid-bootstrap
+		// at this point (checkE2EStatus can take 5s+ waiting on the crypto
+		// manager's IndexedDB restore), and using waitForSessionReady() would
+		// race setAuthenticated() — producing the classic offline symptom
+		// "/ → /auth/login" even though valid credentials are on disk.
+		if (!navigator.onLine) {
+			const hasCredentials = !!localStorage.getItem('reborn_auth_credentials');
+			if (!hasCredentials) {
+				redirect(303, `${base}/auth/login`);
+			}
+			const { cryptoManager } = await import('@reborn/crypto');
+			await cryptoManager.waitForRestore();
+			redirect(
+				303,
+				cryptoManager.isInitialized() ? `${base}/all` : `${base}/auth/unlock`
+			);
+		}
+
 		let currentSession: Awaited<ReturnType<typeof waitForSessionReady>>;
 		try {
 			currentSession = await waitForSessionReady();


### PR DESCRIPTION
initializeAuth() set isLoading=hasTokens at the start of bootstrap, so when access_token was missing (but reborn_auth_credentials was still on disk) isLoading flipped to false before the async getCredentials → setAuthenticated chain ran. +page.ts waitForSessionReady() caught that window with {isAuthenticated:false} and bounced to /auth/login even though a valid profile was persisted.

Keep isLoading=true through the whole init path so readers wait for setAuthenticated(), and short-circuit +page.ts on offline cold start by reading reborn_auth_credentials + cryptoManager.waitForRestore() to pick /all vs /auth/unlock directly. The waitForRestore promise is shared, so no extra delay vs the layout bootstrap.

Also guard setAuthenticated on credentials?.user_profile to handle the 2FA interim-credentials case where user_profile is absent.