### PR TITLE
feat(task): show initial-sync state in main view on fresh login

### DIFF
--- a/apps/reborn-task/src/lib/components/layout/sidebar/SidebarTaskList.svelte
+++ b/apps/reborn-task/src/lib/components/layout/sidebar/SidebarTaskList.svelte
@@ -31,6 +31,7 @@
 	import { trashManagementService } from '$lib/services/trash-management.service';
 	import { t } from '$lib/stores/i18n.store';
 	import { sessionExpired } from '$lib/stores/session-expired.store';
+	import { isInitialSync } from '$lib/stores/sync-status.store';
 	import { createLogger } from '@reborn/utils';
 	import { TaskItem, TaskSortButton } from '$lib/components/tasks';
 	import { DeleteTaskDialog } from '$lib/components/tasks/dialogs';
@@ -416,6 +417,10 @@
 				{:else if $sessionExpired}
 					<p class="text-sm text-muted-foreground">
 						{$t('auth.session.empty_no_data')}
+					</p>
+				{:else if $isInitialSync}
+					<p class="text-sm text-muted-foreground">
+						{$t('sync.initial.title')}
 					</p>
 				{:else}
 					<p class="text-sm text-muted-foreground">

--- a/apps/reborn-task/src/lib/components/sync/InitialSyncState.svelte
+++ b/apps/reborn-task/src/lib/components/sync/InitialSyncState.svelte
@@ -1,0 +1,58 @@
+<!--
+  @component
+  Loading placeholder shown in the main content area during the very first
+  sync after a fresh login (IndexedDB empty). Replaces the standard empty
+  state so users don't think their tasks were lost while data is being
+  fetched and decrypted.
+
+  Uses an internal 300ms delay to avoid flicker on fast syncs.
+-->
+<script lang="ts">
+	import { LoadingSpinner, Skeleton } from '@reborn/ui';
+	import { t } from '$lib/stores/i18n.store';
+
+	let { compact = false }: { compact?: boolean } = $props();
+
+	// Anti-flicker: only render the visible state after 300ms.
+	// Below that threshold a fast sync would cause a jarring flash.
+	let showAfterDelay = $state(false);
+
+	$effect(() => {
+		const timer = setTimeout(() => {
+			showAfterDelay = true;
+		}, 300);
+		return () => clearTimeout(timer);
+	});
+</script>
+
+{#if showAfterDelay}
+	<div
+		class="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-8 text-muted-foreground"
+		role="status"
+		aria-live="polite"
+	>
+		<div class="flex flex-col items-center gap-3 text-center">
+			<LoadingSpinner size="lg" class="text-primary" />
+			<div class="flex flex-col gap-1">
+				<p class="text-sm font-medium text-foreground">
+					{$t('sync.initial.title')}
+				</p>
+				<p class="text-xs opacity-70 max-w-sm">
+					{$t('sync.initial.message')}
+				</p>
+			</div>
+		</div>
+
+		{#if !compact}
+			<div class="w-full max-w-md flex flex-col gap-3" aria-hidden="true">
+				{#each Array(4) as _, i (i)}
+					<div class="flex flex-col gap-2 rounded-md border border-border/40 p-3">
+						<Skeleton class="h-4 w-2/3" />
+						<Skeleton class="h-3 w-full" />
+						<Skeleton class="h-3 w-4/5" />
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/apps/reborn-task/src/lib/components/tasks/FilterViewPlaceholder.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/FilterViewPlaceholder.svelte
@@ -8,7 +8,9 @@
 	import { Lock } from '@lucide/svelte';
 	import { t } from '$lib/stores/i18n.store';
 	import { tasks as allDecryptedTasks } from '$lib/stores/decrypted-tasks.store';
+	import { isInitialSync } from '$lib/stores/sync-status.store';
 	import QuickAddTask from './QuickAddTask.svelte';
+	import InitialSyncState from '$lib/components/sync/InitialSyncState.svelte';
 	import type { Section } from '$lib/components/layout/IconNav.svelte';
 
 	let {
@@ -28,34 +30,38 @@
 	}
 </script>
 
-<div class="flex flex-1 flex-col items-center justify-center h-full text-center px-6 gap-8">
-	{#if showQuickAdd}
-		<div class="w-full max-w-md">
-			<QuickAddTask
-				bind:this={quickAddRef}
-				showListSelect
-				section={filterSection}
-			/>
-		</div>
-	{/if}
-
-	<div class="flex flex-col items-center gap-1">
-		{#if showQuickAdd && hasTasks}
-			<p class="text-xs text-muted-foreground/60">
-				{$t('task.select_from_list_or')}
-			</p>
-		{:else if hasTasks}
-			<p class="text-sm text-muted-foreground">
-				{$t('task.select_from_list')}
-			</p>
-		{:else}
-			<p class="text-sm text-muted-foreground">
-				{$t('task.no_tasks_yet_hint')}
-			</p>
+{#if !hasTasks && $isInitialSync}
+	<InitialSyncState />
+{:else}
+	<div class="flex flex-1 flex-col items-center justify-center h-full text-center px-6 gap-8">
+		{#if showQuickAdd}
+			<div class="w-full max-w-md">
+				<QuickAddTask
+					bind:this={quickAddRef}
+					showListSelect
+					section={filterSection}
+				/>
+			</div>
 		{/if}
-		<p class="inline-flex items-center gap-1.5 text-xs text-muted-foreground/60">
-			<Lock class="h-3 w-3" />
-			{$t('e2e.badge_tooltip')}
-		</p>
+
+		<div class="flex flex-col items-center gap-1">
+			{#if showQuickAdd && hasTasks}
+				<p class="text-xs text-muted-foreground/60">
+					{$t('task.select_from_list_or')}
+				</p>
+			{:else if hasTasks}
+				<p class="text-sm text-muted-foreground">
+					{$t('task.select_from_list')}
+				</p>
+			{:else}
+				<p class="text-sm text-muted-foreground">
+					{$t('task.no_tasks_yet_hint')}
+				</p>
+			{/if}
+			<p class="inline-flex items-center gap-1.5 text-xs text-muted-foreground/60">
+				<Lock class="h-3 w-3" />
+				{$t('e2e.badge_tooltip')}
+			</p>
+		</div>
 	</div>
-</div>
+{/if}

--- a/apps/reborn-task/src/lib/services/sync.service.ts
+++ b/apps/reborn-task/src/lib/services/sync.service.ts
@@ -2,4 +2,10 @@
  * Re-export from the sync folder to maintain backward compatibility
  * with existing imports like: import { syncService } from '$lib/services/sync.service';
  */
-export { syncService, syncProgress, syncConflict, type SyncProgress } from './sync';
+export {
+	syncService,
+	syncProgress,
+	syncConflict,
+	lastSyncedAt,
+	type SyncProgress
+} from './sync';

--- a/apps/reborn-task/src/lib/services/sync/index.ts
+++ b/apps/reborn-task/src/lib/services/sync/index.ts
@@ -2,4 +2,10 @@
  * Re-export main sync service and related types
  * This maintains backward compatibility with existing imports
  */
-export { syncService, syncProgress, syncConflict, type SyncProgress } from './sync.service';
+export {
+	syncService,
+	syncProgress,
+	syncConflict,
+	lastSyncedAt,
+	type SyncProgress
+} from './sync.service';

--- a/apps/reborn-task/src/lib/services/sync/sync.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync.service.ts
@@ -264,6 +264,8 @@ class SyncService {
 				message: 'Sync complete'
 			});
 
+			lastSyncedAt.set(new Date().toISOString());
+
 			// Notify about server-side changes (conflict detection)
 			const totalServerUpdates = listUpdates + taskUpdates;
 			if (totalServerUpdates > 0) {
@@ -348,6 +350,8 @@ class SyncService {
 			// Refresh task counts and title index
 			taskCounts.refresh();
 			await taskTitleIndex.rebuild();
+
+			lastSyncedAt.set(new Date().toISOString());
 
 			// Notify about server-side changes
 			const totalServerUpdates = listUpdates + taskUpdates;
@@ -551,6 +555,11 @@ export const syncProgress = writable<SyncProgress>({
 	progress: 0,
 	message: ''
 });
+
+// Timestamp of the last successful sync. Stays `null` until the very first
+// sync of the current session completes — used by `isInitialSync` in
+// sync-status.store to distinguish "fresh login, syncing" from "no data".
+export const lastSyncedAt = writable<string | null>(null);
 
 // Store for conflict notifications (number of server-updated entities, 0 = no conflict)
 export const syncConflict = writable<number>(0);

--- a/apps/reborn-task/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-task/src/lib/stores/sync-status.store.ts
@@ -1,8 +1,10 @@
 import { derived } from 'svelte/store';
 import { isOnline } from './network.store';
-import { syncProgress } from '$lib/services/sync.service';
+import { syncProgress, lastSyncedAt } from '$lib/services/sync.service';
 import { pendingOperations, failedOperations } from './offline-operations.store';
 import { sessionExpired } from './session-expired.store';
+
+export { lastSyncedAt };
 
 export type SyncStatusType = 'synced' | 'syncing' | 'offline' | 'error' | 'pending' | 'auth-error';
 
@@ -12,6 +14,7 @@ export interface SyncStatusState {
 	failedCount: number;
 	message: string;
 	progress: number;
+	lastSyncedAt: string | null;
 }
 
 /**
@@ -19,8 +22,15 @@ export interface SyncStatusState {
  * Priority: auth-error > offline > syncing > error > pending > synced
  */
 export const syncStatus = derived(
-	[isOnline, syncProgress, pendingOperations, failedOperations, sessionExpired],
-	([$isOnline, $syncProgress, $pendingOps, $failedOps, $sessionExpired]): SyncStatusState => {
+	[isOnline, syncProgress, pendingOperations, failedOperations, sessionExpired, lastSyncedAt],
+	([
+		$isOnline,
+		$syncProgress,
+		$pendingOps,
+		$failedOps,
+		$sessionExpired,
+		$lastSyncedAt
+	]): SyncStatusState => {
 		const pendingCount = $pendingOps.length;
 		const failedCount = $failedOps.length;
 
@@ -30,7 +40,8 @@ export const syncStatus = derived(
 				pendingCount,
 				failedCount,
 				message: '',
-				progress: 0
+				progress: 0,
+				lastSyncedAt: $lastSyncedAt
 			};
 		}
 
@@ -40,7 +51,8 @@ export const syncStatus = derived(
 				pendingCount,
 				failedCount,
 				message: '',
-				progress: 0
+				progress: 0,
+				lastSyncedAt: $lastSyncedAt
 			};
 		}
 
@@ -50,7 +62,8 @@ export const syncStatus = derived(
 				pendingCount,
 				failedCount,
 				message: $syncProgress.message,
-				progress: $syncProgress.progress
+				progress: $syncProgress.progress,
+				lastSyncedAt: $lastSyncedAt
 			};
 		}
 
@@ -60,7 +73,8 @@ export const syncStatus = derived(
 				pendingCount,
 				failedCount,
 				message: '',
-				progress: 0
+				progress: 0,
+				lastSyncedAt: $lastSyncedAt
 			};
 		}
 
@@ -70,7 +84,8 @@ export const syncStatus = derived(
 				pendingCount,
 				failedCount,
 				message: '',
-				progress: 0
+				progress: 0,
+				lastSyncedAt: $lastSyncedAt
 			};
 		}
 
@@ -79,7 +94,16 @@ export const syncStatus = derived(
 			pendingCount: 0,
 			failedCount: 0,
 			message: '',
-			progress: 0
+			progress: 0,
+			lastSyncedAt: $lastSyncedAt
 		};
 	}
+);
+
+// True only during the very first sync after a fresh login (IndexedDB empty,
+// `lastSyncedAt` not yet written). Used to swap empty-list placeholders for a
+// reassuring loading state so users don't think their tasks were lost.
+export const isInitialSync = derived(
+	[syncProgress, lastSyncedAt],
+	([$syncProgress, $lastSyncedAt]) => $syncProgress.isInProgress && $lastSyncedAt === null
 );

--- a/apps/reborn-task/src/routes/(app)/all/+page.svelte
+++ b/apps/reborn-task/src/routes/(app)/all/+page.svelte
@@ -7,9 +7,11 @@
 	import { goto } from '$lib/utils/navigation';
 	import { tasks as allDecryptedTasks } from '$lib/stores/decrypted-tasks.store';
 	import { decryptedLists } from '$lib/stores/decrypted-lists.store';
+	import { isInitialSync } from '$lib/stores/sync-status.store';
 	import { taskOperationsService } from '$lib/services/task-operations.service';
 	import type { TaskListItem } from '$lib/services/task-title-index.svelte';
 	import { TaskItem } from '$lib/components/tasks';
+	import InitialSyncState from '$lib/components/sync/InitialSyncState.svelte';
 
 	let allTasks = $derived($allDecryptedTasks ?? []);
 	let activeTasks = $derived(allTasks.filter((task: TaskListItem) => !task.is_completed));
@@ -48,10 +50,14 @@
 <div class="container mx-auto p-6 max-w-4xl">
 	<div class="mt-6">
 		{#if activeTasks.length === 0 && completedTasks.length === 0}
-			<div class="flex flex-col items-center justify-center py-12 text-center">
-				<ListTodo class="h-12 w-12 text-muted-foreground mb-4" />
-				<p class="text-lg font-medium mb-2">{$t('task.empty_state', { default: 'Brak zadań' })}</p>
-			</div>
+			{#if $isInitialSync}
+				<InitialSyncState compact />
+			{:else}
+				<div class="flex flex-col items-center justify-center py-12 text-center">
+					<ListTodo class="h-12 w-12 text-muted-foreground mb-4" />
+					<p class="text-lg font-medium mb-2">{$t('task.empty_state', { default: 'Brak zadań' })}</p>
+				</div>
+			{/if}
 		{:else}
 			<div class="space-y-2">
 				{#each activeTasks as task (task.id)}

--- a/packages/i18n/src/translations/tasks/de/sync.json
+++ b/packages/i18n/src/translations/tasks/de/sync.json
@@ -58,5 +58,9 @@
     "conflict_message": "Neuere Daten wurden auf dem Server erkannt. Aktualisierte Daten wurden heruntergeladen.",
     "conflict_action": "Aktualisieren",
     "session_expired": "Sitzung abgelaufen"
+  },
+  "initial": {
+    "title": "Aufgaben werden synchronisiert",
+    "message": "Das Herunterladen Ihrer verschlüsselten Daten vom Server kann einen Moment dauern."
   }
 }

--- a/packages/i18n/src/translations/tasks/en/sync.json
+++ b/packages/i18n/src/translations/tasks/en/sync.json
@@ -58,5 +58,9 @@
     "conflict_message": "Newer data was detected on the server. Updated data has been downloaded.",
     "conflict_action": "Refresh",
     "session_expired": "Session expired"
+  },
+  "initial": {
+    "title": "Syncing your tasks",
+    "message": "Downloading your encrypted data from the server may take a moment."
   }
 }

--- a/packages/i18n/src/translations/tasks/es/sync.json
+++ b/packages/i18n/src/translations/tasks/es/sync.json
@@ -58,5 +58,9 @@
     "conflict_message": "Se detectaron datos más recientes en el servidor. Los datos actualizados han sido descargados.",
     "conflict_action": "Actualizar",
     "session_expired": "Sesión expirada"
+  },
+  "initial": {
+    "title": "Sincronizando tus tareas",
+    "message": "La descarga de tus datos cifrados desde el servidor puede tardar un momento."
   }
 }

--- a/packages/i18n/src/translations/tasks/fr/sync.json
+++ b/packages/i18n/src/translations/tasks/fr/sync.json
@@ -58,5 +58,9 @@
     "conflict_message": "Des donn\u00e9es plus r\u00e9centes ont \u00e9t\u00e9 d\u00e9tect\u00e9es sur le serveur. Les donn\u00e9es mises \u00e0 jour ont \u00e9t\u00e9 t\u00e9l\u00e9charg\u00e9es.",
     "conflict_action": "Actualiser",
     "session_expired": "Session expir\u00e9e"
+  },
+  "initial": {
+    "title": "Synchronisation de vos t\u00e2ches",
+    "message": "Le t\u00e9l\u00e9chargement de vos donn\u00e9es chiffr\u00e9es depuis le serveur peut prendre un instant."
   }
 }

--- a/packages/i18n/src/translations/tasks/pl/sync.json
+++ b/packages/i18n/src/translations/tasks/pl/sync.json
@@ -58,5 +58,9 @@
     "conflict_message": "Wykryto nowsze dane na serwerze. Pobrano zaktualizowane dane.",
     "conflict_action": "Odśwież",
     "session_expired": "Sesja wygasła"
+  },
+  "initial": {
+    "title": "Synchronizujemy Twoje zadania",
+    "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać."
   }
 }


### PR DESCRIPTION
After a full logout the empty IndexedDB combined with a slow first sync looked identical to "no tasks" — users feared their data was lost. Add a `lastSyncedAt` writable (next to existing `syncProgress` to avoid a new import-cycle edge), a derived `isInitialSync` flag and an `InitialSyncState` component that replaces the empty placeholder with a spinner, a reassuring message ("Syncing your tasks" / "Downloading your encrypted data from the server may take a moment.") and skeleton cards while `lastSyncedAt` is still null. A 300ms delay avoids flicker on fast syncs.

Wired into the mobile main view, the desktop main panel (FilterViewPlaceholder, gated on `!hasTasks`) and the sidebar SidebarTaskList. Translations added to all five locales (en/pl/de/fr/es).

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>