### PR TITLE
chore(docker): exclude pnpm/npm/yarn caches and dev-only files from b…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,47 @@ logs
 .env
 .env.*
 !.env.example
+
+# Cache pnpm/npm/yarn (gdy store-dir jest lokalny — potrafi mieć ~1 GB)
+.pnpm-store
+.npm
+.yarn
+
+# Lokalne dane (na wypadek bind-mountów na hoście)
+.postgres
+
+# Dev / IDE / CI
+.github
+.githooks
+.vscode
+.idea
+.claude
+.editorconfig
+.htmlhintrc
+.htmlvalidate.json
+.prettierrc
+.prettierignore
+eslint.config.mjs
+knip.json
+
+# Dokumentacja i meta — nieużywane w runtime
+docs
+CHANGELOG.md
+README.md
+LICENSE
+SECURITY.md
+CLAUDE.md
+
+# Infrastruktura buildu — kontekst nie potrzebuje siebie samego
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Backupy / archiwa
+*.log
+*.tar
+*.tar.gz
+*.tgz
+*.zip
+*.sql
+*.dump


### PR DESCRIPTION
…uild context

Build context on prod was 1.05 GB, almost entirely a stray .pnpm-store/ directory left on the host (1-2 GB cache). This caused metadataFile writes to /tmp to fail with "no space left on device" after the image was already built, leaving deploys stuck.

Adds .pnpm-store, .npm, .yarn (cache dirs), .postgres (potential bind-mounts), IDE/CI configs, docs and meta files, and Docker infra files themselves to .dockerignore. Expected context size drops from ~1 GB to tens of MB.