### PR TITLE
fix(notes): add progress feedback and content sanitization to imports

### DIFF
--- a/apps/reborn-notes/src/lib/components/import/MarkdownImportStrategyPicker.svelte
+++ b/apps/reborn-notes/src/lib/components/import/MarkdownImportStrategyPicker.svelte
@@ -21,9 +21,25 @@
       ? 'settings_page.export_import.dedup_prompt_folder'
       : 'settings_page.export_import.dedup_prompt_root'
   );
+
+  let containerEl: HTMLDivElement | null = $state(null);
+
+  // The picker is rendered conditionally by the parent right after the user
+  // closes the OS file/folder picker. Long settings pages can leave the radio
+  // options below the viewport, so we scroll the picker into view and move
+  // focus to the first (currently-selected) radio. `preventScroll: true` on
+  // focus avoids fighting the scrollIntoView animation.
+  $effect(() => {
+    if (!containerEl) return;
+    containerEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    requestAnimationFrame(() => {
+      const firstRadio = containerEl?.querySelector<HTMLInputElement>('input[type="radio"]');
+      firstRadio?.focus({ preventScroll: true });
+    });
+  });
 </script>
 
-<div class="space-y-3">
+<div bind:this={containerEl} class="space-y-3">
   <p class="text-xs font-medium">
     {$t('settings_page.export_import.dedup_files_found', { values: { count } })}
   </p>

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -655,6 +655,15 @@ export type ImportBackupResult = {
   tags: number;
   noteTags: number;
   skipped: number;
+  /**
+   * Total number of unsafe markdown elements removed from imported notes
+   * (base64 data URIs, dangerous HTML tags, javascript:/data:text/html links).
+   * Mirrors the counter from {@link importMarkdownFiles} / {@link importFolder}
+   * so older backups created before content sanitization existed are scrubbed
+   * on import — defense in depth, even though account-key-encrypted content
+   * is only readable on the originating account.
+   */
+  strippedCount: number;
   errors: string[];
 };
 
@@ -679,7 +688,8 @@ export function isEncryptedBackup(raw: string): boolean {
  */
 export async function importJsonBackup(
   raw: string,
-  password?: string
+  password?: string,
+  onProgress?: ImportProgressCallback
 ): Promise<ImportBackupResult> {
   // raw is already in memory (file.text() in UI), but guard against absurd sizes
   if (raw.length > MAX_IMPORT_FILE_SIZE) {
@@ -719,7 +729,7 @@ export async function importJsonBackup(
 
   const now = new Date().toISOString();
   const result: ImportBackupResult = {
-    notes: 0, folders: 0, tags: 0, noteTags: 0, skipped: 0, errors: []
+    notes: 0, folders: 0, tags: 0, noteTags: 0, skipped: 0, strippedCount: 0, errors: []
   };
 
   // Import folders first (notes reference them)
@@ -797,7 +807,16 @@ export async function importJsonBackup(
   // Import notes — strip any shadow indexes a legacy file may have, then
   // rebuild them locally from `metadata_encrypted` (Zero Knowledge: shadow
   // indexes are NEVER trusted from a file).
-  for (const note of backupData.notes ?? []) {
+  // Notes dominate import time (decrypt + sanitize + re-encrypt per note),
+  // so progress is reported only for this loop. Folders/tags above are
+  // typically a handful of items and complete in under a frame.
+  const notes = backupData.notes ?? [];
+  const totalNotes = notes.length;
+  onProgress?.({ phase: 'reading', current: 0, total: totalNotes });
+  let lastEmit = 0;
+
+  for (let i = 0; i < notes.length; i++) {
+    const note = notes[i];
     try {
       // Strip shadow indexes from raw input before validation. Zod's safeParse
       // strips unknowns, so this is mostly defensive — it makes the intent
@@ -842,8 +861,35 @@ export async function importJsonBackup(
         );
       }
 
+      // Defense in depth: scrub unsafe markdown (base64 data URIs, <script>,
+      // javascript: links) from older backups. Mirrors the .md / folder import
+      // path. Decrypts with the current account key, sanitizes plaintext, and
+      // re-encrypts only when something was stripped — preserving Zero
+      // Knowledge: ciphertext leaves the browser, plaintext never does. If
+      // the content is encrypted with a different key (cross-account import)
+      // decryption fails and we leave the ciphertext untouched.
+      let sanitizedContentEncrypted: string | undefined;
+      if (validated.content_encrypted && cryptoManager.isInitialized()) {
+        try {
+          const plaintext = await cryptoManager.decryptText(validated.content_encrypted);
+          const { sanitized, stripped } = sanitizeMarkdownContent(plaintext);
+          if (stripped.length > 0) {
+            sanitizedContentEncrypted = await cryptoManager.encryptText(sanitized);
+            result.strippedCount += stripped.length;
+          }
+        } catch (sanitizeErr) {
+          logger.warn(
+            `Could not sanitize content for imported note ${validated.id} — keeping ciphertext as-is`,
+            sanitizeErr
+          );
+        }
+      }
+
       const wire: NoteEncrypted = {
         ...validated,
+        ...(sanitizedContentEncrypted !== undefined
+          ? { content_encrypted: sanitizedContentEncrypted }
+          : {}),
         user_id: userId,
         sync_status: 'pending',
         sync_version: 0,
@@ -881,6 +927,13 @@ export async function importJsonBackup(
     } catch (e: unknown) {
       result.errors.push(`Note ${(note as { id?: string }).id ?? '?'}: ${e instanceof Error ? e.message : 'błąd'}`);
     }
+
+    const current = i + 1;
+    const nowMs = Date.now();
+    if (current === totalNotes || nowMs - lastEmit >= 50) {
+      onProgress?.({ phase: 'reading', current, total: totalNotes });
+      lastEmit = nowMs;
+    }
   }
 
   // Backwards compat: legacy v1 backups contained an explicit `noteTags`
@@ -905,11 +958,13 @@ export async function importJsonBackup(
 
   // Rebuild in-memory note title index so imported notes are visible
   // immediately without requiring a reload.
+  onProgress?.({ phase: 'indexing', current: 0, total: 1 });
   try {
     await noteIndex.rebuild();
   } catch (e: unknown) {
     logger.warn('Failed to rebuild note index after import', e);
   }
+  onProgress?.({ phase: 'indexing', current: 1, total: 1 });
 
   // Trigger background sync for any items that didn't get pushed inline
   void pushPendingItems();
@@ -976,6 +1031,22 @@ export type ImportMarkdownResult = {
 };
 
 /**
+ * Progress phase reported by the importer to a UI callback.
+ *
+ * - `reading`  — iterating files (read text + decrypt + dedup + write).
+ *                `current`/`total` count files in the import batch.
+ * - `indexing` — rebuilding the in-memory title index after all writes.
+ *                Single-step phase; `current === total === 1`.
+ */
+export type ImportProgress = {
+  phase: 'reading' | 'indexing';
+  current: number;
+  total: number;
+};
+
+export type ImportProgressCallback = (p: ImportProgress) => void;
+
+/**
  * Import notes from an array of .md File objects.
  *
  * `duplicateStrategy` controls behavior when a note with the same title
@@ -988,7 +1059,8 @@ export type ImportMarkdownResult = {
 export async function importMarkdownFiles(
   files: File[],
   folderId?: string,
-  duplicateStrategy: DuplicateStrategy = 'rename'
+  duplicateStrategy: DuplicateStrategy = 'rename',
+  onProgress?: ImportProgressCallback
 ): Promise<ImportMarkdownResult> {
   const totalSize = files.reduce((sum, f) => sum + f.size, 0);
   if (totalSize > MAX_IMPORT_FILE_SIZE) {
@@ -1006,7 +1078,14 @@ export async function importMarkdownFiles(
 
   const lookup = await buildTitleLookupFromIndex();
 
-  for (const file of files) {
+  const total = files.length;
+  onProgress?.({ phase: 'reading', current: 0, total });
+  // Throttle progress events to one per ~50ms so a 1000-file import doesn't
+  // flood the renderer; always report the final count regardless.
+  let lastEmit = 0;
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
     try {
       const raw = await file.text();
       const { title, content } = parseMarkdownFile(raw);
@@ -1036,15 +1115,24 @@ export async function importMarkdownFiles(
     } catch (e: unknown) {
       result.errors.push(`${file.name}: ${e instanceof Error ? e.message : 'Unknown error'}`);
     }
+
+    const current = i + 1;
+    const now = Date.now();
+    if (current === total || now - lastEmit >= 50) {
+      onProgress?.({ phase: 'reading', current, total });
+      lastEmit = now;
+    }
   }
 
   // Rebuild the title index so any in-place overwrites / new notes are
   // visible immediately without requiring a reload.
+  onProgress?.({ phase: 'indexing', current: 0, total: 1 });
   try {
     await noteIndex.rebuild();
   } catch (e: unknown) {
     logger.warn('Failed to rebuild note index after markdown import', e);
   }
+  onProgress?.({ phase: 'indexing', current: 1, total: 1 });
 
   return result;
 }
@@ -1235,7 +1323,8 @@ export type ImportFolderResult = {
  */
 export async function importFolder(
   files: File[],
-  duplicateStrategy: DuplicateStrategy = 'rename'
+  duplicateStrategy: DuplicateStrategy = 'rename',
+  onProgress?: ImportProgressCallback
 ): Promise<ImportFolderResult> {
   const result: ImportFolderResult = {
     imported: 0,
@@ -1328,7 +1417,14 @@ export async function importFolder(
   // 7. Import each note via the duplicate strategy helper.
   //    skipSync: true — avoid per-note pushNote/pushNoteUpdate race condition.
   //    Bulk push happens after the loop (step 7b).
-  for (const file of sizedFiles) {
+  const total = sizedFiles.length;
+  onProgress?.({ phase: 'reading', current: 0, total });
+  // Throttle progress events to one per ~50ms so a 1000-file vault doesn't
+  // flood the renderer; always report the final count regardless.
+  let lastEmit = 0;
+
+  for (let i = 0; i < sizedFiles.length; i++) {
+    const file = sizedFiles[i];
     try {
       const raw = await file.text();
       const parsed = parseMarkdownFile(raw);
@@ -1380,6 +1476,13 @@ export async function importFolder(
     } catch (e: unknown) {
       result.errors.push(`${file.name}: ${e instanceof Error ? e.message : 'Unknown error'}`);
     }
+
+    const current = i + 1;
+    const now = Date.now();
+    if (current === total || now - lastEmit >= 50) {
+      onProgress?.({ phase: 'reading', current, total });
+      lastEmit = now;
+    }
   }
   result.tagsCreated = tagsCounter.count;
 
@@ -1392,11 +1495,13 @@ export async function importFolder(
   void pushPendingItems();
 
   // 8. Rebuild in-memory title index so imports are visible immediately.
+  onProgress?.({ phase: 'indexing', current: 0, total: 1 });
   try {
     await noteIndex.rebuild();
   } catch (e: unknown) {
     logger.warn('Failed to rebuild note index after folder import', e);
   }
+  onProgress?.({ phase: 'indexing', current: 1, total: 1 });
 
   logger.info('Folder import complete', result);
   return result;

--- a/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
@@ -5,7 +5,9 @@
     CardContent,
     CardHeader,
     CardTitle,
-    CardDescription
+    CardDescription,
+    LoadingSpinner,
+    Progress
   } from '@reborn/ui';
   import {
     Download,
@@ -32,7 +34,8 @@
     importJsonBackup,
     isEncryptedBackup,
     type ImportFolderResult,
-    type ImportMarkdownResult
+    type ImportMarkdownResult,
+    type ImportProgress
   } from '$lib/services/export-import.service';
   import type { DuplicateStrategy } from '$lib/services/import-dedup-utils';
   import { notesStore } from '$lib/stores/notes.store';
@@ -42,7 +45,12 @@
   const logger = createLogger('notes:import-export');
 
   // ── Export state ─────────────────────────────────────────────────
-  let exporting = $state(false);
+  // Tracks which export is currently running so we can show a spinner under
+  // the matching section (instead of a single boolean that would either show
+  // three spinners or none of them).
+  type ExportKind = 'zip' | 'backup' | 'encrypted';
+  let exportingKind = $state<ExportKind | null>(null);
+  const exporting = $derived(exportingKind !== null);
 
   // Export encrypted backup
   let showExportPasswordForm = $state(false);
@@ -61,6 +69,9 @@
   // picker with file count, then runs the import with the chosen strategy.
   let pendingMdFiles = $state<File[] | null>(null);
   let pendingMdStrategy = $state<DuplicateStrategy>('rename');
+  // Live progress reported by the importer service. Mirrors `pendingMdFiles`
+  // lifecycle: set when the import starts, cleared when it finishes.
+  let mdProgress = $state<ImportProgress | null>(null);
 
   // Import folder (Obsidian-style vault)
   let importingFolder = $state(false);
@@ -69,6 +80,7 @@
   let pendingFolderFiles = $state<File[] | null>(null);
   let pendingFolderStrategy = $state<DuplicateStrategy>('rename');
   let pendingFolderMdCount = $state(0);
+  let folderProgress = $state<ImportProgress | null>(null);
 
   // Import JSON backup
   let importingBackup = $state(false);
@@ -77,6 +89,7 @@
     folders: number;
     tags: number;
     skipped: number;
+    strippedCount: number;
     errors: string[];
   } | null>(null);
   let backupFileContent = $state<string | null>(null);
@@ -85,29 +98,30 @@
   let backupPassword = $state('');
   let backupPasswordVisible = $state(false);
   let backupError = $state<string | null>(null);
+  let backupProgress = $state<ImportProgress | null>(null);
 
   // ── Export handlers ──────────────────────────────────────────────
 
   async function handleExportAllZip() {
-    exporting = true;
+    exportingKind = 'zip';
     try {
       const allNotes = await getAllNotes();
       await exportNotesAsZip(allNotes, $foldersStore, 'reborn-notes-export');
     } catch (e: unknown) {
       logger.error('Export failed:', e);
     } finally {
-      exporting = false;
+      exportingKind = null;
     }
   }
 
   async function handleExportBackup() {
-    exporting = true;
+    exportingKind = 'backup';
     try {
       await exportJsonBackup();
     } catch (e: unknown) {
       logger.error('Backup export failed:', e);
     } finally {
-      exporting = false;
+      exportingKind = null;
     }
   }
 
@@ -118,7 +132,7 @@
       exportError = $t('settings_page.export_import.password_too_short') || 'Hasło musi mieć minimum 8 znaków.';
       return;
     }
-    exporting = true;
+    exportingKind = 'encrypted';
     exportError = null;
     try {
       await exportEncryptedBackup(exportPassword);
@@ -127,7 +141,7 @@
     } catch (err: unknown) {
       exportError = err instanceof Error ? err.message : 'Export failed';
     } finally {
-      exporting = false;
+      exportingKind = null;
     }
   }
 
@@ -160,8 +174,11 @@
 
     importing = true;
     importResult = null;
+    mdProgress = { phase: 'reading', current: 0, total: files.length };
     try {
-      const result = await importMarkdownFiles(files, undefined, strategy);
+      const result = await importMarkdownFiles(files, undefined, strategy, (p) => {
+        mdProgress = p;
+      });
       importResult = result;
       await Promise.all([notesStore.refresh(), foldersStore.refresh()]);
     } catch (err: unknown) {
@@ -175,6 +192,7 @@
       };
     } finally {
       importing = false;
+      mdProgress = null;
     }
   }
 
@@ -229,13 +247,19 @@
     if (!pendingFolderFiles) return;
     const files = pendingFolderFiles;
     const strategy = pendingFolderStrategy;
+    const initialMdCount = pendingFolderMdCount;
     pendingFolderFiles = null;
     pendingFolderMdCount = 0;
 
     importingFolder = true;
     folderImportResult = null;
+    // Seed with the pre-filter count so the progress bar appears immediately;
+    // the importer re-applies its own filters and reports `total` precisely.
+    folderProgress = { phase: 'reading', current: 0, total: initialMdCount };
     try {
-      const result = await importFolder(files, strategy);
+      const result = await importFolder(files, strategy, (p) => {
+        folderProgress = p;
+      });
       folderImportResult = result;
       await Promise.all([
         notesStore.refresh(),
@@ -258,6 +282,7 @@
       };
     } finally {
       importingFolder = false;
+      folderProgress = null;
     }
   }
 
@@ -305,8 +330,11 @@
     importingBackup = true;
     backupError = null;
     backupImportResult = null;
+    backupProgress = null;
     try {
-      const result = await importJsonBackup(raw, password);
+      const result = await importJsonBackup(raw, password, (p) => {
+        backupProgress = p;
+      });
       backupImportResult = result;
       backupNeedsPassword = false;
       backupFileContent = null;
@@ -320,6 +348,7 @@
       backupError = err instanceof Error ? err.message : 'Import failed';
     } finally {
       importingBackup = false;
+      backupProgress = null;
     }
   }
 
@@ -347,29 +376,39 @@
       </CardHeader>
       <CardContent class="space-y-4">
         <!-- Export all notes as ZIP -->
-        <div
-          class="flex flex-col sm:flex-row sm:items-center gap-3 p-4 rounded-lg border bg-muted/30"
-        >
-          <div class="flex items-center gap-3 flex-1 min-w-0">
-            <FolderArchive class="h-4 w-4 shrink-0 text-muted-foreground" />
-            <div>
-              <p class="text-sm font-medium">{$t('settings_page.export_import.export_all')}</p>
-              <p class="text-xs text-muted-foreground">
-                {$t('settings_page.export_import.export_all_desc')}
-              </p>
+        <div class="p-4 rounded-lg border bg-muted/30">
+          <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+            <div class="flex items-center gap-3 flex-1 min-w-0">
+              <FolderArchive class="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div>
+                <p class="text-sm font-medium">{$t('settings_page.export_import.export_all')}</p>
+                <p class="text-xs text-muted-foreground">
+                  {$t('settings_page.export_import.export_all_desc')}
+                </p>
+              </div>
             </div>
+            <button
+              type="button"
+              onclick={handleExportAllZip}
+              disabled={exporting}
+              class="flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors hover:bg-accent disabled:opacity-50"
+            >
+              <Download class="h-3.5 w-3.5" />
+              {exportingKind === 'zip'
+                ? $t('settings_page.export_import.exporting')
+                : $t('settings_page.export_import.export_zip')}
+            </button>
           </div>
-          <button
-            type="button"
-            onclick={handleExportAllZip}
-            disabled={exporting}
-            class="flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors hover:bg-accent disabled:opacity-50"
-          >
-            <Download class="h-3.5 w-3.5" />
-            {exporting
-              ? $t('settings_page.export_import.exporting')
-              : $t('settings_page.export_import.export_zip')}
-          </button>
+          {#if exportingKind === 'zip'}
+            <div
+              class="mt-3 flex items-center gap-2 rounded-md border bg-background px-3 py-2.5 text-xs text-muted-foreground"
+              role="status"
+              aria-live="polite"
+            >
+              <LoadingSpinner size="sm" />
+              <span>{$t('settings_page.export_import.export_status_zip')}</span>
+            </div>
+          {/if}
         </div>
 
         <!-- Export backup (account-encrypted JSON) -->
@@ -391,7 +430,7 @@
               class="flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors hover:bg-accent disabled:opacity-50"
             >
               <Download class="h-3.5 w-3.5" />
-              {exporting
+              {exportingKind === 'backup'
                 ? $t('settings_page.export_import.exporting')
                 : $t('settings_page.export_import.export_json')}
             </button>
@@ -402,6 +441,16 @@
               {$t('settings_page.export_import.export_backup_warning')}
             </p>
           </div>
+          {#if exportingKind === 'backup'}
+            <div
+              class="flex items-center gap-2 rounded-md border bg-background px-3 py-2.5 text-xs text-muted-foreground"
+              role="status"
+              aria-live="polite"
+            >
+              <LoadingSpinner size="sm" />
+              <span>{$t('settings_page.export_import.export_status_backup')}</span>
+            </div>
+          {/if}
         </div>
 
         <!-- Export encrypted backup (password-protected, portable) -->
@@ -472,7 +521,7 @@
                   class="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
                 >
                   <Download class="h-3.5 w-3.5" />
-                  {exporting
+                  {exportingKind === 'encrypted'
                     ? $t('settings_page.export_import.encrypting')
                     : $t('settings_page.export_import.export_encrypted_btn')}
                 </button>
@@ -489,6 +538,16 @@
                 </button>
               </div>
             </form>
+            {#if exportingKind === 'encrypted'}
+              <div
+                class="flex items-center gap-2 rounded-md border bg-background px-3 py-2.5 text-xs text-muted-foreground"
+                role="status"
+                aria-live="polite"
+              >
+                <LoadingSpinner size="sm" />
+                <span>{$t('settings_page.export_import.export_status_encrypted')}</span>
+              </div>
+            {/if}
           {/if}
         </div>
       </CardContent>
@@ -557,6 +616,32 @@
                   {$t('settings_page.export_import.cancel')}
                 </button>
               </div>
+            </div>
+          {/if}
+
+          {#if importing}
+            <div
+              class="mt-3 rounded-md border bg-muted/40 px-3 py-2.5 text-xs space-y-2"
+              role="status"
+              aria-live="polite"
+            >
+              <div class="flex items-center gap-2 text-muted-foreground">
+                <LoadingSpinner size="sm" />
+                <span>
+                  {#if mdProgress?.phase === 'indexing'}
+                    {$t('settings_page.export_import.import_status_indexing')}
+                  {:else if mdProgress && mdProgress.total > 0}
+                    {$t('settings_page.export_import.import_status_reading', {
+                      values: { current: mdProgress.current, total: mdProgress.total }
+                    })}
+                  {:else}
+                    {$t('settings_page.export_import.import_status_starting')}
+                  {/if}
+                </span>
+              </div>
+              {#if mdProgress?.phase === 'reading' && mdProgress.total > 1}
+                <Progress value={mdProgress.current} max={mdProgress.total} class="h-1.5" />
+              {/if}
             </div>
           {/if}
 
@@ -663,6 +748,32 @@
                   {$t('settings_page.export_import.cancel')}
                 </button>
               </div>
+            </div>
+          {/if}
+
+          {#if importingFolder}
+            <div
+              class="mt-3 rounded-md border bg-muted/40 px-3 py-2.5 text-xs space-y-2"
+              role="status"
+              aria-live="polite"
+            >
+              <div class="flex items-center gap-2 text-muted-foreground">
+                <LoadingSpinner size="sm" />
+                <span>
+                  {#if folderProgress?.phase === 'indexing'}
+                    {$t('settings_page.export_import.import_status_indexing')}
+                  {:else if folderProgress && folderProgress.total > 0}
+                    {$t('settings_page.export_import.import_status_reading', {
+                      values: { current: folderProgress.current, total: folderProgress.total }
+                    })}
+                  {:else}
+                    {$t('settings_page.export_import.import_status_starting')}
+                  {/if}
+                </span>
+              </div>
+              {#if folderProgress?.phase === 'reading' && folderProgress.total > 1}
+                <Progress value={folderProgress.current} max={folderProgress.total} class="h-1.5" />
+              {/if}
             </div>
           {/if}
 
@@ -827,6 +938,32 @@
             </div>
           {/if}
 
+          {#if importingBackup}
+            <div
+              class="mt-3 rounded-md border bg-muted/40 px-3 py-2.5 text-xs space-y-2"
+              role="status"
+              aria-live="polite"
+            >
+              <div class="flex items-center gap-2 text-muted-foreground">
+                <LoadingSpinner size="sm" />
+                <span>
+                  {#if backupProgress?.phase === 'indexing'}
+                    {$t('settings_page.export_import.import_status_indexing')}
+                  {:else if backupProgress && backupProgress.total > 0}
+                    {$t('settings_page.export_import.import_status_reading', {
+                      values: { current: backupProgress.current, total: backupProgress.total }
+                    })}
+                  {:else}
+                    {$t('settings_page.export_import.import_backup_status')}
+                  {/if}
+                </span>
+              </div>
+              {#if backupProgress?.phase === 'reading' && backupProgress.total > 1}
+                <Progress value={backupProgress.current} max={backupProgress.total} class="h-1.5" />
+              {/if}
+            </div>
+          {/if}
+
           {#if backupImportResult}
             <div
               class="mt-3 rounded-md px-3 py-2 text-xs
@@ -848,6 +985,13 @@
               {#if backupImportResult.skipped > 0}
                 <p class="text-muted-foreground">
                   Pominięto {backupImportResult.skipped} elementów (nowsze lokalne wersje).
+                </p>
+              {/if}
+              {#if backupImportResult.strippedCount > 0}
+                <p>
+                  {$t('settings_page.export_import.unsafe_content_stripped', {
+                    values: { count: backupImportResult.strippedCount }
+                  })}
                 </p>
               {/if}
               {#each backupImportResult.errors as err}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -562,7 +562,14 @@
       "backup_password": "Sicherungspasswort",
       "decrypting": "Entschlüsseln…",
       "decrypt_import": "Entschlüsseln & importieren",
-      "imported_summary": "Importiert: {notes} Notizen, {folders} Ordner, {tags} Tags"
+      "imported_summary": "Importiert: {notes} Notizen, {folders} Ordner, {tags} Tags",
+      "import_status_starting": "Import wird vorbereitet…",
+      "import_status_reading": "Importiere Notiz {current} von {total}…",
+      "import_status_indexing": "Suchindex wird aktualisiert…",
+      "import_backup_status": "Sicherung wird importiert, bitte warten…",
+      "export_status_zip": "ZIP-Archiv wird erstellt…",
+      "export_status_backup": "Sicherungsdatei wird erstellt…",
+      "export_status_encrypted": "Sicherung wird verschlüsselt…"
     },
     "about": {
       "title": "Über",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -562,7 +562,14 @@
       "backup_password": "Backup password",
       "decrypting": "Decrypting…",
       "decrypt_import": "Decrypt & import",
-      "imported_summary": "Imported: {notes} notes, {folders} folders, {tags} tags"
+      "imported_summary": "Imported: {notes} notes, {folders} folders, {tags} tags",
+      "import_status_starting": "Preparing import…",
+      "import_status_reading": "Importing note {current} of {total}…",
+      "import_status_indexing": "Updating search index…",
+      "import_backup_status": "Importing backup, please wait…",
+      "export_status_zip": "Building ZIP archive…",
+      "export_status_backup": "Building backup file…",
+      "export_status_encrypted": "Encrypting backup…"
     },
     "about": {
       "title": "About",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -562,7 +562,14 @@
       "backup_password": "Contraseña de la copia de seguridad",
       "decrypting": "Descifrando…",
       "decrypt_import": "Descifrar e importar",
-      "imported_summary": "Importado: {notes} notas, {folders} carpetas, {tags} etiquetas"
+      "imported_summary": "Importado: {notes} notas, {folders} carpetas, {tags} etiquetas",
+      "import_status_starting": "Preparando importación…",
+      "import_status_reading": "Importando nota {current} de {total}…",
+      "import_status_indexing": "Actualizando índice de búsqueda…",
+      "import_backup_status": "Importando copia de seguridad, espere…",
+      "export_status_zip": "Creando archivo ZIP…",
+      "export_status_backup": "Creando archivo de copia de seguridad…",
+      "export_status_encrypted": "Cifrando copia de seguridad…"
     },
     "about": {
       "title": "Acerca de",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -562,7 +562,14 @@
       "backup_password": "Mot de passe de la sauvegarde",
       "decrypting": "Déchiffrement…",
       "decrypt_import": "Déchiffrer et importer",
-      "imported_summary": "Importé : {notes} notes, {folders} dossiers, {tags} tags"
+      "imported_summary": "Importé : {notes} notes, {folders} dossiers, {tags} tags",
+      "import_status_starting": "Préparation de l'import…",
+      "import_status_reading": "Import de la note {current} sur {total}…",
+      "import_status_indexing": "Mise à jour de l'index de recherche…",
+      "import_backup_status": "Import de la sauvegarde, veuillez patienter…",
+      "export_status_zip": "Création de l'archive ZIP…",
+      "export_status_backup": "Création du fichier de sauvegarde…",
+      "export_status_encrypted": "Chiffrement de la sauvegarde…"
     },
     "about": {
       "title": "À propos",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -562,7 +562,14 @@
       "backup_password": "Hasło kopii zapasowej",
       "decrypting": "Odszyfrowywanie…",
       "decrypt_import": "Odszyfruj i importuj",
-      "imported_summary": "Zaimportowano: {notes} notatek, {folders} folderów, {tags} tagów"
+      "imported_summary": "Zaimportowano: {notes} notatek, {folders} folderów, {tags} tagów",
+      "import_status_starting": "Przygotowywanie importu…",
+      "import_status_reading": "Importowanie notatki {current} z {total}…",
+      "import_status_indexing": "Aktualizacja indeksu wyszukiwania…",
+      "import_backup_status": "Trwa import kopii zapasowej, proszę czekać…",
+      "export_status_zip": "Tworzenie archiwum ZIP…",
+      "export_status_backup": "Tworzenie pliku kopii zapasowej…",
+      "export_status_encrypted": "Szyfrowanie kopii zapasowej…"
     },
     "about": {
       "title": "O aplikacji",


### PR DESCRIPTION
- Inline spinner + per-file progress bar for .md, folder and JSON backup imports; long-running imports no longer look frozen.
- Strategy picker scrolls into view and focuses the first radio when it appears, so the 3 dedup options can never end up below the fold.
- Per-section export spinner (ZIP / account backup / encrypted backup) using a tri-state ExportKind instead of a single boolean.
- importJsonBackup now decrypts, sanitizes and re-encrypts note content on the client (defense in depth) — older backups predating the markdown sanitizer get scrubbed of base64 blobs, dangerous HTML and javascript: URIs on import. Plaintext never leaves the browser.
- New i18n keys for status messages in EN/PL/DE/FR/ES.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>