### PR TITLE
feat(notes): show subfolders in folder view

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -18,6 +18,8 @@
   import NoteListSearchBar from './notes/NoteListSearchBar.svelte';
   import NoteListSortMenu from './notes/NoteListSortMenu.svelte';
   import MoveToFolderMenu from './notes/MoveToFolderMenu.svelte';
+  import SubfolderList from './SubfolderList.svelte';
+  import type { FolderWithChildren } from '@reborn/types';
 
   // ── Infinite scroll ────────────────────────────────────────────
   const PAGE_SIZE = 50;
@@ -66,8 +68,10 @@
     prominentHeader = false,
     autoFocusSearch = false,
     searchOnly = false,
+    subfolders = [],
     onback,
-    oncreate
+    oncreate,
+    onSubfolderSelect
   }: {
     activeFolderName?: string;
     activeSection?: string;
@@ -76,8 +80,10 @@
     prominentHeader?: boolean;
     autoFocusSearch?: boolean;
     searchOnly?: boolean;
+    subfolders?: FolderWithChildren[];
     onback?: () => void;
     oncreate?: () => void | Promise<void>;
+    onSubfolderSelect?: (id: string) => void;
   } = $props();
 
   const isMobileQuery = useIsMobile();
@@ -316,39 +322,44 @@
 
   <!-- Notes list -->
   <div class="flex-1 overflow-y-auto px-3">
+    {#if subfolders.length > 0 && !searchInput && !searchOnly}
+      <SubfolderList {subfolders} onselect={(id) => onSubfolderSelect?.(id)} />
+    {/if}
     {#if searchOnly && !searchInput}
       <div class="px-4 py-12 text-center">
         <Search class="mx-auto mb-3 h-8 w-8 text-muted-foreground/40" />
         <p class="text-sm text-muted-foreground">{$t('notes.search_hint')}</p>
       </div>
     {:else if $notesStore.length === 0}
-      <div class="px-4 py-8 text-center">
-        {#if searchInput}
-          <p class="text-sm text-muted-foreground">
-            {$t('notes.no_match', { values: { query: searchInput } })}
-          </p>
-          <button
-            type="button"
-            onclick={clearSearch}
-            class="mt-2 text-xs text-primary underline-offset-4 hover:underline"
-          >
-            {$t('notes.clear_search')}
-          </button>
-        {:else if isTrash}
-          <p class="text-sm text-muted-foreground">{$t('trash.empty_short')}</p>
-        {:else if $sessionExpired}
-          <p class="text-sm text-muted-foreground">{$t('auth.session.empty_no_data')}</p>
-        {:else}
-          <p class="text-sm text-muted-foreground">{$t('notes.no_notes_short')}</p>
-          <button
-            type="button"
-            onclick={handleCreate}
-            class="mt-2 text-xs text-primary underline-offset-4 hover:underline"
-          >
-            {$t('notes.create_one')}
-          </button>
-        {/if}
-      </div>
+      {#if subfolders.length === 0 || searchInput}
+        <div class="px-4 py-8 text-center">
+          {#if searchInput}
+            <p class="text-sm text-muted-foreground">
+              {$t('notes.no_match', { values: { query: searchInput } })}
+            </p>
+            <button
+              type="button"
+              onclick={clearSearch}
+              class="mt-2 text-xs text-primary underline-offset-4 hover:underline"
+            >
+              {$t('notes.clear_search')}
+            </button>
+          {:else if isTrash}
+            <p class="text-sm text-muted-foreground">{$t('trash.empty_short')}</p>
+          {:else if $sessionExpired}
+            <p class="text-sm text-muted-foreground">{$t('auth.session.empty_no_data')}</p>
+          {:else}
+            <p class="text-sm text-muted-foreground">{$t('notes.no_notes_short')}</p>
+            <button
+              type="button"
+              onclick={handleCreate}
+              class="mt-2 text-xs text-primary underline-offset-4 hover:underline"
+            >
+              {$t('notes.create_one')}
+            </button>
+          {/if}
+        </div>
+      {/if}
     {:else}
       <ul class="flex flex-col gap-2 py-1">
         {#each visibleNotes as note (note.id)}

--- a/apps/reborn-notes/src/lib/components/SubfolderList.svelte
+++ b/apps/reborn-notes/src/lib/components/SubfolderList.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { Folder, ChevronRight } from '@lucide/svelte';
+  import type { FolderWithChildren } from '@reborn/types';
+  import { t } from '$lib/stores/i18n.store';
+
+  let {
+    subfolders,
+    onselect
+  }: {
+    subfolders: FolderWithChildren[];
+    onselect: (id: string) => void;
+  } = $props();
+</script>
+
+{#if subfolders.length > 0}
+  <div class="mb-3 flex flex-col gap-1">
+    <h2
+      class="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+    >
+      {$t('folders.subfolders')}
+    </h2>
+    <ul class="flex flex-col gap-1" role="list">
+      {#each subfolders as folder (folder.id)}
+        <li>
+          <div
+            role="button"
+            tabindex="0"
+            class="group flex cursor-pointer items-center gap-2 rounded-lg p-3 text-sm transition-colors hover:bg-accent/50"
+            onclick={() => onselect(folder.id)}
+            onkeydown={(e) => e.key === 'Enter' && onselect(folder.id)}
+          >
+            <Folder class="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span class="min-w-0 flex-1 truncate">{folder.name}</span>
+            <ChevronRight
+              class="h-4 w-4 shrink-0 text-muted-foreground/60 transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground"
+            />
+          </div>
+        </li>
+      {/each}
+    </ul>
+  </div>
+{/if}

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -89,6 +89,13 @@
     editingId = null;
   }
 
+  function handleRowSelect(folder: FolderWithChildren) {
+    if ((folder.children?.length ?? 0) > 0) {
+      expandedIds.add(folder.id);
+    }
+    onselect(folder.id);
+  }
+
   // ── Context menu (kebab) ────────────────────────────────────────
   const isMobileQuery = useIsMobile();
   let menuOpenId = $state<string | null>(null);
@@ -292,8 +299,8 @@
         style="padding-left: {depth * 0.75 + 0.5}rem"
         role="button"
         tabindex="0"
-        onclick={() => onselect(folder.id)}
-        onkeydown={(e) => e.key === 'Enter' && onselect(folder.id)}
+        onclick={() => handleRowSelect(folder)}
+        onkeydown={(e) => e.key === 'Enter' && handleRowSelect(folder)}
         aria-label={$t('folders.folder_label', { values: { name: folder.name } })}
       >
         <!-- Folder icon -->
@@ -329,7 +336,7 @@
               if (isExpanded) expandedIds.delete(folder.id);
               else expandedIds.add(folder.id);
             }}
-            class="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+            class="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
             aria-label={isExpanded ? $t('folders.collapse') : $t('folders.expand')}
             tabindex="-1"
           >

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -53,7 +53,11 @@
   import { noteIndex } from '$lib/services/note-index.svelte';
   import { tagManager } from '$lib/services/tag-manager.svelte';
   import { toastStore } from '@reborn/ui';
-  import { flattenFolderTree, getAncestorIds } from '$lib/utils/folder-helpers';
+  import {
+    flattenFolderTree,
+    getAncestorIds,
+    findChildrenOfParent
+  } from '$lib/utils/folder-helpers';
   import { goto } from '$lib/utils/navigation';
   import { createScrollSync } from '$lib/utils/scroll-sync';
 
@@ -65,6 +69,16 @@
   let activeTagId = $state<string | null>(null);
   const activeStarred = $derived(activeSection === 'starred');
   const activeTrash = $derived(activeSection === 'trash');
+  const activeFolderSubfolders = $derived(
+    activeSection === 'folders' && activeFolderId
+      ? findChildrenOfParent($foldersStore, activeFolderId)
+      : []
+  );
+  const activeFolderParentId = $derived(
+    activeSection === 'folders' && activeFolderId
+      ? (getAncestorIds(activeFolderId, $foldersStore)[0] ?? null)
+      : null
+  );
 
   // ── Tag: mobile new tag input focus ────────────────────────────
   let mobileNewTagInput = $state<HTMLInputElement | null>(null);
@@ -511,11 +525,21 @@
     await noteDetailService.flushAndSnapshot();
     activeFolderId = id;
     activeNoteId.set(null);
+    if (id) {
+      getAncestorIds(id, $foldersStore).forEach((ancestorId) => expandedIds.add(ancestorId));
+      expandedIds.add(id);
+    }
     if (isMobile) {
       mobileView = 'list';
       pushMobileHistory();
     } else {
       closeSidebarSignal++;
+    }
+  }
+
+  function handleFolderBack() {
+    if (activeFolderParentId) {
+      void handleFolderSelect(activeFolderParentId);
     }
   }
 
@@ -891,6 +915,8 @@
                 {activeFolderName}
                 {activeSection}
                 isTrash={activeTrash}
+                subfolders={activeFolderSubfolders}
+                onSubfolderSelect={handleFolderSelect}
                 autoFocusSearch={activeSection === 'search'}
                 searchOnly={activeSection === 'search'}
                 prominentHeader={activeStarred ||
@@ -1281,6 +1307,9 @@
             {activeSection}
             isTrash={false}
             showSidebarTrigger
+            subfolders={activeFolderSubfolders}
+            onSubfolderSelect={handleFolderSelect}
+            onback={activeFolderParentId ? handleFolderBack : undefined}
             oncreate={handleNewNote}
           />
         </div>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -111,6 +111,7 @@
     "folder_name_placeholder": "Ordnernamen eingeben",
     "create_subfolder": "Unterordner erstellen",
     "new_subfolder": "Neuer Unterordner",
+    "subfolders": "Unterordner",
     "rename": "Umbenennen",
     "folder_actions": "Ordner-Aktionen",
     "collapse": "Einklappen",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -111,6 +111,7 @@
     "folder_name_placeholder": "Enter folder name",
     "create_subfolder": "Create Subfolder",
     "new_subfolder": "New subfolder",
+    "subfolders": "Subfolders",
     "rename": "Rename",
     "folder_actions": "Folder actions",
     "collapse": "Collapse",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -111,6 +111,7 @@
     "folder_name_placeholder": "Introduzca el nombre de la carpeta",
     "create_subfolder": "Crear subcarpeta",
     "new_subfolder": "Nueva subcarpeta",
+    "subfolders": "Subcarpetas",
     "rename": "Renombrar",
     "folder_actions": "Acciones de carpeta",
     "collapse": "Contraer",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -111,6 +111,7 @@
     "folder_name_placeholder": "Saisissez le nom du dossier",
     "create_subfolder": "Créer un sous-dossier",
     "new_subfolder": "Nouveau sous-dossier",
+    "subfolders": "Sous-dossiers",
     "rename": "Renommer",
     "folder_actions": "Actions sur le dossier",
     "collapse": "Réduire",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -111,6 +111,7 @@
     "folder_name_placeholder": "Wprowadź nazwę folderu",
     "create_subfolder": "Utwórz podfolder",
     "new_subfolder": "Nowy podfolder",
+    "subfolders": "Podfoldery",
     "rename": "Zmień nazwę",
     "folder_actions": "Akcje folderu",
     "collapse": "Zwiń",


### PR DESCRIPTION
When opening a folder that contains subfolders, the main panel now lists those subfolders above the notes, so folders with no direct notes (but populated subfolders) no longer appear empty. Subfolder rows are clickable and navigate into the child folder.

Additional UX polish around folder navigation:
- Clicking a folder name in the sidebar tree auto-expands its branch (previously only the small chevron toggled expansion).
- Selecting any folder also expands the path of ancestors in the sidebar, so the active folder is always visible in context.
- The folder header in the desktop main panel shows a back arrow when the active folder has a parent, navigating one level up.
- Cursor on the chevron expand button now stays as a pointer instead of falling back to the default arrow.

Adds i18n key `folders.subfolders` for EN/PL/DE/FR/ES.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>