### PR TITLE
fix(task): remove redundant onStorageInit from E2E restore path

### DIFF
--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -489,6 +489,13 @@ export class AuthOperationsService {
 	 * Check and restore E2E encryption status.
 	 * Uses CryptoManager.waitForRestore() which restores the master key from
 	 * IndexedDB (survives browser/PWA restart) or sessionStorage (fallback).
+	 *
+	 * We only flip `hasE2E` here — do NOT trigger onStorageInit('restore').
+	 * +layout.svelte's onMount already awaits cryptoManager.waitForRestore()
+	 * and refreshes all stores; the $effect watching hasE2E runs initialSync
+	 * with a `hasTriggeredInitialSync` dedup flag. Calling onStorageInit here
+	 * would race those two paths and, on offline cold starts, caused decrypt
+	 * `OperationError` failures and a bogus redirect to /auth/login.
 	 */
 	private async checkE2EStatus() {
 		try {
@@ -499,12 +506,6 @@ export class AuthOperationsService {
 
 			if (cryptoManager.isInitialized()) {
 				logger.info('E2E initialized (master key restored from IndexedDB)');
-
-				// Trigger onStorageInit to ensure stores are initialized.
-				// 'restore' context — same user, key loaded from IndexedDB. Do NOT clear data.
-				await this.onStorageInit(cryptoManager, 'restore');
-
-				// Update session to reflect E2E status
 				const sessionManager = this.getSessionManager();
 				sessionManager.setSession({ hasE2E: true });
 			} else {


### PR DESCRIPTION
checkE2EStatus() triggered onStorageInit('restore') which raced against +layout.svelte's onMount and $effect-on-hasE2E, both of which already refresh stores (with hasTriggeredInitialSync dedup). The racing call chain reached refreshDecryptedLists before crypto was settled, producing OperationError decrypt failures and a bogus /auth/login redirect on offline cold starts. Now only flip hasE2E and let the layout handle it.