### PR TITLE
refactor(notes): generate PDF via jsPDF + html2canvas-pro instead of native print

### DIFF
--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -43,6 +43,8 @@
     "@reborn/utils": "workspace:*",
     "diff": "8.0.4",
     "dompurify": "3.4.0",
+    "html2canvas-pro": "1.6.7",
+    "jspdf": "2.5.2",
     "jszip": "3.10.1",
     "marked": "14.1.4",
     "otpauth": "9.5.0"

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -179,239 +179,263 @@ export function exportNoteAsMarkdown(note: NoteDecrypted, tagNames: string[] = [
 }
 
 /**
- * Print stylesheet inlined into the iframe document below. Kept in this
- * module (not in app.css) because the iframe is a separate document and
- * cannot inherit the parent's `<style>` blocks. `@page { margin: 0 }` plus
- * body padding suppresses the browser's default header (URL/date) and
- * footer (page number). All sizes target paper, not screen.
+ * Style block injected into the off-screen container that jsPDF rasterizes.
+ * html2canvas reads computed styles from a real DOM element, so the rules
+ * below define the visual output. No `@page` — page geometry is set on the
+ * jsPDF instance (`format: 'a4'`, `margin: [40,40,40,40]`).
+ *
+ * Fonts are kept to system stacks. Web fonts that haven't been used elsewhere
+ * on the page may not be loaded by the time html2canvas snapshots, which
+ * silently substitutes them and can shift line widths.
  */
-const PRINT_STYLES = `
-@page { margin: 0; }
-* { box-sizing: border-box; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-html, body { margin: 0; padding: 0; }
-body {
-  padding: 1.5cm;
+const PDF_STYLES = `
+.reborn-pdf-root, .reborn-pdf-root * { box-sizing: border-box; }
+.reborn-pdf-root {
   color: #000;
   background: #fff;
-  font-family: 'Roboto', ui-sans-serif, system-ui, sans-serif;
+  font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   font-size: 11pt;
   line-height: 1.55;
 }
-h1, h2, h3, h4, h5, h6 {
-  break-after: avoid;
-  page-break-after: avoid;
+.reborn-pdf-root h1, .reborn-pdf-root h2, .reborn-pdf-root h3,
+.reborn-pdf-root h4, .reborn-pdf-root h5, .reborn-pdf-root h6 {
   line-height: 1.25;
   font-weight: 600;
 }
-.reborn-print-title {
-  margin: 0 0 0.75em;
-  padding-bottom: 0.4em;
-  border-bottom: 1px solid #ccc;
-  font-size: 1.75rem;
-}
-.reborn-print-body h1 { font-size: 1.5rem;  margin: 1em 0 0.4em; }
-.reborn-print-body h2 { font-size: 1.3rem;  margin: 1em 0 0.4em; }
-.reborn-print-body h3 { font-size: 1.15rem; margin: 0.8em 0 0.3em; }
-.reborn-print-body h4 { font-size: 1rem;    margin: 0.8em 0 0.3em; }
-p { margin: 0 0 0.75em; }
-a { color: #1d4ed8; text-decoration: underline; word-break: break-word; }
-ul, ol { margin: 0 0 0.75em 1.5em; padding: 0; }
-li + li { margin-top: 0.2em; }
-blockquote {
+.reborn-pdf-root .reborn-pdf-body h1 { font-size: 1.5rem;  margin: 0.5em 0 0.4em; }
+.reborn-pdf-root .reborn-pdf-body h1:first-child { margin-top: 0; }
+.reborn-pdf-root .reborn-pdf-body h2 { font-size: 1.3rem;  margin: 1em 0 0.4em; }
+.reborn-pdf-root .reborn-pdf-body h3 { font-size: 1.15rem; margin: 0.8em 0 0.3em; }
+.reborn-pdf-root .reborn-pdf-body h4 { font-size: 1rem;    margin: 0.8em 0 0.3em; }
+.reborn-pdf-root p { margin: 0 0 0.75em; }
+.reborn-pdf-root a { color: #1d4ed8; text-decoration: underline; word-break: break-word; }
+.reborn-pdf-root ul, .reborn-pdf-root ol { margin: 0 0 0.75em 1.5em; padding: 0; }
+.reborn-pdf-root li + li { margin-top: 0.2em; }
+.reborn-pdf-root blockquote {
   margin: 0 0 0.75em;
   padding: 0.4em 0.9em;
   border-left: 3px solid #999;
   color: #444;
-  break-inside: avoid;
-  page-break-inside: avoid;
 }
-code {
+.reborn-pdf-root code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.875em;
   background: #f3f3f3;
   padding: 0.1em 0.35em;
   border-radius: 3px;
 }
-pre {
+.reborn-pdf-root pre {
   margin: 0 0 0.75em;
   padding: 0.75em;
   background: #f3f3f3;
   border-radius: 4px;
   white-space: pre-wrap;
   word-wrap: break-word;
-  break-inside: avoid;
-  page-break-inside: avoid;
 }
-pre code { background: transparent; padding: 0; }
-table {
+.reborn-pdf-root pre code { background: transparent; padding: 0; }
+.reborn-pdf-root table {
   width: 100%;
   border-collapse: collapse;
   margin: 0 0 0.75em;
-  break-inside: avoid;
-  page-break-inside: avoid;
 }
-th, td { border: 1px solid #ccc; padding: 0.4em 0.6em; text-align: left; }
-th { background: #f3f3f3; font-weight: 600; }
-img { max-width: 100%; height: auto; break-inside: avoid; page-break-inside: avoid; }
-hr { margin: 1em 0; border: none; border-top: 1px solid #ccc; }
+.reborn-pdf-root th, .reborn-pdf-root td {
+  border: 1px solid #ccc;
+  padding: 0.4em 0.6em;
+  text-align: left;
+}
+.reborn-pdf-root th { background: #f3f3f3; font-weight: 600; }
+.reborn-pdf-root img { max-width: 100%; height: auto; }
+.reborn-pdf-root hr { margin: 1em 0; border: none; border-top: 1px solid #ccc; }
 `.trim();
 
-function escapeHtml(s: string): string {
-  return s.replace(
-    /[&<>"']/g,
-    (c) =>
-      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c
-  );
-}
-
 /**
- * Export a single note as PDF via the browser's native print dialog
- * ("Save as PDF" target). Zero Knowledge: the rendered HTML is built and
- * printed entirely client-side — plaintext never leaves the browser. No
- * external library is loaded; we reuse `marked` + DOMPurify already in deps.
+ * Export a single note as PDF, generated entirely client-side.
  *
- * Renders into a hidden iframe with its own document. Crucial for PWA mode
- * on Android: appending to the main document and relying on `@media print`
- * to hide the rest produced a blank PDF — Brave/Chrome on Android render a
- * "viewport snapshot" for print in standalone PWAs, and the appended node
- * sat below the fold. The iframe is an isolated document, so the print
- * engine sees only its content regardless of host PWA layout/viewport.
+ * Pipeline: marked → DOMPurify → off-screen DOM → html2canvas-pro (raster) →
+ * jsPDF (manual slice pagination via addImage). Plaintext never leaves the
+ * device.
  *
- * As a side effect, the iframe's `<title>` becomes the suggested filename
- * (Android Brave/Chrome use the printed document's title, not the host
- * page's `document.title` — that's why pre-iframe versions named the file
- * after the PWA's manifest title).
+ * Why direct html2canvas-pro + addImage instead of `jsPDF.html()`:
+ * `pdf.html()` routes through `pdf.context2d` which renders text as native
+ * PDF text using Helvetica (Latin-1 only). Polish characters and any non-
+ * Latin-1 UTF-8 come out garbled (multi-byte sequences misread as separate
+ * Latin-1 codepoints). Embedding a Unicode TrueType font would solve it but
+ * requires shipping a ~150 KB font asset. Manual raster pagination keeps the
+ * pipeline simple and renders any character correctly because everything is
+ * pixels — at the cost of selectable text in the output.
+ *
+ * Replaces the previous native-print approach (3 iterations) which never
+ * worked on Android PWA — the platform print framework treated the iframe as
+ * a viewport snapshot and ignored multi-page pagination.
  */
-export function exportNoteAsPdf(note: NoteDecrypted): void {
-  // Fresh Marked instance so we don't inherit MarkdownPreview's custom image
-  // renderer (which emits placeholders instead of native <img> — we want
-  // real images embedded in the PDF).
+export async function exportNoteAsPdf(note: NoteDecrypted): Promise<void> {
+  // Fresh Marked instance — don't inherit MarkdownPreview's custom image
+  // renderer (which emits placeholders); we want real <img> in the PDF.
   const printMarked = new Marked({ gfm: true, breaks: true });
   const rawHtml = printMarked.parse(note.content ?? '', { async: false }) as string;
   const safeBodyHtml = DOMPurify.sanitize(rawHtml, { USE_PROFILES: { html: true } });
 
   const filename = sanitizeFilename(note.title);
-  const safeTitle = escapeHtml(note.title || 'Untitled');
 
-  const docHtml = `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>${escapeHtml(filename)}</title>
-<style>${PRINT_STYLES}</style>
-</head>
-<body>
-<h1 class="reborn-print-title">${safeTitle}</h1>
-<div class="reborn-print-body">${safeBodyHtml}</div>
-</body>
-</html>`;
-
-  const iframe = document.createElement('iframe');
-  iframe.setAttribute('aria-hidden', 'true');
-  iframe.setAttribute('title', filename);
-  // Full viewport size, but invisible to the user. Two reasons:
-  // - Android Brave PWA: a 0×0 iframe paginated to a single page (only the
-  //   start of long notes printed). With real dimensions the print framework
-  //   computes paged layout from actual content height.
-  // - iOS Safari: refuses to print iframes that aren't laid out. `opacity: 0`
-  //   keeps the iframe in the layout tree (unlike `display: none` /
-  //   `visibility: hidden` which can cause iOS to print blank pages).
-  iframe.style.cssText = [
-    'position:fixed',
+  // html2canvas-pro reads layout from a real, laid-out element. Off-screen via
+  // `left: -10000px; top: 0` rather than huge negative top — the latter put
+  // the element 100000px below the viewport's natural origin and confused
+  // pagination. `top: 0` keeps the element at the document top in absolute
+  // coordinates, just shifted horizontally out of view.
+  const container = document.createElement('div');
+  container.className = 'reborn-pdf-root';
+  container.setAttribute('aria-hidden', 'true');
+  container.style.cssText = [
+    'position:absolute',
+    'left:-10000px',
     'top:0',
-    'left:0',
-    'width:100%',
-    'height:100%',
-    'border:0',
-    'opacity:0',
+    'width:800px',
     'pointer-events:none',
     'z-index:-1'
   ].join(';');
 
-  // Desktop Chromium uses the PARENT document's title for the print job's
-  // suggested filename — even when printing an iframe with its own <title>.
-  // Android Chrome/Brave, conversely, prefers the PWA manifest name and
-  // ignores `document.title` swaps but DOES honor the iframe document's
-  // <title>. Setting both covers all platforms.
-  const previousTitle = document.title;
-  document.title = filename;
+  const styleEl = document.createElement('style');
+  styleEl.textContent = PDF_STYLES;
+  container.appendChild(styleEl);
 
-  let cleanedUp = false;
-  const cleanup = () => {
-    if (cleanedUp) return;
-    cleanedUp = true;
-    document.title = previousTitle;
-    iframe.remove();
-  };
+  const bodyEl = document.createElement('div');
+  bodyEl.className = 'reborn-pdf-body';
+  bodyEl.innerHTML = safeBodyHtml;
+  container.appendChild(bodyEl);
 
-  document.body.appendChild(iframe);
+  document.body.appendChild(container);
 
-  // Use document.open()/write()/close() instead of `srcdoc`. iOS Safari has a
-  // long-standing bug where `iframe.contentWindow.print()` on a srcdoc-loaded
-  // iframe ends up printing the *parent* page (or blank pages with the
-  // browser's default header/footer chrome) instead of the iframe content.
-  // The classic write() path produces a real `about:blank` document that
-  // iOS prints reliably.
-  const doc = iframe.contentDocument;
-  if (!doc) {
-    cleanup();
-    return;
-  }
-  doc.open();
-  doc.write(docHtml);
-  doc.close();
-
-  const win = iframe.contentWindow;
-  if (!win) {
-    cleanup();
-    return;
-  }
-  win.addEventListener('afterprint', cleanup);
-
-  // Wait for images inside the iframe to finish decoding, otherwise mobile
-  // print engines snapshot before they render and clip content. Falls back to
-  // a 1.5s timeout so the print is never blocked indefinitely by a stuck img.
-  const triggerPrint = () => {
-    try {
-      win.focus();
-      win.print();
-    } catch {
-      cleanup();
-    }
-  };
-
-  const images = Array.from(doc.images);
-  if (images.length === 0) {
-    setTimeout(triggerPrint, 100);
-  } else {
-    let pending = images.length;
-    let timedOut = false;
-    const onOneImageDone = () => {
-      pending -= 1;
-      if (pending <= 0 && !timedOut) {
-        // One extra frame for layout to settle after the last decode.
-        setTimeout(triggerPrint, 50);
-      }
+  try {
+    // Collect candidate page-break boundaries in container-local CSS pixels.
+    // Measured BEFORE html2canvas runs because html2canvas removes its
+    // overlay clone after rendering — the source container is unaffected.
+    const renderScale = 2;
+    const containerTop = container.getBoundingClientRect().top;
+    const breakBoundariesCss: number[] = [];
+    const collect = (el: Element) => {
+      const bottom = el.getBoundingClientRect().bottom - containerTop;
+      if (bottom > 0) breakBoundariesCss.push(bottom);
     };
-    for (const img of images) {
-      if (img.complete) {
-        onOneImageDone();
-      } else {
-        img.addEventListener('load', onOneImageDone, { once: true });
-        img.addEventListener('error', onOneImageDone, { once: true });
+    // Top-level body blocks (h1-h6, p, ul, ol, table, pre, blockquote, hr,
+    // figure, …). Each is a natural break point.
+    for (const child of Array.from(bodyEl.children)) {
+      collect(child);
+      // Descend one level for lists — breaking between <li> on the same page
+      // is much friendlier than slicing through a single bullet.
+      if (child.tagName === 'UL' || child.tagName === 'OL') {
+        for (const li of Array.from(child.children)) collect(li);
       }
     }
-    setTimeout(() => {
-      if (pending > 0) {
-        timedOut = true;
-        triggerPrint();
-      }
-    }, 1500);
-  }
+    breakBoundariesCss.sort((a, b) => a - b);
 
-  // Hard fallback — Brave/Safari sometimes never fire afterprint when the
-  // user dismisses the print sheet on mobile.
-  setTimeout(cleanup, 60_000);
+    const [{ default: jsPDF }, { default: html2canvas }] = await Promise.all([
+      import('jspdf'),
+      import('html2canvas-pro')
+    ]);
+
+    const fullCanvas = await html2canvas(container, {
+      scale: renderScale,
+      useCORS: true,
+      logging: false,
+      backgroundColor: '#ffffff'
+    });
+
+    const pdf = new jsPDF({ unit: 'pt', format: 'a4', compress: true });
+    const pageWidthPt = pdf.internal.pageSize.getWidth(); // 595
+    const pageHeightPt = pdf.internal.pageSize.getHeight(); // 842
+    const marginPt = 40;
+    const contentWidthPt = pageWidthPt - 2 * marginPt; // 515
+    const contentHeightPt = pageHeightPt - 2 * marginPt; // 762
+
+    // Source canvas: `fullCanvas.width × fullCanvas.height` pixels. We map it
+    // onto the PDF so its width spans `contentWidthPt`. `pxPerPt` is how many
+    // source-pixel rows correspond to one PDF point.
+    const pxPerPt = fullCanvas.width / contentWidthPt;
+    const idealSliceHeightPx = Math.floor(contentHeightPt * pxPerPt);
+    // Convert CSS-pixel boundaries to canvas-pixel coordinates.
+    const boundariesPx = breakBoundariesCss.map((b) =>
+      Math.round(b * renderScale)
+    );
+
+    // Compute page slices by walking boundaries: for each page, prefer the
+    // largest block-bottom boundary that fits within the ideal slice; if none
+    // is available (e.g., a single block taller than a page), fall back to the
+    // hard pixel cut so we don't loop forever.
+    const slices: { startY: number; endY: number }[] = [];
+    let pageStartY = 0;
+    while (pageStartY < fullCanvas.height) {
+      const idealEnd = Math.min(
+        pageStartY + idealSliceHeightPx,
+        fullCanvas.height
+      );
+      if (idealEnd === fullCanvas.height) {
+        slices.push({ startY: pageStartY, endY: fullCanvas.height });
+        break;
+      }
+      // Largest boundary in (pageStartY, idealEnd]
+      let chosen = -1;
+      for (const b of boundariesPx) {
+        if (b > pageStartY && b <= idealEnd && b > chosen) chosen = b;
+        else if (b > idealEnd) break; // sorted ascending
+      }
+      const endY = chosen > pageStartY ? chosen : idealEnd;
+      slices.push({ startY: pageStartY, endY });
+      pageStartY = endY;
+    }
+
+    const sliceCanvas = document.createElement('canvas');
+    const sliceCtx = sliceCanvas.getContext('2d');
+    if (!sliceCtx) throw new Error('Failed to acquire 2d context for PDF slice');
+
+    for (let i = 0; i < slices.length; i++) {
+      if (i > 0) pdf.addPage();
+      const { startY, endY } = slices[i];
+      const sliceHeightPx = endY - startY;
+      const sliceHeightPt = sliceHeightPx / pxPerPt;
+
+      sliceCanvas.width = fullCanvas.width;
+      sliceCanvas.height = sliceHeightPx;
+      // White background — JPEG has no alpha; transparent pixels would
+      // otherwise encode as black.
+      sliceCtx.fillStyle = '#ffffff';
+      sliceCtx.fillRect(0, 0, sliceCanvas.width, sliceCanvas.height);
+      sliceCtx.drawImage(
+        fullCanvas,
+        0,
+        startY,
+        fullCanvas.width,
+        sliceHeightPx,
+        0,
+        0,
+        fullCanvas.width,
+        sliceHeightPx
+      );
+
+      const sliceData = sliceCanvas.toDataURL('image/jpeg', 0.92);
+      pdf.addImage(
+        sliceData,
+        'JPEG',
+        marginPt,
+        marginPt,
+        contentWidthPt,
+        sliceHeightPt
+      );
+    }
+
+    pdf.save(`${filename}.pdf`);
+  } catch (e) {
+    logger.error('PDF export failed', e);
+    throw e;
+  } finally {
+    container.remove();
+    // html2canvas-pro appends `<iframe class="html2canvas-container">` to body
+    // for its DOM clone. On success it cleans up; on a thrown error mid-render
+    // the iframe can be left behind — drop it so the page isn't holding a
+    // hidden, off-screen frame in memory.
+    document
+      .querySelectorAll('iframe.html2canvas-container')
+      .forEach((el) => el.remove());
+  }
 }
 
 /** Export multiple notes as a .zip archive (JSZip, dynamically imported). */

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -161,7 +161,11 @@
       toastStore.error($t('notes.export_failed'));
       return;
     }
-    exportNoteAsPdf(fullNote);
+    try {
+      await exportNoteAsPdf(fullNote);
+    } catch {
+      toastStore.error($t('notes.export_failed'));
+    }
   }
 
   async function handleDetailCopyLink(noteArg?: NoteListItem) {

--- a/apps/reborn-notes/vite.config.ts
+++ b/apps/reborn-notes/vite.config.ts
@@ -22,7 +22,15 @@ export default defineConfig({
       '@reborn/types': resolve('../../packages/types/src/index.ts'),
       '@reborn/utils': resolve('../../packages/utils/src/index.ts'),
       '@reborn/storage': resolve('../../packages/storage/src/index.ts'),
-      '@reborn/i18n': resolve('../../packages/i18n/src/index.ts')
+      '@reborn/i18n': resolve('../../packages/i18n/src/index.ts'),
+      // jsPDF's `html()` does `await import("html2canvas")` internally. The
+      // upstream package (1.4.1, last released 2022) cannot parse modern CSS
+      // color functions like `oklch()` — Tailwind v4 emits oklch in :root
+      // variables, and html2canvas reads computed styles across the whole
+      // ancestor chain, so it fails on the very first parse. `html2canvas-pro`
+      // is the maintained fork that adds oklch / lab / lch support; aliasing
+      // here makes jsPDF resolve to it without modifying jsPDF source.
+      html2canvas: 'html2canvas-pro'
     }
   },
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,12 @@ importers:
       dompurify:
         specifier: 3.4.0
         version: 3.4.0
+      html2canvas-pro:
+        specifier: 1.6.7
+        version: 1.6.7
+      jspdf:
+        specifier: 2.5.2
+        version: 2.5.2
       jszip:
         specifier: 3.10.1
         version: 3.10.1
@@ -1928,105 +1934,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2208,25 +2198,21 @@ packages:
     resolution: {integrity: sha512-0U2Q760B0pf9dQBGK3qes25jm1SwqGZ4bCgrdfccWpkka+Z+wWyIga55fAh3KIJQr5Cdw6QgsPKra6HbIFbpfQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@21.2.0':
     resolution: {integrity: sha512-lM5GEliTA8TH8l64v1zq3sfsSOsODy+KdBLkcis0mNsuCop1kv/CxyuE0X3PwCGAGFchzDNj7mDprRR4FLfWoA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@21.2.0':
     resolution: {integrity: sha512-5KoTe9Kv9elMWPvlWI4cXLXYmFjnD2asQIMgR4eSuWi09CqX9ua4mIyKC5sPjgy9VxWUhaKx+fZydp+akWh37w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@21.2.0':
     resolution: {integrity: sha512-UbFzIU331vEEprCeKN01k+9Sn1y9pQO32/6yV4eLvK/FdrvzJahu0Dn+IinvCqdIAMiUvIdkBtcKirQby+Pc2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@21.2.0':
     resolution: {integrity: sha512-mKqED/y9hD4qTPSeBTc3uZHQozm0XtqnnnrZui4BdXJOMvS3llCiCxmZF2E5N6GZl5L5sb6nNkjhzJDbAfs3TQ==}
@@ -2312,85 +2298,71 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-gnu@5.3.0':
     resolution: {integrity: sha512-u2ndfeEUrW898eXM+qPxIN8TvTPjI90NDQBRgaxxkOfNw3xaotloeiZGz5+Yzlfxgvxr9DY9FdYkqhUhSnGhOw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-arm64-musl@5.3.0':
     resolution: {integrity: sha512-TzbjmFkcnESGuVItQ2diKacX8vu5G0bH3BHmIlmY4OSRLyoAlrJFwGKAHmh6C9+Amfcjo2rx8vdm7swzmsGC6Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@5.3.0':
     resolution: {integrity: sha512-NH3pjAqh8nuN29iRuRfTY42Vn03ctoR9VE8llfoUKUfhHUjFHYOXK5VSkhjj1usG8AeuesvqrQnLptCRQVTi/Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-s390x-gnu@5.3.0':
     resolution: {integrity: sha512-tuZtkK9sJYh2MC2uhol1M/8IMTB6ZQ5jmqP2+k5XNXnOb/im94Y5uV/u2lXwVyIuKHZZHtr+0d1HrOiNahoKpw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@5.3.0':
     resolution: {integrity: sha512-VzhPYmZCtoES/ThcPdGSmMop7JlwgqtSvlgtKCW15ByV2JKyl8kHAHnPSBfpIooXb0ehFnRdxFtL9qtAEWy01g==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-x64-musl@5.3.0':
     resolution: {integrity: sha512-Hi39cWzul24rGljN4Vf1lxjXzQdCrdxO5oCT7KJP4ndSlqIUODJnfnMAP1YhcnIRvNvk+5E6sZtnEmFUd/4d8Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -2618,42 +2590,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -2751,79 +2717,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -3142,28 +3095,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.12.14':
     resolution: {integrity: sha512-ZkOOIpSMXuPAjfOXEIAEQcrPOgLi6CaXvA5W+GYnpIpFG21Nd0qb0WbwFRv4K8BRtl993Q21v0gPpOaFHU+wdA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.12.14':
     resolution: {integrity: sha512-71EPPccwJiJUxd2aMwNlTfom2mqWEWYGdbeTju01tzSHsEuD7E6ePlgC3P3ngBqB3urj41qKs87z7zPOswT5Iw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.12.14':
     resolution: {integrity: sha512-nImF1hZJqKTcl0WWjHqlelOhvuB9rU9kHIw/CmISBUZXogjLIvGyop1TtJNz0ULcz2Oxr3Q2YpwfrzsgvgbGkA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.12.14':
     resolution: {integrity: sha512-sABFQFxSuStFoxvEWZUHWYldtB1B4A9eDNFd4Ty50q7cemxp7uoscFoaCqfXSGNBwwBwpS5EiPB6YN4y6hqmLQ==}
@@ -3239,28 +3188,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3366,6 +3311,9 @@ packages:
 
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
@@ -3746,6 +3694,11 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atob@2.1.2:
+    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
+    engines: {node: '>= 4.5.0'}
+    hasBin: true
+
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3809,6 +3762,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3860,6 +3817,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  btoa@1.2.1:
+    resolution: {integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==}
+    engines: {node: '>= 0.4.0'}
+    hasBin: true
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -3909,6 +3871,10 @@ packages:
 
   caniuse-lite@1.0.30001785:
     resolution: {integrity: sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -4035,6 +4001,9 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -4052,6 +4021,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -4180,6 +4152,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@2.5.9:
+    resolution: {integrity: sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==}
 
   dompurify@3.4.0:
     resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
@@ -4679,6 +4654,14 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html2canvas-pro@1.6.7:
+    resolution: {integrity: sha512-BzuCTXx0jf2TfnrJrtjMCY1FR9rxlPdy7yLWt9ZMhZm7Ylaw9MLb7agSheqv2mT/ARduBHDAqvJIFlbxrZfyOA==}
+    engines: {node: '>=16.0.0'}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -4925,6 +4908,9 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jspdf@2.5.2:
+    resolution: {integrity: sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==}
+
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
@@ -5000,28 +4986,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5395,6 +5377,9 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
 
@@ -5632,6 +5617,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
@@ -5678,6 +5666,9 @@ packages:
 
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   regexpu-core@6.4.0:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
@@ -5743,6 +5734,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rolldown@1.0.0-rc.15:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
@@ -5915,6 +5910,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -6065,6 +6064,10 @@ packages:
       '@sveltejs/kit': 1.x || 2.x
       svelte: 3.x || 4.x || >=5.0.0-next.51
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -6093,6 +6096,9 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -6323,6 +6329,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
@@ -9360,6 +9369,9 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
+  '@types/raf@3.4.3':
+    optional: true
+
   '@types/react@19.1.8':
     dependencies:
       csstype: 3.2.3
@@ -9407,10 +9419,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.58.0
       '@typescript-eslint/type-utils': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -9939,6 +9951,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atob@2.1.2: {}
+
   autoprefixer@10.4.27(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
@@ -10018,6 +10032,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.14: {}
@@ -10078,6 +10094,8 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  btoa@1.2.1: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -10129,6 +10147,18 @@ snapshots:
     optional: true
 
   caniuse-lite@1.0.30001785: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   chai@5.3.3:
     dependencies:
@@ -10250,6 +10280,9 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
+  core-js@3.49.0:
+    optional: true
+
   core-util-is@1.0.3: {}
 
   corser@2.0.1: {}
@@ -10269,6 +10302,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css.escape@1.5.1: {}
 
@@ -10357,6 +10394,9 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@2.5.9:
+    optional: true
 
   dompurify@3.4.0:
     optionalDependencies:
@@ -10986,6 +11026,17 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html2canvas-pro@1.6.7:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -11238,6 +11289,18 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jspdf@2.5.2:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      atob: 2.1.2
+      btoa: 1.2.1
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 2.5.9
+      html2canvas: 1.4.1
 
   jszip@3.10.1:
     dependencies:
@@ -11766,6 +11829,9 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  performance-now@2.1.0:
+    optional: true
+
   pg-cloudflare@1.3.0:
     optional: true
 
@@ -11973,6 +12039,11 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   rc9@2.1.2:
     dependencies:
       defu: 6.1.7
@@ -12030,6 +12101,9 @@ snapshots:
 
   regenerate@1.4.2: {}
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   regexpu-core@6.4.0:
     dependencies:
       regenerate: 1.4.2
@@ -12084,6 +12158,9 @@ snapshots:
   retry@0.12.0: {}
 
   reusify@1.1.0: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rolldown@1.0.0-rc.15:
     dependencies:
@@ -12316,6 +12393,9 @@ snapshots:
   sqlstring@2.3.3: {}
 
   stackback@0.0.2: {}
+
+  stackblur-canvas@2.7.0:
+    optional: true
 
   std-env@3.10.0: {}
 
@@ -12553,6 +12633,9 @@ snapshots:
       - '@types/json-schema'
       - typescript
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
@@ -12577,6 +12660,10 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -12742,7 +12829,7 @@ snapshots:
 
   typescript-eslint@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.4.2))(typescript@5.8.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -12796,6 +12883,10 @@ snapshots:
   url-join@4.0.1: {}
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@14.0.0: {}
 


### PR DESCRIPTION
Three iterations of the iframe + window.print() approach (PR #46/#47/#48) never worked on Android Brave PWA — the platform print framework treats iframe.print() as a viewport snapshot in standalone mode and ignores multi-page pagination regardless of iframe size or image-load wait. PDF export was effectively desktop + iPad only. Mobile is a key use case for this feature, so a broken Android path means a broken feature.

Replace exportNoteAsPdf() with a fully client-side pipeline:

- Render markdown to an off-screen DOM container (positioned at left:-10000px so html2canvas-pro can read computed layout).
- Rasterize the container with html2canvas-pro to one canvas.
- Manually paginate the canvas into A4 slices and embed each as a JPEG via pdf.addImage(). Smart break points: collect bottom-edge Y of every top-level body block (and <li> within lists) before rasterization, then pick the largest boundary that fits in each ideal slice instead of cutting through the middle of a heading or paragraph. Falls back to a hard pixel cut only when a single block is taller than a page (e.g., a long table).

Two library decisions worth surfacing:

- html2canvas-pro 1.6.7 instead of html2canvas 1.4.1: the upstream package (last release 2022) cannot parse modern CSS color functions, and Tailwind v4 emits oklch() in :root variables. html2canvas reads computed styles across the whole ancestor chain, so inline hex overrides on our container do not help — the engine throws on the first parse. The pro fork adds oklch/lab/lch support and is API- compatible. Vite alias maps html2canvas → html2canvas-pro so jsPDF's internal `import("html2canvas")` resolves to the fork without modifying jsPDF.
- Direct addImage instead of pdf.html(): pdf.html() routes through pdf.context2d which renders text as native PDF text using the built-in Helvetica font (Latin-1 only). Polish characters and any non-Latin-1 UTF-8 come out garbled (multi-byte sequences read as separate Latin-1 codepoints — "narzędzi" became "n a r z d z i"). Solving that via fontFaces would require shipping a ~150 KB TTF asset; pure raster keeps the pipeline simpler at the cost of selectable text in the output.

Pinned exact versions (no ^): jspdf 2.5.2, html2canvas-pro 1.6.7. Both are lazy-loaded via Promise.all of dynamic imports, kept off the initial bundle.

Caller (handleDetailExportPdf) now awaits the export and toasts notes.export_failed on rejection. Service logs the underlying error via logger.error and defensively removes orphan <iframe class="html2canvas-container"> in finally (html2canvas-pro leaves it behind on a thrown error mid-render).

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>