### PR TITLE
feat(notes): add per-folder markdown import + clarify root prompt

### DIFF
--- a/apps/reborn-notes/src/lib/components/import/ImportMarkdownToFolderDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/import/ImportMarkdownToFolderDialog.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+  import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Button
+  } from '@reborn/ui';
+  import { Upload } from '@lucide/svelte';
+  import { t } from '$lib/stores/i18n.store';
+  import {
+    importMarkdownFiles,
+    type ImportMarkdownResult
+  } from '$lib/services/export-import.service';
+  import type { DuplicateStrategy } from '$lib/services/import-dedup-utils';
+  import { notesStore } from '$lib/stores/notes.store';
+  import { foldersStore } from '$lib/stores/folders.store';
+  import MarkdownImportStrategyPicker from './MarkdownImportStrategyPicker.svelte';
+
+  let {
+    open = $bindable(false),
+    files,
+    folderId,
+    folderName
+  }: {
+    open: boolean;
+    files: File[] | null;
+    folderId: string | null;
+    folderName: string;
+  } = $props();
+
+  let strategy = $state<DuplicateStrategy>('rename');
+  let importing = $state(false);
+  let result = $state<ImportMarkdownResult | null>(null);
+
+  // Reset internal state every time the dialog closes — the parent decides
+  // when to open it again (with fresh files / target).
+  $effect(() => {
+    if (!open) {
+      strategy = 'rename';
+      importing = false;
+      result = null;
+    }
+  });
+
+  async function runImport() {
+    if (!files || !folderId) return;
+    importing = true;
+    result = null;
+    try {
+      const r = await importMarkdownFiles(files, folderId, strategy);
+      result = r;
+      await Promise.all([notesStore.refresh(), foldersStore.refresh()]);
+    } catch (err: unknown) {
+      result = {
+        imported: 0,
+        duplicatesSkipped: 0,
+        duplicatesOverwritten: 0,
+        duplicatesRenamed: 0,
+        strippedCount: 0,
+        errors: [err instanceof Error ? err.message : 'Import failed']
+      };
+    } finally {
+      importing = false;
+    }
+  }
+
+  function close() {
+    open = false;
+  }
+</script>
+
+<Dialog bind:open>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>
+        {$t('folders.import_markdown.dialog_title', { values: { name: folderName } })}
+      </DialogTitle>
+      <DialogDescription>
+        {$t('folders.import_markdown.dialog_description')}
+      </DialogDescription>
+    </DialogHeader>
+
+    {#if files && !result}
+      <MarkdownImportStrategyPicker
+        count={files.length}
+        bind:strategy
+        promptVariant="folder"
+        radioGroupName="folder-md-import-strategy"
+      />
+    {/if}
+
+    {#if result}
+      <div
+        class="rounded-md px-3 py-2 text-xs space-y-1
+        {result.errors.length === 0
+          ? 'bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-400'
+          : 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'}"
+      >
+        {#if result.imported > 0}
+          <p>
+            {$t('settings_page.export_import.imported_count', {
+              values: { count: result.imported }
+            })}
+          </p>
+        {/if}
+        {#if result.duplicatesOverwritten > 0}
+          <p class="text-muted-foreground">
+            {$t('settings_page.export_import.dedup_count_overwritten', {
+              values: { count: result.duplicatesOverwritten }
+            })}
+          </p>
+        {/if}
+        {#if result.duplicatesRenamed > 0}
+          <p class="text-muted-foreground">
+            {$t('settings_page.export_import.dedup_count_renamed', {
+              values: { count: result.duplicatesRenamed }
+            })}
+          </p>
+        {/if}
+        {#if result.duplicatesSkipped > 0}
+          <p class="text-muted-foreground">
+            {$t('settings_page.export_import.dedup_count_skipped', {
+              values: { count: result.duplicatesSkipped }
+            })}
+          </p>
+        {/if}
+        {#if result.strippedCount > 0}
+          <p>
+            {$t('settings_page.export_import.unsafe_content_stripped', {
+              values: { count: result.strippedCount }
+            })}
+          </p>
+        {/if}
+        {#each result.errors as err}
+          <p>{err}</p>
+        {/each}
+      </div>
+    {/if}
+
+    <DialogFooter>
+      {#if !result}
+        <Button variant="outline" onclick={close} disabled={importing}>
+          {$t('settings_page.export_import.cancel')}
+        </Button>
+        <Button onclick={runImport} disabled={importing || !files || files.length === 0}>
+          <Upload class="mr-1.5 h-3.5 w-3.5" />
+          {importing
+            ? $t('settings_page.export_import.importing')
+            : $t('settings_page.export_import.dedup_start')}
+        </Button>
+      {:else}
+        <Button onclick={close}>
+          {$t('folders.import_markdown.dialog_close')}
+        </Button>
+      {/if}
+    </DialogFooter>
+  </DialogContent>
+</Dialog>

--- a/apps/reborn-notes/src/lib/components/import/MarkdownImportStrategyPicker.svelte
+++ b/apps/reborn-notes/src/lib/components/import/MarkdownImportStrategyPicker.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { t } from '$lib/stores/i18n.store';
+  import type { DuplicateStrategy } from '$lib/services/import-dedup-utils';
+
+  let {
+    count,
+    strategy = $bindable<DuplicateStrategy>('rename'),
+    promptVariant = 'root',
+    radioGroupName = 'md-strategy'
+  }: {
+    count: number;
+    strategy?: DuplicateStrategy;
+    // 'root'   — files land in "All notes" (Settings → Import .md)
+    // 'folder' — files land in a specific folder (folder context, vault import)
+    promptVariant?: 'root' | 'folder';
+    radioGroupName?: string;
+  } = $props();
+
+  const promptKey = $derived(
+    promptVariant === 'folder'
+      ? 'settings_page.export_import.dedup_prompt_folder'
+      : 'settings_page.export_import.dedup_prompt_root'
+  );
+</script>
+
+<div class="space-y-3">
+  <p class="text-xs font-medium">
+    {$t('settings_page.export_import.dedup_files_found', { values: { count } })}
+  </p>
+  <p class="text-xs text-muted-foreground">
+    {$t(promptKey)}
+  </p>
+  <div class="space-y-2">
+    {#each ['rename', 'skip', 'overwrite'] as opt (opt)}
+      <label class="flex items-start gap-2 text-xs cursor-pointer">
+        <input
+          type="radio"
+          name={radioGroupName}
+          value={opt}
+          bind:group={strategy}
+          class="mt-0.5"
+        />
+        <span>
+          <span class="font-medium">
+            {$t(`settings_page.export_import.dedup_${opt}`)}
+          </span>
+          <span class="block text-muted-foreground">
+            {$t(`settings_page.export_import.dedup_${opt}_desc`)}
+          </span>
+        </span>
+      </label>
+    {/each}
+  </div>
+</div>

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -13,7 +13,8 @@
     MoreHorizontal,
     FolderPlus,
     Pencil,
-    Trash2
+    Trash2,
+    Upload
   } from '@lucide/svelte';
   import {
     Button,
@@ -34,6 +35,7 @@
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
   import type { DeleteFolderMode } from '$lib/services/folder.service';
   import DeleteFolderDialog from './DeleteFolderDialog.svelte';
+  import ImportMarkdownToFolderDialog from '$lib/components/import/ImportMarkdownToFolderDialog.svelte';
   import FolderTree from './FolderTree.svelte';
 
   let {
@@ -141,6 +143,42 @@
     }
     folderToDelete = null;
   }
+
+  // ── Import .md to folder ────────────────────────────────────────
+  let importDialogOpen = $state(false);
+  let importTargetFolder = $state<FolderWithChildren | null>(null);
+  let importPendingFiles = $state<File[] | null>(null);
+  let importFileInputEl = $state<HTMLInputElement | null>(null);
+
+  function handleImportHere(folder: FolderWithChildren, e?: Event) {
+    e?.stopPropagation();
+    menuOpenId = null;
+    folderActionSheetOpen = false;
+    importTargetFolder = folder;
+    // Reset value so re-selecting the same files re-fires `change`.
+    if (importFileInputEl) importFileInputEl.value = '';
+    importFileInputEl?.click();
+  }
+
+  function handleImportFilesSelected(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const files = Array.from(input.files ?? []);
+    input.value = '';
+    if (files.length === 0 || !importTargetFolder) {
+      importTargetFolder = null;
+      return;
+    }
+    importPendingFiles = files;
+    importDialogOpen = true;
+  }
+
+  $effect(() => {
+    // When dialog closes, drop the file/folder context (parent of source of truth).
+    if (!importDialogOpen) {
+      importPendingFiles = null;
+      importTargetFolder = null;
+    }
+  });
 
   // ── Drag & Drop ─────────────────────────────────────────────────
   let dragOverId = $state<string | null>(null);
@@ -338,6 +376,10 @@
                   <Pencil class="h-3.5 w-3.5" />
                   {$t('folders.rename')}
                 </DropdownMenuItem>
+                <DropdownMenuItem onclick={(e) => handleImportHere(folder, e)}>
+                  <Upload class="h-3.5 w-3.5" />
+                  {$t('folders.import_markdown.action')}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   class="text-destructive focus:text-destructive"
@@ -396,6 +438,14 @@
       </Button>
       <Button
         variant="ghost"
+        class="w-full justify-start"
+        onclick={() => activeMenuFolder && handleImportHere(activeMenuFolder)}
+      >
+        <Upload class="mr-2 h-4 w-4" />
+        {$t('folders.import_markdown.action')}
+      </Button>
+      <Button
+        variant="ghost"
         class="w-full justify-start text-destructive hover:text-destructive"
         onclick={() => activeMenuFolder && handleDelete(activeMenuFolder)}
       >
@@ -411,4 +461,21 @@
   folderId={folderToDelete?.id ?? null}
   folderName={folderToDelete?.name ?? ''}
   onConfirm={confirmDeleteFolder}
+/>
+
+<!-- Hidden file input for "Import .md tutaj" — triggered from the menu -->
+<input
+  bind:this={importFileInputEl}
+  type="file"
+  accept=".md,text/markdown"
+  multiple
+  class="hidden"
+  onchange={handleImportFilesSelected}
+/>
+
+<ImportMarkdownToFolderDialog
+  bind:open={importDialogOpen}
+  files={importPendingFiles}
+  folderId={importTargetFolder?.id ?? null}
+  folderName={importTargetFolder?.name ?? ''}
 />

--- a/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
@@ -36,6 +36,7 @@
   } from '$lib/services/export-import.service';
   import type { DuplicateStrategy } from '$lib/services/import-dedup-utils';
   import { notesStore } from '$lib/stores/notes.store';
+  import MarkdownImportStrategyPicker from '$lib/components/import/MarkdownImportStrategyPicker.svelte';
   import { createLogger } from '@reborn/utils';
 
   const logger = createLogger('notes:import-export');
@@ -531,35 +532,12 @@
 
           {#if pendingMdFiles}
             <div class="mt-3 space-y-3 rounded-md border border-primary/40 bg-background p-3">
-              <p class="text-xs font-medium">
-                {$t('settings_page.export_import.dedup_files_found', {
-                  values: { count: pendingMdFiles.length }
-                })}
-              </p>
-              <p class="text-xs text-muted-foreground">
-                {$t('settings_page.export_import.dedup_prompt')}
-              </p>
-              <div class="space-y-2">
-                {#each ['rename', 'skip', 'overwrite'] as opt (opt)}
-                  <label class="flex items-start gap-2 text-xs cursor-pointer">
-                    <input
-                      type="radio"
-                      name="md-strategy"
-                      value={opt}
-                      bind:group={pendingMdStrategy}
-                      class="mt-0.5"
-                    />
-                    <span>
-                      <span class="font-medium">
-                        {$t(`settings_page.export_import.dedup_${opt}`)}
-                      </span>
-                      <span class="block text-muted-foreground">
-                        {$t(`settings_page.export_import.dedup_${opt}_desc`)}
-                      </span>
-                    </span>
-                  </label>
-                {/each}
-              </div>
+              <MarkdownImportStrategyPicker
+                count={pendingMdFiles.length}
+                bind:strategy={pendingMdStrategy}
+                promptVariant="root"
+                radioGroupName="md-strategy"
+              />
               <div class="flex gap-2">
                 <button
                   type="button"
@@ -660,35 +638,12 @@
 
           {#if pendingFolderFiles}
             <div class="mt-3 space-y-3 rounded-md border border-primary/40 bg-background p-3">
-              <p class="text-xs font-medium">
-                {$t('settings_page.export_import.dedup_files_found', {
-                  values: { count: pendingFolderMdCount }
-                })}
-              </p>
-              <p class="text-xs text-muted-foreground">
-                {$t('settings_page.export_import.dedup_prompt')}
-              </p>
-              <div class="space-y-2">
-                {#each ['rename', 'skip', 'overwrite'] as opt (opt)}
-                  <label class="flex items-start gap-2 text-xs cursor-pointer">
-                    <input
-                      type="radio"
-                      name="folder-strategy"
-                      value={opt}
-                      bind:group={pendingFolderStrategy}
-                      class="mt-0.5"
-                    />
-                    <span>
-                      <span class="font-medium">
-                        {$t(`settings_page.export_import.dedup_${opt}`)}
-                      </span>
-                      <span class="block text-muted-foreground">
-                        {$t(`settings_page.export_import.dedup_${opt}_desc`)}
-                      </span>
-                    </span>
-                  </label>
-                {/each}
-              </div>
+              <MarkdownImportStrategyPicker
+                count={pendingFolderMdCount}
+                bind:strategy={pendingFolderStrategy}
+                promptVariant="folder"
+                radioGroupName="folder-strategy"
+              />
               <div class="flex gap-2">
                 <button
                   type="button"

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -132,6 +132,12 @@
       "confirm_cascade": "Ordner und Notizen löschen",
       "cancel": "Abbrechen"
     },
+    "import_markdown": {
+      "action": ".md hierher importieren",
+      "dialog_title": ".md in „{name}“ importieren",
+      "dialog_description": "Die ausgewählten Markdown-Dateien werden in diesen Ordner importiert.",
+      "dialog_close": "Schließen"
+    },
     "errors": {
       "create_failed": "Ordner konnte nicht erstellt werden",
       "update_failed": "Ordner konnte nicht aktualisiert werden",
@@ -531,7 +537,8 @@
       "folder_import_skipped_too_large": "{count} Datei(en) größer als 500 KB übersprungen",
       "folder_import_skipped_hidden": "{count} Datei(en) in versteckten Ordnern übersprungen (.obsidian, .trash usw.)",
       "dedup_files_found": "{count} Notiz(en) zum Importieren gefunden",
-      "dedup_prompt": "Was soll passieren, wenn eine Notiz mit demselben Namen bereits im selben Ordner existiert?",
+      "dedup_prompt_root": "Was soll passieren, wenn eine Notiz mit demselben Namen bereits in „Alle Notizen“ existiert?",
+      "dedup_prompt_folder": "Was soll passieren, wenn eine Notiz mit demselben Namen bereits im selben Ordner existiert?",
       "dedup_rename": "Beide Kopien behalten",
       "dedup_rename_desc": "Als neue Notiz mit Suffix importieren (z. B. „Notiz (2)\")",
       "dedup_skip": "Duplikate überspringen",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -132,6 +132,12 @@
       "confirm_cascade": "Delete folder and notes",
       "cancel": "Cancel"
     },
+    "import_markdown": {
+      "action": "Import .md here",
+      "dialog_title": "Import .md into \"{name}\"",
+      "dialog_description": "The selected Markdown files will be imported into this folder.",
+      "dialog_close": "Close"
+    },
     "errors": {
       "create_failed": "Failed to create folder",
       "update_failed": "Failed to update folder",
@@ -531,7 +537,8 @@
       "folder_import_skipped_too_large": "Skipped {count} file(s) larger than 500 KB",
       "folder_import_skipped_hidden": "Skipped {count} file(s) in hidden folders (.obsidian, .trash, etc.)",
       "dedup_files_found": "{count} note(s) ready to import",
-      "dedup_prompt": "What should happen when a note with the same name already exists in the same folder?",
+      "dedup_prompt_root": "What should happen when a note with the same name already exists in \"All Notes\"?",
+      "dedup_prompt_folder": "What should happen when a note with the same name already exists in the same folder?",
       "dedup_rename": "Keep both copies",
       "dedup_rename_desc": "Import as a new note with a suffix (e.g. \"Note (2)\")",
       "dedup_skip": "Skip duplicates",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -132,6 +132,12 @@
       "confirm_cascade": "Eliminar carpeta y notas",
       "cancel": "Cancelar"
     },
+    "import_markdown": {
+      "action": "Importar .md aquí",
+      "dialog_title": "Importar .md en «{name}»",
+      "dialog_description": "Los archivos Markdown seleccionados se importarán a esta carpeta.",
+      "dialog_close": "Cerrar"
+    },
     "errors": {
       "create_failed": "Error al crear la carpeta",
       "update_failed": "Error al actualizar la carpeta",
@@ -531,7 +537,8 @@
       "folder_import_skipped_too_large": "{count} archivo(s) de más de 500 KB omitido(s)",
       "folder_import_skipped_hidden": "{count} archivo(s) en carpetas ocultas omitido(s) (.obsidian, .trash, etc.)",
       "dedup_files_found": "{count} nota(s) listas para importar",
-      "dedup_prompt": "¿Qué hacer cuando ya existe una nota con el mismo nombre en la misma carpeta?",
+      "dedup_prompt_root": "¿Qué hacer cuando ya existe una nota con el mismo nombre en «Todas las notas»?",
+      "dedup_prompt_folder": "¿Qué hacer cuando ya existe una nota con el mismo nombre en la misma carpeta?",
       "dedup_rename": "Conservar ambas copias",
       "dedup_rename_desc": "Importar como nueva nota con sufijo (p. ej. «Nota (2)»)",
       "dedup_skip": "Omitir duplicados",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -132,6 +132,12 @@
       "confirm_cascade": "Supprimer le dossier et les notes",
       "cancel": "Annuler"
     },
+    "import_markdown": {
+      "action": "Importer .md ici",
+      "dialog_title": "Importer .md dans « {name} »",
+      "dialog_description": "Les fichiers Markdown sélectionnés seront importés dans ce dossier.",
+      "dialog_close": "Fermer"
+    },
     "errors": {
       "create_failed": "Échec de la création du dossier",
       "update_failed": "Échec de la mise à jour du dossier",
@@ -531,7 +537,8 @@
       "folder_import_skipped_too_large": "{count} fichier(s) de plus de 500 Ko ignoré(s)",
       "folder_import_skipped_hidden": "{count} fichier(s) dans des dossiers cachés ignoré(s) (.obsidian, .trash, etc.)",
       "dedup_files_found": "{count} note(s) prête(s) à importer",
-      "dedup_prompt": "Que faire lorsqu'une note du même nom existe déjà dans le même dossier ?",
+      "dedup_prompt_root": "Que faire lorsqu'une note du même nom existe déjà dans « Toutes les notes » ?",
+      "dedup_prompt_folder": "Que faire lorsqu'une note du même nom existe déjà dans le même dossier ?",
       "dedup_rename": "Conserver les deux copies",
       "dedup_rename_desc": "Importer comme nouvelle note avec un suffixe (par ex. « Note (2) »)",
       "dedup_skip": "Ignorer les doublons",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -132,6 +132,12 @@
       "confirm_cascade": "Usuń folder i notatki",
       "cancel": "Anuluj"
     },
+    "import_markdown": {
+      "action": "Importuj .md tutaj",
+      "dialog_title": "Importuj .md do „{name}”",
+      "dialog_description": "Wybrane pliki Markdown zostaną zaimportowane do tego folderu.",
+      "dialog_close": "Zamknij"
+    },
     "errors": {
       "create_failed": "Nie udało się utworzyć folderu",
       "update_failed": "Nie udało się zaktualizować folderu",
@@ -531,7 +537,8 @@
       "folder_import_skipped_too_large": "Pominięto {count} plików przekraczających 500 KB",
       "folder_import_skipped_hidden": "Pominięto {count} plików z ukrytych folderów (.obsidian, .trash itp.)",
       "dedup_files_found": "Znaleziono {count} notatek do importu",
-      "dedup_prompt": "Co zrobić, gdy notatka o tej samej nazwie już istnieje w tym samym folderze?",
+      "dedup_prompt_root": "Co zrobić, gdy notatka o tej samej nazwie już istnieje w „Wszystkich notatkach”?",
+      "dedup_prompt_folder": "Co zrobić, gdy notatka o tej samej nazwie już istnieje w tym samym folderze?",
       "dedup_rename": "Zachowaj obie kopie",
       "dedup_rename_desc": "Importuj jako nową notatkę z sufiksem (np. „Notatka (2)\")",
       "dedup_skip": "Pomiń duplikat",


### PR DESCRIPTION
- Sidebar folder dropdown (and mobile sheet) gets a new "Import .md here" action that imports selected files directly into the clicked folder via a dedicated dialog. Previously the only single-file md import lived in Settings and silently landed in "All Notes".
- Extract MarkdownImportStrategyPicker as a shared component reused by Settings (root + folder vault) and the new dialog — single source of truth for the file count + dedup radio UI.
- Split dedup_prompt translation key into _root / _folder variants (PL/EN/DE/FR/ES). The previous single key wrongly implied folder context for the Settings → Markdown import that lands at root.