### PR TITLE
fix(release): sync private workspace manifests in nx release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,8 @@ memory/
 .github/instructions/
 .githooks/
 docs/development/
-scripts/
+scripts/*
+!scripts/release.mjs
 tmp/
 patches/
 *.bak

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/reborn-notes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/apps/reborn-task/package.json
+++ b/apps/reborn-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reborn-task",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/source",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "clean": "chmod +x ./scripts/clean-all.sh && ./scripts/clean-all.sh",
@@ -15,8 +15,8 @@
     "db:seed": "cd packages/database && pnpm db:seed",
     "db:setup": "pnpm db:generate && pnpm db:migrate && pnpm db:seed",
     "knip": "knip",
-    "release": "nx release",
-    "release:dry": "nx release --dry-run"
+    "release": "node scripts/release.mjs",
+    "release:dry": "node scripts/release.mjs --dry-run"
   },
   "private": true,
   "devDependencies": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/i18n",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Internationalization package for Reborn apps",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Release wrapper for the Nx monorepo.
+//
+// nx release skips package.json files marked "private": true and never touches
+// the workspace-root package.json. In this repo the root + apps + @reborn/i18n
+// are all private, so a plain nx release leaves them stale — and
+// apps/*/vite.config.ts injects __APP_VERSION__ from the root manifest, so the
+// UI version freezes at the old number.
+//
+// This script runs nx release in two phases and syncs the missing manifests in
+// between, so the final release commit carries a coherent version across the
+// whole workspace.
+import { releaseChangelog, releaseVersion } from 'nx/release/index.js';
+import { readFile, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(new URL('..', import.meta.url).pathname);
+
+const PRIVATE_MANIFESTS = [
+	'package.json',
+	'apps/reborn-task/package.json',
+	'apps/reborn-notes/package.json',
+	'packages/i18n/package.json'
+];
+
+const argv = process.argv.slice(2);
+const dryRun = argv.includes('--dry-run');
+const firstRelease = argv.includes('--first-release');
+const verbose = argv.includes('--verbose');
+
+const { workspaceVersion, projectsVersionData } = await releaseVersion({
+	dryRun,
+	firstRelease,
+	verbose,
+	gitCommit: false,
+	gitTag: false,
+	stageChanges: true
+});
+
+if (!workspaceVersion) {
+	console.log('\n[release] No workspace version bump — nothing to sync.');
+	process.exit(0);
+}
+
+const syncedFiles = [];
+for (const relPath of PRIVATE_MANIFESTS) {
+	const absPath = resolve(ROOT, relPath);
+	const raw = await readFile(absPath, 'utf-8');
+	const pkg = JSON.parse(raw);
+	if (pkg.version === workspaceVersion) continue;
+
+	const previous = pkg.version;
+	pkg.version = workspaceVersion;
+	const trailingNewline = raw.endsWith('\n') ? '\n' : '';
+	if (!dryRun) {
+		await writeFile(absPath, JSON.stringify(pkg, null, 2) + trailingNewline);
+	}
+	syncedFiles.push(relPath);
+	console.log(
+		`[release] ${dryRun ? '[dry-run] would sync' : 'synced'} ${relPath}: ${previous} → ${workspaceVersion}`
+	);
+}
+
+if (!dryRun && syncedFiles.length > 0) {
+	execFileSync('git', ['add', '--', ...syncedFiles], { stdio: 'inherit', cwd: ROOT });
+}
+
+await releaseChangelog({
+	dryRun,
+	firstRelease,
+	verbose,
+	version: workspaceVersion,
+	versionData: projectsVersionData,
+	gitCommit: true,
+	gitTag: true,
+	stageChanges: true
+});


### PR DESCRIPTION
The default @nx/js:release-version executor skips package.json files marked "private": true and never touches the workspace-root manifest. In this repo the root, both apps and @reborn/i18n are private, so `nx release` left them at 0.1.0 while bumping the other packages to 0.1.1. Since apps/*/vite.config.ts injects __APP_VERSION__ from the root package.json, the UI in /settings froze at the old version on production.

- scripts/release.mjs: wrap nx release programmatic API (releaseVersion + releaseChangelog) with a sync step for the four private manifests, so the release commit carries a coherent version across the whole workspace.
- package.json: point "release" / "release:dry" scripts at the wrapper.
- Sync stale 0.1.0 manifests (root, apps, i18n) to 0.1.1 to match the rest.
- .gitignore: keep scripts/ ignored but expose scripts/release.mjs so the release flow works from a fresh clone.