### PR TITLE
fix(types): pass explicit key schema to z.record()

### DIFF
--- a/packages/types/src/schemas/api/requests.ts
+++ b/packages/types/src/schemas/api/requests.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
  */
 export const ApiRequestSchema = z.object({
   data: z.unknown(),
-  headers: z.record(z.string()).optional()
+  headers: z.record(z.string(), z.string()).optional()
 });
 
 /**


### PR DESCRIPTION
## Summary

- Replaces `z.record(z.string())` with `z.record(z.string(), z.string())` in `ApiRequestSchema` ([packages/types/src/schemas/api/requests.ts:8](packages/types/src/schemas/api/requests.ts#L8)).
- Unblocks the next CI failure on PR #93 (Renovate: zod → v4) — surfaced after #95 merged.

## Why this is safe

In Zod v3 the single-argument form `z.record(valueSchema)` defaults the key schema to `z.string()`. In v4 that overload was removed; both key and value schemas are now required. The two-argument form is valid under v3, so the fix is forward-compatible and v3-clean.

Runtime semantics are identical: the previous form already meant "string keys → string values".

## Heads-up: `.passthrough()` still pending

PR #93 will still fail after this lands. Three call sites use `.passthrough()` ([packages/types/src/schemas/storage.ts:149](packages/types/src/schemas/storage.ts#L149), [:167](packages/types/src/schemas/storage.ts#L167), [:187](packages/types/src/schemas/storage.ts#L187)), and v4 changed the unknown-key API (the `.passthrough()` method was removed in favor of `.loose()` / object-level config). That migration is **not** v3-compatible, so it has to be done directly on the Renovate branch (or a dedicated v4-only PR), not as another prep commit on main.

## Test plan

- [x] `pnpm nx build @reborn/types` passes locally on the current zod 3.25.76.
- [ ] CI on this PR is green.
- [ ] After merge, Renovate rebases #93 and CI moves past `requests.ts:8` — expected next failure: `.passthrough()` in `storage.ts`.