### PR TITLE
fix(notes): propagate soft-delete and restore across devices

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -154,6 +154,64 @@ describe('notes-sync — regression (offline data loss)', () => {
     expect(fn).toMatch(/pushNoteDelete\s*\(\s*n\.id\s*\)/);
   });
 
+  it('soft-delete and restore endpoints bump sync_version and return it (BUG-6)', () => {
+    const deleteSrc = readFileSync(
+      resolve(__dirname, '../../routes/api/notes/[id]/+server.ts'),
+      'utf-8'
+    );
+    // Soft delete branch (the non-permanent one) must bump sync_version and
+    // return the new value, otherwise pull-side version gate skips the archive
+    // propagation on the second device.
+    const deleteHandler = deleteSrc.slice(deleteSrc.indexOf('export const DELETE'));
+    expect(deleteHandler).toMatch(/deleted_at:\s*new Date\(\)/);
+    expect(deleteHandler).toMatch(/sync_version:\s*\{\s*increment:\s*1\s*\}/);
+    expect(deleteHandler).toMatch(/sync_version:\s*updated\.sync_version/);
+
+    const restoreSrc = readFileSync(
+      resolve(__dirname, '../../routes/api/notes/[id]/restore/+server.ts'),
+      'utf-8'
+    );
+    const restoreHandler = restoreSrc.slice(restoreSrc.indexOf('export const POST'));
+    expect(restoreHandler).toMatch(/deleted_at:\s*null/);
+    expect(restoreHandler).toMatch(/sync_version:\s*\{\s*increment:\s*1\s*\}/);
+    expect(restoreHandler).toMatch(/sync_version:\s*updated\.sync_version/);
+  });
+
+  it('pushNoteDelete and pushNoteRestore mirror server sync_version locally (BUG-6)', () => {
+    const src = readSource('./notes-sync.service.ts');
+
+    const deleteBody = src.slice(
+      src.indexOf('export function pushNoteDelete'),
+      src.indexOf('export function pushNoteRestore')
+    );
+    // Must parse the response body and extract sync_version.
+    expect(deleteBody).toMatch(/await res\.json\(\)/);
+    expect(deleteBody).toMatch(/data\?\.sync_version/);
+    // And apply it in noteStore.save under serverSyncVersion.
+    expect(deleteBody).toMatch(/sync_version:\s*serverSyncVersion/);
+
+    const restoreBody = src.slice(
+      src.indexOf('export function pushNoteRestore'),
+      src.indexOf('export function pushFolder')
+    );
+    expect(restoreBody).toMatch(/await res\.json\(\)/);
+    expect(restoreBody).toMatch(/data\?\.sync_version/);
+    expect(restoreBody).toMatch(/sync_version:\s*serverSyncVersion/);
+  });
+
+  it('pullNotes reconciles is_archived when server differs, even at equal sync_version (BUG-6)', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const pullNotes = src.slice(
+      src.indexOf('async function pullNotes'),
+      src.indexOf('// ── Push helpers')
+    );
+    // The equal-version branch must check !!localNote.is_archived against
+    // serverArchived and save when they differ.
+    expect(pullNotes).toMatch(/serverArchived\s*=\s*!!n\.deleted_at\s*\|\|\s*!!n\.is_archived/);
+    expect(pullNotes).toMatch(/!!localNote\.is_archived\s*!==\s*serverArchived/);
+    expect(pullNotes).toMatch(/is_archived:\s*serverArchived/);
+  });
+
   it('pull helpers remove ghost items (synced locally but deleted on server)', () => {
     const src = readSource('./notes-sync.service.ts');
 

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -326,7 +326,26 @@ async function pullNotes(): Promise<void> {
 
       // Skip if server version is not newer than local (sync_version conflict detection)
       const serverVersion = n.sync_version ?? 1;
+      const serverArchived = !!n.deleted_at || !!n.is_archived;
       if (localNote && serverVersion <= (localNote.sync_version ?? 0)) {
+        // Archive-state reconciliation (rule 11.e defense in depth). Even when
+        // versions match, if the server says archived and we say active (or
+        // vice versa), trust the server. This guards against:
+        //   1. Old server deploys that didn't bump sync_version on soft-delete/restore.
+        //   2. Rows where the server bumped but the client's pushNoteDelete/Restore
+        //      response was dropped before we could mirror the new version locally.
+        // We only adjust is_archived here — content fields stay as they are so
+        // local edits aren't clobbered.
+        if (
+          localNote.sync_status === 'synced' &&
+          !!localNote.is_archived !== serverArchived
+        ) {
+          logger.info(
+            `Reconciling archive state for note ${n.id}: local=${localNote.is_archived} server=${serverArchived}`
+          );
+          await noteStore.save({ ...localNote, is_archived: serverArchived });
+        }
+
         // Reconciliation: see pullFolders() for rationale. Covers notes whose edits
         // never reached the server because sync_status was left at 'synced' after
         // a failed fire-and-forget push.
@@ -375,7 +394,7 @@ async function pullNotes(): Promise<void> {
         metadata_encrypted: n.metadata_encrypted,
         is_pinned,
         is_starred,
-        is_archived: !!n.deleted_at || !!n.is_archived,
+        is_archived: serverArchived,
         sync_version: serverVersion,
         sync_status: 'synced',
         created_at: n.created_at,
@@ -747,16 +766,37 @@ export function pushNoteDelete(id: string, permanent = false): void {
       if (!res.ok) throw new Error(`DELETE /api/notes/${id}: ${res.status}`);
       if (permanent) return;
 
+      // Server bumps sync_version on soft-delete (since rule 11.e) and returns
+      // the new value. We MUST mirror it locally, otherwise the next pull sees
+      // server=N+1 vs local=N and re-applies the archive state we already have
+      // — harmless but churn. More importantly, future pushes would operate on
+      // stale sync_version and look like conflicts.
+      let serverSyncVersion: number | undefined;
+      try {
+        const body = await res.json();
+        serverSyncVersion = body?.data?.sync_version;
+      } catch {
+        // Old server deploy — no body. Leave sync_version untouched.
+      }
+
       // Intent-check: if the user restored the note while DELETE was in flight,
       // `current.is_archived` will be false. Marking 'synced' would strand the
       // local restore — chain a pushNoteRestore instead. See guideline 36 rule 11.b.
       const current = await noteStore.get(id);
       if (!current) return;
       if (current.is_archived) {
-        await noteStore.save({ ...current, sync_status: 'synced' });
+        await noteStore.save({
+          ...current,
+          sync_status: 'synced',
+          sync_version: serverSyncVersion ?? current.sync_version
+        });
       } else {
         logger.debug(`Note ${id} restored during delete push — chaining restore`);
-        await noteStore.save({ ...current, sync_status: 'pending' });
+        await noteStore.save({
+          ...current,
+          sync_status: 'pending',
+          sync_version: serverSyncVersion ?? current.sync_version
+        });
         pushNoteRestore(id);
       }
     })
@@ -772,18 +812,33 @@ export function pushNoteRestore(id: string): void {
       });
       if (!res.ok) throw new Error(`POST /api/notes/${id}/restore: ${res.status}`);
 
+      // Server bumps sync_version on restore (since rule 11.e) and returns it.
+      // Mirror locally; fall back to preserving the current value on old deploys.
+      let serverSyncVersion: number | undefined;
+      try {
+        const body = await res.json();
+        serverSyncVersion = body?.data?.sync_version;
+      } catch {
+        // Old server deploy — no body.
+      }
+
       // Intent-check: if the user re-archived the note while /restore was in
-      // flight, chain a pushNoteDelete to catch up. `sync_version` must be
-      // preserved — the restore endpoint doesn't bump it server-side and
-      // doesn't return it, so clobbering with `1` (old behaviour) sabotaged
-      // conflict detection in the next pull. See guideline 36 rule 11.b.
+      // flight, chain a pushNoteDelete to catch up. See guideline 36 rule 11.b.
       const current = await noteStore.get(id);
       if (!current) return;
       if (!current.is_archived) {
-        await noteStore.save({ ...current, sync_status: 'synced' });
+        await noteStore.save({
+          ...current,
+          sync_status: 'synced',
+          sync_version: serverSyncVersion ?? current.sync_version
+        });
       } else {
         logger.debug(`Note ${id} re-archived during restore push — chaining delete`);
-        await noteStore.save({ ...current, sync_status: 'pending' });
+        await noteStore.save({
+          ...current,
+          sync_status: 'pending',
+          sync_version: serverSyncVersion ?? current.sync_version
+        });
         pushNoteDelete(id);
       }
     })

--- a/apps/reborn-notes/src/routes/api/notes/[id]/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/[id]/+server.ts
@@ -123,14 +123,25 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
 
     if (permanent) {
       await prisma.note.delete({ where: { id: params.id } });
-    } else {
-      await prisma.note.update({
-        where: { id: params.id },
-        data: { deleted_at: new Date() }
-      });
+      return json({ success: true });
     }
 
-    return json({ success: true });
+    // Soft-delete MUST bump sync_version so other devices pick up the archive
+    // state on next pull. Without the bump the pull-side gate
+    // `serverVersion <= localVersion` short-circuits and `is_archived` never
+    // propagates across devices. See guideline 36 rule 11.e.
+    const updated = await prisma.note.update({
+      where: { id: params.id },
+      data: { deleted_at: new Date(), sync_version: { increment: 1 } }
+    });
+
+    return json({
+      success: true,
+      data: {
+        sync_version: updated.sync_version,
+        updated_at: updated.updated_at.toISOString()
+      }
+    });
   } catch (err: unknown) {
     logger.error('DELETE /api/notes/[id] error:', err);
     return json({ success: false, error: 'Internal server error' }, { status: 500 });

--- a/apps/reborn-notes/src/routes/api/notes/[id]/restore/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/[id]/restore/+server.ts
@@ -15,9 +15,21 @@ export const POST: RequestHandler = async ({ request, params }) => {
     const existing = await prisma.note.findFirst({ where: { id: params.id, user_id: userId } });
     if (!existing) return json({ success: false, error: 'Not found' }, { status: 404 });
 
-    await prisma.note.update({ where: { id: params.id }, data: { deleted_at: null } });
+    // Restore MUST bump sync_version so other devices pick up the un-archive
+    // on next pull (pull-side gate skips otherwise). Mirrors the bump on
+    // soft-delete. See guideline 36 rule 11.e.
+    const updated = await prisma.note.update({
+      where: { id: params.id },
+      data: { deleted_at: null, sync_version: { increment: 1 } }
+    });
 
-    return json({ success: true });
+    return json({
+      success: true,
+      data: {
+        sync_version: updated.sync_version,
+        updated_at: updated.updated_at.toISOString()
+      }
+    });
   } catch (err: unknown) {
     logger.error('POST /api/notes/[id]/restore error:', err);
     return json({ success: false, error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
Soft-delete (DELETE /api/notes/[id]) and restore (POST /api/notes/[id]/restore) did not bump sync_version server-side, so on the second device the pull-side gate `serverVersion <= localVersion` short-circuited and is_archived never propagated. Archiving a note on device A left it on the normal list on device B; emptying trash (permanent delete) was the only operation that crossed the sync boundary.

Both endpoints now increment sync_version and return { sync_version, updated_at }. pushNoteDelete and pushNoteRestore parse the response and mirror the new sync_version locally. As defense in depth, pullNotes now reconciles is_archived even when sync_version matches — this guards against old server deploys and future mutations that forget the bump.