### PR TITLE
fix(notes): switch to all-notes view when creating from trash + use e…

### DIFF
--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -234,7 +234,7 @@
     >
       <Trash2 class="h-3.5 w-3.5" />
       {#if !isMobile}
-        {$t('notes.delete')}
+        {$t('notes.delete_permanently')}
       {/if}
     </button>
   {/if}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy, untrack } from 'svelte';
+  import { onMount, onDestroy, tick, untrack } from 'svelte';
   import { beforeNavigate } from '$app/navigation';
   import { base } from '$app/paths';
   import { SvelteSet } from 'svelte/reactivity';
@@ -458,6 +458,16 @@
 
   // ── New note ─────────────────────────────────────────────────────
   async function handleNewNote() {
+    // Trash/starred/tags filter out a freshly created note (no deletion / star /
+    // tag yet), so the user would create a note and see nothing. Switch to "All
+    // notes" first and await tick so the section $effect drives the store filter
+    // before we call create() + refresh().
+    if (activeSection === 'trash' || activeSection === 'starred' || activeSection === 'tags') {
+      activeSection = 'all';
+      activeFolderId = undefined;
+      activeTagId = null;
+      await tick();
+    }
     const date = new Date().toISOString().slice(0, 10);
     const settings = await getSettings();
     const prefix = settings?.language === 'pl' ? 'Notatka' : 'Note';


### PR DESCRIPTION
…xisting delete_permanently i18n key

When the user clicked the new-note icon while in the Trash (or Starred / Tags) view, the freshly created note was filtered out by the active section filter and appeared to vanish. handleNewNote now resets activeSection to 'all' (clearing folder/tag selection) and awaits tick before calling notesStore.create(), so the section $effect rewires the store filter via setFolder(undefined) before refresh() runs.

The trash-mode header button referenced notes.delete, which did not exist in any of the 5 locale files (en/pl/de/fr/es), causing a [svelte-i18n] warning and showing the raw key in the UI. Switched to the existing notes.delete_permanently key, which is semantically correct (the button calls onpermanentdelete) and already translated in every locale.