### PR TITLE
chore(docker): pre-build apps in multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ coverage
 logs
 *.tsbuildinfo
 .DS_Store
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.6
+#
+# Multi-stage Dockerfile for Reborn Apps (reborn-task + reborn-notes).
+#
+# Targets:
+#   - reborn-task  : production runtime for reborn-task (port 4200)
+#   - reborn-notes : production runtime for reborn-notes (port 4201)
+#
+# Build examples:
+#   docker build --target reborn-task  -t reborn-task  .
+#   docker build --target reborn-notes -t reborn-notes .
+#
+# Used by docker-compose.prod.yml via `build.target`.
+
+# ─── Base: shared Node + pnpm layer ────────────────────────────
+FROM node:20-alpine AS base
+WORKDIR /app
+RUN npm install -g pnpm@10 --quiet
+
+# ─── Deps: install workspace + build shared packages ───────────
+# Kept separate from app builds so its cache is reused between task/notes.
+FROM base AS deps
+# Dummy DATABASE_URL so `prisma generate` (package postinstall) does not fail.
+ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" \
+    NX_DAEMON=false
+COPY . .
+RUN pnpm install --frozen-lockfile
+# @reborn/database ships as compiled dist (apps resolve via package.json main),
+# so it must be built explicitly before building the SvelteKit apps.
+RUN pnpm nx build @reborn/database
+
+# ─── Build: reborn-task ────────────────────────────────────────
+# SvelteKit bakes PUBLIC_* env vars and NODE_ENV at build time, so each app
+# needs its own build stage with the correct env. PUBLIC_SITE_URL is a build
+# ARG so non-reapps.eu deployments can override via --build-arg.
+FROM deps AS build-task
+ARG PUBLIC_SITE_URL=https://reapps.eu
+ENV NODE_ENV=production \
+    PUBLIC_BASE_PATH=/task \
+    PUBLIC_SITE_URL=${PUBLIC_SITE_URL}
+RUN pnpm nx build reborn-task
+
+# ─── Build: reborn-notes ───────────────────────────────────────
+FROM deps AS build-notes
+ARG PUBLIC_SITE_URL=https://reapps.eu
+ENV NODE_ENV=production \
+    PUBLIC_BASE_PATH=/notes \
+    PUBLIC_SITE_URL=${PUBLIC_SITE_URL}
+RUN pnpm nx build reborn-notes
+
+# ─── Runtime: reborn-task ──────────────────────────────────────
+FROM base AS reborn-task
+ENV NODE_ENV=production
+COPY --from=build-task --chown=node:node /app /app
+USER node
+EXPOSE 4200
+# Prisma migrations run on boot (idempotent). Only reborn-task runs them —
+# reborn-notes shares the same DB schema.
+CMD ["sh", "-c", "pnpm --filter @reborn/database exec prisma migrate deploy && exec node apps/reborn-task/build"]
+
+# ─── Runtime: reborn-notes ─────────────────────────────────────
+FROM base AS reborn-notes
+ENV NODE_ENV=production
+COPY --from=build-notes --chown=node:node /app /app
+USER node
+EXPOSE 4201
+CMD ["node", "apps/reborn-notes/build"]


### PR DESCRIPTION
Container startup drops from ~3 min (pnpm install + nx build in docker-compose command) to <15s (node apps/<app>/build). Eliminates the 502 window on deploy/restart visible in UptimeRobot.

- Dockerfile: base → deps (pnpm install + nx build @reborn/database) → build-task / build-notes (each with own PUBLIC_BASE_PATH + PUBLIC_SITE_URL baked at build time) → reborn-task / reborn-notes runtime (USER node, CMD = node apps/<app>/build; task also runs prisma migrate deploy on boot).
- .dockerignore: add .env / .env.* to prevent leaking secrets into the image via COPY . .

docker-compose.prod.yml (gitignored) switches from command-in-compose to build.target and !reset of dev-only volumes/env_file/command — deployed via SCP per existing workflow.