### PR TITLE
revert(docker): downgrade postgres back to v17 and block major bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,6 +53,13 @@
       "matchManagers": ["github-actions"],
       "automerge": false,
       "labels": ["dependencies", "ci"]
+    },
+    {
+      "description": "Postgres major bumps break the storage layout (v18+ require new mount path + pg_upgrade) — disable to prevent accidental merge. Re-enable temporarily and plan dump/restore across local/staging/prod when ready to upgrade.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: reborn-apps
 
 services:
   db:
-    image: postgres:18-alpine
+    image: postgres:17-alpine
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
## Why

PR #86 bumped `postgres:17-alpine` → `postgres:18-alpine`. The v18+ Docker
images dropped support for mounting at `/var/lib/postgresql/data` and require
`/var/lib/postgresql` with version-prefixed subdirectories
(see [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)),
which breaks all three compose stacks (base, prod, staging). The `db`
container fails to start even on a fresh volume — confirmed locally with
`docker-compose.localprod.yml`.

## What

- Revert `docker-compose.yml` to `postgres:17-alpine`.
- Add a Renovate rule disabling postgres major bumps so this doesn't
  recur. Re-enable temporarily when planning a deliberate upgrade
  (dump from 17, restructure mount path, restore into 18, across
  local/staging/prod).

## Risk

- Local: unblocks dev (verified — full stack healthy).
- Staging/prod: **safe** as long as they haven't been redeployed since #86
  was merged (running containers still hold the cached PG17 image). After
  this merge, next redeploy will pull the correct PG17 image again.