### PR TITLE
fix(notes): serialize per-entity push ops and intent-check delete/res…

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -67,6 +67,93 @@ describe('notes-sync — regression (offline data loss)', () => {
     expect(firstPushCall).toBeLessThan(firstPullCall);
   });
 
+  it('delete/restore push ops are serialized per-entity (BUG-5 part A/B/C)', () => {
+    const src = readSource('./notes-sync.service.ts');
+
+    // The helper itself must exist.
+    expect(src).toMatch(/function\s+serializePerEntity\s*</);
+
+    // Every push* that mutates a single (type, id) must route through it,
+    // otherwise the network can reorder the wire and diverge server vs local.
+    const mustSerialize: Array<[RegExp, 'note' | 'folder' | 'tag']> = [
+      [/export function pushNote\b/, 'note'],
+      [/export function pushNoteUpdate\b/, 'note'],
+      [/export function pushNoteDelete\b/, 'note'],
+      [/export function pushNoteRestore\b/, 'note'],
+      [/export function pushFolder\b/, 'folder'],
+      [/export function pushFolderUpdate\b/, 'folder'],
+      [/export function pushFolderDelete\b/, 'folder'],
+      [/export function pushTag\b/, 'tag'],
+      [/export function pushTagUpdate\b/, 'tag'],
+      [/export function pushTagDelete\b/, 'tag']
+    ];
+    for (const [signature, type] of mustSerialize) {
+      const match = signature.exec(src);
+      expect(match, `signature not found: ${signature}`).not.toBeNull();
+      const start = match!.index;
+      // Scan only the next ~600 chars — long enough for the wrapper, short
+      // enough to avoid crossing into the next function.
+      const body = src.slice(start, start + 600);
+      expect(body, `${signature} must call serializePerEntity('${type}', …)`).toMatch(
+        new RegExp(`serializePerEntity\\(\\s*'${type}'`)
+      );
+    }
+  });
+
+  it('pushNoteDelete chains restore when is_archived flipped during push (BUG-5 A)', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const body = src.slice(
+      src.indexOf('export function pushNoteDelete'),
+      src.indexOf('export function pushNoteRestore')
+    );
+    // Intent-check branch: if current.is_archived is false, chain restore.
+    expect(body).toMatch(/current\.is_archived/);
+    expect(body).toMatch(/pushNoteRestore\s*\(\s*id\s*\)/);
+    // Must keep sync_status pending when intent flipped.
+    expect(body).toMatch(/sync_status:\s*'pending'/);
+  });
+
+  it('pushNoteRestore chains delete when is_archived flipped during push (BUG-5 A)', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const body = src.slice(
+      src.indexOf('export function pushNoteRestore'),
+      src.indexOf('export function pushFolder')
+    );
+    expect(body).toMatch(/current\.is_archived/);
+    expect(body).toMatch(/pushNoteDelete\s*\(\s*id\s*\)/);
+    // Old bug: sync_version clobbered to 1 after restore. Must NOT reappear.
+    expect(body).not.toMatch(/sync_version:\s*1\b/);
+  });
+
+  it('pushFolderDelete / pushTagDelete do not clobber sync_version to 1 (BUG-5)', () => {
+    const src = readSource('./notes-sync.service.ts');
+
+    const folderDelete = src.slice(
+      src.indexOf('export function pushFolderDelete'),
+      src.indexOf('export function pushTag\b') !== -1
+        ? src.indexOf('export function pushTag\b')
+        : src.indexOf('export function pushTag(')
+    );
+    expect(folderDelete).not.toMatch(/sync_version:\s*1\b/);
+
+    const tagDelete = src.slice(src.indexOf('export function pushTagDelete'));
+    expect(tagDelete).not.toMatch(/sync_version:\s*1\b/);
+  });
+
+  it('pushPendingItems partitions archived pending notes into delete retries (BUG-5)', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function pushPendingItems'),
+      src.indexOf('/** Retry a function with exponential backoff')
+    );
+    // Non-archived pending notes still POST /api/notes.
+    expect(fn).toMatch(/const\s+pendingNotes\s*=\s*allNotes\.filter/);
+    expect(fn).toMatch(/!n\.is_archived/);
+    // Archived pending notes get their own bucket and go through pushNoteDelete.
+    expect(fn).toMatch(/const\s+pendingArchivedNotes\s*=\s*allNotes\.filter/);
+    expect(fn).toMatch(/pushNoteDelete\s*\(\s*n\.id\s*\)/);
+  });
+
   it('pull helpers remove ghost items (synced locally but deleted on server)', () => {
     const src = readSource('./notes-sync.service.ts');
 

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -437,17 +437,35 @@ export async function pushPendingItems(): Promise<void> {
 
   const pendingFolders = allFolders.filter((f) => f.sync_status === 'pending');
   const pendingTags = allTags.filter((t) => t.sync_status === 'pending');
-  const pendingNotes = allNotes.filter((n) => n.sync_status === 'pending');
+  // Partition notes by is_archived: non-archived pending rows are failed
+  // creates/updates and go through POST /api/notes; archived pending rows are
+  // failed soft-deletes and must be retried via pushNoteDelete. Before this
+  // split, a retried archived note would have been POSTed like a new note,
+  // resurrecting it on the server.
+  const pendingNotes = allNotes.filter(
+    (n) => n.sync_status === 'pending' && !n.is_archived
+  );
+  const pendingArchivedNotes = allNotes.filter(
+    (n) => n.sync_status === 'pending' && n.is_archived
+  );
 
-  if (pendingFolders.length + pendingTags.length + pendingNotes.length === 0) return;
+  if (
+    pendingFolders.length +
+      pendingTags.length +
+      pendingNotes.length +
+      pendingArchivedNotes.length ===
+    0
+  )
+    return;
 
   logger.info(
-    `Pushing pending items: ${pendingFolders.length} folders, ${pendingTags.length} tags, ${pendingNotes.length} notes`
+    `Pushing pending items: ${pendingFolders.length} folders, ${pendingTags.length} tags, ${pendingNotes.length} notes, ${pendingArchivedNotes.length} archived notes`
   );
 
   // Push folders & tags first (notes reference them)
   await Promise.allSettled([
     ...pendingFolders.map((f) =>
+      serializePerEntity('folder', f.id, () =>
       pushSilently(async (idempotencyKey) => {
         const pushedFields = {
           name_encrypted: f.name_encrypted,
@@ -473,71 +491,84 @@ export async function pushPendingItems(): Promise<void> {
           });
         }
       })
+      )
     ),
     ...pendingTags.map((t) =>
-      pushSilently(async (idempotencyKey) => {
-        const pushedFields = {
-          name_encrypted: t.name_encrypted,
-          color_encrypted: t.color_encrypted ?? null
-        };
-        const payload = { id: t.id, ...pushedFields, created_at: t.created_at };
-        validateEncryptedPayload(payload as Record<string, unknown>);
-        const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags`, {
-          method: 'POST',
-          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-          body: JSON.stringify(payload)
-        });
-        if (!res.ok) throw new Error(`POST /api/tags: ${res.status}`);
-        const { data: resData } = await res.json();
-        const current = await tagStore.get(t.id);
-        if (current) {
-          const stillDirty = pushedFieldsDiffer(current, pushedFields);
-          await tagStore.save({
-            ...current,
-            sync_status: stillDirty ? 'pending' : 'synced',
-            sync_version: resData?.sync_version ?? 1
+      serializePerEntity('tag', t.id, () =>
+        pushSilently(async (idempotencyKey) => {
+          const pushedFields = {
+            name_encrypted: t.name_encrypted,
+            color_encrypted: t.color_encrypted ?? null
+          };
+          const payload = { id: t.id, ...pushedFields, created_at: t.created_at };
+          validateEncryptedPayload(payload as Record<string, unknown>);
+          const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags`, {
+            method: 'POST',
+            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+            body: JSON.stringify(payload)
           });
-        }
-      })
+          if (!res.ok) throw new Error(`POST /api/tags: ${res.status}`);
+          const { data: resData } = await res.json();
+          const current = await tagStore.get(t.id);
+          if (current) {
+            const stillDirty = pushedFieldsDiffer(current, pushedFields);
+            await tagStore.save({
+              ...current,
+              sync_status: stillDirty ? 'pending' : 'synced',
+              sync_version: resData?.sync_version ?? 1
+            });
+          }
+        })
+      )
     )
   ]);
 
-  // Then push notes
+  // Then push notes (POST for creates/updates)
   await Promise.allSettled(
     pendingNotes.map((n) =>
-      pushSilently(async (idempotencyKey) => {
-        const pushedFields = {
-          title_encrypted: n.title_encrypted,
-          content_encrypted: n.content_encrypted,
-          folder_id: n.folder_id ?? null,
-          metadata_encrypted: n.metadata_encrypted ?? null
-        };
-        const payload = {
-          id: n.id,
-          ...pushedFields,
-          metadata_encrypted: n.metadata_encrypted ?? undefined,
-          created_at: n.created_at
-        };
-        validateEncryptedPayload(payload as Record<string, unknown>);
-        const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes`, {
-          method: 'POST',
-          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-          body: JSON.stringify(payload)
-        });
-        if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
-        const { data: resData } = await res.json();
-        const current = await noteStore.get(n.id);
-        if (current) {
-          const stillDirty = pushedFieldsDiffer(current, pushedFields);
-          await noteStore.save({
-            ...current,
-            sync_status: stillDirty ? 'pending' : 'synced',
-            sync_version: resData?.sync_version ?? 1
+      serializePerEntity('note', n.id, () =>
+        pushSilently(async (idempotencyKey) => {
+          const pushedFields = {
+            title_encrypted: n.title_encrypted,
+            content_encrypted: n.content_encrypted,
+            folder_id: n.folder_id ?? null,
+            metadata_encrypted: n.metadata_encrypted ?? null
+          };
+          const payload = {
+            id: n.id,
+            ...pushedFields,
+            metadata_encrypted: n.metadata_encrypted ?? undefined,
+            created_at: n.created_at
+          };
+          validateEncryptedPayload(payload as Record<string, unknown>);
+          const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes`, {
+            method: 'POST',
+            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+            body: JSON.stringify(payload)
           });
-        }
-      })
+          if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
+          const { data: resData } = await res.json();
+          const current = await noteStore.get(n.id);
+          if (current) {
+            const stillDirty = pushedFieldsDiffer(current, pushedFields);
+            await noteStore.save({
+              ...current,
+              sync_status: stillDirty ? 'pending' : 'synced',
+              sync_version: resData?.sync_version ?? 1
+            });
+          }
+        })
+      )
     )
   );
+
+  // Retry archived-pending notes via DELETE (see partition comment above).
+  // pushNoteDelete is itself serialized per-entity, so if a POST for the same
+  // note is still in the chain (e.g. first-time create+archive), the DELETE
+  // waits for it to land.
+  for (const n of pendingArchivedNotes) {
+    pushNoteDelete(n.id);
+  }
 
   // Push pending note versions
   await pushPendingVersions();
@@ -580,6 +611,38 @@ async function pushSilently(fn: (idempotencyKey: string) => Promise<void>): Prom
 }
 
 /**
+ * Per-entity FIFO queue. All `push*` operations targeting the same
+ * `(type, id)` pair are chained so they execute sequentially, preventing the
+ * network from reordering create/update/delete/restore for a single entity.
+ *
+ * Without this, the browser can dispatch a POST /folders and a DELETE
+ * /folders/{id} concurrently; if the network delivers DELETE first the folder
+ * stays on the server after the POST — divergent from the empty local state.
+ * The delete↔restore race for notes has the same shape.
+ *
+ * Different entities keep running in parallel. A chain entry clears itself
+ * from the map once it's the tail, so the map doesn't grow unbounded.
+ */
+const entityChains = new Map<string, Promise<unknown>>();
+
+function serializePerEntity<T>(
+  type: 'note' | 'folder' | 'tag',
+  id: string,
+  task: () => Promise<T>
+): Promise<T> {
+  const key = `${type}:${id}`;
+  const prev = entityChains.get(key) ?? Promise.resolve();
+  const next = prev.then(task, task);
+  entityChains.set(
+    key,
+    next.finally(() => {
+      if (entityChains.get(key) === next) entityChains.delete(key);
+    })
+  );
+  return next;
+}
+
+/**
  * Return true if any key in `pushed` has a different value in `current`.
  *
  * Used by push success callbacks to detect the race where a second local edit
@@ -600,40 +663,42 @@ function pushedFieldsDiffer(current: object, pushed: Record<string, unknown>): b
 }
 
 export function pushNote(note: NoteEncrypted | NoteStoredLocal): void {
-  void pushSilently(async (idempotencyKey) => {
-    const pushedFields = {
-      title_encrypted: note.title_encrypted,
-      content_encrypted: note.content_encrypted,
-      folder_id: note.folder_id ?? null,
-      metadata_encrypted: note.metadata_encrypted ?? null
-    };
-    const payload = {
-      id: note.id,
-      ...pushedFields,
-      metadata_encrypted: note.metadata_encrypted ?? undefined,
-      created_at: note.created_at
-    };
-    validateEncryptedPayload(payload as Record<string, unknown>);
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes`, {
-      method: 'POST',
-      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify(payload)
-    });
-    if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
-    const { data } = await res.json();
-    const current = await noteStore.get(note.id);
-    if (current) {
-      const stillDirty = pushedFieldsDiffer(current, pushedFields);
-      if (stillDirty) {
-        logger.debug(`Note ${note.id} changed during push — keeping sync_status=pending`);
-      }
-      await noteStore.save({
-        ...current,
-        sync_status: stillDirty ? 'pending' : 'synced',
-        sync_version: data?.sync_version ?? 1
+  void serializePerEntity('note', note.id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const pushedFields = {
+        title_encrypted: note.title_encrypted,
+        content_encrypted: note.content_encrypted,
+        folder_id: note.folder_id ?? null,
+        metadata_encrypted: note.metadata_encrypted ?? null
+      };
+      const payload = {
+        id: note.id,
+        ...pushedFields,
+        metadata_encrypted: note.metadata_encrypted ?? undefined,
+        created_at: note.created_at
+      };
+      validateEncryptedPayload(payload as Record<string, unknown>);
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes`, {
+        method: 'POST',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify(payload)
       });
-    }
-  });
+      if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
+      const { data } = await res.json();
+      const current = await noteStore.get(note.id);
+      if (current) {
+        const stillDirty = pushedFieldsDiffer(current, pushedFields);
+        if (stillDirty) {
+          logger.debug(`Note ${note.id} changed during push — keeping sync_status=pending`);
+        }
+        await noteStore.save({
+          ...current,
+          sync_status: stillDirty ? 'pending' : 'synced',
+          sync_version: data?.sync_version ?? 1
+        });
+      }
+    })
+  );
 }
 
 export function pushNoteUpdate(
@@ -645,55 +710,84 @@ export function pushNoteUpdate(
     >
   >
 ): void {
-  void pushSilently(async (idempotencyKey) => {
-    validateEncryptedPayload(fields as Record<string, unknown>);
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes/${id}`, {
-      method: 'PATCH',
-      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify(fields)
-    });
-    if (!res.ok) throw new Error(`PATCH /api/notes/${id}: ${res.status}`);
-    const { data } = await res.json();
-    const current = await noteStore.get(id);
-    if (current) {
-      const stillDirty = pushedFieldsDiffer(current, fields);
-      if (stillDirty) {
-        logger.debug(`Note ${id} changed during push — keeping sync_status=pending`);
-      }
-      await noteStore.save({
-        ...current,
-        sync_status: stillDirty ? 'pending' : 'synced',
-        sync_version: data?.sync_version ?? current.sync_version ?? 1
+  void serializePerEntity('note', id, () =>
+    pushSilently(async (idempotencyKey) => {
+      validateEncryptedPayload(fields as Record<string, unknown>);
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes/${id}`, {
+        method: 'PATCH',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify(fields)
       });
-    }
-  });
+      if (!res.ok) throw new Error(`PATCH /api/notes/${id}: ${res.status}`);
+      const { data } = await res.json();
+      const current = await noteStore.get(id);
+      if (current) {
+        const stillDirty = pushedFieldsDiffer(current, fields);
+        if (stillDirty) {
+          logger.debug(`Note ${id} changed during push — keeping sync_status=pending`);
+        }
+        await noteStore.save({
+          ...current,
+          sync_status: stillDirty ? 'pending' : 'synced',
+          sync_version: data?.sync_version ?? current.sync_version ?? 1
+        });
+      }
+    })
+  );
 }
 
 export function pushNoteDelete(id: string, permanent = false): void {
-  void pushSilently(async (idempotencyKey) => {
-    const path = permanent ? `/api/notes/${id}?permanent=true` : `/api/notes/${id}`;
-    const res = await authFetch(`${PUBLIC_BASE_PATH}${path}`, {
-      method: 'DELETE',
-      headers: { 'Idempotency-Key': idempotencyKey }
-    });
-    if (!res.ok) throw new Error(`DELETE /api/notes/${id}: ${res.status}`);
-    if (!permanent) {
-      const archived = await noteStore.get(id);
-      if (archived) await noteStore.save({ ...archived, sync_status: 'synced' });
-    }
-  });
+  void serializePerEntity('note', id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const path = permanent ? `/api/notes/${id}?permanent=true` : `/api/notes/${id}`;
+      const res = await authFetch(`${PUBLIC_BASE_PATH}${path}`, {
+        method: 'DELETE',
+        headers: { 'Idempotency-Key': idempotencyKey }
+      });
+      if (!res.ok) throw new Error(`DELETE /api/notes/${id}: ${res.status}`);
+      if (permanent) return;
+
+      // Intent-check: if the user restored the note while DELETE was in flight,
+      // `current.is_archived` will be false. Marking 'synced' would strand the
+      // local restore — chain a pushNoteRestore instead. See guideline 36 rule 11.b.
+      const current = await noteStore.get(id);
+      if (!current) return;
+      if (current.is_archived) {
+        await noteStore.save({ ...current, sync_status: 'synced' });
+      } else {
+        logger.debug(`Note ${id} restored during delete push — chaining restore`);
+        await noteStore.save({ ...current, sync_status: 'pending' });
+        pushNoteRestore(id);
+      }
+    })
+  );
 }
 
 export function pushNoteRestore(id: string): void {
-  void pushSilently(async (idempotencyKey) => {
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes/${id}/restore`, {
-      method: 'POST',
-      headers: { 'Idempotency-Key': idempotencyKey }
-    });
-    if (!res.ok) throw new Error(`POST /api/notes/${id}/restore: ${res.status}`);
-    const current = await noteStore.get(id);
-    if (current) await noteStore.save({ ...current, sync_status: 'synced', sync_version: 1 });
-  });
+  void serializePerEntity('note', id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes/${id}/restore`, {
+        method: 'POST',
+        headers: { 'Idempotency-Key': idempotencyKey }
+      });
+      if (!res.ok) throw new Error(`POST /api/notes/${id}/restore: ${res.status}`);
+
+      // Intent-check: if the user re-archived the note while /restore was in
+      // flight, chain a pushNoteDelete to catch up. `sync_version` must be
+      // preserved — the restore endpoint doesn't bump it server-side and
+      // doesn't return it, so clobbering with `1` (old behaviour) sabotaged
+      // conflict detection in the next pull. See guideline 36 rule 11.b.
+      const current = await noteStore.get(id);
+      if (!current) return;
+      if (!current.is_archived) {
+        await noteStore.save({ ...current, sync_status: 'synced' });
+      } else {
+        logger.debug(`Note ${id} re-archived during restore push — chaining delete`);
+        await noteStore.save({ ...current, sync_status: 'pending' });
+        pushNoteDelete(id);
+      }
+    })
+  );
 }
 
 export function pushFolder(
@@ -702,78 +796,86 @@ export function pushFolder(
     'id' | 'name_encrypted' | 'parent_id' | 'order_index' | 'created_at'
   >
 ): void {
-  void pushSilently(async (idempotencyKey) => {
-    const pushedFields = {
-      name_encrypted: folder.name_encrypted,
-      parent_id: folder.parent_id ?? null,
-      order_index: folder.order_index
-    };
-    const payload = {
-      id: folder.id,
-      ...pushedFields,
-      created_at: folder.created_at
-    };
-    validateEncryptedPayload(payload as Record<string, unknown>);
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders`, {
-      method: 'POST',
-      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify(payload)
-    });
-    if (!res.ok) throw new Error(`POST /api/folders: ${res.status}`);
-    const { data } = await res.json();
-    const current = await folderStore.get(folder.id);
-    if (current) {
-      const stillDirty = pushedFieldsDiffer(current, pushedFields);
-      if (stillDirty) {
-        logger.debug(`Folder ${folder.id} changed during push — keeping sync_status=pending`);
-      }
-      await folderStore.save({
-        ...current,
-        sync_status: stillDirty ? 'pending' : 'synced',
-        sync_version: data?.sync_version ?? 1
+  void serializePerEntity('folder', folder.id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const pushedFields = {
+        name_encrypted: folder.name_encrypted,
+        parent_id: folder.parent_id ?? null,
+        order_index: folder.order_index
+      };
+      const payload = {
+        id: folder.id,
+        ...pushedFields,
+        created_at: folder.created_at
+      };
+      validateEncryptedPayload(payload as Record<string, unknown>);
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders`, {
+        method: 'POST',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify(payload)
       });
-    }
-  });
+      if (!res.ok) throw new Error(`POST /api/folders: ${res.status}`);
+      const { data } = await res.json();
+      const current = await folderStore.get(folder.id);
+      if (current) {
+        const stillDirty = pushedFieldsDiffer(current, pushedFields);
+        if (stillDirty) {
+          logger.debug(`Folder ${folder.id} changed during push — keeping sync_status=pending`);
+        }
+        await folderStore.save({
+          ...current,
+          sync_status: stillDirty ? 'pending' : 'synced',
+          sync_version: data?.sync_version ?? 1
+        });
+      }
+    })
+  );
 }
 
 export function pushFolderUpdate(
   id: string,
   fields: { name_encrypted?: string; parent_id?: string | null; order_index?: number }
 ): void {
-  void pushSilently(async (idempotencyKey) => {
-    validateEncryptedPayload(fields as Record<string, unknown>);
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders/${id}`, {
-      method: 'PATCH',
-      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify(fields)
-    });
-    if (!res.ok) throw new Error(`PATCH /api/folders/${id}: ${res.status}`);
-    const { data } = await res.json();
-    const current = await folderStore.get(id);
-    if (current) {
-      const stillDirty = pushedFieldsDiffer(current, fields);
-      if (stillDirty) {
-        logger.debug(`Folder ${id} changed during push — keeping sync_status=pending`);
-      }
-      await folderStore.save({
-        ...current,
-        sync_status: stillDirty ? 'pending' : 'synced',
-        sync_version: data?.sync_version ?? current.sync_version ?? 1
+  void serializePerEntity('folder', id, () =>
+    pushSilently(async (idempotencyKey) => {
+      validateEncryptedPayload(fields as Record<string, unknown>);
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders/${id}`, {
+        method: 'PATCH',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify(fields)
       });
-    }
-  });
+      if (!res.ok) throw new Error(`PATCH /api/folders/${id}: ${res.status}`);
+      const { data } = await res.json();
+      const current = await folderStore.get(id);
+      if (current) {
+        const stillDirty = pushedFieldsDiffer(current, fields);
+        if (stillDirty) {
+          logger.debug(`Folder ${id} changed during push — keeping sync_status=pending`);
+        }
+        await folderStore.save({
+          ...current,
+          sync_status: stillDirty ? 'pending' : 'synced',
+          sync_version: data?.sync_version ?? current.sync_version ?? 1
+        });
+      }
+    })
+  );
 }
 
 export function pushFolderDelete(id: string): void {
-  void pushSilently(async (idempotencyKey) => {
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders/${id}`, {
-      method: 'DELETE',
-      headers: { 'Idempotency-Key': idempotencyKey }
-    });
-    if (!res.ok) throw new Error(`DELETE /api/folders/${id}: ${res.status}`);
-    const current = await folderStore.get(id);
-    if (current) await folderStore.save({ ...current, sync_status: 'synced', sync_version: 1 });
-  });
+  void serializePerEntity('folder', id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders/${id}`, {
+        method: 'DELETE',
+        headers: { 'Idempotency-Key': idempotencyKey }
+      });
+      if (!res.ok) throw new Error(`DELETE /api/folders/${id}: ${res.status}`);
+      // Folder is hard-deleted locally before this runs (see folder.service.ts
+      // deleteFolder), so there is nothing to reconcile. We deliberately do NOT
+      // resurrect the row and clobber sync_version the way the old code did —
+      // that broke conflict detection on the rare in-flight re-sync path.
+    })
+  );
 }
 
 export function pushTag(tag: {
@@ -782,77 +884,84 @@ export function pushTag(tag: {
   color_encrypted?: string;
   created_at: string;
 }): void {
-  void pushSilently(async (idempotencyKey) => {
-    const pushedFields = {
-      name_encrypted: tag.name_encrypted,
-      color_encrypted: tag.color_encrypted ?? null
-    };
-    const payload = {
-      id: tag.id,
-      ...pushedFields,
-      created_at: tag.created_at
-    };
-    validateEncryptedPayload(payload as Record<string, unknown>);
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags`, {
-      method: 'POST',
-      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify(payload)
-    });
-    if (!res.ok) throw new Error(`POST /api/tags: ${res.status}`);
-    const { data: resData } = await res.json();
-    const current = await tagStore.get(tag.id);
-    if (current) {
-      const stillDirty = pushedFieldsDiffer(current, pushedFields);
-      if (stillDirty) {
-        logger.debug(`Tag ${tag.id} changed during push — keeping sync_status=pending`);
-      }
-      await tagStore.save({
-        ...current,
-        sync_status: stillDirty ? 'pending' : 'synced',
-        sync_version: resData?.sync_version ?? 1
+  void serializePerEntity('tag', tag.id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const pushedFields = {
+        name_encrypted: tag.name_encrypted,
+        color_encrypted: tag.color_encrypted ?? null
+      };
+      const payload = {
+        id: tag.id,
+        ...pushedFields,
+        created_at: tag.created_at
+      };
+      validateEncryptedPayload(payload as Record<string, unknown>);
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags`, {
+        method: 'POST',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify(payload)
       });
-    }
-  });
+      if (!res.ok) throw new Error(`POST /api/tags: ${res.status}`);
+      const { data: resData } = await res.json();
+      const current = await tagStore.get(tag.id);
+      if (current) {
+        const stillDirty = pushedFieldsDiffer(current, pushedFields);
+        if (stillDirty) {
+          logger.debug(`Tag ${tag.id} changed during push — keeping sync_status=pending`);
+        }
+        await tagStore.save({
+          ...current,
+          sync_status: stillDirty ? 'pending' : 'synced',
+          sync_version: resData?.sync_version ?? 1
+        });
+      }
+    })
+  );
 }
 
 export function pushTagUpdate(
   id: string,
   fields: { name_encrypted?: string; color_encrypted?: string | null }
 ): void {
-  void pushSilently(async (idempotencyKey) => {
-    validateEncryptedPayload(fields as Record<string, unknown>);
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags/${id}`, {
-      method: 'PATCH',
-      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify(fields)
-    });
-    if (!res.ok) throw new Error(`PATCH /api/tags/${id}: ${res.status}`);
-    const { data: resData } = await res.json();
-    const current = await tagStore.get(id);
-    if (current) {
-      const stillDirty = pushedFieldsDiffer(current, fields);
-      if (stillDirty) {
-        logger.debug(`Tag ${id} changed during push — keeping sync_status=pending`);
-      }
-      await tagStore.save({
-        ...current,
-        sync_status: stillDirty ? 'pending' : 'synced',
-        sync_version: resData?.sync_version ?? current.sync_version + 1
+  void serializePerEntity('tag', id, () =>
+    pushSilently(async (idempotencyKey) => {
+      validateEncryptedPayload(fields as Record<string, unknown>);
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags/${id}`, {
+        method: 'PATCH',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify(fields)
       });
-    }
-  });
+      if (!res.ok) throw new Error(`PATCH /api/tags/${id}: ${res.status}`);
+      const { data: resData } = await res.json();
+      const current = await tagStore.get(id);
+      if (current) {
+        const stillDirty = pushedFieldsDiffer(current, fields);
+        if (stillDirty) {
+          logger.debug(`Tag ${id} changed during push — keeping sync_status=pending`);
+        }
+        await tagStore.save({
+          ...current,
+          sync_status: stillDirty ? 'pending' : 'synced',
+          sync_version: resData?.sync_version ?? current.sync_version + 1
+        });
+      }
+    })
+  );
 }
 
 export function pushTagDelete(id: string): void {
-  void pushSilently(async (idempotencyKey) => {
-    const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags/${id}`, {
-      method: 'DELETE',
-      headers: { 'Idempotency-Key': idempotencyKey }
-    });
-    if (!res.ok) throw new Error(`DELETE /api/tags/${id}: ${res.status}`);
-    const current = await tagStore.get(id);
-    if (current) await tagStore.save({ ...current, sync_status: 'synced', sync_version: 1 });
-  });
+  void serializePerEntity('tag', id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags/${id}`, {
+        method: 'DELETE',
+        headers: { 'Idempotency-Key': idempotencyKey }
+      });
+      if (!res.ok) throw new Error(`DELETE /api/tags/${id}: ${res.status}`);
+      // Tag is hard-deleted locally before this runs (see tag.service.ts
+      // deleteTag), so there is nothing to reconcile. No sync_version reset —
+      // that's the same bug we removed from pushFolderDelete.
+    })
+  );
 }
 
 // ── Note version sync ──────────────────────────────────────────────


### PR DESCRIPTION
…tore

Prevents three race classes that could diverge server state from IndexedDB: A) delete↔restore (user archives, then undoes before DELETE response), B) create↔delete (network reorders POST and DELETE for the same entity), C) edit↔delete (PATCH in flight when DELETE is dispatched).

Every push* operation now funnels through serializePerEntity(type, id, …) which FIFO-chains tasks keyed by entity; different entities still push in parallel. pushNoteDelete/pushNoteRestore read current.is_archived after the response and chain the opposite op if the user flipped intent during the request. pushFolderDelete/pushTagDelete drop the sync_version:1 clobber that sabotaged later conflict detection. pushPendingItems now partitions notes by is_archived so archived-pending rows retry via pushNoteDelete instead of being POSTed like new notes.