### PR TITLE
fix(notes): order folder/tag pushes before notes during folder import

### DIFF
--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -900,7 +900,10 @@ async function findOrCreateFolderByPath(
       parentId = existing.id;
       continue;
     }
-    const newId = await FolderService.createFolder(segment, parentId);
+    // skipSync: folder import bulk-pushes everything via pushPendingItems()
+    // at the end so folders are guaranteed on the server before notes that
+    // reference them — otherwise the server's folder_id FK check returns 404.
+    const newId = await FolderService.createFolder(segment, parentId, { skipSync: true });
     lookup.push({ id: newId, name: segment, parent_id: parentId });
     counter.count++;
     parentId = newId;
@@ -920,7 +923,8 @@ async function findOrCreateTagByName(
   const lower = tagName.toLowerCase();
   const existing = lookup.find((t) => t.name.toLowerCase() === lower);
   if (existing) return existing.id;
-  const newId = await TagService.createTag(tagName);
+  // skipSync: see findOrCreateFolderByPath — bulk push at end of importFolder().
+  const newId = await TagService.createTag(tagName, undefined, { skipSync: true });
   lookup.push({ id: newId, name: tagName });
   counter.count++;
   return newId;
@@ -1055,7 +1059,6 @@ export async function importFolder(
   // 7. Import each note via the duplicate strategy helper.
   //    skipSync: true — avoid per-note pushNote/pushNoteUpdate race condition.
   //    Bulk push happens after the loop (step 7b).
-  const importedNoteIds: string[] = [];
   for (const file of sizedFiles) {
     try {
       const raw = await file.text();
@@ -1087,7 +1090,7 @@ export async function importFolder(
         }
       }
 
-      const { outcome, noteId } = await applyDuplicateStrategy({
+      const { outcome } = await applyDuplicateStrategy({
         baseTitle: title,
         content: sanitizedContent,
         folderId,
@@ -1104,7 +1107,6 @@ export async function importFolder(
         if (outcome === 'overwritten') result.duplicatesOverwritten++;
         else if (outcome === 'renamed') result.duplicatesRenamed++;
         result.imported++;
-        importedNoteIds.push(noteId);
       }
     } catch (e: unknown) {
       result.errors.push(`${file.name}: ${e instanceof Error ? e.message : 'Unknown error'}`);
@@ -1112,11 +1114,13 @@ export async function importFolder(
   }
   result.tagsCreated = tagsCounter.count;
 
-  // 7b. Bulk-push all imported notes (latest version from IndexedDB, with tags).
-  for (const noteId of importedNoteIds) {
-    const note = await noteStore.get(noteId);
-    if (note) pushNote(note);
-  }
+  // 7b. Trigger one ordered bulk push (folders → tags → notes). All items in
+  //     this import were saved with sync_status='pending' (skipSync on every
+  //     create call), so pushPendingItems() picks them up and orders pushes
+  //     correctly. Without this ordering, notes would POST before their parent
+  //     folders, causing the server's folder_id FK check to return 404 and
+  //     forcing the client into 1-2s retry backoff per note.
+  void pushPendingItems();
 
   // 8. Rebuild in-memory title index so imports are visible immediately.
   try {

--- a/apps/reborn-notes/src/lib/services/folder-push-order.spec.ts
+++ b/apps/reborn-notes/src/lib/services/folder-push-order.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import type { FolderEncrypted } from '@reborn/types';
+import { buildFolderLayers } from './folder-push-order';
+
+function f(id: string, parent_id: string | null = null): FolderEncrypted {
+  return {
+    id,
+    user_id: 'u',
+    parent_id: parent_id ?? undefined,
+    name_encrypted: 'enc',
+    order_index: 0,
+    is_archived: false,
+    sync_status: 'pending',
+    sync_version: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z'
+  };
+}
+
+function ids(layer: FolderEncrypted[]): string[] {
+  return layer.map((x) => x.id).sort();
+}
+
+describe('buildFolderLayers', () => {
+  it('empty → no layers', () => {
+    expect(buildFolderLayers([])).toEqual([]);
+  });
+
+  it('flat list of roots → single layer', () => {
+    const layers = buildFolderLayers([f('a'), f('b'), f('c')]);
+    expect(layers).toHaveLength(1);
+    expect(ids(layers[0])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('two-level tree → two layers (root before child)', () => {
+    const layers = buildFolderLayers([f('child', 'root'), f('root')]);
+    expect(layers).toHaveLength(2);
+    expect(ids(layers[0])).toEqual(['root']);
+    expect(ids(layers[1])).toEqual(['child']);
+  });
+
+  it('three-level chain → three layers', () => {
+    const layers = buildFolderLayers([f('c', 'b'), f('b', 'a'), f('a')]);
+    expect(layers).toHaveLength(3);
+    expect(ids(layers[0])).toEqual(['a']);
+    expect(ids(layers[1])).toEqual(['b']);
+    expect(ids(layers[2])).toEqual(['c']);
+  });
+
+  it('siblings group into the same layer', () => {
+    const layers = buildFolderLayers([
+      f('root'),
+      f('a', 'root'),
+      f('b', 'root'),
+      f('c', 'root')
+    ]);
+    expect(layers).toHaveLength(2);
+    expect(ids(layers[0])).toEqual(['root']);
+    expect(ids(layers[1])).toEqual(['a', 'b', 'c']);
+  });
+
+  it("parent already on server (not in pending) → child goes to layer 0", () => {
+    // Parent 'srv' isn't in the pending list — server already has it. Child
+    // can push immediately without waiting for any other layer.
+    const layers = buildFolderLayers([f('child', 'srv')]);
+    expect(layers).toHaveLength(1);
+    expect(ids(layers[0])).toEqual(['child']);
+  });
+
+  it('mixed: roots, server-parented, and nested all in one batch', () => {
+    const layers = buildFolderLayers([
+      f('root1'), // layer 0
+      f('serverChild', 'serverParent'), // layer 0 (parent not pending)
+      f('a', 'root1'), // layer 1
+      f('grand', 'a') // layer 2
+    ]);
+    expect(layers).toHaveLength(3);
+    expect(ids(layers[0])).toEqual(['root1', 'serverChild']);
+    expect(ids(layers[1])).toEqual(['a']);
+    expect(ids(layers[2])).toEqual(['grand']);
+  });
+
+  it('every folder appears exactly once across layers', () => {
+    const input = [
+      f('root'),
+      f('a', 'root'),
+      f('b', 'root'),
+      f('c', 'a'),
+      f('d', 'b'),
+      f('e', 'c')
+    ];
+    const layers = buildFolderLayers(input);
+    const flat = layers.flat().map((x) => x.id).sort();
+    expect(flat).toEqual(['a', 'b', 'c', 'd', 'e', 'root']);
+  });
+
+  it('cycle: leftovers are appended as a final layer instead of dropped', () => {
+    // Synthetic cycle a→b→a. Cannot occur with valid server-side data, but
+    // the helper must not loop forever or silently drop folders.
+    const layers = buildFolderLayers([f('a', 'b'), f('b', 'a')]);
+    expect(layers).toHaveLength(1);
+    expect(ids(layers[0])).toEqual(['a', 'b']);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/folder-push-order.ts
+++ b/apps/reborn-notes/src/lib/services/folder-push-order.ts
@@ -1,0 +1,45 @@
+import type { FolderEncrypted } from '@reborn/types';
+
+/**
+ * Group folders into BFS layers so pushes go parent-before-child.
+ *
+ * The server's `POST /api/folders` handler rejects with 404 "Parent folder
+ * not found" when `parent_id` references a folder that hasn't landed yet.
+ * Flat parallel push (`Promise.allSettled([...folders.map()])`) triggers a
+ * wave of 404s + retry-backoff whenever a vault import creates a deeply
+ * nested hierarchy from scratch.
+ *
+ * Layering rule:
+ *   - Layer 0: folders with no `parent_id`, OR `parent_id` not present in
+ *              the pending set (parent already on the server — safe).
+ *   - Layer N: folders whose parent landed in layers 0..N-1.
+ *
+ * Within a layer, siblings are independent and push in parallel; awaiting
+ * between layers guarantees children see their parents server-side.
+ *
+ * Cycles cannot exist in valid folder data (server enforces a tree), but if
+ * one does sneak in via corruption, leftover folders get appended as a final
+ * layer so the server can reject them rather than the client silently
+ * dropping them on the floor.
+ */
+export function buildFolderLayers(folders: FolderEncrypted[]): FolderEncrypted[][] {
+  if (folders.length === 0) return [];
+  const pendingIds = new Set(folders.map((f) => f.id));
+  const placed = new Set<string>();
+  const layers: FolderEncrypted[][] = [];
+
+  while (placed.size < folders.length) {
+    const layer = folders.filter(
+      (f) =>
+        !placed.has(f.id) &&
+        (!f.parent_id || !pendingIds.has(f.parent_id) || placed.has(f.parent_id))
+    );
+    if (layer.length === 0) {
+      layers.push(folders.filter((f) => !placed.has(f.id)));
+      break;
+    }
+    layers.push(layer);
+    for (const f of layer) placed.add(f.id);
+  }
+  return layers;
+}

--- a/apps/reborn-notes/src/lib/services/folder.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder.service.ts
@@ -83,7 +83,14 @@ export async function getFolderTree(): Promise<FolderWithChildren[]> {
   return Promise.all(all.map(convertNode as never));
 }
 
-export async function createFolder(name: string, parentId?: string): Promise<string> {
+// `options.skipSync` defers the network push to the caller — used by batch
+// importers (folder/vault import) that must order folder pushes BEFORE note
+// pushes to avoid the server's `folder_id` FK check returning 404.
+export async function createFolder(
+  name: string,
+  parentId?: string,
+  options?: { skipSync?: boolean }
+): Promise<string> {
   const data: Omit<FolderEncrypted, 'id' | 'order_index' | 'created_at' | 'updated_at'> = {
     user_id: getUserId(),
     name_encrypted: await encodeName(name.trim()),
@@ -94,7 +101,7 @@ export async function createFolder(name: string, parentId?: string): Promise<str
   };
   const id = await folderOperations.createFolder(data);
   const created = await folderStore.get(id);
-  if (created)
+  if (created && !options?.skipSync)
     pushFolder({
       id: created.id,
       name_encrypted: created.name_encrypted,

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -239,4 +239,71 @@ describe('notes-sync — regression (offline data loss)', () => {
     expect(pullNotes).toMatch(/noteStore\.deleteMany/);
     expect(pullNotes).toMatch(/sync_status.*===.*'synced'/);
   });
+
+  it('pushPendingItems pushes folders BFS-by-layer (parent before child)', () => {
+    // Server's POST /api/folders FK-checks parent_id and 404s if the parent
+    // isn't on the server yet. Flat Promise.allSettled would 404-spam mid-batch
+    // on nested vault imports — pushPendingItems must use buildFolderLayers
+    // and await each layer before starting the next.
+    const src = readSource('./notes-sync.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function pushPendingItems'),
+      src.indexOf('/** Retry a function with exponential backoff')
+    );
+
+    // Must consume the layered helper.
+    expect(fn).toMatch(/buildFolderLayers\s*\(\s*pendingFolders\s*\)/);
+
+    // The folder push must live inside `for (const layer of …)` with an
+    // `await Promise.allSettled` per iteration. Loose match: `for` block
+    // appears, and within the file, the `/api/folders` POST is reachable
+    // only through that loop.
+    expect(fn).toMatch(/for\s*\(\s*const\s+layer\s+of\s+buildFolderLayers/);
+
+    // Sanity: the old flat folder-and-tag combined Promise.allSettled is gone.
+    // (If both were in one settle, layering wouldn't matter.)
+    const foldersPostIdx = fn.indexOf("'/api/folders'") >= 0
+      ? fn.indexOf("'/api/folders'")
+      : fn.indexOf('/api/folders');
+    const tagsPostIdx = fn.indexOf("'/api/tags'") >= 0
+      ? fn.indexOf("'/api/tags'")
+      : fn.indexOf('/api/tags');
+    expect(foldersPostIdx).toBeGreaterThan(-1);
+    expect(tagsPostIdx).toBeGreaterThan(-1);
+    // Between folders POST and tags POST there must be a `})` closing the
+    // folder for-loop, then a fresh `await Promise.allSettled` for tags.
+    const between = fn.slice(foldersPostIdx, tagsPostIdx);
+    expect(between).toMatch(/await\s+Promise\.allSettled/);
+  });
+
+  it('importFolder bulk-pushes via pushPendingItems, not per-note pushNote', () => {
+    // Without ordering, notes POST before their just-created folders land,
+    // and the server's folder_id FK check returns 404. The fix routes every
+    // create through skipSync and finishes with one ordered pushPendingItems().
+    const src = readSource('./export-import.service.ts');
+
+    // Helpers (findOrCreateFolderByPath / findOrCreateTagByName) live above
+    // importFolder. Scope the skipSync checks to that helper region so we
+    // don't accidentally match unrelated callsites.
+    const helpersStart = src.indexOf('async function findOrCreateFolderByPath');
+    const importFolderStart = src.indexOf('export async function importFolder');
+    expect(helpersStart).toBeGreaterThan(-1);
+    expect(importFolderStart).toBeGreaterThan(helpersStart);
+    const helpers = src.slice(helpersStart, importFolderStart);
+
+    expect(helpers).toMatch(
+      /FolderService\.createFolder\([^)]*\{\s*skipSync:\s*true\s*\}\s*\)/
+    );
+    expect(helpers).toMatch(
+      /TagService\.createTag\([^)]*\{\s*skipSync:\s*true\s*\}\s*\)/
+    );
+
+    // No direct pushNote/pushFolder/pushTag calls inside importFolder —
+    // pushPendingItems() is the single push path so order is enforced.
+    const importFolder = src.slice(importFolderStart);
+    expect(importFolder).not.toMatch(/\bpushNote\s*\(/);
+    expect(importFolder).not.toMatch(/\bpushFolder\s*\(/);
+    expect(importFolder).not.toMatch(/\bpushTag\s*\(/);
+    expect(importFolder).toMatch(/pushPendingItems\s*\(/);
+  });
 });

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -45,6 +45,7 @@ import { authFetch } from '$lib/utils/auth-fetch';
 import { validateEncryptedPayload } from '@reborn/crypto';
 import { refreshQuota } from '$lib/stores/storage-quota.store';
 import { connectivityStore } from '$lib/stores/connectivity.store';
+import { buildFolderLayers } from './folder-push-order';
 
 const logger = createLogger('Notes-Sync');
 
@@ -508,38 +509,50 @@ export async function pushPendingItems(): Promise<void> {
     `Pushing pending items: ${pendingFolders.length} folders, ${pendingTags.length} tags, ${pendingNotes.length} notes, ${pendingArchivedNotes.length} archived notes`
   );
 
-  // Push folders & tags first (notes reference them)
-  await Promise.allSettled([
-    ...pendingFolders.map((f) =>
-      serializePerEntity('folder', f.id, () =>
-      pushSilently(async (idempotencyKey) => {
-        const pushedFields = {
-          name_encrypted: f.name_encrypted,
-          parent_id: f.parent_id ?? null,
-          order_index: f.order_index
-        };
-        const payload = { id: f.id, ...pushedFields, created_at: f.created_at };
-        validateEncryptedPayload(payload as Record<string, unknown>);
-        const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders`, {
-          method: 'POST',
-          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-          body: JSON.stringify(payload)
-        });
-        if (!res.ok) throw new Error(`POST /api/folders: ${res.status}`);
-        const { data: resData } = await res.json();
-        const current = await folderStore.get(f.id);
-        if (current) {
-          const stillDirty = pushedFieldsDiffer(current, pushedFields);
-          await folderStore.save({
-            ...current,
-            sync_status: stillDirty ? 'pending' : 'synced',
-            sync_version: resData?.sync_version ?? 1
-          });
-        }
-      })
+  // Push folders BFS-by-layer so parents land before children. Server's
+  // POST /api/folders rejects with 404 "Parent folder not found" when
+  // parent_id references a folder not yet on the server — flat
+  // Promise.allSettled would 404-spam mid-batch on vault imports with
+  // nested hierarchies. Siblings within a layer push in parallel.
+  for (const layer of buildFolderLayers(pendingFolders)) {
+    await Promise.allSettled(
+      layer.map((f) =>
+        serializePerEntity('folder', f.id, () =>
+          pushSilently(async (idempotencyKey) => {
+            const pushedFields = {
+              name_encrypted: f.name_encrypted,
+              parent_id: f.parent_id ?? null,
+              order_index: f.order_index
+            };
+            const payload = { id: f.id, ...pushedFields, created_at: f.created_at };
+            validateEncryptedPayload(payload as Record<string, unknown>);
+            const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders`, {
+              method: 'POST',
+              headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+              body: JSON.stringify(payload)
+            });
+            if (!res.ok) throw new Error(`POST /api/folders: ${res.status}`);
+            const { data: resData } = await res.json();
+            const current = await folderStore.get(f.id);
+            if (current) {
+              const stillDirty = pushedFieldsDiffer(current, pushedFields);
+              await folderStore.save({
+                ...current,
+                sync_status: stillDirty ? 'pending' : 'synced',
+                sync_version: resData?.sync_version ?? 1
+              });
+            }
+          })
+        )
       )
-    ),
-    ...pendingTags.map((t) =>
+    );
+  }
+
+  // Tags don't reference folders — push in parallel after folders are
+  // settled. Notes' metadata_encrypted may embed tag ids, so tags must
+  // land before the notes layer below.
+  await Promise.allSettled(
+    pendingTags.map((t) =>
       serializePerEntity('tag', t.id, () =>
         pushSilently(async (idempotencyKey) => {
           const pushedFields = {
@@ -567,7 +580,7 @@ export async function pushPendingItems(): Promise<void> {
         })
       )
     )
-  ]);
+  );
 
   // Then push notes (POST for creates/updates)
   await Promise.allSettled(

--- a/apps/reborn-notes/src/lib/services/tag.service.ts
+++ b/apps/reborn-notes/src/lib/services/tag.service.ts
@@ -98,8 +98,18 @@ export async function getAllTags(): Promise<TagDecrypted[]> {
   return decrypted.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-/** Create a new tag. Returns the new tag ID. */
-export async function createTag(name: string, color?: string): Promise<string> {
+/**
+ * Create a new tag. Returns the new tag ID.
+ *
+ * `options.skipSync` defers the network push to the caller — used by batch
+ * importers that bulk-push everything via `pushPendingItems()` at the end so
+ * folders/tags land before any note that references them.
+ */
+export async function createTag(
+  name: string,
+  color?: string,
+  options?: { skipSync?: boolean }
+): Promise<string> {
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
   const tag = {
@@ -114,12 +124,14 @@ export async function createTag(name: string, color?: string): Promise<string> {
     updated_at: now
   };
   await tagOperations.saveTag(tag);
-  pushTag({
-    id,
-    name_encrypted: tag.name_encrypted,
-    color_encrypted: tag.color_encrypted,
-    created_at: now
-  });
+  if (!options?.skipSync) {
+    pushTag({
+      id,
+      name_encrypted: tag.name_encrypted,
+      color_encrypted: tag.color_encrypted,
+      created_at: now
+    });
+  }
   return id;
 }
 


### PR DESCRIPTION
Folder vault import surfaced two parent→child push races against the server's foreign-key checks:

1. Notes POSTed before their just-created folders landed (POST /api/notes → 404 Folder not found). Importer fired off pushFolder()/pushNote() per item without ordering, so notes raced their parent folders to the server.

2. After fixing #1, deeply nested vaults still hit POST /api/folders → 404 Parent folder not found because pushPendingItems() pushed all folders flat through one Promise.allSettled.

Fix:

- FolderService.createFolder() and TagService.createTag() now accept { skipSync?: boolean } so importFolder() can skip per-item fire-and-forget pushes and rely on a single ordered drain at the end.
- importFolder()'s findOrCreateFolderByPath / findOrCreateTagByName pass skipSync: true; the per-note pushNote() loop is replaced by one void pushPendingItems() call so the global folder→tag→note ordering applies.
- New pure helper buildFolderLayers() (folder-push-order.ts) groups pending folders into BFS layers (parents before children); folders whose parent is already on the server land in layer 0 alongside roots. Cycles/orphans fall through as the final layer for the server to reject.
- pushPendingItems() now iterates folder layers with await Promise.allSettled per layer and pushes tags in a separate Promise.allSettled afterwards.

Tests:

- 9 behavioural tests for buildFolderLayers (empty, flat, chain, siblings, mixed, server-parented parent, cycle, exact-once invariant).
- Source-level regression assertions in notes-sync.regression.spec.ts guard against (a) reintroducing direct pushNote/pushFolder/pushTag inside importFolder, and (b) regressing pushPendingItems back to a flat folder Promise.allSettled.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>