### PR TITLE
fix(task): sync pending offline ops on PWA cold start

### DIFF
--- a/apps/reborn-task/src/lib/services/sync/sync-offline.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-offline.service.ts
@@ -20,7 +20,7 @@ export class SyncOfflineService extends SyncBaseService {
 	/**
 	 * Get pending offline operations
 	 */
-	getPendingOperations(): StorageOfflineOperation[] {
+	async getPendingOperations(): Promise<StorageOfflineOperation[]> {
 		return offlineOperationsStore.getPendingOperations();
 	}
 
@@ -45,8 +45,8 @@ export class SyncOfflineService extends SyncBaseService {
 	/**
 	 * Get IDs of entities that have pending or failed operations in the queue
 	 */
-	getPendingEntityIds(entityType?: string): Set<string> {
-		const ops = this.getPendingOperations();
+	async getPendingEntityIds(entityType?: string): Promise<Set<string>> {
+		const ops = await this.getPendingOperations();
 		const ids = new Set<string>();
 		for (const op of ops) {
 			if (!entityType || op.entityType === entityType) {

--- a/apps/reborn-task/src/lib/stores/offline-operations.store.ts
+++ b/apps/reborn-task/src/lib/stores/offline-operations.store.ts
@@ -62,14 +62,16 @@ export const offlineOperationsStore = {
 	},
 
 	/**
-	 * Get pending operations synchronously from current store value
+	 * Get pending operations directly from IndexedDB.
+	 *
+	 * Reads from the persistent store (not the reactive `items` writable) so that
+	 * sync works on cold start even when no code path has populated `items` yet —
+	 * e.g. PWA restart with an existing session, where `$effect`-on-hasE2E triggers
+	 * `initialSync` before any operation has run `refreshItems` as a side-effect.
 	 */
-	getPendingOperations(): StorageOfflineOperation[] {
-		let operations: StorageOfflineOperation[] = [];
-		storageOfflineOps.items.subscribe(value => {
-			operations = value.filter(op => op.status === 'pending' || !op.status);
-		})();
-		return operations;
+	async getPendingOperations(): Promise<StorageOfflineOperation[]> {
+		const all = await storageOfflineOps.getAll();
+		return all.filter(op => op.status === 'pending' || !op.status);
 	},
 
 	/**

--- a/apps/reborn-task/src/routes/+layout.svelte
+++ b/apps/reborn-task/src/routes/+layout.svelte
@@ -144,12 +144,17 @@
 					await initializeStorage('task');
 					logger.info('Database initialized successfully');
 
-					// Force refresh of all stores after initialization
-					const { taskStore, listStore, subtaskStore } = await import('@reborn/storage');
+					// Force refresh of all stores after initialization.
+					// offlineOperationsStore must be refreshed on cold start so its reactive
+					// writable reflects rows persisted in IndexedDB — otherwise pending-count
+					// indicators show 0 until the first local mutation triggers a refresh.
+					const { taskStore, listStore, subtaskStore, offlineOperationsStore } =
+						await import('@reborn/storage');
 					await Promise.all([
 						taskStore.refreshItems(),
 						listStore.refreshItems(),
-						subtaskStore.refreshItems()
+						subtaskStore.refreshItems(),
+						offlineOperationsStore.refreshItems()
 					]);
 					logger.info('All stores refreshed after initialization');
 
@@ -168,11 +173,18 @@
 			} else {
 				logger.info('Database already initialized');
 
-				// Refresh decrypted stores on mount even if database was already initialized
+				// Refresh decrypted stores on mount even if database was already initialized.
+				// Also refresh offlineOperationsStore so pending-count indicators are accurate
+				// on cold start (derived stores feed SyncStatusIndicator / SyncStatusFooter).
 				const { refreshDecryptedLists } = await import('$lib/stores/decrypted-lists.store');
 				const { refreshDecryptedSubtasks } = await import('$lib/stores/decrypted-subtasks.store');
+				const { offlineOperationsStore } = await import('@reborn/storage');
 
-				await Promise.all([refreshDecryptedLists(), refreshDecryptedSubtasks()]);
+				await Promise.all([
+					refreshDecryptedLists(),
+					refreshDecryptedSubtasks(),
+					offlineOperationsStore.refreshItems()
+				]);
 				logger.info('Decrypted stores refreshed on mount');
 				// Build task index cache (blocking — stores read from index)
 				await taskTitleIndex.build();


### PR DESCRIPTION
getPendingOperations() read from the reactive `items` writable, which on cold start was never populated — refreshItems() only ran as a side effect of save()/delete(), and the one cold-start path that called it (onStorageInit('restore')) was removed in 6a7ba59. Tasks created offline stayed in IndexedDB but sync silently reported 0 ops, until the next local mutation's refreshItems() side effect loaded them. Read pending ops directly from IndexedDB, and refresh offlineOperationsStore in the layout init so pending-count indicators are accurate after cold start.