### PR TITLE
fix(notes): render single newlines as line breaks in markdown preview

### DIFF
--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -77,7 +77,7 @@
     </div>`;
   };
 
-  marked.use({ renderer });
+  marked.use({ renderer, gfm: true, breaks: true });
 
   const html = $derived.by(() => {
     if (!content) return '';


### PR DESCRIPTION
Enable marked's `breaks: true` (GFM line breaks) so a single Enter in the editor produces a `<br>` in the preview, matching the editor's visual layout. Empty lines still create new paragraphs.