### PR TITLE
feat(notes): add PDF export via native print dialog

### DIFF
--- a/apps/reborn-notes/src/app.css
+++ b/apps/reborn-notes/src/app.css
@@ -88,6 +88,138 @@
   }
 }
 
+/*
+ * Print stylesheet — used by "Export as PDF" via window.print().
+ * Hides every body child except the dynamically-injected
+ * `.reborn-print-target` container (built in export-import.service.ts).
+ */
+@media print {
+  body > *:not(.reborn-print-target) {
+    display: none !important;
+  }
+
+  .reborn-print-target {
+    display: block !important;
+    /* Padding replaces @page margin so the browser has no margin area to
+       render its default header (URL/date) and footer (page number) into. */
+    padding: 1.5cm;
+    color: #000;
+    background: #fff;
+    font-family: 'Roboto', ui-sans-serif, system-ui, sans-serif;
+    line-height: 1.55;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .reborn-print-target h1,
+  .reborn-print-target h2,
+  .reborn-print-target h3,
+  .reborn-print-target h4,
+  .reborn-print-target h5,
+  .reborn-print-target h6 {
+    break-after: avoid;
+    page-break-after: avoid;
+    line-height: 1.25;
+    font-weight: 600;
+  }
+  .reborn-print-target > h1:first-child {
+    margin: 0 0 0.75em;
+    padding-bottom: 0.4em;
+    border-bottom: 1px solid #ccc;
+    font-size: 1.75rem;
+  }
+  .reborn-print-target__body h1 { font-size: 1.5rem; margin: 1em 0 0.4em; }
+  .reborn-print-target__body h2 { font-size: 1.3rem; margin: 1em 0 0.4em; }
+  .reborn-print-target__body h3 { font-size: 1.15rem; margin: 0.8em 0 0.3em; }
+  .reborn-print-target__body h4 { font-size: 1rem;    margin: 0.8em 0 0.3em; }
+
+  .reborn-print-target p {
+    margin: 0 0 0.75em;
+  }
+
+  .reborn-print-target a {
+    color: #1d4ed8;
+    text-decoration: underline;
+    word-break: break-word;
+  }
+
+  .reborn-print-target ul,
+  .reborn-print-target ol {
+    margin: 0 0 0.75em 1.5em;
+    padding: 0;
+  }
+  .reborn-print-target li + li { margin-top: 0.2em; }
+
+  .reborn-print-target blockquote {
+    margin: 0 0 0.75em;
+    padding: 0.4em 0.9em;
+    border-left: 3px solid #999;
+    color: #444;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .reborn-print-target code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.875em;
+    background: #f3f3f3;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+  }
+  .reborn-print-target pre {
+    margin: 0 0 0.75em;
+    padding: 0.75em;
+    background: #f3f3f3;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  .reborn-print-target pre code {
+    background: transparent;
+    padding: 0;
+  }
+
+  .reborn-print-target table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 0.75em;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  .reborn-print-target th,
+  .reborn-print-target td {
+    border: 1px solid #ccc;
+    padding: 0.4em 0.6em;
+    text-align: left;
+  }
+  .reborn-print-target th { background: #f3f3f3; font-weight: 600; }
+
+  .reborn-print-target img {
+    max-width: 100%;
+    height: auto;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .reborn-print-target hr {
+    margin: 1em 0;
+    border: none;
+    border-top: 1px solid #ccc;
+  }
+}
+
+/*
+ * margin: 0 zeroes the @page area where browsers draw their default
+ * header (URL/date) and footer (page number). Content padding moved to
+ * `.reborn-print-target`. Users can still re-enable headers/footers via
+ * the print dialog's "More settings" checkbox.
+ */
+@page {
+  margin: 0;
+}
+
 /* CodeMirror base styles */
 @layer base {
   .cm-editor {

--- a/apps/reborn-notes/src/lib/components/editor/NoteDetailActions.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteDetailActions.svelte
@@ -7,6 +7,7 @@
     StarOff,
     FolderInput,
     Download,
+    FileText,
     Link2,
     ScanEye,
     Trash2
@@ -30,6 +31,7 @@
     onstar,
     onmove,
     onexport,
+    onexportpdf,
     oncopylink,
     onshowxray,
     ondelete
@@ -41,6 +43,7 @@
     onstar: () => void;
     onmove: (folderId: string | null, e?: Event) => void;
     onexport: () => void;
+    onexportpdf: () => void;
     oncopylink: () => void;
     onshowxray: () => void;
     ondelete: () => void;
@@ -121,6 +124,10 @@
           <DropdownMenuItem onclick={onexport}>
             <Download class="h-3.5 w-3.5" />
             {$t('notes.export_markdown')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onclick={onexportpdf}>
+            <FileText class="h-3.5 w-3.5" />
+            {$t('notes.export_pdf')}
           </DropdownMenuItem>
           <DropdownMenuItem onclick={oncopylink}>
             <Link2 class="h-3.5 w-3.5" />

--- a/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
@@ -6,6 +6,7 @@
     StarOff,
     FolderInput,
     Download,
+    FileText,
     Link2,
     ScanEye,
     Trash2,
@@ -25,6 +26,7 @@
     onstar,
     onmove,
     onexport,
+    onexportpdf,
     oncopylink,
     ondelete,
     onrestore,
@@ -39,6 +41,8 @@
     onstar: (id: string) => void;
     onmove: (id: string) => void;
     onexport: (note: NoteListItem) => void;
+    /** Optional — only shown in the open-note context (NoteList omits it). */
+    onexportpdf?: (note: NoteListItem) => void;
     oncopylink: (note: NoteListItem) => void;
     ondelete: (id: string) => void;
     onrestore: (id: string) => void;
@@ -116,6 +120,16 @@
           <Download class="mr-2 h-4 w-4" />
           {$t('notes.export_markdown')}
         </Button>
+        {#if onexportpdf}
+          <Button
+            variant="ghost"
+            class="w-full justify-start"
+            onclick={() => note && onexportpdf?.(note)}
+          >
+            <FileText class="mr-2 h-4 w-4" />
+            {$t('notes.export_pdf')}
+          </Button>
+        {/if}
         <Button
           variant="ghost"
           class="w-full justify-start"

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -27,6 +27,8 @@ import {
   noteTagQueries,
   type NoteTag
 } from '@reborn/storage';
+import { Marked } from 'marked';
+import DOMPurify from 'dompurify';
 import { get } from 'svelte/store';
 import { authStore } from '$lib/stores/auth.store';
 import {
@@ -174,6 +176,61 @@ export function exportNoteAsMarkdown(note: NoteDecrypted, tagNames: string[] = [
   const content = buildMarkdownContent(note, tagNames);
   const blob = new Blob([content], { type: 'text/markdown; charset=utf-8' });
   downloadBlob(blob, `${sanitizeFilename(note.title)}.md`);
+}
+
+/**
+ * Export a single note as PDF via the browser's native print dialog
+ * ("Save as PDF" target). Zero Knowledge: the rendered HTML is built and
+ * printed entirely client-side — plaintext never leaves the browser. No
+ * external library is loaded; we reuse `marked` + DOMPurify already in deps.
+ *
+ * Renders into a dedicated off-screen container (`.reborn-print-target`)
+ * appended to `document.body`. Global `@media print` rules in `app.css`
+ * hide every other body child during printing so the dialog only sees the
+ * clean note content. The container is removed after the `afterprint` event
+ * (or on a defensive timeout fallback for browsers that fire it unreliably).
+ */
+export function exportNoteAsPdf(note: NoteDecrypted): void {
+  // Fresh Marked instance so we don't pick up the custom image renderer
+  // configured in MarkdownPreview (which would emit placeholders instead
+  // of native <img> tags — we want real images embedded in the PDF).
+  const printMarked = new Marked({ gfm: true, breaks: true });
+  const rawHtml = printMarked.parse(note.content ?? '', { async: false }) as string;
+  const safeHtml = DOMPurify.sanitize(rawHtml, { USE_PROFILES: { html: true } });
+
+  const container = document.createElement('div');
+  container.className = 'reborn-print-target';
+
+  const heading = document.createElement('h1');
+  heading.textContent = note.title || 'Untitled';
+  container.appendChild(heading);
+
+  const body = document.createElement('div');
+  body.className = 'reborn-print-target__body';
+  body.innerHTML = safeHtml;
+  container.appendChild(body);
+
+  document.body.appendChild(container);
+
+  // Browsers use document.title as the suggested filename in "Save as PDF".
+  const previousTitle = document.title;
+  document.title = sanitizeFilename(note.title);
+
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    document.title = previousTitle;
+    container.remove();
+    window.removeEventListener('afterprint', cleanup);
+  };
+
+  window.addEventListener('afterprint', cleanup);
+  // Defensive fallback — Safari/iOS fire `afterprint` inconsistently when the
+  // user dismisses the print sheet without printing.
+  setTimeout(cleanup, 60_000);
+
+  window.print();
 }
 
 /** Export multiple notes as a .zip archive (JSZip, dynamically imported). */

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -43,7 +43,7 @@
   // Stores / services
   import { notesStore, activeNoteId, type NoteListItem } from '$lib/stores/notes.store';
   import * as NoteService from '$lib/services/note.service';
-  import { exportNoteAsMarkdown } from '$lib/services/export-import.service';
+  import { exportNoteAsMarkdown, exportNoteAsPdf } from '$lib/services/export-import.service';
   import { foldersStore } from '$lib/stores/folders.store';
   import { tagsStore } from '$lib/stores/tags.store';
   import { getSettings } from '$lib/utils/app-settings';
@@ -150,6 +150,18 @@
     }
     const tagNames = $tagsStore.filter((tg) => target.tags?.includes(tg.id)).map((tg) => tg.name);
     exportNoteAsMarkdown(fullNote, tagNames);
+  }
+
+  async function handleDetailExportPdf(noteArg?: NoteListItem) {
+    detailActionSheetOpen = false;
+    const target = noteArg ?? detailMenuNote;
+    if (!target) return;
+    const fullNote = await NoteService.getNote(target.id);
+    if (!fullNote) {
+      toastStore.error($t('notes.export_failed'));
+      return;
+    }
+    exportNoteAsPdf(fullNote);
   }
 
   async function handleDetailCopyLink(noteArg?: NoteListItem) {
@@ -1042,6 +1054,7 @@
                   onstar={handleDetailStar}
                   onmove={handleDetailMoveDesktop}
                   onexport={() => handleDetailExport()}
+                  onexportpdf={() => handleDetailExportPdf()}
                   oncopylink={() => handleDetailCopyLink()}
                   onshowxray={() => { showEncryptionXRay = true; }}
                   ondelete={handleDetailDelete}
@@ -1254,6 +1267,7 @@
                 onstar={handleDetailStar}
                 onmove={handleDetailMoveDesktop}
                 onexport={() => handleDetailExport()}
+                onexportpdf={() => handleDetailExportPdf()}
                 oncopylink={() => handleDetailCopyLink()}
                 onshowxray={() => { showEncryptionXRay = true; }}
                 ondelete={handleDetailDelete}
@@ -1436,6 +1450,7 @@
   onstar={() => handleDetailStar()}
   onmove={() => handleDetailOpenMoveMobile()}
   onexport={(note) => handleDetailExport(note)}
+  onexportpdf={(note) => handleDetailExportPdf(note)}
   oncopylink={(note) => handleDetailCopyLink(note)}
   ondelete={() => handleDetailDelete()}
   onhistory={handleDetailHistory}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -55,6 +55,7 @@
     "folder_no_results": "Keine passenden Ordner",
     "folder_no_subfolders": "Keine Unterordner",
     "export_markdown": "Als Markdown exportieren",
+    "export_pdf": "Als PDF exportieren",
     "export_failed": "Export der Notiz fehlgeschlagen",
     "copy_note_link": "Notiz-Link kopieren",
     "note_link_copied": "Notiz-Link in die Zwischenablage kopiert",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -55,6 +55,7 @@
     "folder_no_results": "No matching folders",
     "folder_no_subfolders": "No subfolders",
     "export_markdown": "Export as Markdown",
+    "export_pdf": "Export as PDF",
     "export_failed": "Failed to export note",
     "copy_note_link": "Copy note link",
     "note_link_copied": "Note link copied to clipboard",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -55,6 +55,7 @@
     "folder_no_results": "No hay carpetas coincidentes",
     "folder_no_subfolders": "Sin subcarpetas",
     "export_markdown": "Exportar como Markdown",
+    "export_pdf": "Exportar como PDF",
     "export_failed": "Error al exportar la nota",
     "copy_note_link": "Copiar enlace de nota",
     "note_link_copied": "Enlace de nota copiado al portapapeles",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -55,6 +55,7 @@
     "folder_no_results": "Aucun dossier correspondant",
     "folder_no_subfolders": "Aucun sous-dossier",
     "export_markdown": "Exporter en Markdown",
+    "export_pdf": "Exporter en PDF",
     "export_failed": "Échec de l'exportation de la note",
     "copy_note_link": "Copier le lien de la note",
     "note_link_copied": "Lien de la note copié dans le presse-papiers",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -55,6 +55,7 @@
     "folder_no_results": "Brak pasujących folderów",
     "folder_no_subfolders": "Brak podfolderów",
     "export_markdown": "Eksportuj jako Markdown",
+    "export_pdf": "Eksportuj jako PDF",
     "export_failed": "Nie udało się wyeksportować notatki",
     "copy_note_link": "Kopiuj link do notatki",
     "note_link_copied": "Link do notatki skopiowany do schowka",


### PR DESCRIPTION
Adds "Export as PDF" to the open-note menu (desktop dropdown + mobile sheet). Uses the browser's native window.print() with "Save as PDF" — no external PDF library, no server-side rendering. Plaintext is rendered into an off-screen .reborn-print-target via marked + DOMPurify (reused from MarkdownPreview deps) and never leaves the browser, preserving Zero Knowledge guarantees. Global @media print hides app chrome and zeroes @page margins to suppress the browser's default header/footer.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>