### PR TITLE
feat(notes): include subfolders in folder-view search

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -20,6 +20,8 @@
   import MoveToFolderMenu from './notes/MoveToFolderMenu.svelte';
   import SubfolderList from './SubfolderList.svelte';
   import type { FolderWithChildren } from '@reborn/types';
+  import { foldersStore } from '$lib/stores/folders.store';
+  import { buildBreadcrumb } from '$lib/utils/folder-helpers';
 
   // ── Infinite scroll ────────────────────────────────────────────
   const PAGE_SIZE = 50;
@@ -63,6 +65,7 @@
   let {
     activeFolderName = '',
     activeSection = 'all',
+    activeFolderId = null,
     isTrash = false,
     showSidebarTrigger = false,
     prominentHeader = false,
@@ -75,6 +78,8 @@
   }: {
     activeFolderName?: string;
     activeSection?: string;
+    /** Current folder ID — used to render a breadcrumb under search results from subfolders. */
+    activeFolderId?: string | null;
     isTrash?: boolean;
     showSidebarTrigger?: boolean;
     prominentHeader?: boolean;
@@ -99,6 +104,26 @@
       notesStore.setSearch('');
       notesStore.setSearchInContent(false);
     });
+  });
+
+  // Mobile: returning from a note panel to the list should reset search.
+  // The list panel stays mounted behind the note (CSS translate), so without
+  // this the previous query lingers. Desktop keeps the list visible alongside
+  // the note, so there is no "return" event there.
+  let prevActiveNoteId: string | null = null;
+  $effect(() => {
+    const current = $activeNoteId;
+    const prev = prevActiveNoteId;
+    prevActiveNoteId = current;
+    if (isMobileQuery.value && prev !== null && current === null) {
+      untrack(() => {
+        if (!searchInput && !searchInContent) return;
+        searchInput = '';
+        searchInContent = false;
+        notesStore.setSearch('');
+        notesStore.setSearchInContent(false);
+      });
+    }
   });
 
   $effect(() => {
@@ -246,6 +271,23 @@
     noteToPermanentDelete = null;
   }
 
+  /**
+   * Build a breadcrumb for a note relative to the active folder. Used when search
+   * is active in a folder view to show notes from subfolders with their location.
+   * Empty string when the note is in the active folder itself or breadcrumb does
+   * not apply (no active folder, or note has no folder).
+   */
+  function getRelativeBreadcrumb(noteFolderId: string | undefined): string {
+    if (!searchInput) return '';
+    if (activeFolderId === null || activeFolderId === undefined) return '';
+    if (!noteFolderId || noteFolderId === activeFolderId) return '';
+    const fullPath = buildBreadcrumb($foldersStore, noteFolderId);
+    if (fullPath.length === 0) return '';
+    const rootIdx = fullPath.findIndex((c) => c.id === activeFolderId);
+    const relative = rootIdx === -1 ? fullPath : fullPath.slice(rootIdx + 1);
+    return relative.map((c) => c.name).join(' / ');
+  }
+
   const activeMenuNote = $derived(
     menuOpenId ? ($notesStore.find((n) => n.id === menuOpenId) ?? null) : null
   );
@@ -335,7 +377,13 @@
         <div class="px-4 py-8 text-center">
           {#if searchInput}
             <p class="text-sm text-muted-foreground">
-              {$t('notes.no_match', { values: { query: searchInput } })}
+              {#if activeFolderId && activeFolderName}
+                {$t('notes.no_match_in_folder', {
+                  values: { query: searchInput, folder: activeFolderName }
+                })}
+              {:else}
+                {$t('notes.no_match', { values: { query: searchInput } })}
+              {/if}
             </p>
             <button
               type="button"
@@ -368,6 +416,7 @@
           <NoteListItemComponent
             {note}
             {isTrash}
+            breadcrumb={getRelativeBreadcrumb(note.folder_id)}
             bind:movingNoteId
             onmenuopen={handleMenuOpen}
             onpin={handleTogglePin}

--- a/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
@@ -6,6 +6,7 @@
     Star,
     StarOff,
     FolderInput,
+    Folder,
     Download,
     Link2,
     Trash2,
@@ -31,6 +32,7 @@
   let {
     note,
     isTrash = false,
+    breadcrumb = '',
     movingNoteId = $bindable<string | null>(null),
     onmenuopen,
     onpin,
@@ -44,6 +46,8 @@
   }: {
     note: NoteListItem;
     isTrash?: boolean;
+    /** Folder path to show under the title — used for search results from subfolders. */
+    breadcrumb?: string;
     movingNoteId: string | null;
     onmenuopen: (noteId: string) => void;
     onpin: (noteId: string, e?: Event) => void;
@@ -91,6 +95,15 @@
           <Star class="mt-1.5 h-3.5 w-3.5 md:mt-1 md:h-3 md:w-3 shrink-0 fill-amber-400 text-amber-400" />
         {/if}
       </div>
+      {#if breadcrumb}
+        <p
+          class="mt-0.5 flex min-w-0 items-center gap-1 text-[12px] md:text-[11px] text-muted-foreground"
+          title={breadcrumb}
+        >
+          <Folder class="h-3 w-3 shrink-0" />
+          <span class="truncate" dir="rtl">{breadcrumb}</span>
+        </p>
+      {/if}
       {#if noteTags.length > 0}
         <div class="mt-1 flex flex-wrap gap-1">
           {#each noteTags as tag (tag.id)}

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -34,6 +34,11 @@ export type SortBy = 'updated_at' | 'created_at' | 'title';
 
 export interface FilterOptions {
   folderId?: string | null;
+  /**
+   * Restrict to a set of folder IDs (e.g. a folder + all its descendants).
+   * Takes precedence over `folderId` when both are provided. Empty array → no matches.
+   */
+  folderIds?: string[];
   tagId?: string;
   starred?: boolean;
   archived?: boolean;
@@ -215,6 +220,7 @@ class NoteIndex {
 
     const {
       folderId,
+      folderIds,
       tagId,
       starred,
       archived = false,
@@ -230,8 +236,12 @@ class NoteIndex {
     // archived filter
     entries = entries.filter(([, e]) => e.isArchived === archived);
 
-    // folder filter (null = root/no folder, undefined = all)
-    if (folderId !== undefined) {
+    // folder filter — folderIds (set) takes precedence over folderId (single)
+    if (folderIds !== undefined) {
+      const set = new Set(folderIds);
+      entries = entries.filter(([, e]) => e.folderId !== undefined && set.has(e.folderId));
+    } else if (folderId !== undefined) {
+      // null = root/no folder, undefined = all
       if (folderId === null) {
         entries = entries.filter(([, e]) => !e.folderId);
       } else {

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -166,6 +166,17 @@ export async function getNotesByFolder(
   return attachTagIds(sortByUpdated(decrypted));
 }
 
+/**
+ * Active notes belonging to any of the given folders (subtree search).
+ * Empty array → empty result.
+ */
+export async function getNotesByFolders(folderIds: string[]): Promise<NoteDecrypted[]> {
+  if (folderIds.length === 0) return [];
+  const notes = await noteQueries.byFolders(folderIds);
+  const decrypted = await Promise.all(notes.map(toDecrypted));
+  return attachTagIds(sortByUpdated(decrypted));
+}
+
 /** Notes that have a specific tag, sorted by last updated. */
 export async function getNotesByTag(tagId: string): Promise<NoteDecrypted[]> {
   const noteIds = await noteTagQueries.getNotesForTag(tagId);

--- a/apps/reborn-notes/src/lib/stores/notes.store.ts
+++ b/apps/reborn-notes/src/lib/stores/notes.store.ts
@@ -4,6 +4,8 @@ import { browser } from '$app/environment';
 import type { NoteDecrypted } from '@reborn/types';
 import * as NoteService from '$lib/services/note.service';
 import { noteIndex, type NoteListItem, type SortBy } from '$lib/services/note-index.svelte';
+import { foldersStore } from '$lib/stores/folders.store';
+import { getDescendantFolderIds } from '$lib/utils/folder-helpers';
 
 export type { SortBy, NoteListItem };
 
@@ -65,12 +67,30 @@ function createNotesStore() {
     }
   );
 
+  /**
+   * When in folder view AND a non-empty search query is active, expand the scope
+   * to include the folder + all its descendant subfolders. Returns the descendant
+   * folder IDs, or `null` when subtree mode is not active (caller falls back to
+   * `currentFolderId`). Toggling `searchInContent` alone (without a query) does
+   * not expand the scope.
+   */
+  function getSearchSubtreeFolderIds(): string[] | null {
+    if (currentTrash || currentStarred || currentTagId) return null;
+    if (typeof currentFolderId !== 'string') return null;
+    if (!get(searchQuery).trim()) return null;
+    const tree = get(foldersStore);
+    const ids = getDescendantFolderIds(tree, currentFolderId);
+    return ids.length > 0 ? ids : null;
+  }
+
   /** Build filter options from current store state. */
   function buildFilterOptions() {
     if (currentTrash) return { archived: true as const };
     const base = { archived: false as const };
     if (currentStarred) return { ...base, starred: true as const };
     if (currentTagId) return { ...base, tagId: currentTagId };
+    const subtreeIds = getSearchSubtreeFolderIds();
+    if (subtreeIds) return { ...base, folderIds: subtreeIds };
     return { ...base, folderId: currentFolderId };
   }
 
@@ -122,6 +142,13 @@ function createNotesStore() {
         data = all.filter((n) => n.is_starred);
       } else if (currentTagId) {
         data = await NoteService.getNotesByTag(currentTagId);
+      } else if (typeof currentFolderId === 'string') {
+        // Subtree search: include the folder + all its descendants
+        const subtreeIds = getDescendantFolderIds(get(foldersStore), currentFolderId);
+        data =
+          subtreeIds.length > 0
+            ? await NoteService.getNotesByFolders(subtreeIds)
+            : await NoteService.getNotesByFolder(currentFolderId);
       } else {
         data = await NoteService.getNotesByFolder(currentFolderId);
       }
@@ -173,7 +200,15 @@ function createNotesStore() {
   }
 
   function setSearch(query: string) {
+    const prev = get(searchQuery);
     searchQuery.set(query);
+    // If we toggled between empty and non-empty in folder view, the filter scope
+    // changes (folder ↔ subtree) — re-run the index query.
+    const prevEmpty = !prev.trim();
+    const nextEmpty = !query.trim();
+    if (prevEmpty !== nextEmpty && typeof currentFolderId === 'string') {
+      refresh();
+    }
     // If content search is active, trigger full-decrypt search
     if (get(searchInContent) && query.trim()) {
       triggerContentSearch(query);

--- a/apps/reborn-notes/src/lib/utils/folder-helpers.test.ts
+++ b/apps/reborn-notes/src/lib/utils/folder-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildBreadcrumb,
   buildPathString,
   getAncestorIds,
+  getDescendantFolderIds,
   flattenFolderTree,
   flattenFoldersWithDepth
 } from './folder-helpers';
@@ -96,6 +97,38 @@ describe('buildPathString', () => {
 
   it('respects custom separator', () => {
     expect(buildPathString(tree, 'arch', ' › ')).toBe('Dev › Reapps');
+  });
+});
+
+describe('getDescendantFolderIds', () => {
+  it('returns root + all descendants for a folder with subtree', () => {
+    const ids = getDescendantFolderIds(tree, 'dev');
+    expect(ids.sort()).toEqual(['arch', 'dev', 'devsub', 'guide', 'reapps'].sort());
+  });
+
+  it('returns just the folder id for a leaf', () => {
+    expect(getDescendantFolderIds(tree, 'arch')).toEqual(['arch']);
+  });
+
+  it('returns just the folder id for a top-level folder with no children', () => {
+    expect(getDescendantFolderIds(tree, 'people')).toEqual(['people']);
+  });
+
+  it('returns empty array for a non-existent folder id', () => {
+    expect(getDescendantFolderIds(tree, 'nope')).toEqual([]);
+  });
+
+  it('returns empty array for an empty tree', () => {
+    expect(getDescendantFolderIds([], 'anything')).toEqual([]);
+  });
+
+  it('places the root id first', () => {
+    const ids = getDescendantFolderIds(tree, 'reapps');
+    expect(ids[0]).toBe('reapps');
+    expect(ids).toContain('arch');
+    expect(ids).toContain('devsub');
+    expect(ids).toContain('guide');
+    expect(ids).toHaveLength(4);
   });
 });
 

--- a/apps/reborn-notes/src/lib/utils/folder-helpers.ts
+++ b/apps/reborn-notes/src/lib/utils/folder-helpers.ts
@@ -75,6 +75,36 @@ export function buildPathString(
     .join(separator);
 }
 
+/**
+ * Return the folder ID set of the subtree rooted at `rootId` (rootId + all descendants).
+ * Returns an empty array if `rootId` is not found in `tree`.
+ */
+export function getDescendantFolderIds(
+  tree: FolderWithChildren[],
+  rootId: string
+): string[] {
+  function findRoot(nodes: FolderWithChildren[]): FolderWithChildren | null {
+    for (const n of nodes) {
+      if (n.id === rootId) return n;
+      const sub = findRoot(n.children ?? []);
+      if (sub) return sub;
+    }
+    return null;
+  }
+  const root = findRoot(tree);
+  if (!root) return [];
+  const ids: string[] = [];
+  const visited = new Set<string>();
+  function walk(n: FolderWithChildren): void {
+    if (visited.has(n.id)) return;
+    visited.add(n.id);
+    ids.push(n.id);
+    for (const c of n.children ?? []) walk(c);
+  }
+  walk(root);
+  return ids;
+}
+
 /** Return IDs of all ancestors (parent → root) so the tree can be expanded to show `folderId`. */
 export function getAncestorIds(folderId: string, tree: FolderWithChildren[]): string[] {
   const parentMap = new Map<string, string>();

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -971,6 +971,7 @@
               <NoteList
                 {activeFolderName}
                 {activeSection}
+                activeFolderId={activeFolderId ?? null}
                 isTrash={activeTrash}
                 subfolders={activeFolderSubfolders}
                 onSubfolderSelect={handleFolderSelect}
@@ -1364,6 +1365,7 @@
           <NoteList
             {activeFolderName}
             {activeSection}
+            activeFolderId={activeFolderId ?? null}
             isTrash={false}
             showSidebarTrigger
             subfolders={activeFolderSubfolders}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -41,6 +41,7 @@
     "search_hint": "Tippen Sie, um Ihre Notizen zu durchsuchen",
     "search_in_content": "Im Inhalt suchen",
     "no_match": "Keine Notizen für \"{query}\" gefunden.",
+    "no_match_in_folder": "Keine Notizen für \"{query}\" in \"{folder}\" oder Unterordnern gefunden.",
     "pin_to_top": "Oben anheften",
     "unpin": "Lösen",
     "star": "Markieren",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -41,6 +41,7 @@
     "search_hint": "Type to search your notes",
     "search_in_content": "Search in content",
     "no_match": "No notes match \"{query}\".",
+    "no_match_in_folder": "No notes match \"{query}\" in \"{folder}\" or its subfolders.",
     "pin_to_top": "Pin to top",
     "unpin": "Unpin",
     "star": "Star",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -41,6 +41,7 @@
     "search_hint": "Escriba para buscar en sus notas",
     "search_in_content": "Buscar en el contenido",
     "no_match": "Ninguna nota coincide con \"{query}\".",
+    "no_match_in_folder": "Ninguna nota coincide con \"{query}\" en \"{folder}\" o sus subcarpetas.",
     "pin_to_top": "Fijar arriba",
     "unpin": "Desfijar",
     "star": "Destacar",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -41,6 +41,7 @@
     "search_hint": "Saisissez pour rechercher dans vos notes",
     "search_in_content": "Rechercher dans le contenu",
     "no_match": "Aucune note ne correspond à \"{query}\".",
+    "no_match_in_folder": "Aucune note ne correspond à \"{query}\" dans \"{folder}\" ou ses sous-dossiers.",
     "pin_to_top": "Épingler en haut",
     "unpin": "Désépingler",
     "star": "Marquer comme favori",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -41,6 +41,7 @@
     "search_hint": "Wpisz frazę, aby wyszukać notatki",
     "search_in_content": "Szukaj w treści",
     "no_match": "Brak notatek pasujących do „{query}”.",
+    "no_match_in_folder": "Brak notatek pasujących do „{query}” w folderze „{folder}” i podfolderach.",
     "pin_to_top": "Przypnij na górze",
     "unpin": "Odepnij",
     "star": "Oznacz gwiazdką",

--- a/packages/storage/src/stores/note.store.ts
+++ b/packages/storage/src/stores/note.store.ts
@@ -85,6 +85,28 @@ export const noteQueries = {
   },
 
   /**
+   * Get active notes belonging to any of the given folders. Empty array → no matches.
+   * De-duplicates by note id (the same note never lives in two folders, but the
+   * store guarantees nothing about overlapping IDs across query() calls).
+   */
+  byFolders: async (folderIds: string[]): Promise<NoteStoredLocal[]> => {
+    if (folderIds.length === 0) return [];
+    const results = await Promise.all(
+      folderIds.map(id => noteStore.query('folder_id', id))
+    );
+    const seen = new Set<string>();
+    const merged: NoteStoredLocal[] = [];
+    for (const batch of results) {
+      for (const note of batch) {
+        if (note.is_archived || seen.has(note.id)) continue;
+        seen.add(note.id);
+        merged.push(note);
+      }
+    }
+    return merged;
+  },
+
+  /**
    * Get pinned notes
    */
   getPinned: async (): Promise<NoteStoredLocal[]> => {


### PR DESCRIPTION
When a user types into the search bar inside a folder view, expand the scope to include the folder + all its descendant subfolders. Subfolders are hidden during the search so the list shows pure results, and notes from subfolders carry a folder-icon breadcrumb (path relative to the active folder). Clearing the search restores the normal navigation view.

On mobile, returning from a note to the list panel now also resets the search — the list panel stays mounted behind the note, so without this the previous query would linger.

- folder-helpers: getDescendantFolderIds(tree, rootId) with cycle guard
- note-index: FilterOptions.folderIds (set) takes precedence over folderId
- storage: noteQueries.byFolders(ids) with dedupe
- note.service: getNotesByFolders(ids) for content-search subtree
- notes.store: subtree mode active only when search query is non-empty; scope flip triggers refresh()
- i18n: notes.no_match_in_folder in pl/en/de/fr/es

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>