### PR TITLE
fix(types): use ZodError.issues instead of deprecated .errors

### DIFF
--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -18,7 +18,7 @@ export function validateBody<T>(schema: z.ZodType<T>, body: unknown): Validation
     return {
       success: false,
       error: 'Invalid request data',
-      details: result.error.errors
+      details: result.error.issues
     };
   }
   return { success: true, data: result.data };


### PR DESCRIPTION
## Summary

- Replaces `result.error.errors` with `result.error.issues` in `validateBody()` ([packages/types/src/validation.ts:21](packages/types/src/validation.ts#L21)).
- `errors` is a deprecated getter on Zod v3's `ZodError` and was removed in v4 — using `issues` works on both versions.
- Unblocks PR #93 (Renovate: zod → v4), where this was the first hard build failure surfaced in CI.

## Why this is safe

The currently pinned `zod@3.25.76` exposes both `issues: ZodIssue[]` (the canonical field) and `get errors(): ZodIssue[]` (deprecated alias). Switching to `issues` is a no-op at runtime under v3 and the only forward-compatible spelling under v4.

## Heads-up: more Zod v4 work likely needed

CI bailed at the first error, so additional v4 breaking changes weren't yet exposed. Quick grep flagged the following sites that will likely need follow-up on the Renovate branch (or a separate prep PR if v3-compatible):

- [packages/types/src/schemas/storage.ts:149](packages/types/src/schemas/storage.ts#L149), [:167](packages/types/src/schemas/storage.ts#L167), [:187](packages/types/src/schemas/storage.ts#L187) — three uses of `.passthrough()`. Zod v4 changed unknown-key handling (the `loose`/`strict`/`strip` mode is now part of object config), so these will likely need rework. Not v3-compatible — has to land on the v4 branch.
- [packages/types/src/schemas/api/requests.ts:8](packages/types/src/schemas/api/requests.ts#L8) — `z.record(z.string()).optional()`. v4 dropped the single-argument form; needs `z.record(z.string(), z.string())`. The two-arg form is also valid in v3, so could be done as another prep PR.

Out of scope for this PR; just flagging for whoever picks up #93.

## Test plan

- [x] `pnpm nx build @reborn/types` passes locally.
- [ ] CI on this PR is green (no other consumers of `.error.errors` in the repo — verified via grep).
- [ ] After merge, Renovate rebases #93 and the `@reborn/types:build` step gets past line 21 (further v4 errors expected per heads-up above).