### PR TITLE
feat(notes): show initial-sync state in main view on fresh login

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -10,7 +10,7 @@
   import { tagsStore } from '$lib/stores/tags.store';
   import { SidebarTrigger } from '@reborn/ui/sidebar';
   import { t } from '$lib/stores/i18n.store';
-  import { sessionExpired } from '$lib/stores/sync-status.store';
+  import { sessionExpired, isInitialSync } from '$lib/stores/sync-status.store';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
   import ConfirmDialog from './shared/ConfirmDialog.svelte';
   import NoteListItemComponent from './notes/NoteListItem.svelte';
@@ -348,6 +348,8 @@
             <p class="text-sm text-muted-foreground">{$t('trash.empty_short')}</p>
           {:else if $sessionExpired}
             <p class="text-sm text-muted-foreground">{$t('auth.session.empty_no_data')}</p>
+          {:else if $isInitialSync}
+            <p class="text-sm text-muted-foreground">{$t('sync_status.initial.title')}</p>
           {:else}
             <p class="text-sm text-muted-foreground">{$t('notes.no_notes_short')}</p>
             <button

--- a/apps/reborn-notes/src/lib/components/sync/InitialSyncState.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/InitialSyncState.svelte
@@ -1,0 +1,58 @@
+<!--
+  @component
+  Loading placeholder shown in the main content area during the very first
+  sync after a fresh login (IndexedDB empty). Replaces the standard
+  "select or create a note" empty state so users don't think their notes
+  were lost while data is being fetched and decrypted.
+
+  Uses an internal 300ms delay to avoid flicker on fast syncs.
+-->
+<script lang="ts">
+  import { LoadingSpinner, Skeleton } from '@reborn/ui';
+  import { t } from '$lib/stores/i18n.store';
+
+  let { compact = false }: { compact?: boolean } = $props();
+
+  // Anti-flicker: only render the visible state after 300ms.
+  // Below that threshold a fast sync would cause a jarring flash.
+  let showAfterDelay = $state(false);
+
+  $effect(() => {
+    const timer = setTimeout(() => {
+      showAfterDelay = true;
+    }, 300);
+    return () => clearTimeout(timer);
+  });
+</script>
+
+{#if showAfterDelay}
+  <div
+    class="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-8 text-muted-foreground"
+    role="status"
+    aria-live="polite"
+  >
+    <div class="flex flex-col items-center gap-3 text-center">
+      <LoadingSpinner size="lg" class="text-primary" />
+      <div class="flex flex-col gap-1">
+        <p class="text-sm font-medium text-foreground">
+          {$t('sync_status.initial.title')}
+        </p>
+        <p class="text-xs opacity-70 max-w-sm">
+          {$t('sync_status.initial.message')}
+        </p>
+      </div>
+    </div>
+
+    {#if !compact}
+      <div class="w-full max-w-md flex flex-col gap-3" aria-hidden="true">
+        {#each Array(4) as _, i (i)}
+          <div class="flex flex-col gap-2 rounded-md border border-border/40 p-3">
+            <Skeleton class="h-4 w-2/3" />
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-4/5" />
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -121,3 +121,11 @@ export const syncStatus = derived(
     return { status, pendingCount: $pendingCount, lastSyncedAt: $lastSyncedAt };
   }
 );
+
+// True only during the very first pull after a fresh login (IndexedDB empty,
+// `lastSyncedAt` not yet written). Used to swap empty-list placeholders for a
+// reassuring loading state so users don't think their notes were lost.
+export const isInitialSync = derived(
+  [isSyncing, lastSyncedAt],
+  ([$isSyncing, $lastSyncedAt]) => $isSyncing && $lastSyncedAt === null
+);

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -9,6 +9,8 @@
   import IconNav, { type Section } from '$lib/components/layout/IconNav.svelte';
   import SidebarAutoClose from '$lib/components/layout/SidebarAutoClose.svelte';
   import SyncStatusFooter from '$lib/components/sync/SyncStatusFooter.svelte';
+  import InitialSyncState from '$lib/components/sync/InitialSyncState.svelte';
+  import { isInitialSync } from '$lib/stores/sync-status.store';
   import {
     SidebarProvider,
     Sidebar,
@@ -1105,6 +1107,8 @@
               />
             </div>
           {/if}
+        {:else if $isInitialSync}
+          <InitialSyncState compact />
         {:else}
           <div class="flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
             <p class="text-sm">{$t('notes.select_or_create')}</p>
@@ -1348,12 +1352,16 @@
             >
           </span>
         </header>
-        <div class="flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
-          <div class="flex flex-col items-center gap-1 text-center">
-            <p class="text-sm">{$t('notes.select_or_create')}</p>
-            <p class="text-xs opacity-60">{$t('notes.e2e_info')}</p>
+        {#if $isInitialSync}
+          <InitialSyncState />
+        {:else}
+          <div class="flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
+            <div class="flex flex-col items-center gap-1 text-center">
+              <p class="text-sm">{$t('notes.select_or_create')}</p>
+              <p class="text-xs opacity-60">{$t('notes.e2e_info')}</p>
+            </div>
           </div>
-        </div>
+        {/if}
       {/if}
     </SidebarInset>
   </SidebarProvider>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -429,7 +429,11 @@
     "not_synced": "Noch nicht synchronisiert",
     "click_to_sync": "Zum Synchronisieren klicken",
     "session_expired": "Sitzung abgelaufen",
-    "re_login": "Erneut anmelden"
+    "re_login": "Erneut anmelden",
+    "initial": {
+      "title": "Notizen werden synchronisiert",
+      "message": "Das Herunterladen Ihrer verschlüsselten Daten vom Server kann einen Moment dauern."
+    }
   },
   "view_mode": {
     "edit": "Bearbeiten",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -429,7 +429,11 @@
     "not_synced": "Not synced yet",
     "click_to_sync": "Click to sync",
     "session_expired": "Session expired",
-    "re_login": "Log in again"
+    "re_login": "Log in again",
+    "initial": {
+      "title": "Syncing your notes",
+      "message": "Downloading your encrypted data from the server may take a moment."
+    }
   },
   "view_mode": {
     "edit": "Edit",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -429,7 +429,11 @@
     "not_synced": "Aún no sincronizado",
     "click_to_sync": "Pulse para sincronizar",
     "session_expired": "Sesión expirada",
-    "re_login": "Iniciar sesión de nuevo"
+    "re_login": "Iniciar sesión de nuevo",
+    "initial": {
+      "title": "Sincronizando tus notas",
+      "message": "La descarga de tus datos cifrados desde el servidor puede tardar un momento."
+    }
   },
   "view_mode": {
     "edit": "Editar",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -429,7 +429,11 @@
     "not_synced": "Pas encore synchronisé",
     "click_to_sync": "Cliquez pour synchroniser",
     "session_expired": "Session expirée",
-    "re_login": "Se reconnecter"
+    "re_login": "Se reconnecter",
+    "initial": {
+      "title": "Synchronisation de vos notes",
+      "message": "Le téléchargement de vos données chiffrées depuis le serveur peut prendre un instant."
+    }
   },
   "view_mode": {
     "edit": "Modifier",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -429,7 +429,11 @@
     "not_synced": "Jeszcze nie zsynchronizowane",
     "click_to_sync": "Kliknij, aby zsynchronizować",
     "session_expired": "Sesja wygasła",
-    "re_login": "Zaloguj ponownie"
+    "re_login": "Zaloguj ponownie",
+    "initial": {
+      "title": "Synchronizujemy Twoje notatki",
+      "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać."
+    }
   },
   "view_mode": {
     "edit": "Edycja",


### PR DESCRIPTION
After a full logout the empty IndexedDB combined with a slow first sync looked identical to "no notes" — users feared their data was lost. Add a derived `isInitialSync` flag and an `InitialSyncState` component that replaces the empty placeholder with a spinner, a reassuring message ("Syncing your notes" / "Downloading your encrypted data from the server may take a moment.") and skeleton cards while `lastSyncedAt` is still null. A 300ms delay avoids flicker on fast syncs.

Wired into the desktop main view, mobile empty state, and the sidebar NoteList. Translations added to all five locales (en/pl/de/fr/es).

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>