### PR TITLE
fix(auth): handle 2FA in re-auth flow and serialize refresh across tabs

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -10,6 +10,7 @@ import { authStore, CREDENTIALS_KEY, ACCESS_TOKEN_KEY } from '$lib/stores/auth.s
 import { sessionExpired } from '$lib/stores/sync-status.store';
 import { clearAllUserData, isDatabaseInitialized } from '@reborn/storage';
 import { createLogger } from '@reborn/utils';
+import type { ReAuthResult } from '@reborn/ui';
 
 const logger = createLogger('Notes-Auth');
 
@@ -103,70 +104,138 @@ export async function loginInNotes(username: string, password: string): Promise<
   }
 }
 
+/** Pull fresh data from server and refresh in-memory stores after re-auth. */
+async function refreshAfterReauth(): Promise<void> {
+  try {
+    const { pullFromServer, refreshStoresAfterPull } = await import(
+      '$lib/services/notes-sync.service'
+    );
+    const synced = await pullFromServer();
+    if (synced) await refreshStoresAfterPull();
+  } catch {
+    // Non-blocking — re-auth succeeded even if sync fails.
+    // User can trigger manual sync via SyncStatusFooter.
+  }
+}
+
 /**
- * Re-authenticate after session expiry.
- * Calls login API to obtain new tokens, saves them to localStorage,
- * but does NOT clear the master key from CryptoManager (preserves E2E access).
- * Resets sessionExpired flag and triggers a sync pull.
+ * Re-authenticate after session expiry — password step.
+ *
+ * Calls /api/auth/login to obtain new tokens. Master key in CryptoManager is
+ * preserved (E2E access kept across session-expiry events).
+ *
+ * If the account has 2FA enabled the endpoint returns `twoFactorRequired: true`
+ * without an access token — we propagate that to the caller so the UI can
+ * collect a TOTP/recovery code and call {@link verifyTotpForReauth}.
  */
-export async function reAuthenticate(password: string): Promise<boolean> {
-  const credentials = localStorage.getItem(CREDENTIALS_KEY);
-  if (!credentials) return false;
+export async function reAuthenticate(password: string): Promise<ReAuthResult> {
+  const credentialsRaw = localStorage.getItem(CREDENTIALS_KEY);
+  if (!credentialsRaw) return { kind: 'error', message: 'Missing credentials' };
 
   let username: string;
   try {
-    const parsed = JSON.parse(credentials);
+    const parsed = JSON.parse(credentialsRaw);
     username = parsed.user_profile?.username;
-    if (!username) return false;
+    if (!username) return { kind: 'error', message: 'Missing username' };
   } catch {
-    return false;
+    return { kind: 'error', message: 'Corrupted credentials' };
   }
 
+  let res: Response;
   try {
-    const res = await fetch(`${PUBLIC_BASE_PATH}/api/auth/login`, {
+    res = await fetch(`${PUBLIC_BASE_PATH}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
     });
-
-    const body = await res.json();
-    if (!res.ok || !body.success || !body.data?.access_token) return false;
-
-    const { data } = body;
-
-    // Update access token in localStorage (SSO-compatible)
-    localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
-    // Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
-
-    // Update credentials (keep existing master key + profile)
-    try {
-      const existing = JSON.parse(credentials);
-      localStorage.setItem(CREDENTIALS_KEY, JSON.stringify(existing));
-    } catch {
-      /* keep existing credentials */
-    }
-
-    // Clear session expired flag
-    sessionExpired.set(false);
-
-    // Pull fresh data from server and refresh in-memory stores.
-    // Without refreshStoresAfterPull(), pullFromServer() only writes to IndexedDB
-    // and the UI remains stale until a manual page reload.
-    try {
-      const { pullFromServer, refreshStoresAfterPull } = await import(
-        '$lib/services/notes-sync.service'
-      );
-      const synced = await pullFromServer();
-      if (synced) {
-        await refreshStoresAfterPull();
-      }
-    } catch {
-      // Non-blocking — re-auth succeeded even if sync fails.
-      // User can trigger manual sync via SyncStatusFooter.
-    }
-
-    return true;
-  } catch {
-    return false;
+  } catch (err) {
+    return { kind: 'error', message: err instanceof Error ? err.message : 'Network error' };
   }
+
+  if (res.status === 429) {
+    const retryAfterHeader = res.headers.get('Retry-After');
+    const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 0;
+    return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
+  }
+
+  if (res.status === 401) return { kind: 'invalid_password' };
+
+  let body: any;
+  try {
+    body = await res.json();
+  } catch {
+    return { kind: 'error', message: 'Invalid server response' };
+  }
+
+  if (!res.ok || !body?.success) {
+    return { kind: 'error', message: body?.error };
+  }
+
+  const { data } = body;
+
+  if (data?.twoFactorRequired) {
+    if (!data.userId) return { kind: 'error', message: 'Missing userId in 2FA response' };
+    return { kind: 'two_factor_required', userId: data.userId };
+  }
+
+  if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
+
+  localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
+
+  // Credentials remain the same — touch to ensure they're still parseable
+  try {
+    localStorage.setItem(CREDENTIALS_KEY, credentialsRaw);
+  } catch {
+    /* keep existing */
+  }
+
+  sessionExpired.set(false);
+  await refreshAfterReauth();
+  return { kind: 'ok' };
+}
+
+/**
+ * Re-authenticate after session expiry — TOTP step (invoked from ReAuthModal
+ * after {@link reAuthenticate} returned `two_factor_required`).
+ */
+export async function verifyTotpForReauth(userId: string, code: string): Promise<ReAuthResult> {
+  let res: Response;
+  try {
+    res = await fetch(`${PUBLIC_BASE_PATH}/api/auth/2fa/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, code })
+    });
+  } catch (err) {
+    return { kind: 'error', message: err instanceof Error ? err.message : 'Network error' };
+  }
+
+  if (res.status === 429) {
+    const retryAfterHeader = res.headers.get('Retry-After');
+    const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 0;
+    return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
+  }
+
+  let body: any;
+  try {
+    body = await res.json();
+  } catch {
+    return { kind: 'error', message: 'Invalid server response' };
+  }
+
+  if (!res.ok || !body?.success) {
+    // The server returns 400 for invalid codes — treat as invalid_totp so the
+    // UI can show a code-specific error instead of the generic password one.
+    if (res.status === 400) return { kind: 'invalid_totp' };
+    return { kind: 'error', message: body?.error };
+  }
+
+  const { data } = body;
+  if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
+
+  localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
+
+  sessionExpired.set(false);
+  await refreshAfterReauth();
+  return { kind: 'ok' };
 }

--- a/apps/reborn-notes/src/lib/utils/auth-fetch.ts
+++ b/apps/reborn-notes/src/lib/utils/auth-fetch.ts
@@ -1,5 +1,6 @@
 import { base } from '$app/paths';
 import { sessionExpired } from '$lib/stores/sync-status.store';
+import { withRefreshLock } from '@reborn/auth';
 
 /**
  * Fetch wrapper with automatic token refresh for authenticated API calls.
@@ -7,17 +8,26 @@ import { sessionExpired } from '$lib/stores/sync-status.store';
  * If the initial request returns 401, attempts to refresh the access token
  * using the stored refresh_token, then retries the original request once.
  *
- * Uses a singleton refresh promise to prevent race conditions when multiple
- * concurrent requests all receive 401 at the same time.
+ * `withRefreshLock` serializes the refresh across every tab/app on this
+ * origin so that reborn-task + reborn-notes cannot both hit /api/auth/refresh
+ * with the same refresh-token cookie (which would trip the server-side token
+ * reuse detector and invalidate the entire token family). An in-process
+ * singleton prevents redundant fetches from concurrent 401s inside one tab.
  *
  * Usage: drop-in replacement for `fetch()` in authenticated pages.
  */
 
-// Singleton: only one refresh request can be in-flight at a time.
+// In-tab singleton: only one refresh fetch can be in-flight inside this tab.
 // All concurrent 401 handlers wait on the same promise.
 let refreshPromise: Promise<string | null> | null = null;
 
-async function doRefresh(): Promise<string | null> {
+async function doRefresh(tokenBeforeLock: string | null): Promise<string | null> {
+  // Inside the cross-tab lock another tab may have already refreshed for us.
+  // If the localStorage access token changed while we were queued, skip the
+  // redundant fetch and use the fresh one.
+  const current = localStorage.getItem('access_token');
+  if (current && current !== tokenBeforeLock) return current;
+
   try {
     // Refresh token is sent automatically via httpOnly cookie — no need to read from localStorage
     const refreshRes = await fetch(`${base}/api/auth/refresh`, {
@@ -42,7 +52,8 @@ async function doRefresh(): Promise<string | null> {
 
 function refreshAccessToken(): Promise<string | null> {
   if (!refreshPromise) {
-    refreshPromise = doRefresh().finally(() => {
+    const tokenBeforeLock = localStorage.getItem('access_token');
+    refreshPromise = withRefreshLock(() => doRefresh(tokenBeforeLock)).finally(() => {
       refreshPromise = null;
     });
   }

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
   import { noteIndex } from '$lib/services/note-index.svelte';
   import { refreshPendingCount, isOnline, sessionExpired } from '$lib/stores/sync-status.store';
   import { initI18n, setLocale, locale } from '$lib/stores/i18n.store';
-  import { reAuthenticate } from '$lib/services/notes-auth.service';
+  import { reAuthenticate, verifyTotpForReauth } from '$lib/services/notes-auth.service';
   import { SessionExpiredBanner } from '@reborn/ui';
   import LoadingScreen from '$lib/components/LoadingScreen.svelte';
   import { createLogger } from '@reborn/utils';
@@ -232,6 +232,7 @@
       visible={$sessionExpired && navigator.onLine}
       username={$authStore.username ?? ''}
       onReAuth={reAuthenticate}
+      onVerifyTotp={verifyTotpForReauth}
     />
     {@render children()}
     <Toaster />

--- a/apps/reborn-task/src/lib/auth/adapters/authApi.ts
+++ b/apps/reborn-task/src/lib/auth/adapters/authApi.ts
@@ -4,6 +4,7 @@ import type {
 	RegisterResult,
 	TwoFactorVerificationResult
 } from '@reborn/auth';
+import { withRefreshLock } from '@reborn/auth';
 import { createLogger } from '@reborn/utils';
 import { syncService } from '$lib/services/sync.service';
 
@@ -185,52 +186,72 @@ export class AuthApiAdapter implements IAuthApiClient {
 	}
 
 	async refreshToken(_refreshToken?: string): Promise<LoginResult> {
-		try {
-			// Refresh token is sent automatically via httpOnly cookie.
-			// The _refreshToken parameter is kept for interface compatibility but ignored.
-			const response = await fetch(`${this.apiUrl}/auth/refresh`, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({})
-			});
+		// Serialize refresh across every tab/app on this origin so concurrent
+		// calls from reborn-task + reborn-notes cannot both hit /api/auth/refresh
+		// with the same refresh-token cookie (which would trip the server's
+		// token-reuse detector and invalidate the entire family). Inside the
+		// lock, first check whether another tab already produced a fresh token
+		// so we can skip the redundant fetch.
+		const tokenBeforeLock =
+			typeof localStorage !== 'undefined' ? localStorage.getItem('access_token') : null;
 
-			const data = await response.json();
+		return withRefreshLock(async () => {
+			const current =
+				typeof localStorage !== 'undefined' ? localStorage.getItem('access_token') : null;
+			if (current && current !== tokenBeforeLock) {
+				// Another tab refreshed for us while we were queued — use that token,
+				// don't call the server again.
+				syncService.setAuthToken(current);
+				return { success: true, accessToken: current };
+			}
 
-			if (!response.ok || !data.success) {
+			try {
+				// Refresh token is sent automatically via httpOnly cookie.
+				// The _refreshToken parameter is kept for interface compatibility but ignored.
+				const response = await fetch(`${this.apiUrl}/auth/refresh`, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({})
+				});
+
+				const data = await response.json();
+
+				if (!response.ok || !data.success) {
+					return {
+						success: false,
+						message: data.error || 'Token refresh failed'
+					};
+				}
+
+				const result: LoginResult = {
+					success: true,
+					user: data.data.user,
+					accessToken: data.data.access_token,
+					// refresh_token is managed exclusively via httpOnly cookie (set by server)
+					encryptedMasterKey: data.data.encryptedMasterKey,
+					masterKeySalt: data.data.masterKeySalt
+				};
+
+				// Set token in sync service immediately
+				if (result.accessToken) {
+					// Save to localStorage
+					localStorage.setItem('access_token', result.accessToken);
+					// Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
+					// Then set in sync service
+					syncService.setAuthToken(result.accessToken);
+					logger.debug('Auth token set in sync service immediately after refresh API call');
+				}
+
+				return result;
+			} catch (error: unknown) {
+				logger.error('Token refresh API error:', error);
 				return {
 					success: false,
-					message: data.error || 'Token refresh failed'
+					message: error instanceof Error ? error.message : 'Network error'
 				};
 			}
-
-			const result: LoginResult = {
-				success: true,
-				user: data.data.user,
-				accessToken: data.data.access_token,
-				// refresh_token is managed exclusively via httpOnly cookie (set by server)
-				encryptedMasterKey: data.data.encryptedMasterKey,
-				masterKeySalt: data.data.masterKeySalt
-			};
-
-			// Set token in sync service immediately
-			if (result.accessToken) {
-				// Save to localStorage
-				localStorage.setItem('access_token', result.accessToken);
-				// Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
-				// Then set in sync service
-				syncService.setAuthToken(result.accessToken);
-				logger.debug('Auth token set in sync service immediately after refresh API call');
-			}
-
-			return result;
-		} catch (error: unknown) {
-			logger.error('Token refresh API error:', error);
-			return {
-				success: false,
-				message: error instanceof Error ? error.message : 'Network error'
-			};
-		}
+		});
 	}
 }

--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -12,6 +12,7 @@ import { AuthStorageAdapter } from '$lib/auth/adapters/authStorage';
 import { createLogger } from '@reborn/utils';
 import { SUPPORTED_LOCALES, type SupportedLocale } from '@reborn/i18n';
 import type { CryptoManager } from '@reborn/crypto';
+import type { ReAuthResult } from '@reborn/ui';
 import { syncService } from './sync.service';
 import { taskTitleIndex } from './task-title-index.svelte';
 import { taskListStore } from '$lib/stores/decrypted-lists.store';
@@ -449,13 +450,15 @@ export class AuthOperationsService {
 				if (navigator.onLine) {
 					const sessionValid = await this.checkSession();
 					if (!sessionValid) {
-						// Session expired — re-authenticate with the same password
+						// Session expired — re-authenticate with the same password.
+						// If 2FA is required or re-auth fails, leave the banner flow to
+						// prompt the user; unlock itself already succeeded.
 						logger.info('Session expired after unlock, attempting auto re-authentication');
-						const reAuthOk = await this.reAuthenticate(password);
-						if (reAuthOk) {
+						const reAuthResult = await this.reAuthenticate(password);
+						if (reAuthResult.kind === 'ok') {
 							logger.info('Auto re-authentication successful after unlock');
 						} else {
-							logger.warn('Auto re-authentication failed after unlock');
+							logger.warn(`Auto re-authentication did not complete: ${reAuthResult.kind}`);
 						}
 					}
 
@@ -783,87 +786,149 @@ export class AuthOperationsService {
 		// is cleaned up by CryptoManager.clearMasterKey() during the logout flow.
 	}
 
+	/** Pull fresh data from server and refresh in-memory stores after re-auth. */
+	private async refreshAfterReauth(accessToken: string): Promise<void> {
+		localStorage.setItem('access_token', accessToken);
+		syncService.setAuthToken(accessToken);
+		this.clearSessionExpired();
+		this.startBackgroundTokenRefresh();
+
+		try {
+			await syncService.initialSync();
+
+			const { refreshDecryptedLists } = await import('$lib/stores/decrypted-lists.store');
+			const { refreshDecryptedSubtasks } = await import(
+				'$lib/stores/decrypted-subtasks.store'
+			);
+
+			await taskListStore.loadLists();
+			await Promise.all([refreshDecryptedLists(), refreshDecryptedSubtasks()]);
+			await taskTitleIndex.rebuild();
+
+			const { taskCounts } = await import('$lib/stores/task-counts.store');
+			taskCounts.refresh();
+		} catch {
+			// Non-blocking — re-auth succeeded even if sync fails.
+			// User can trigger manual sync later.
+		}
+	}
+
 	/**
-	 * Re-authenticate after session expiry.
-	 * Calls login API to obtain new tokens, saves them to localStorage,
-	 * but does NOT clear the master key from CryptoManager (preserves E2E access).
-	 * Resets sessionExpired flag and triggers a sync.
+	 * Re-authenticate after session expiry — password step.
+	 *
+	 * Calls /api/auth/login to obtain new tokens. Master key in CryptoManager
+	 * is preserved (E2E access kept across session-expiry events).
+	 *
+	 * If the account has 2FA enabled, the endpoint returns `twoFactorRequired`
+	 * without an access token — propagate that so the UI can collect a TOTP
+	 * code and call {@link verifyTotpForReauth}.
 	 */
-	async reAuthenticate(password: string): Promise<boolean> {
-		if (!browser) return false;
+	async reAuthenticate(password: string): Promise<ReAuthResult> {
+		if (!browser) return { kind: 'error', message: 'Not in browser' };
 
 		const credentials = localStorage.getItem('reborn_auth_credentials');
-		if (!credentials) return false;
+		if (!credentials) return { kind: 'error', message: 'Missing credentials' };
 
 		let username: string;
 		try {
 			const parsed = JSON.parse(credentials);
 			username = parsed.user_profile?.username;
-			if (!username) return false;
+			if (!username) return { kind: 'error', message: 'Missing username' };
 		} catch {
-			return false;
+			return { kind: 'error', message: 'Corrupted credentials' };
 		}
 
+		const { PUBLIC_BASE_PATH } = await import('$env/static/public');
+		let res: Response;
 		try {
-			const { PUBLIC_BASE_PATH } = await import('$env/static/public');
-			const res = await fetch(`${PUBLIC_BASE_PATH}/api/auth/login`, {
+			res = await fetch(`${PUBLIC_BASE_PATH}/api/auth/login`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ username, password })
 			});
-
-			const body = await res.json();
-			if (!res.ok || !body.success || !body.data?.access_token) return false;
-
-			const { data } = body;
-
-			// Update access token
-			localStorage.setItem('access_token', data.access_token);
-			// Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
-
-			// Update credentials (keep existing master key + profile)
-			try {
-				const existing = JSON.parse(credentials);
-				localStorage.setItem('reborn_auth_credentials', JSON.stringify(existing));
-			} catch {
-				/* keep existing */
-			}
-
-			// Update sync service auth token
-			syncService.setAuthToken(data.access_token);
-
-			// Clear session expired flag
-			this.clearSessionExpired();
-
-			// Restart background token refresh
-			this.startBackgroundTokenRefresh();
-
-			// Pull fresh data from server and refresh in-memory stores.
-			// syncToServer() only pushes local ops — after session expiry we need
-			// a full pull so IndexedDB (and the UI) reflect the server state.
-			try {
-				await syncService.initialSync();
-
-				const { refreshDecryptedLists } = await import('$lib/stores/decrypted-lists.store');
-				const { refreshDecryptedSubtasks } = await import(
-					'$lib/stores/decrypted-subtasks.store'
-				);
-
-				await taskListStore.loadLists();
-				await Promise.all([refreshDecryptedLists(), refreshDecryptedSubtasks()]);
-				await taskTitleIndex.rebuild();
-
-				const { taskCounts } = await import('$lib/stores/task-counts.store');
-				taskCounts.refresh();
-			} catch {
-				// Non-blocking — re-auth succeeded even if sync fails.
-				// User can trigger manual sync later.
-			}
-
-			return true;
-		} catch {
-			return false;
+		} catch (err) {
+			return {
+				kind: 'error',
+				message: err instanceof Error ? err.message : 'Network error'
+			};
 		}
+
+		if (res.status === 429) {
+			const retryAfterHeader = res.headers.get('Retry-After');
+			const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 0;
+			return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
+		}
+
+		if (res.status === 401) return { kind: 'invalid_password' };
+
+		let body: any;
+		try {
+			body = await res.json();
+		} catch {
+			return { kind: 'error', message: 'Invalid server response' };
+		}
+
+		if (!res.ok || !body?.success) return { kind: 'error', message: body?.error };
+
+		const { data } = body;
+
+		if (data?.twoFactorRequired) {
+			if (!data.userId)
+				return { kind: 'error', message: 'Missing userId in 2FA response' };
+			return { kind: 'two_factor_required', userId: data.userId };
+		}
+
+		if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
+
+		await this.refreshAfterReauth(data.access_token);
+		return { kind: 'ok' };
+	}
+
+	/**
+	 * Re-authenticate after session expiry — TOTP step (invoked from
+	 * ReAuthModal after {@link reAuthenticate} returned `two_factor_required`).
+	 */
+	async verifyTotpForReauth(userId: string, code: string): Promise<ReAuthResult> {
+		if (!browser) return { kind: 'error', message: 'Not in browser' };
+
+		const { PUBLIC_BASE_PATH } = await import('$env/static/public');
+		let res: Response;
+		try {
+			res = await fetch(`${PUBLIC_BASE_PATH}/api/auth/2fa/verify`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ userId, code })
+			});
+		} catch (err) {
+			return {
+				kind: 'error',
+				message: err instanceof Error ? err.message : 'Network error'
+			};
+		}
+
+		if (res.status === 429) {
+			const retryAfterHeader = res.headers.get('Retry-After');
+			const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 0;
+			return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
+		}
+
+		let body: any;
+		try {
+			body = await res.json();
+		} catch {
+			return { kind: 'error', message: 'Invalid server response' };
+		}
+
+		if (!res.ok || !body?.success) {
+			if (res.status === 400) return { kind: 'invalid_totp' };
+			return { kind: 'error', message: body?.error };
+		}
+
+		const { data } = body;
+		if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
+
+		await this.refreshAfterReauth(data.access_token);
+		return { kind: 'ok' };
 	}
 
 	/**

--- a/apps/reborn-task/src/routes/+layout.svelte
+++ b/apps/reborn-task/src/routes/+layout.svelte
@@ -252,6 +252,7 @@
 		visible={$sessionExpired && navigator.onLine}
 		username={$session?.user?.username ?? ''}
 		onReAuth={(password) => authOperationsService.reAuthenticate(password)}
+		onVerifyTotp={(userId, code) => authOperationsService.verifyTotpForReauth(userId, code)}
 	/>
 	<div class="svelte-app-ready min-h-screen bg-background text-foreground transition-colors">
 		{#if children}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -35,6 +35,9 @@ export type {
 export { solvePowChallenge } from './utils/pow-solver';
 export type { PowChallengeData } from './utils/pow-solver';
 
+// Cross-tab/cross-app refresh-token coordination
+export { withRefreshLock } from './utils/refresh-lock';
+
 // Export guards
 export {
   createAuthGuard,

--- a/packages/auth/src/utils/refresh-lock.ts
+++ b/packages/auth/src/utils/refresh-lock.ts
@@ -1,0 +1,98 @@
+/**
+ * Cross-tab / cross-app refresh-token coordination.
+ *
+ * Two SvelteKit apps (reborn-task + reborn-notes) running on the same origin
+ * share the httpOnly `refresh_token` cookie. If two tabs (or two apps) hit
+ * `/api/auth/refresh` simultaneously with the same token, the server detects
+ * the second call as "token reuse" and revokes the entire token family — the
+ * user sees an unexpected session-expired banner within minutes of opening
+ * both apps.
+ *
+ * `withRefreshLock` serializes refresh calls across every tab/app on the same
+ * origin so at most one refresh runs at a time. Inside the callback the caller
+ * can first consult `localStorage` for a freshly-minted access_token written
+ * by the tab that held the lock previously, avoiding a redundant fetch.
+ *
+ * Preferred implementation: Web Locks API (`navigator.locks.request`), which
+ * is designed for exactly this use case and serializes across every same-origin
+ * browsing context. Fallback: localStorage-based mutex with a short timeout in
+ * case the API is unavailable or restricted (very old browsers / some PWA
+ * sandbox edge cases).
+ */
+
+const LOCK_NAME = 'reborn_auth_refresh';
+const FALLBACK_LOCK_KEY = '__reborn_refresh_lock_v1';
+const FALLBACK_STALE_MS = 10_000;
+const FALLBACK_POLL_MS = 75;
+
+type LockRunner = <T>(fn: () => Promise<T>) => Promise<T>;
+
+function hasWebLocks(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof (navigator as Navigator & { locks?: unknown }).locks !== 'undefined'
+  );
+}
+
+const webLocksRunner: LockRunner = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const locks = (navigator as Navigator & {
+    locks: { request: (name: string, cb: () => unknown) => Promise<unknown> };
+  }).locks;
+  return (await locks.request(LOCK_NAME, () => fn())) as T;
+};
+
+/**
+ * localStorage-backed fallback. Not as robust as Web Locks (races still
+ * possible under extreme contention) but good enough to prevent the common
+ * "two apps refresh at the same time" case and auto-heals after 10s.
+ */
+const localStorageRunner: LockRunner = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof localStorage === 'undefined') return fn();
+
+  const ownerId = `${Date.now()}:${Math.random().toString(36).slice(2)}`;
+
+  // Busy-wait for up to 10s, then forcibly take the lock (previous holder
+  // likely crashed or left the page without releasing).
+  const deadline = Date.now() + FALLBACK_STALE_MS;
+  while (Date.now() < deadline) {
+    const raw = localStorage.getItem(FALLBACK_LOCK_KEY);
+    if (!raw) break;
+    try {
+      const held = JSON.parse(raw) as { owner: string; expires: number };
+      if (held.expires < Date.now()) break;
+      if (held.owner === ownerId) break;
+    } catch {
+      break;
+    }
+    await new Promise((r) => setTimeout(r, FALLBACK_POLL_MS));
+  }
+
+  localStorage.setItem(
+    FALLBACK_LOCK_KEY,
+    JSON.stringify({ owner: ownerId, expires: Date.now() + FALLBACK_STALE_MS })
+  );
+
+  try {
+    return await fn();
+  } finally {
+    try {
+      const raw = localStorage.getItem(FALLBACK_LOCK_KEY);
+      if (raw) {
+        const held = JSON.parse(raw) as { owner: string };
+        if (held.owner === ownerId) localStorage.removeItem(FALLBACK_LOCK_KEY);
+      }
+    } catch {
+      localStorage.removeItem(FALLBACK_LOCK_KEY);
+    }
+  }
+};
+
+/**
+ * Run `fn` while holding the cross-tab refresh lock. Every caller across every
+ * tab/app on this origin queues on the same lock, so at most one refresh hits
+ * the server at a time.
+ */
+export function withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
+  const runner: LockRunner = hasWebLocks() ? webLocksRunner : localStorageRunner;
+  return runner(fn);
+}

--- a/packages/i18n/src/translations/common/de.json
+++ b/packages/i18n/src/translations/common/de.json
@@ -84,7 +84,19 @@
       "submitting": "Anmeldung...",
       "error_auth_failed": "Authentifizierung fehlgeschlagen. Bitte überprüfen Sie Ihr Passwort.",
       "error_unknown": "Authentifizierung fehlgeschlagen",
-      "empty_no_data": "Keine Daten verfügbar — Sitzung abgelaufen. Melden Sie sich erneut an, um Ihre Daten zu synchronisieren."
+      "error_locked": "Konto vorübergehend gesperrt. Zu viele fehlgeschlagene Versuche. Erneut versuchen in {seconds}s.",
+      "empty_no_data": "Keine Daten verfügbar — Sitzung abgelaufen. Melden Sie sich erneut an, um Ihre Daten zu synchronisieren.",
+      "totp_title": "Zwei-Faktor-Verifizierung",
+      "totp_description": "Geben Sie den Code aus Ihrer Authenticator-App ein, um die erneute Anmeldung abzuschließen.",
+      "totp_label": "2FA-Code",
+      "totp_placeholder": "000000",
+      "totp_submit_button": "Verifizieren",
+      "totp_verifying": "Verifizierung...",
+      "totp_error_invalid": "Ungültiger Code. Bitte versuchen Sie es erneut.",
+      "use_recovery": "Wiederherstellungscode verwenden",
+      "use_app": "Authenticator-App verwenden",
+      "recovery_label": "Wiederherstellungscode",
+      "recovery_placeholder": "XXXXX-XXXXX"
     },
     "2fa": {
       "recovery_code_label": "Wiederherstellungscode",

--- a/packages/i18n/src/translations/common/en.json
+++ b/packages/i18n/src/translations/common/en.json
@@ -84,7 +84,19 @@
       "submitting": "Signing in...",
       "error_auth_failed": "Authentication failed. Please check your password.",
       "error_unknown": "Authentication failed",
-      "empty_no_data": "No data available — session expired. Sign in again to sync your data."
+      "error_locked": "Account temporarily locked. Too many failed attempts. Try again in {seconds}s.",
+      "empty_no_data": "No data available — session expired. Sign in again to sync your data.",
+      "totp_title": "Two-factor verification",
+      "totp_description": "Enter the code from your authenticator app to finish re-authenticating.",
+      "totp_label": "2FA code",
+      "totp_placeholder": "000000",
+      "totp_submit_button": "Verify",
+      "totp_verifying": "Verifying...",
+      "totp_error_invalid": "Invalid code. Please try again.",
+      "use_recovery": "Use a recovery code",
+      "use_app": "Use authenticator app",
+      "recovery_label": "Recovery code",
+      "recovery_placeholder": "XXXXX-XXXXX"
     },
     "2fa": {
       "recovery_code_label": "Recovery Code",

--- a/packages/i18n/src/translations/common/es.json
+++ b/packages/i18n/src/translations/common/es.json
@@ -84,7 +84,19 @@
       "submitting": "Iniciando sesión...",
       "error_auth_failed": "La autenticación falló. Por favor, verifique su contraseña.",
       "error_unknown": "La autenticación falló",
-      "empty_no_data": "No hay datos disponibles — sesión expirada. Inicie sesión de nuevo para sincronizar sus datos."
+      "error_locked": "Cuenta bloqueada temporalmente. Demasiados intentos fallidos. Inténtelo de nuevo en {seconds}s.",
+      "empty_no_data": "No hay datos disponibles — sesión expirada. Inicie sesión de nuevo para sincronizar sus datos.",
+      "totp_title": "Verificación en dos pasos",
+      "totp_description": "Introduzca el código de su aplicación de autenticación para terminar de iniciar sesión de nuevo.",
+      "totp_label": "Código 2FA",
+      "totp_placeholder": "000000",
+      "totp_submit_button": "Verificar",
+      "totp_verifying": "Verificando...",
+      "totp_error_invalid": "Código no válido. Inténtelo de nuevo.",
+      "use_recovery": "Usar código de recuperación",
+      "use_app": "Usar aplicación de autenticación",
+      "recovery_label": "Código de recuperación",
+      "recovery_placeholder": "XXXXX-XXXXX"
     },
     "2fa": {
       "recovery_code_label": "Código de recuperación",

--- a/packages/i18n/src/translations/common/fr.json
+++ b/packages/i18n/src/translations/common/fr.json
@@ -84,7 +84,19 @@
       "submitting": "Connexion...",
       "error_auth_failed": "L'authentification a échoué. Veuillez vérifier votre mot de passe.",
       "error_unknown": "L'authentification a échoué",
-      "empty_no_data": "Aucune donnée disponible — session expirée. Reconnectez-vous pour synchroniser vos données."
+      "error_locked": "Compte temporairement verrouillé. Trop de tentatives échouées. Réessayez dans {seconds}s.",
+      "empty_no_data": "Aucune donnée disponible — session expirée. Reconnectez-vous pour synchroniser vos données.",
+      "totp_title": "Vérification à deux facteurs",
+      "totp_description": "Entrez le code de votre application d'authentification pour terminer la reconnexion.",
+      "totp_label": "Code 2FA",
+      "totp_placeholder": "000000",
+      "totp_submit_button": "Vérifier",
+      "totp_verifying": "Vérification...",
+      "totp_error_invalid": "Code invalide. Veuillez réessayer.",
+      "use_recovery": "Utiliser un code de récupération",
+      "use_app": "Utiliser l'application d'authentification",
+      "recovery_label": "Code de récupération",
+      "recovery_placeholder": "XXXXX-XXXXX"
     },
     "2fa": {
       "recovery_code_label": "Code de récupération",

--- a/packages/i18n/src/translations/common/pl.json
+++ b/packages/i18n/src/translations/common/pl.json
@@ -84,7 +84,19 @@
       "submitting": "Logowanie...",
       "error_auth_failed": "Uwierzytelnianie nie powiodło się. Sprawdź swoje hasło.",
       "error_unknown": "Uwierzytelnianie nie powiodło się",
-      "empty_no_data": "Brak danych — sesja wygasła. Zaloguj się ponownie, aby zsynchronizować dane."
+      "error_locked": "Konto tymczasowo zablokowane. Zbyt wiele nieudanych prób. Spróbuj ponownie za {seconds} s.",
+      "empty_no_data": "Brak danych — sesja wygasła. Zaloguj się ponownie, aby zsynchronizować dane.",
+      "totp_title": "Weryfikacja dwuetapowa",
+      "totp_description": "Wprowadź kod z aplikacji uwierzytelniającej, aby dokończyć ponowne logowanie.",
+      "totp_label": "Kod 2FA",
+      "totp_placeholder": "000000",
+      "totp_submit_button": "Zweryfikuj",
+      "totp_verifying": "Weryfikacja...",
+      "totp_error_invalid": "Nieprawidłowy kod. Spróbuj ponownie.",
+      "use_recovery": "Użyj kodu zapasowego",
+      "use_app": "Użyj kodu z aplikacji",
+      "recovery_label": "Kod zapasowy",
+      "recovery_placeholder": "XXXXX-XXXXX"
     },
     "2fa": {
       "recovery_code_label": "Kod zapasowy",

--- a/packages/ui/src/components/auth/ReAuthModal.svelte
+++ b/packages/ui/src/components/auth/ReAuthModal.svelte
@@ -1,8 +1,13 @@
 <!--
   @component
   Modal dialog for re-authentication when session has expired.
-  Asks for password only (username is readonly from the current session).
-  Does NOT logout or clear master key — just refreshes tokens.
+
+  Two-step flow when 2FA is enabled:
+    1. Password step (username readonly, password input)
+    2. TOTP step (6-digit code OR recovery code via toggle)
+
+  Does NOT log out or clear the master key — just refreshes tokens so the
+  user keeps offline access to locally decrypted data.
 -->
 <script lang="ts">
   import { t } from '@reborn/i18n';
@@ -15,145 +20,335 @@
     DialogHeader,
     DialogTitle
   } from '../dialog';
+  import { KeyRound, Shield } from '@lucide/svelte';
+  import type { ReAuthResult } from './reauth-types';
 
   let {
     open = $bindable(false),
     username = '',
-    loading = false,
-    error = null,
-    onSubmit
+    onSubmitPassword,
+    onSubmitTotp
   } = $props<{
     open?: boolean;
     username?: string;
-    loading?: boolean;
-    error?: string | null;
-    onSubmit?: (password: string) => void;
+    /** Called with the password. Returns a ReAuthResult. */
+    onSubmitPassword?: (password: string) => Promise<ReAuthResult>;
+    /** Called with a TOTP or recovery code once 2FA is required. */
+    onSubmitTotp?: (userId: string, code: string) => Promise<ReAuthResult>;
   }>();
 
+  type Step = 'password' | 'totp';
+
+  let step = $state<Step>('password');
   let password = $state('');
   let showPassword = $state(false);
+  let totpCode = $state('');
+  let useRecovery = $state(false);
+  let pendingUserId = $state<string | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
 
-  function handleSubmit(event: Event) {
-    event.preventDefault();
-    if (!password || loading) return;
-    onSubmit?.(password);
+  function resetAll() {
+    step = 'password';
+    password = '';
+    showPassword = false;
+    totpCode = '';
+    useRecovery = false;
+    pendingUserId = null;
+    loading = false;
+    error = null;
   }
 
   function handleOpenChange(isOpen: boolean) {
     open = isOpen;
-    if (!isOpen) {
-      password = '';
-      showPassword = false;
+    if (!isOpen) resetAll();
+  }
+
+  function describeResult(result: ReAuthResult): string | null {
+    switch (result.kind) {
+      case 'ok':
+        return null;
+      case 'invalid_password':
+        return $t('auth.session.error_auth_failed');
+      case 'invalid_totp':
+        return $t('auth.session.totp_error_invalid');
+      case 'locked':
+        return $t('auth.session.error_locked', { values: { seconds: result.retryAfter } });
+      case 'two_factor_required':
+        return null;
+      case 'error':
+        return result.message ?? $t('auth.session.error_unknown');
+      default:
+        return $t('auth.session.error_unknown');
+    }
+  }
+
+  async function handlePasswordSubmit(event: Event) {
+    event.preventDefault();
+    if (!password || loading) return;
+
+    loading = true;
+    error = null;
+
+    try {
+      const result = (await onSubmitPassword?.(password)) ?? {
+        kind: 'error',
+        message: $t('auth.session.error_unknown')
+      };
+
+      if (result.kind === 'ok') {
+        open = false;
+        resetAll();
+        return;
+      }
+
+      if (result.kind === 'two_factor_required') {
+        pendingUserId = result.userId;
+        step = 'totp';
+        totpCode = '';
+        error = null;
+        return;
+      }
+
+      error = describeResult(result);
+    } catch (err: unknown) {
+      error = err instanceof Error ? err.message : $t('auth.session.error_unknown');
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleTotpSubmit(event: Event) {
+    event.preventDefault();
+    const trimmed = totpCode.trim();
+    if (!trimmed || loading || !pendingUserId) return;
+
+    if (!useRecovery && trimmed.length !== 6) {
+      error = $t('auth.session.totp_error_invalid');
+      return;
+    }
+
+    loading = true;
+    error = null;
+
+    try {
+      const result = (await onSubmitTotp?.(pendingUserId, trimmed)) ?? {
+        kind: 'error',
+        message: $t('auth.session.error_unknown')
+      };
+
+      if (result.kind === 'ok') {
+        open = false;
+        resetAll();
+        return;
+      }
+
+      error = describeResult(result);
+    } catch (err: unknown) {
+      error = err instanceof Error ? err.message : $t('auth.session.error_unknown');
+    } finally {
+      loading = false;
     }
   }
 </script>
 
 <Dialog bind:open onOpenChange={handleOpenChange}>
   <DialogContent class="sm:max-w-md">
-    <DialogHeader>
-      <DialogTitle>{$t('auth.session.reauth_title')}</DialogTitle>
-      <DialogDescription>
-        {$t('auth.session.reauth_description')}
-      </DialogDescription>
-    </DialogHeader>
+    {#if step === 'password'}
+      <DialogHeader>
+        <DialogTitle>{$t('auth.session.reauth_title')}</DialogTitle>
+        <DialogDescription>
+          {$t('auth.session.reauth_description')}
+        </DialogDescription>
+      </DialogHeader>
 
-    <form onsubmit={handleSubmit} class="space-y-4">
-      <div>
-        <label for="reauth-username" class="block text-sm font-medium text-muted-foreground">
-          {$t('auth.session.username_label')}
-        </label>
-        <input
-          id="reauth-username"
-          type="text"
-          value={username}
-          readonly
-          disabled
-          class="mt-1 block w-full rounded-md border border-input bg-muted px-3 py-2 text-sm opacity-75"
-        />
-      </div>
-
-      <div>
-        <label for="reauth-password" class="block text-sm font-medium text-foreground">
-          {$t('auth.session.password_label')}
-        </label>
-        <div class="relative mt-1">
+      <form onsubmit={handlePasswordSubmit} class="space-y-4">
+        <div>
+          <label for="reauth-username" class="block text-sm font-medium text-muted-foreground">
+            {$t('auth.session.username_label')}
+          </label>
           <input
-            id="reauth-password"
-            name="password"
-            type={showPassword ? 'text' : 'password'}
-            autocomplete="current-password"
-            required
-            bind:value={password}
-            disabled={loading}
-            placeholder={$t('auth.session.password_placeholder')}
-            class="block w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            id="reauth-username"
+            type="text"
+            value={username}
+            readonly
+            disabled
+            class="mt-1 block w-full rounded-md border border-input bg-muted px-3 py-2 text-sm opacity-75"
           />
+        </div>
+
+        <div>
+          <label for="reauth-password" class="block text-sm font-medium text-foreground">
+            {$t('auth.session.password_label')}
+          </label>
+          <div class="relative mt-1">
+            <input
+              id="reauth-password"
+              name="password"
+              type={showPassword ? 'text' : 'password'}
+              autocomplete="current-password"
+              required
+              bind:value={password}
+              disabled={loading}
+              placeholder={$t('auth.session.password_placeholder')}
+              class="block w-full rounded-md border border-input bg-background px-3 py-2 pr-10 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <button
+              type="button"
+              class="absolute inset-y-0 right-0 flex items-center pr-3"
+              onclick={() => {
+                showPassword = !showPassword;
+              }}
+            >
+              {#if showPassword}
+                <svg
+                  class="h-4 w-4 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                  />
+                </svg>
+              {:else}
+                <svg
+                  class="h-4 w-4 text-muted-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  />
+                </svg>
+              {/if}
+            </button>
+          </div>
+        </div>
+
+        {#if error}
+          <p class="text-sm text-destructive">{error}</p>
+        {/if}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            type="button"
+            onclick={() => {
+              open = false;
+            }}>{$t('common.cancel')}</Button
+          >
+          <Button type="submit" disabled={loading || !password}>
+            {#if loading}
+              {$t('auth.session.submitting')}
+            {:else}
+              {$t('auth.session.submit_button')}
+            {/if}
+          </Button>
+        </DialogFooter>
+      </form>
+    {:else}
+      <DialogHeader>
+        <DialogTitle>{$t('auth.session.totp_title')}</DialogTitle>
+        <DialogDescription>
+          {$t('auth.session.totp_description')}
+        </DialogDescription>
+      </DialogHeader>
+
+      <form onsubmit={handleTotpSubmit} class="space-y-4">
+        {#if !useRecovery}
+          <div>
+            <label for="reauth-totp" class="block text-sm font-medium text-foreground">
+              {$t('auth.session.totp_label')}
+            </label>
+            <input
+              id="reauth-totp"
+              name="totp"
+              type="text"
+              inputmode="numeric"
+              autocomplete="one-time-code"
+              maxlength={6}
+              pattern="[0-9]*"
+              required
+              bind:value={totpCode}
+              disabled={loading}
+              placeholder={$t('auth.session.totp_placeholder')}
+              class="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-center font-mono text-2xl tracking-[0.5em] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </div>
+        {:else}
+          <div>
+            <label for="reauth-recovery" class="block text-sm font-medium text-foreground">
+              {$t('auth.session.recovery_label')}
+            </label>
+            <input
+              id="reauth-recovery"
+              name="recovery"
+              type="text"
+              autocomplete="off"
+              required
+              bind:value={totpCode}
+              disabled={loading}
+              placeholder={$t('auth.session.recovery_placeholder')}
+              class="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-center font-mono text-lg tracking-wider placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </div>
+        {/if}
+
+        <div class="text-center">
           <button
             type="button"
-            class="absolute inset-y-0 right-0 flex items-center pr-3"
             onclick={() => {
-              showPassword = !showPassword;
+              useRecovery = !useRecovery;
+              totpCode = '';
+              error = null;
             }}
+            class="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground underline transition-colors"
           >
-            {#if showPassword}
-              <svg
-                class="h-4 w-4 text-muted-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                />
-              </svg>
+            {#if useRecovery}
+              <Shield class="h-3.5 w-3.5" />
+              {$t('auth.session.use_app')}
             {:else}
-              <svg
-                class="h-4 w-4 text-muted-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                />
-              </svg>
+              <KeyRound class="h-3.5 w-3.5" />
+              {$t('auth.session.use_recovery')}
             {/if}
           </button>
         </div>
-      </div>
 
-      {#if error}
-        <p class="text-sm text-destructive">{error}</p>
-      {/if}
+        {#if error}
+          <p class="text-sm text-destructive">{error}</p>
+        {/if}
 
-      <DialogFooter>
-        <Button
-          variant="outline"
-          type="button"
-          onclick={() => {
-            open = false;
-          }}>{$t('common.cancel')}</Button
-        >
-        <Button type="submit" disabled={loading || !password}>
-          {#if loading}
-            {$t('auth.session.submitting')}
-          {:else}
-            {$t('auth.session.submit_button')}
-          {/if}
-        </Button>
-      </DialogFooter>
-    </form>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            type="button"
+            onclick={() => {
+              open = false;
+            }}>{$t('common.cancel')}</Button
+          >
+          <Button type="submit" disabled={loading || !totpCode}>
+            {#if loading}
+              {$t('auth.session.totp_verifying')}
+            {:else}
+              {$t('auth.session.totp_submit_button')}
+            {/if}
+          </Button>
+        </DialogFooter>
+      </form>
+    {/if}
   </DialogContent>
 </Dialog>

--- a/packages/ui/src/components/auth/SessionExpiredBanner.svelte
+++ b/packages/ui/src/components/auth/SessionExpiredBanner.svelte
@@ -3,47 +3,34 @@
   Non-dismissible banner shown when the user's session has expired.
   Displays at the top of the page and opens a re-auth modal on click.
   Does NOT trigger logout — preserves master key in RAM (offline-first).
+
+  The modal handles the full re-auth flow, including the 2FA second step
+  when the account has two-factor authentication enabled.
 -->
 <script lang="ts">
   import { AlertTriangle } from '@lucide/svelte';
   import { t } from '@reborn/i18n';
   import ReAuthModal from './ReAuthModal.svelte';
+  import type { ReAuthResult } from './reauth-types';
 
   let {
     username = '',
     visible = false,
-    onReAuth
+    onReAuth,
+    onVerifyTotp
   } = $props<{
     username?: string;
     visible?: boolean;
-    onReAuth?: (password: string) => Promise<boolean>;
+    /** Submit password — may return `two_factor_required` to trigger TOTP step. */
+    onReAuth?: (password: string) => Promise<ReAuthResult>;
+    /** Submit TOTP / recovery code after `two_factor_required`. */
+    onVerifyTotp?: (userId: string, code: string) => Promise<ReAuthResult>;
   }>();
 
   let modalOpen = $state(false);
-  let loading = $state(false);
-  let error = $state<string | null>(null);
 
   function handleBannerClick() {
-    error = null;
     modalOpen = true;
-  }
-
-  async function handleSubmit(password: string) {
-    loading = true;
-    error = null;
-
-    try {
-      const success = await onReAuth?.(password);
-      if (success) {
-        modalOpen = false;
-      } else {
-        error = $t('auth.session.error_auth_failed');
-      }
-    } catch (err: unknown) {
-      error = err instanceof Error ? err.message : $t('auth.session.error_unknown');
-    } finally {
-      loading = false;
-    }
   }
 </script>
 
@@ -60,4 +47,9 @@
   </div>
 {/if}
 
-<ReAuthModal bind:open={modalOpen} {username} {loading} {error} onSubmit={handleSubmit} />
+<ReAuthModal
+  bind:open={modalOpen}
+  {username}
+  onSubmitPassword={onReAuth}
+  onSubmitTotp={onVerifyTotp}
+/>

--- a/packages/ui/src/components/auth/index.ts
+++ b/packages/ui/src/components/auth/index.ts
@@ -11,3 +11,4 @@ export { default as UnlockE2E } from './UnlockE2E.svelte';
 export { default as UnlockPage } from './UnlockPage.svelte';
 export { default as SessionExpiredBanner } from './SessionExpiredBanner.svelte';
 export { default as ReAuthModal } from './ReAuthModal.svelte';
+export type { ReAuthResult } from './reauth-types';

--- a/packages/ui/src/components/auth/reauth-types.ts
+++ b/packages/ui/src/components/auth/reauth-types.ts
@@ -1,0 +1,14 @@
+/**
+ * Result of a re-authentication attempt after session expiry.
+ *
+ * `two_factor_required` is returned when the account has 2FA enabled and the
+ * password has been verified — the UI must then collect a TOTP/recovery code
+ * and call the TOTP verify callback with `userId`.
+ */
+export type ReAuthResult =
+  | { kind: 'ok' }
+  | { kind: 'invalid_password' }
+  | { kind: 'two_factor_required'; userId: string }
+  | { kind: 'invalid_totp' }
+  | { kind: 'locked'; retryAfter: number }
+  | { kind: 'error'; message?: string };


### PR DESCRIPTION
Re-auth after session expiry on 2FA-enabled accounts silently failed because reAuthenticate() expected an access_token in the /api/auth/login response, while the server returns { twoFactorRequired: true } without one. The modal showed "check your password" even when the password was correct; only a full logout + login flow (which handles 2FA) worked.

Also serialize /api/auth/refresh calls across tabs and apps via the Web Locks API: concurrent refreshes from reborn-notes + reborn-task sharing the httpOnly refresh_token cookie tripped the server's token family reuse detector, prematurely invalidating valid sessions.

- ReAuthResult union + two-step ReAuthModal (password -> TOTP/recovery)
- verifyTotpForReauth() in both apps; master key preserved throughout
- withRefreshLock() helper in @reborn/auth (Web Locks + localStorage fallback)
- i18n keys for TOTP step across pl/en/de/fr/es