### PR TITLE
fix(task,notes): cache-bust app icons via ?v query string

### DIFF
--- a/apps/reborn-notes/src/app.html
+++ b/apps/reborn-notes/src/app.html
@@ -2,7 +2,7 @@
 <html lang="%lang%" data-sveltekit-template>
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.svg?v=2026-04-26" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
 		<meta name="theme-color" content="#FFD43B" />
@@ -11,7 +11,8 @@
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 		<meta name="apple-mobile-web-app-title" content="re/notes" />
-		<link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png" />
+		<!-- Bump ?v=YYYY-MM-DD when icons change to bypass Safari/iOS WebClip cache. -->
+		<link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png?v=2026-04-26" />
 		%sveltekit.head%
 		<script nonce="%sveltekit.nonce%">
 			(function(){

--- a/apps/reborn-notes/src/routes/manifest.webmanifest/+server.ts
+++ b/apps/reborn-notes/src/routes/manifest.webmanifest/+server.ts
@@ -11,8 +11,13 @@ import type { RequestHandler } from '@sveltejs/kit';
  *   dev  (port 4300): PUBLIC_BASE_PATH=""   → start_url: "/"
  *   prod (same-origin): PUBLIC_BASE_PATH="/notes" → start_url: "/notes"
  */
+// Bump when icon files change to bypass browser HTTP cache and Android
+// adaptive-icon cache. Keep in sync with the value in `src/app.html`.
+const ICON_VERSION = '2026-04-26';
+
 export const GET: RequestHandler = () => {
   const base = env.PUBLIC_BASE_PATH ?? '';
+  const v = `?v=${ICON_VERSION}`;
 
   const manifest = {
     name: 're/notes',
@@ -27,25 +32,25 @@ export const GET: RequestHandler = () => {
     lang: 'pl',
     icons: [
       {
-        src: `${base}/icons/icon-192.png`,
+        src: `${base}/icons/icon-192.png${v}`,
         sizes: '192x192',
         type: 'image/png',
         purpose: 'any'
       },
       {
-        src: `${base}/icons/icon-512.png`,
+        src: `${base}/icons/icon-512.png${v}`,
         sizes: '512x512',
         type: 'image/png',
         purpose: 'any'
       },
       {
-        src: `${base}/icons/icon-512-maskable.png`,
+        src: `${base}/icons/icon-512-maskable.png${v}`,
         sizes: '512x512',
         type: 'image/png',
         purpose: 'maskable'
       },
       {
-        src: `${base}/favicon.svg`,
+        src: `${base}/favicon.svg${v}`,
         sizes: 'any',
         type: 'image/svg+xml'
       }

--- a/apps/reborn-task/src/app.html
+++ b/apps/reborn-task/src/app.html
@@ -2,7 +2,7 @@
 <html lang="%lang%" data-sveltekit-template>
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.svg?v=2026-04-26" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<title>re/task</title>
 		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
@@ -11,7 +11,8 @@
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 		<meta name="apple-mobile-web-app-title" content="re/task" />
-		<link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png" />
+		<!-- Bump ?v=YYYY-MM-DD when icons change to bypass Safari/iOS WebClip cache. -->
+		<link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png?v=2026-04-26" />
 		%sveltekit.head%
 		<script nonce="%sveltekit.nonce%">
 			(function(){

--- a/apps/reborn-task/src/routes/manifest.webmanifest/+server.ts
+++ b/apps/reborn-task/src/routes/manifest.webmanifest/+server.ts
@@ -11,8 +11,13 @@ import type { RequestHandler } from '@sveltejs/kit';
  *   dev  (port 4200): PUBLIC_BASE_PATH=""  → start_url: "/"
  *   prod (same-origin): PUBLIC_BASE_PATH="/task" → start_url: "/task"
  */
+// Bump when icon files change to bypass browser HTTP cache and Android
+// adaptive-icon cache. Keep in sync with the value in `src/app.html`.
+const ICON_VERSION = '2026-04-26';
+
 export const GET: RequestHandler = () => {
 	const base = env.PUBLIC_BASE_PATH ?? '';
+	const v = `?v=${ICON_VERSION}`;
 
 	const manifest = {
 		name: 're/task',
@@ -27,25 +32,25 @@ export const GET: RequestHandler = () => {
 		lang: 'pl',
 		icons: [
 			{
-				src: `${base}/icons/icon-192.png`,
+				src: `${base}/icons/icon-192.png${v}`,
 				sizes: '192x192',
 				type: 'image/png',
 				purpose: 'any'
 			},
 			{
-				src: `${base}/icons/icon-512.png`,
+				src: `${base}/icons/icon-512.png${v}`,
 				sizes: '512x512',
 				type: 'image/png',
 				purpose: 'any'
 			},
 			{
-				src: `${base}/icons/icon-512-maskable.png`,
+				src: `${base}/icons/icon-512-maskable.png${v}`,
 				sizes: '512x512',
 				type: 'image/png',
 				purpose: 'maskable'
 			},
 			{
-				src: `${base}/favicon.svg`,
+				src: `${base}/favicon.svg${v}`,
 				sizes: 'any',
 				type: 'image/svg+xml'
 			}


### PR DESCRIPTION
Browsers (and Cloudflare in front) cache PNG/SVG icons aggressively, so even after the icon files are updated on the server, returning users may still see the old artwork until the cache expires. On iOS this is worse: WebClips installed before the change keep their cached icon at the OS level even after the HTTP cache clears.

Append `?v=2026-04-26` to all icon URLs in `app.html` (favicon and apple-touch-icon) and in the dynamic PWA manifest (icon-192/512, maskable, favicon). Browsers treat the new URL as a fresh resource and fetch the updated bytes on the next page load.

Bump the date in both `app.html` files and in the `ICON_VERSION` constant of each manifest route whenever icons change.

Note: this does not retroactively refresh icons for existing iOS Web Clips — those need to be removed and re-added (and ideally the iPad restarted to clear SpringBoard's icon cache).

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>