### PR TITLE
chore(release): source GITHUB_TOKEN from gh CLI when unset

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -59,6 +59,26 @@ function git(args) {
 	return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8' }).trim();
 }
 
+// nx.json configures `createRelease: "github"`, which requires nx to call the
+// GitHub REST API. nx reads the token from GITHUB_TOKEN/GH_TOKEN only — it does
+// not fall back to `gh auth`. When neither env var is set (typical local dev),
+// the API call 401s and nx drops into an interactive prompt that hangs
+// non-TTY runs. Fix: source the token from `gh auth token` when available.
+function ensureGithubToken() {
+	if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) return;
+	try {
+		const token = execFileSync('gh', ['auth', 'token'], { encoding: 'utf-8' }).trim();
+		if (token) {
+			process.env.GITHUB_TOKEN = token;
+			console.log('[release] Sourced GITHUB_TOKEN from `gh auth token`.');
+		}
+	} catch {
+		console.warn(
+			'[release] No GITHUB_TOKEN/GH_TOKEN set and `gh auth token` unavailable — GitHub Release creation may fail.'
+		);
+	}
+}
+
 function getLastReleaseTag() {
 	try {
 		const tags = git(['tag', '--list', 'v*', '--sort=-v:refname'])
@@ -158,6 +178,8 @@ for (const relPath of PRIVATE_MANIFESTS) {
 if (!dryRun && syncedFiles.length > 0) {
 	execFileSync('git', ['add', '--', ...syncedFiles], { stdio: 'inherit', cwd: ROOT });
 }
+
+if (!dryRun) ensureGithubToken();
 
 await releaseChangelog({
 	dryRun,


### PR DESCRIPTION
## Summary

Fix the local-release hang that surfaced on v0.1.4: the release script runs `nx releaseChangelog` with `createRelease: \"github\"`, which calls the GitHub REST API using `GITHUB_TOKEN`/`GH_TOKEN` from the environment. Nx has no built-in `gh` CLI integration, so when neither env var is set (typical local dev) the API 401s and nx falls back to an interactive prompt that hangs non-TTY runs — leaving the version bump, commit, tag, and push done but **no GitHub Release created**.

The script now calls `gh auth token` to source the token automatically when the env vars are missing. If `gh` is unavailable or not logged in, it logs a warning and preserves the previous behavior.

## Test plan

- [x] Dry-run still works: `pnpm release:dry` produces the expected diff.
- [ ] Real release (next version bump): script creates the GitHub Release without prompts or manual `gh release create` follow-up.

## Notes

Only the `releaseChangelog` call uses the token, so `ensureGithubToken()` is invoked right before that step and only when not in dry-run mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)