### PR TITLE
fix: back sync indicator with real connectivity probe

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -31,12 +31,12 @@ describe('notes-sync — regression (offline data loss)', () => {
 
   it('online handler pushes pending items BEFORE pulling (BUG-3)', () => {
     const src = readSource('../stores/sync-status.store.ts');
-    const onlineHandler = src.slice(
-      src.indexOf("addEventListener('online'"),
-      src.indexOf("addEventListener('offline'")
-    );
-    // Look only at CALL sites, not the destructuring import (which lists names
-    // in arbitrary order).
+    // The online-transition handler now lives inside a connectivity.subscribe
+    // callback (we replaced navigator.onLine with a probe-backed store). Scope
+    // the check to that callback block.
+    const anchor = src.indexOf('connectivity.subscribe');
+    expect(anchor).toBeGreaterThan(-1);
+    const onlineHandler = src.slice(anchor, anchor + 1500);
     const pushCallIdx = onlineHandler.search(/pushPendingItems\s*\(/);
     const pullCallIdx = onlineHandler.search(/pullFromServer\s*\(/);
     expect(pushCallIdx).toBeGreaterThan(-1);

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -44,6 +44,7 @@ import {
 import { authFetch } from '$lib/utils/auth-fetch';
 import { validateEncryptedPayload } from '@reborn/crypto';
 import { refreshQuota } from '$lib/stores/storage-quota.store';
+import { connectivityStore } from '$lib/stores/connectivity.store';
 
 const logger = createLogger('Notes-Sync');
 
@@ -51,6 +52,27 @@ const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 function isUnauthorizedError(e: unknown): boolean {
   return e instanceof Error && e.message.includes('401');
+}
+
+function isNetworkError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  if (e.name === 'AbortError' || e.name === 'TimeoutError') return true;
+  const msg = e.message.toLowerCase();
+  return (
+    msg.includes('failed to fetch') ||
+    msg.includes('network') ||
+    msg.includes('timeout') ||
+    msg.includes('abort')
+  );
+}
+
+/**
+ * Central hook for any caught sync error. Hints the connectivity store whenever
+ * the failure smells like a dead network — which `navigator.onLine` would
+ * otherwise miss under an active VPN tunnel.
+ */
+function reportSyncError(e: unknown): void {
+  if (isNetworkError(e)) connectivityStore?.markFailure();
 }
 
 function isAuthenticated(): boolean {
@@ -114,11 +136,13 @@ export async function pullFromServer(): Promise<boolean> {
     await Promise.all([
       pullFolders().catch((e) => {
         if (isUnauthorizedError(e)) gotUnauthorized = true;
+        reportSyncError(e);
         logger.error('Pull folders failed:', e);
         success = false;
       }),
       pullTags().catch((e) => {
         if (isUnauthorizedError(e)) gotUnauthorized = true;
+        reportSyncError(e);
         logger.error('Pull tags failed:', e);
         success = false;
       })
@@ -127,6 +151,7 @@ export async function pullFromServer(): Promise<boolean> {
     if (!gotUnauthorized) {
       await pullNotes().catch((e) => {
         if (isUnauthorizedError(e)) gotUnauthorized = true;
+        reportSyncError(e);
         logger.error('Pull notes failed:', e);
         success = false;
       });
@@ -136,6 +161,7 @@ export async function pullFromServer(): Promise<boolean> {
         const allNotes = (await noteStore.getAll()) as NoteEncrypted[];
         const noteIds = allNotes.map((n) => n.id);
         await pullNoteVersions(noteIds).catch((e) => {
+          reportSyncError(e);
           logger.error('Pull note versions failed:', e);
           // Non-critical — don't set success=false
         });
@@ -151,7 +177,8 @@ export async function pullFromServer(): Promise<boolean> {
     } else {
       syncError.set(true);
     }
-  } catch {
+  } catch (e) {
+    reportSyncError(e);
     syncError.set(true);
     success = false;
   } finally {
@@ -623,6 +650,7 @@ async function pushSilently(fn: (idempotencyKey: string) => Promise<void>): Prom
   try {
     await retryWithBackoff(() => fn(idempotencyKey));
   } catch (err: unknown) {
+    reportSyncError(err);
     logger.error('Push sync failed after retries (will retry on next periodic sync):', err);
   } finally {
     void refreshPendingCount();

--- a/apps/reborn-notes/src/lib/stores/connectivity.store.ts
+++ b/apps/reborn-notes/src/lib/stores/connectivity.store.ts
@@ -1,0 +1,40 @@
+import { base } from '$app/paths';
+import { browser } from '$app/environment';
+import { derived, readable, type Readable } from 'svelte/store';
+import {
+  getConnectivity,
+  type ConnectivityState,
+  type ConnectivityStore
+} from '@reborn/api-client';
+
+/**
+ * App-local wrapper around `@reborn/api-client`'s connectivity singleton.
+ * Binds the probe endpoint to this app's `/api/health` and exposes Svelte
+ * stores for reactive consumption.
+ *
+ * Why an active probe instead of `navigator.onLine`: an active VPN tunnel
+ * (e.g. Proton in airplane mode) keeps a network interface up, so the browser
+ * reports `online: true` even when there is no upstream. Only a real HTTP
+ * round-trip against our own origin tells the truth.
+ */
+
+const ssrState: ConnectivityState = { status: 'unknown', lastProbeAt: null };
+
+export const connectivityStore: ConnectivityStore | null = browser
+  ? getConnectivity({ endpoint: `${base}/api/health` })
+  : null;
+
+export const connectivity: Readable<ConnectivityState> = connectivityStore
+  ? { subscribe: connectivityStore.subscribe.bind(connectivityStore) }
+  : readable(ssrState);
+
+export const isOnline: Readable<boolean> = derived(
+  connectivity,
+  ($c) => $c.status === 'online' || $c.status === 'unknown'
+);
+
+/** Synchronous check: `true` unless the last probe definitively failed. */
+export function checkOnline(): boolean {
+  if (!connectivityStore) return true;
+  return connectivityStore.getState().status !== 'offline';
+}

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -1,6 +1,12 @@
 import { writable, derived } from 'svelte/store';
 import { browser } from '$app/environment';
 import { noteStore, folderStore, tagStore } from '@reborn/storage';
+import {
+  connectivity,
+  connectivityStore,
+  isOnline as connectivityIsOnline,
+  checkOnline as checkConnectivityOnline
+} from './connectivity.store';
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -21,17 +27,23 @@ export interface SyncStatusState {
 
 // ── Online/offline ───────────────────────────────────────────────
 
-function createOnlineStore() {
-  const { subscribe, set } = writable(browser ? navigator.onLine : true);
+// Re-export the active-probe connectivity store under the legacy `isOnline`
+// name so consumers don't need to change. `navigator.onLine` is unreliable
+// with a VPN tunnel (e.g. Proton in airplane mode), so we back this with a
+// real HTTP probe — see `connectivity.store.ts`.
+export const isOnline = connectivityIsOnline;
 
-  if (browser) {
-    window.addEventListener('online', () => {
-      set(true);
-      // Trigger sync when coming back online (lazy import to avoid circular deps).
-      // CRITICAL: push BEFORE pull — running them in parallel risks pull reaching
-      // the server before push completes, so items still 'pending' locally would
-      // be re-fetched as already-synced versions and subsequent push attempts
-      // would conflict.
+/** Synchronous helper to check current online status (probe-backed). */
+export const checkOnline = checkConnectivityOnline;
+
+// When connectivity transitions offline → online, kick off a sync just like
+// the old `window.addEventListener('online')` handler did. CRITICAL: push
+// BEFORE pull — parallel runs let pull overwrite still-pending offline edits.
+if (browser && connectivityStore) {
+  let wasOnline = connectivityStore.getState().status === 'online';
+  connectivity.subscribe(($c) => {
+    const nowOnline = $c.status === 'online';
+    if (nowOnline && !wasOnline) {
       import('$lib/services/notes-sync.service').then(
         async ({ pullFromServer, pushPendingItems, refreshStoresAfterPull }) => {
           try {
@@ -39,22 +51,13 @@ function createOnlineStore() {
             const synced = await pullFromServer();
             if (synced) await refreshStoresAfterPull();
           } catch {
-            // fire-and-forget: background sync, errors handled internally
+            // fire-and-forget
           }
         }
       );
-    });
-    window.addEventListener('offline', () => set(false));
-  }
-
-  return { subscribe };
-}
-
-export const isOnline = createOnlineStore();
-
-/** Synchronous helper to check current online status */
-export function checkOnline(): boolean {
-  return browser ? navigator.onLine : true;
+    }
+    wasOnline = nowOnline;
+  });
 }
 
 // ── Sync progress (set by sync service) ─────────────────────────

--- a/apps/reborn-notes/src/lib/utils/auth-fetch.ts
+++ b/apps/reborn-notes/src/lib/utils/auth-fetch.ts
@@ -83,6 +83,19 @@ function refreshAccessToken(): Promise<string | null> {
   return refreshPromise;
 }
 
+/**
+ * Default per-request timeout. Without this a fetch against a VPN black hole
+ * (navigator.onLine=true but no upstream) never resolves, so sync's `finally`
+ * never runs and the spinner spins forever. Caller-provided `init.signal`
+ * takes precedence — if present, we respect it untouched.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+function buildSignal(init?: RequestInit): AbortSignal {
+  if (init?.signal) return init.signal;
+  return AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS);
+}
+
 export async function authFetch(input: string, init?: RequestInit): Promise<Response> {
   const accessToken = localStorage.getItem('access_token');
 
@@ -91,7 +104,8 @@ export async function authFetch(input: string, init?: RequestInit): Promise<Resp
     headers.set('Authorization', `Bearer ${accessToken}`);
   }
 
-  const response = await fetch(input, { ...init, headers });
+  const signal = buildSignal(init);
+  const response = await fetch(input, { ...init, headers, signal });
 
   if (response.status !== 401) return response;
 
@@ -102,8 +116,9 @@ export async function authFetch(input: string, init?: RequestInit): Promise<Resp
     return response;
   }
 
-  // Retry original request with the new token
+  // Retry original request with the new token. Reuse the same signal so the
+  // retry inherits the caller's cancellation / timeout budget.
   const retryHeaders = new Headers(init?.headers);
   retryHeaders.set('Authorization', `Bearer ${newToken}`);
-  return fetch(input, { ...init, headers: retryHeaders });
+  return fetch(input, { ...init, headers: retryHeaders, signal });
 }

--- a/apps/reborn-notes/src/routes/api/health/+server.ts
+++ b/apps/reborn-notes/src/routes/api/health/+server.ts
@@ -4,6 +4,10 @@ import type { RequestHandler } from './$types';
 
 declare const __APP_VERSION__: string;
 
+// Lightweight reachability check. Skips the DB round-trip so the client-side
+// connectivity probe stays fast and costs nothing beyond routing the request.
+export const HEAD: RequestHandler = () => new Response(null, { status: 200 });
+
 export const GET: RequestHandler = async () => {
 	let dbStatus = 'unknown';
 

--- a/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
@@ -17,9 +17,12 @@ export abstract class SyncBaseService {
 		const baseUrl = `${PUBLIC_BASE_PATH}/api`;
 		this.logger.debug('Initializing sync service with base URL:', baseUrl);
 
-		// Create API client - AuthInterceptor will handle auth headers
+		// Create API client - AuthInterceptor will handle auth headers.
+		// Shorter timeout so a VPN black hole (navigator.onLine=true but no
+		// upstream) doesn't hang a sync for the default 30 s.
 		this.apiClient = new ApiClient({
-			baseUrl
+			baseUrl,
+			timeout: 15_000
 		});
 	}
 

--- a/apps/reborn-task/src/lib/services/sync/sync.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync.service.ts
@@ -6,9 +6,18 @@ import { SyncListsService } from './sync-lists.service';
 import { SyncTasksService } from './sync-tasks.service';
 import { SyncSubtasksService } from './sync-subtasks.service';
 import { SyncOfflineService } from './sync-offline.service';
+import { connectivityStore, checkOnline } from '$lib/stores/connectivity.store';
+import { isNetworkError } from '$lib/stores/network.store';
 import type { StorageOfflineOperation, TaskEncryptedBooleans } from '@reborn/types';
 
 const logger = createLogger('SyncService');
+
+/** Hint the connectivity probe on network-smelling errors so the indicator
+ * catches up with reality (navigator.onLine cannot, because a VPN tunnel
+ * satisfies the browser's "interface present" heuristic). */
+function reportIfNetwork(err: unknown): void {
+	if (isNetworkError(err)) connectivityStore?.markFailure();
+}
 
 export interface SyncProgress {
 	isInProgress: boolean;
@@ -266,6 +275,7 @@ class SyncService {
 
 			logger.info('Initial sync completed');
 		} catch (error: unknown) {
+			reportIfNetwork(error);
 			logger.error('Initial sync failed:', error);
 			this.updateProgress({
 				isInProgress: false,
@@ -286,7 +296,7 @@ class SyncService {
 	 * Multiple calls within the delay window are collapsed into one sync.
 	 */
 	scheduleSyncSoon(): void {
-		if (!navigator.onLine) return;
+		if (!checkOnline()) return;
 
 		if (this.syncSoonTimer) {
 			clearTimeout(this.syncSoonTimer);
@@ -306,7 +316,7 @@ class SyncService {
 	 * Unlike initialSync(), no progress callbacks and no soft-delete wait.
 	 */
 	async periodicSync(): Promise<void> {
-		if (!navigator.onLine) {
+		if (!checkOnline()) {
 			logger.debug('Offline - skipping periodic sync');
 			return;
 		}
@@ -350,6 +360,7 @@ class SyncService {
 
 			logger.info('Periodic sync completed');
 		} catch (error: unknown) {
+			reportIfNetwork(error);
 			logger.error('Periodic sync failed:', error);
 		} finally {
 			this.isSyncing = false;
@@ -361,7 +372,7 @@ class SyncService {
 	 * This should be called periodically or after changes
 	 */
 	async syncToServer(): Promise<{ failedCount: number }> {
-		if (!navigator.onLine) {
+		if (!checkOnline()) {
 			logger.info('Offline - skipping sync to server');
 			return { failedCount: 0 };
 		}
@@ -387,6 +398,7 @@ class SyncService {
 
 			return { failedCount: result.failedCount };
 		} catch (error: unknown) {
+			reportIfNetwork(error);
 			logger.error('Failed to sync to server:', error);
 			throw error;
 		} finally {
@@ -405,7 +417,7 @@ class SyncService {
 		const processedOps: StorageOfflineOperation[] = [];
 		let failedCount = 0;
 
-		if (!navigator.onLine) {
+		if (!checkOnline()) {
 			logger.info('Offline - skipping offline operations sync');
 			return { processedOps, failedCount };
 		}
@@ -464,6 +476,7 @@ class SyncService {
 					// Track processed operation
 					processedOps.push(operation);
 				} catch (error: unknown) {
+					reportIfNetwork(error);
 					logger.error(`Failed to sync operation ${operation.id}:`, error);
 					failedCount++;
 
@@ -484,6 +497,7 @@ class SyncService {
 			// Refresh task counts after syncing changes
 			taskCounts.refresh();
 		} catch (error: unknown) {
+			reportIfNetwork(error);
 			logger.error('Failed to sync offline operations:', error);
 		}
 

--- a/apps/reborn-task/src/lib/stores/connectivity.store.ts
+++ b/apps/reborn-task/src/lib/stores/connectivity.store.ts
@@ -1,0 +1,40 @@
+import { base } from '$app/paths';
+import { browser } from '$app/environment';
+import { derived, readable, type Readable } from 'svelte/store';
+import {
+	getConnectivity,
+	type ConnectivityState,
+	type ConnectivityStore
+} from '@reborn/api-client';
+
+/**
+ * App-local wrapper around `@reborn/api-client`'s connectivity singleton.
+ * Binds the probe endpoint to this app's `/api/health` and exposes Svelte
+ * stores for reactive consumption.
+ *
+ * Why an active probe instead of `navigator.onLine`: an active VPN tunnel
+ * (e.g. Proton in airplane mode) keeps a network interface up, so the browser
+ * reports `online: true` even when there is no upstream. Only a real HTTP
+ * round-trip against our own origin tells the truth.
+ */
+
+const ssrState: ConnectivityState = { status: 'unknown', lastProbeAt: null };
+
+export const connectivityStore: ConnectivityStore | null = browser
+	? getConnectivity({ endpoint: `${base}/api/health` })
+	: null;
+
+export const connectivity: Readable<ConnectivityState> = connectivityStore
+	? { subscribe: connectivityStore.subscribe.bind(connectivityStore) }
+	: readable(ssrState);
+
+export const isOnline: Readable<boolean> = derived(
+	connectivity,
+	($c) => $c.status === 'online' || $c.status === 'unknown'
+);
+
+/** Synchronous check: `true` unless the last probe definitively failed. */
+export function checkOnline(): boolean {
+	if (!connectivityStore) return true;
+	return connectivityStore.getState().status !== 'offline';
+}

--- a/apps/reborn-task/src/lib/stores/network.store.ts
+++ b/apps/reborn-task/src/lib/stores/network.store.ts
@@ -1,61 +1,45 @@
-import { writable, derived } from 'svelte/store';
+import { derived } from 'svelte/store';
 import { browser } from '$app/environment';
 import { createLogger } from '@reborn/utils';
 import { syncService } from '$lib/services/sync.service';
+import {
+	connectivity,
+	connectivityStore,
+	isOnline as connectivityIsOnline,
+	checkOnline as checkConnectivityOnline
+} from './connectivity.store';
 
 const logger = createLogger('NetworkStore');
 
-// Create online/offline status store
-function createNetworkStore() {
-	const { subscribe, set } = writable(browser ? navigator.onLine : true);
-	
-	if (browser) {
-		// Set up event listeners
-		const handleOnline = () => {
-			logger.info('Network status: Online');
-			set(true);
-			
-			// Trigger sync when coming back online
-			logger.info('Triggering sync after coming online');
-			syncService.syncToServer().catch(error => {
+// Re-export the active-probe connectivity store under the legacy `isOnline`
+// name. `navigator.onLine` lies under an active VPN tunnel (e.g. Proton in
+// airplane mode) so we back this with a real HTTP probe — see
+// `connectivity.store.ts`.
+export const isOnline = connectivityIsOnline;
+
+// Trigger sync on offline → online transitions, matching the old
+// `window.addEventListener('online')` handler.
+if (browser && connectivityStore) {
+	let wasOnline = connectivityStore.getState().status === 'online';
+	connectivity.subscribe(($c) => {
+		const nowOnline = $c.status === 'online';
+		if (nowOnline && !wasOnline) {
+			logger.info('Connectivity restored — triggering sync');
+			syncService.syncToServer().catch((error) => {
 				logger.error('Failed to sync after coming online:', error);
 			});
-		};
-		
-		const handleOffline = () => {
-			logger.info('Network status: Offline');
-			set(false);
-		};
-		
-		// Add event listeners
-		window.addEventListener('online', handleOnline);
-		window.addEventListener('offline', handleOffline);
-		
-		// Clean up on unload
-		window.addEventListener('beforeunload', () => {
-			window.removeEventListener('online', handleOnline);
-			window.removeEventListener('offline', handleOffline);
-		});
-	}
-	
-	return {
-		subscribe
-	};
+		}
+		wasOnline = nowOnline;
+	});
 }
-
-// Export the store
-export const isOnline = createNetworkStore();
 
 // Derived store for network status message
-export const networkStatus = derived(
-	isOnline,
-	$isOnline => $isOnline ? 'Online' : 'Offline'
+export const networkStatus = derived(isOnline, ($isOnline) =>
+	$isOnline ? 'Online' : 'Offline'
 );
 
-// Helper to check if we're online
-export function checkOnline(): boolean {
-	return browser ? navigator.onLine : true;
-}
+// Synchronous helper, probe-backed.
+export const checkOnline = checkConnectivityOnline;
 
 /**
  * Determines if an error is network-related

--- a/apps/reborn-task/src/routes/api/health/+server.ts
+++ b/apps/reborn-task/src/routes/api/health/+server.ts
@@ -4,6 +4,10 @@ import type { RequestHandler } from './$types';
 
 declare const __APP_VERSION__: string;
 
+// Lightweight reachability check. Skips the DB round-trip so the client-side
+// connectivity probe stays fast and costs nothing beyond routing the request.
+export const HEAD: RequestHandler = () => new Response(null, { status: 200 });
+
 export const GET: RequestHandler = async () => {
 	let dbStatus = 'unknown';
 

--- a/packages/api-client/src/connectivity.test.ts
+++ b/packages/api-client/src/connectivity.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { probeOnline } from './connectivity';
+
+describe('probeOnline', () => {
+  const endpoint = 'https://example.test/api/health';
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns true on 2xx HEAD', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 200 }));
+    await expect(probeOnline(endpoint)).resolves.toBe(true);
+  });
+
+  it('returns false on 5xx HEAD', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 503 }));
+    await expect(probeOnline(endpoint)).resolves.toBe(false);
+  });
+
+  it('falls back to GET on 405 HEAD and respects its result', async () => {
+    const fetchSpy = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'HEAD') return new Response(null, { status: 405 });
+      return new Response('ok', { status: 200 });
+    });
+    globalThis.fetch = fetchSpy;
+    await expect(probeOnline(endpoint)).resolves.toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns false when fetch rejects (network / DNS / VPN black hole)', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    await expect(probeOnline(endpoint)).resolves.toBe(false);
+  });
+
+  it('returns false on AbortError (timeout)', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    });
+    await expect(probeOnline(endpoint, 100)).resolves.toBe(false);
+  });
+
+  it('omits credentials to avoid hot cookies', async () => {
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchSpy;
+    await probeOnline(endpoint);
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(init.credentials).toBe('omit');
+    expect(init.cache).toBe('no-store');
+  });
+});

--- a/packages/api-client/src/connectivity.ts
+++ b/packages/api-client/src/connectivity.ts
@@ -1,0 +1,217 @@
+/**
+ * Active connectivity probing.
+ *
+ * `navigator.onLine` only reports whether a network interface exists — an
+ * active VPN tunnel without upstream (e.g. Proton in airplane mode) still
+ * yields `true`. The only reliable signal is a real HTTP round-trip against
+ * a same-origin endpoint within a short budget.
+ *
+ * `probeOnline()` is a stateless one-shot check. `getConnectivity()` returns
+ * a framework-agnostic reactive store (Svelte-compatible `subscribe`) that
+ * re-probes on `online` / `visibilitychange` events and on a visibility-gated
+ * interval. Consumers (sync services) can also hint a failure via
+ * `markFailure()` to trigger an immediate re-probe.
+ */
+
+import { createLogger } from '@reborn/utils';
+
+const logger = createLogger('Connectivity');
+
+export type ConnectivityStatus = 'online' | 'offline' | 'unknown';
+
+export interface ConnectivityState {
+  status: ConnectivityStatus;
+  lastProbeAt: number | null;
+}
+
+export interface ConnectivityOptions {
+  /** Full URL of a same-origin endpoint that returns 2xx when reachable. */
+  endpoint: string;
+  /** Per-probe timeout. Default 3000ms. */
+  probeTimeoutMs?: number;
+  /** Visibility-gated interval between probes. Default 30000ms. 0 disables the timer. */
+  intervalMs?: number;
+}
+
+const DEFAULT_PROBE_TIMEOUT_MS = 3000;
+const DEFAULT_INTERVAL_MS = 30_000;
+
+/**
+ * Stateless connectivity probe. Returns `true` only on a 2xx response within
+ * `timeoutMs`. Swallows all errors (network, abort, CORS, etc.) → `false`.
+ *
+ * Falls back to GET when the server rejects HEAD (404/405), so the probe still
+ * works against endpoints that only implement GET.
+ */
+export async function probeOnline(
+  endpoint: string,
+  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS
+): Promise<boolean> {
+  if (typeof fetch === 'undefined') return false;
+  try {
+    const res = await fetch(endpoint, {
+      method: 'HEAD',
+      cache: 'no-store',
+      credentials: 'omit',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.ok) return true;
+    if (res.status === 404 || res.status === 405) {
+      const getRes = await fetch(endpoint, {
+        method: 'GET',
+        cache: 'no-store',
+        credentials: 'omit',
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      return getRes.ok;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+type Listener = (state: ConnectivityState) => void;
+
+export class ConnectivityStore {
+  private state: ConnectivityState = { status: 'unknown', lastProbeAt: null };
+  private listeners = new Set<Listener>();
+  private options: Required<ConnectivityOptions>;
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+  private inFlight: Promise<boolean> | null = null;
+
+  private readonly onOnline = () => {
+    void this.refresh();
+  };
+  private readonly onOffline = () => {
+    this.setState({ status: 'offline', lastProbeAt: Date.now() });
+  };
+  private readonly onVisibility = () => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+      void this.refresh();
+    }
+  };
+
+  constructor(options: ConnectivityOptions) {
+    this.options = {
+      endpoint: options.endpoint,
+      probeTimeoutMs: options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS,
+      intervalMs: options.intervalMs ?? DEFAULT_INTERVAL_MS,
+    };
+
+    if (typeof window === 'undefined') return;
+
+    // Seed from navigator.onLine — the probe confirms shortly after. Keeping
+    // status=unknown when the browser says "online" avoids flashing `offline`
+    // before we've confirmed the VPN lie.
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      this.state = { status: 'offline', lastProbeAt: null };
+    }
+
+    window.addEventListener('online', this.onOnline);
+    window.addEventListener('offline', this.onOffline);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this.onVisibility);
+    }
+    this.startInterval();
+    void this.refresh();
+  }
+
+  /** Svelte readable contract: emits current state synchronously, then on change. */
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getState(): ConnectivityState {
+    return this.state;
+  }
+
+  /** Fire a probe. Concurrent callers share the same in-flight promise. */
+  async refresh(): Promise<boolean> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = (async () => {
+      const ok = await probeOnline(this.options.endpoint, this.options.probeTimeoutMs);
+      this.setState({
+        status: ok ? 'online' : 'offline',
+        lastProbeAt: Date.now(),
+      });
+      return ok;
+    })().finally(() => {
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  /**
+   * Hint that a sync/fetch just failed. Triggers an immediate re-probe so the
+   * indicator catches up with reality (the prior probe may be minutes stale).
+   * Coalesced: does nothing if a probe is already in flight.
+   */
+  markFailure(): void {
+    if (!this.inFlight) void this.refresh();
+  }
+
+  private setState(next: ConnectivityState): void {
+    const statusChanged = next.status !== this.state.status;
+    this.state = next;
+    if (statusChanged) {
+      logger.info(`Connectivity: ${next.status}`);
+    }
+    for (const listener of this.listeners) listener(this.state);
+  }
+
+  private startInterval(): void {
+    if (this.options.intervalMs <= 0 || this.intervalHandle) return;
+    this.intervalHandle = setInterval(() => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+      void this.refresh();
+    }, this.options.intervalMs);
+  }
+
+  /** Teardown — primarily for tests / HMR. */
+  destroy(): void {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('online', this.onOnline);
+      window.removeEventListener('offline', this.onOffline);
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', this.onVisibility);
+      }
+    }
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    this.listeners.clear();
+  }
+}
+
+let singleton: ConnectivityStore | null = null;
+let singletonEndpoint: string | null = null;
+
+/**
+ * Process-wide singleton. The first call binds the endpoint; subsequent calls
+ * with a different endpoint log a warning and return the existing store —
+ * each app must call this exactly once from its bootstrap.
+ */
+export function getConnectivity(options: ConnectivityOptions): ConnectivityStore {
+  if (!singleton) {
+    singleton = new ConnectivityStore(options);
+    singletonEndpoint = options.endpoint;
+  } else if (singletonEndpoint !== options.endpoint) {
+    logger.warn(
+      `connectivity already initialized with endpoint ${singletonEndpoint}; ignoring ${options.endpoint}`
+    );
+  }
+  return singleton;
+}
+
+/** Test-only: drops the singleton so the next call reconstructs it. */
+export function __resetConnectivityForTests(): void {
+  singleton?.destroy();
+  singleton = null;
+  singletonEndpoint = null;
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -26,6 +26,15 @@ export { OfflineQueue } from './utils/offline-queue';
 export { IdResolver } from './utils/id-resolver';
 export { RetryManager } from './utils/retry-manager';
 
+// Connectivity probe
+export {
+  probeOnline,
+  getConnectivity,
+  ConnectivityStore,
+  __resetConnectivityForTests
+} from './connectivity';
+export type { ConnectivityStatus, ConnectivityState, ConnectivityOptions } from './connectivity';
+
 // Endpoint exports
 export { AuthEndpoints } from './endpoints/auth';
 export { TaskEndpoints } from './endpoints/tasks';


### PR DESCRIPTION
## Summary

- Replace `navigator.onLine` with an active HTTP probe to `/api/health` (via new `@reborn/api-client` connectivity store) in both apps. An active VPN tunnel (e.g. Proton in airplane mode) makes the browser report `online: true` even without upstream, so only a real round-trip tells the truth.
- Thread `connectivity.markFailure()` into sync error paths — network-smelling failures now flip the indicator back to offline instead of lingering as "synced" (Task) or spinning forever (Notes).
- Cap per-request timeouts: Notes `authFetch` at 15 s, Task `ApiClient` at 15 s (down from 30 s) so a black-hole VPN cannot stall a sync.

## Details

- New `packages/api-client/src/connectivity.ts`: stateless `probeOnline()` + reactive `ConnectivityStore` singleton. Visibility-gated 30 s interval + re-probe on `online` / `visibilitychange` / `markFailure()` hint. 6 unit tests.
- Both apps gain a lightweight `HEAD /api/health` handler so probes skip the DB round-trip.
- `apps/reborn-notes/src/lib/stores/connectivity.store.ts` and `apps/reborn-task/src/lib/stores/connectivity.store.ts` bind the singleton to `${base}/api/health` and expose Svelte-compatible stores (`connectivity`, `isOnline`, `checkOnline()`).
- Notes `sync-status.store` and Task `network.store` now derive `isOnline` from the probe; offline → online transition still pushes pending ops before pulling.
- Updated BUG-3 regression test to target the new `connectivity.subscribe` callback instead of the removed `window.addEventListener('online', …)` block.

## Test plan

- [x] `pnpm nx test api-client` → 18/18 green
- [x] `pnpm nx test reborn-notes` → 65/65 green (regression spec updated)
- [x] `pnpm nx test reborn-task` → 10/10 green
- [x] `pnpm nx check reborn-notes` → 0 errors
- [x] `pnpm nx check reborn-task` → 0 errors
- [x] `pnpm nx build reborn-notes reborn-task` → both built
- [ ] Manual: VPN on + airplane mode → Notes spinner stops, Task indicator shows "offline" (not "synced").
- [ ] Manual: Disable airplane mode with VPN still on → indicator flips to "online" within one probe interval, queued sync fires.
- [ ] Manual: No VPN / normal online → no regression in sync timing or status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)