### PR TITLE
chore(ci): delay auto-merge of Renovate vulnerability fixes by 3 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,7 +60,8 @@
     "labels": ["security"],
     "automerge": true,
     "automergeType": "pr",
-    "semanticCommitType": "fix"
+    "semanticCommitType": "fix",
+    "minimumReleaseAge": "3 days"
   },
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Summary

- Adds `minimumReleaseAge: "3 days"` to the `vulnerabilityAlerts` block in `.github/renovate.json`.
- Auto-merge for CVE fixes now waits until the package has been published for at least 3 days.
- Mitigates supply-chain attacks where a compromised maintainer account publishes malware disguised as a vulnerability fix — community typically detects and yanks such releases within the first ~48h.

## Context

GitHub `Allow auto-merge` was enabled on 2026-04-23. In our Renovate config only `vulnerabilityAlerts` has `automerge: true` — every other `packageRule` (patch/minor/major/svelte/nx/prisma/tailwind/github-actions) remains manual. This PR tightens the one path that can auto-merge without human review.

Tradeoff: CVE fixes now land 3 days later than upstream publication. Acceptable given per-username account lockout and the absence of exposed exploitable surface for most vulnerable-dep classes we use.

## Test plan

- [ ] CI passes (build + test + check)
- [ ] Renovate config validates (ran on next Renovate scan, Monday 9:00 Europe/Warsaw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)