### PR TITLE
chore(ci): split nx affected into per-target steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,10 @@ jobs:
 
       # Run affected check (svelte-check), tests and build
       # Note: removed 'lint' as it's not configured in the project
-      - run: pnpm nx affected -t check test build
+      # Targets are run in separate steps (not `-t check test build`) so that
+      # check/test/build for the same project don't run in parallel — all three
+      # invoke `svelte-kit sync` (directly or via the Vite plugin) and writing
+      # to `.svelte-kit/types/` concurrently caused intermittent ENOENT races.
+      - run: pnpm nx affected -t check
+      - run: pnpm nx affected -t test
+      - run: pnpm nx affected -t build


### PR DESCRIPTION
Running `nx affected -t check test build` caused intermittent ENOENT failures on `reborn-task:build` because check, test, and build for the same project run in parallel under Nx and all invoke `svelte-kit sync` (directly or via the Vite plugin), racing on `.svelte-kit/types/`.

Splitting into three sequential `nx affected` invocations preserves cross-project parallelism within each phase while preventing the same-project sync race.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>