### PR TITLE
chore(docker): gitignore docker-compose.staging.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,9 @@ patches/
 fix-build.sh
 reborn-apps.code-workspace
 
-# Production config — deployed via SCP, not in repo
+# Production/staging config — deployed via SCP, not in repo
 docker-compose.prod.yml
+docker-compose.staging.yml
 nginx/prod.conf
 
 # Dev Container (Claude Code specific mounts)


### PR DESCRIPTION
## Summary

- Adds `docker-compose.staging.yml` to `.gitignore` — staging override now lives on the VPS only (same pattern as `docker-compose.prod.yml`).
- Updates the adjacent gitignore comment from "Production config" to "Production/staging config".

## Context

Staging was previously set up ad-hoc on the server (pre-Dockerfile era, with `pnpm install` + `nx build` in `command:`). After PR #36 migrated prod to a multi-stage Dockerfile, staging needs the same treatment. The override file differs from prod only in ports, hostnames, and DB name/volume — but it still contains no secrets (those come from `/opt/reborn-apps-staging/.env`), so gitignoring + SCP is the right pattern.

## Test plan

- [x] `docker-compose.staging.yml` deployed to `/opt/reborn-apps-staging/` via SCP
- [x] `docker compose ... -p reborn-staging build` succeeds with Dockerfile targets
- [x] `docker compose ... -p reborn-staging up -d --wait` brings staging up healthy
- [x] Sanity check: `JWT_SECRET` / `REFRESH_TOKEN_SECRET` lengths > 0 in both staging containers
- [x] Login works at https://staging.reapps.eu/task and /notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)