### PR TITLE
chore(docker): add localprod compose override for prod-build smoke te…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ reborn-apps.code-workspace
 # Production/staging config — deployed via SCP, not in repo
 docker-compose.prod.yml
 docker-compose.staging.yml
+docker-compose.localprod.yml
 nginx/prod.conf
 
 # Dev Container (Claude Code specific mounts)


### PR DESCRIPTION
…sting on localhost

Adds docker-compose.localprod.yml (gitignored, like prod.yml/staging.yml) — a mirror of docker-compose.prod.yml using the same multi-stage Dockerfile and build targets, but with ORIGIN/PUBLIC_SITE_URL set to http://localhost so it composes cleanly with docker-compose.proxy.yml for end-to-end pre-deploy verification on the developer's machine.

The base docker-compose.yml + proxy.yml runs Vite dev-host with HMR, which is great for iteration but never exercises the production build artifact. The 2026-04-24 incident (env_file: !reset [] silently dropping JWT/SESSION/ REFRESH secrets) would have been caught locally if such a smoke-test path existed. This override fills that gap.

Only .gitignore is committed — the override file itself is local config, matching the existing pattern for prod.yml and staging.yml. Guideline 43 (production-update-workflow) gains a §1.3 documenting when and how to use the smoke test.