### PR TITLE
fix(auth): recover from master key / IDB ciphertext mismatch

### DIFF
--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -97,10 +97,18 @@ function createAuthStore() {
       if (!newState.isAuthenticated) {
         // Cross-app logout detected — hard redirect avoids reactive cascades
         // (empty stores, "?" avatar, effect_update_depth_exceeded).
+        // Clear Notes IndexedDB BEFORE redirect so a subsequent login with
+        // a different account can't reach decrypt with stale ciphertexts
+        // encrypted under the previous user's master key (OperationError).
         logger.info('Cross-app logout detected via storage event — redirecting to login');
         sessionExpired.set(false);
         cryptoManager.clearMasterKey();
-        window.location.href = `${base}/auth/login`;
+        import('@reborn/storage')
+          .then(({ clearAllUserData }) => clearAllUserData())
+          .catch((err) => logger.error('Failed to clear IndexedDB on cross-app logout:', err))
+          .finally(() => {
+            window.location.href = `${base}/auth/login`;
+          });
         return;
       }
 

--- a/apps/reborn-notes/src/routes/auth/login/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/login/+page.svelte
@@ -6,6 +6,7 @@
   import { page } from '$app/stores';
   import { LoginPage } from '@reborn/ui';
   import { authStore } from '$lib/stores/auth.store';
+  import { sessionExpired } from '$lib/stores/sync-status.store';
   import { loginInNotes } from '$lib/services/notes-auth.service';
   import { t } from '$lib/stores/i18n.store';
 
@@ -20,6 +21,10 @@
   });
 
   onMount(() => {
+    // Reaching the login page = no live session to expire.
+    // Belt-and-suspenders cleanup so the banner never lingers when a
+    // non-standard path dropped us here (cross-app logout, etc.).
+    sessionExpired.set(false);
     if ($authStore.isAuthenticated) {
       goto($authStore.hasE2E ? returnTo : '/auth/unlock');
     }

--- a/apps/reborn-task/src/hooks.client.ts
+++ b/apps/reborn-task/src/hooks.client.ts
@@ -9,6 +9,7 @@ if (import.meta.hot) {
 import { cryptoManager } from '@reborn/crypto';
 import { base } from '$app/paths';
 import { authOperationsService } from '$lib/services/auth-operations.service';
+import { sessionExpired } from '$lib/stores/session-expired.store';
 import { trashManagementService } from '$lib/services/trash-management.service';
 import { recurrenceService } from '$lib/services/recurrence.service';
 import { pushNotificationService } from '$lib/services/push-notification.service';
@@ -71,11 +72,25 @@ window.addEventListener('storage', (e) => {
 	if (e.key !== CREDENTIALS_KEY) return;
 
 	if (e.newValue === null) {
-		// Credentials removed → cross-app (or cross-tab) logout
+		// Credentials removed → cross-app (or cross-tab) logout.
+		// Clear local state BEFORE the redirect so the next login doesn't
+		// find stale ciphertexts in IndexedDB encrypted under a previous
+		// user's master key — that caused AES-GCM OperationError on decrypt.
 		logger.info('Cross-app logout detected via storage event — redirecting to login');
+		sessionExpired.set(false);
 		cryptoManager.clearMasterKey();
-		window.location.href = `${base}/auth/login`;
-	} else if (e.oldValue === null) {
+		// Fire-and-forget — the hard redirect below completes the logout even
+		// if the IDB clear is still in flight.
+		import('@reborn/storage')
+			.then(({ clearAllUserData }) => clearAllUserData())
+			.catch((err) => logger.error('Failed to clear IndexedDB on cross-app logout:', err))
+			.finally(() => {
+				window.location.href = `${base}/auth/login`;
+			});
+		return;
+	}
+
+	if (e.oldValue === null) {
 		// Credentials appeared (was absent, now present) → cross-app login
 		// Redirect to E2E unlock — master key must be decrypted with the user's password
 		logger.info('Cross-app login detected via storage event — redirecting to unlock');

--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -28,6 +28,66 @@ declare global {
 }
 
 export class AuthOperationsService {
+	/**
+	 * Detect local IDB data encrypted under a different master key than the one
+	 * currently loaded, and recover by wiping local data + re-pulling from server.
+	 *
+	 * Happens when a user logs out in the peer app (storage event clears the
+	 * crypto key) and logs in as a different user, but Task's IndexedDB still
+	 * holds ciphertexts from the previous user. Next decrypt throws AES-GCM
+	 * OperationError — this helper turns that into a clean recovery.
+	 *
+	 * Safe no-op when: no key loaded, IDB empty, offline, or data is readable.
+	 * Returns `true` if a recovery wipe was performed (caller should re-sync).
+	 */
+	async recoverFromKeyMismatch(): Promise<boolean> {
+		if (!browser) return false;
+		try {
+			const { cryptoManager } = await import('@reborn/crypto');
+			if (!cryptoManager.isInitialized()) return false;
+
+			const { listStore } = await import('@reborn/storage');
+			const { get } = await import('svelte/store');
+
+			const encryptedLists = get(listStore.items) as Array<{
+				name_encrypted?: string;
+				deleted_at?: string | null;
+			}>;
+			const probe = encryptedLists.find((l) => !l.deleted_at && l.name_encrypted);
+			if (!probe?.name_encrypted) return false;
+
+			try {
+				await cryptoManager.decryptText(probe.name_encrypted);
+				return false; // data decrypts — all good
+			} catch {
+				logger.warn(
+					'Local data appears encrypted under a different master key — recovering'
+				);
+			}
+
+			if (!navigator.onLine) {
+				logger.error(
+					'Offline — cannot wipe & re-pull. Local Task data will remain unreadable until online.'
+				);
+				return false;
+			}
+
+			const { clearAllUserData } = await import('@reborn/storage');
+			await clearAllUserData();
+			logger.info('Local IndexedDB wiped after key/data mismatch — triggering initial sync');
+
+			try {
+				await syncService.initialSync();
+			} catch (err) {
+				logger.error('Initial sync after recovery failed:', err);
+			}
+			return true;
+		} catch (error: unknown) {
+			logger.error('Key-mismatch recovery failed:', error);
+			return false;
+		}
+	}
+
 	private isDefinitiveSessionExpiry(message: string | undefined): boolean {
 		if (!message) return false;
 		const normalized = message.toLowerCase();
@@ -125,6 +185,20 @@ export class AuthOperationsService {
 			} catch (loadError) {
 				logger.error('Failed to load task lists:', loadError);
 				// Continue - empty list is better than failure
+			}
+
+			// Restore path: guard against stale ciphertexts encrypted under a
+			// previous user's key. `context==='login'` already cleared IDB above,
+			// so this is a no-op there.
+			if (context === 'restore') {
+				const recovered = await this.recoverFromKeyMismatch();
+				if (recovered) {
+					try {
+						await taskListStore.loadLists();
+					} catch (err) {
+						logger.error('Failed to reload lists after key-mismatch recovery:', err);
+					}
+				}
 			}
 
 			// Perform initial sync if online (non-blocking)

--- a/apps/reborn-task/src/routes/+layout.svelte
+++ b/apps/reborn-task/src/routes/+layout.svelte
@@ -163,6 +163,15 @@
 					const { refreshDecryptedSubtasks } = await import('$lib/stores/decrypted-subtasks.store');
 					await Promise.all([refreshDecryptedLists(), refreshDecryptedSubtasks()]);
 					logger.info('Decrypted stores refreshed');
+
+					// If the restored master key doesn't match the ciphertexts in IDB
+					// (e.g. cross-app login after account switch), wipe local data and
+					// re-pull from server. No-op on the happy path.
+					const recovered = await authOperationsService.recoverFromKeyMismatch();
+					if (recovered) {
+						await Promise.all([refreshDecryptedLists(), refreshDecryptedSubtasks()]);
+					}
+
 					// Build task index cache (blocking — stores read from index)
 					await taskTitleIndex.build();
 					// E2E already active on mount → prevent $effect from duplicating sync
@@ -186,6 +195,15 @@
 					offlineOperationsStore.refreshItems()
 				]);
 				logger.info('Decrypted stores refreshed on mount');
+
+				// If the restored master key doesn't match the ciphertexts in IDB
+				// (e.g. cross-app login after account switch), wipe local data and
+				// re-pull from server. No-op on the happy path.
+				const recovered = await authOperationsService.recoverFromKeyMismatch();
+				if (recovered) {
+					await Promise.all([refreshDecryptedLists(), refreshDecryptedSubtasks()]);
+				}
+
 				// Build task index cache (blocking — stores read from index)
 				await taskTitleIndex.build();
 				// E2E already active on mount → prevent $effect from duplicating sync

--- a/apps/reborn-task/src/routes/auth/login/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/login/+page.svelte
@@ -5,6 +5,7 @@
 	import { page } from '$app/stores';
 	import { t } from '$lib/stores/i18n.store';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
+	import { sessionExpired } from '$lib/stores/session-expired.store';
 	import { LoginPage } from '@reborn/ui';
 	import { createLogger } from '@reborn/utils';
 
@@ -19,6 +20,10 @@
 			// Get return URL from query params
 			const url = new URL($page.url);
 			returnTo = url.searchParams.get('returnTo') || '/all';
+			// Reaching the login page = there's no live session to expire.
+			// Belt-and-suspenders cleanup so the banner never lingers when
+			// a non-standard path dropped us here (cross-app logout, etc.).
+			sessionExpired.set(false);
 		}
 	});
 


### PR DESCRIPTION
After cross-app logout the peer app's storage-event handler cleared only the shared master key — local IndexedDB still held ciphertexts from the previous session. A subsequent login under a different account then hit AES-GCM OperationError on every decrypt, and a stale sessionExpired flag kept the "Session expired" banner glued to the login screen.

- Task & Notes cross-app logout handlers now wipe their app's IndexedDB and clear sessionExpired before the hard redirect, so the next login starts from a clean store.
- Add recoverFromKeyMismatch() safety net in Task: on cold-start layout init and onStorageInit('restore'), probe-decrypt a stored list and, on failure, clearAllUserData() + initialSync() to re-pull from server. Recovers users whose IDB is already out of sync with the current key.
- Login pages reset sessionExpired in onMount as a belt-and-suspenders against any other path dropping the user at /auth/login with the banner still raised.