### PR TITLE
fix(auth): single-flight 401 refresh and retry across sync paths

### DIFF
--- a/apps/reborn-notes/src/lib/utils/auth-fetch.ts
+++ b/apps/reborn-notes/src/lib/utils/auth-fetch.ts
@@ -1,124 +1,18 @@
 import { base } from '$app/paths';
+import { createAuthFetch } from '@reborn/auth';
 import { sessionExpired } from '$lib/stores/sync-status.store';
-import { withRefreshLock } from '@reborn/auth';
-import { createLogger } from '@reborn/utils';
-
-const logger = createLogger('AuthFetch');
 
 /**
- * Fetch wrapper with automatic token refresh for authenticated API calls.
+ * App-level singleton of the authenticated fetch wrapper.
  *
- * If the initial request returns 401, attempts to refresh the access token
- * using the stored refresh_token, then retries the original request once.
- *
- * `withRefreshLock` serializes the refresh across every tab/app on this
- * origin so that reborn-task + reborn-notes cannot both hit /api/auth/refresh
- * with the same refresh-token cookie (which would trip the server-side token
- * reuse detector and invalidate the entire token family). An in-process
- * singleton prevents redundant fetches from concurrent 401s inside one tab.
+ * Backed by the shared `createAuthFetch` factory in `@reborn/auth`, so the
+ * single-flight refresh logic (in-tab Promise + cross-tab Web Locks) is
+ * identical to reborn-task and the two apps coordinate through the same
+ * lock when both are open on the same origin.
  *
  * Usage: drop-in replacement for `fetch()` in authenticated pages.
  */
-
-// In-tab singleton: only one refresh fetch can be in-flight inside this tab.
-// All concurrent 401 handlers wait on the same promise.
-let refreshPromise: Promise<string | null> | null = null;
-
-async function doRefresh(tokenBeforeLock: string | null): Promise<string | null> {
-  // Inside the cross-tab lock another tab may have already refreshed for us.
-  // If the localStorage access token changed while we were queued, skip the
-  // redundant fetch and use the fresh one.
-  const current = localStorage.getItem('access_token');
-  if (current && current !== tokenBeforeLock) return current;
-
-  try {
-    // Refresh token is sent automatically via httpOnly cookie — no need to read from localStorage
-    const refreshRes = await fetch(`${base}/api/auth/refresh`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({})
-    });
-
-    if (!refreshRes.ok) {
-      // DIAGNOSTIC (temporary): surface server-side refresh failure reason so we can
-      // distinguish "Token reuse detected" vs "Invalid or expired" vs "No refresh token".
-      // Remove once the session-expiry root cause is identified.
-      try {
-        const errBody = await refreshRes.clone().json();
-        logger.warn('/api/auth/refresh failed', {
-          status: refreshRes.status,
-          body: errBody,
-          hasDocumentCookie: typeof document !== 'undefined' && document.cookie.length > 0,
-          time: new Date().toISOString()
-        });
-      } catch (parseErr) {
-        logger.warn('/api/auth/refresh failed (non-JSON body)', {
-          status: refreshRes.status,
-          time: new Date().toISOString(),
-          parseErr
-        });
-      }
-      return null;
-    }
-
-    const refreshData = await refreshRes.json();
-    if (!refreshData.success || !refreshData.data?.access_token) return null;
-
-    const newToken = refreshData.data.access_token;
-    localStorage.setItem('access_token', newToken);
-    // Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
-    return newToken;
-  } catch {
-    return null;
-  }
-}
-
-function refreshAccessToken(): Promise<string | null> {
-  if (!refreshPromise) {
-    const tokenBeforeLock = localStorage.getItem('access_token');
-    refreshPromise = withRefreshLock(() => doRefresh(tokenBeforeLock)).finally(() => {
-      refreshPromise = null;
-    });
-  }
-  return refreshPromise;
-}
-
-/**
- * Default per-request timeout. Without this a fetch against a VPN black hole
- * (navigator.onLine=true but no upstream) never resolves, so sync's `finally`
- * never runs and the spinner spins forever. Caller-provided `init.signal`
- * takes precedence — if present, we respect it untouched.
- */
-const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
-
-function buildSignal(init?: RequestInit): AbortSignal {
-  if (init?.signal) return init.signal;
-  return AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT_MS);
-}
-
-export async function authFetch(input: string, init?: RequestInit): Promise<Response> {
-  const accessToken = localStorage.getItem('access_token');
-
-  const headers = new Headers(init?.headers);
-  if (accessToken && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${accessToken}`);
-  }
-
-  const signal = buildSignal(init);
-  const response = await fetch(input, { ...init, headers, signal });
-
-  if (response.status !== 401) return response;
-
-  // Attempt token refresh (singleton — safe for concurrent calls)
-  const newToken = await refreshAccessToken();
-  if (!newToken) {
-    sessionExpired.set(true);
-    return response;
-  }
-
-  // Retry original request with the new token. Reuse the same signal so the
-  // retry inherits the caller's cancellation / timeout budget.
-  const retryHeaders = new Headers(init?.headers);
-  retryHeaders.set('Authorization', `Bearer ${newToken}`);
-  return fetch(input, { ...init, headers: retryHeaders, signal });
-}
+export const authFetch = createAuthFetch({
+  refreshUrl: `${base}/api/auth/refresh`,
+  onSessionExpired: () => sessionExpired.set(true)
+});

--- a/apps/reborn-task/src/hooks.server.ts
+++ b/apps/reborn-task/src/hooks.server.ts
@@ -80,54 +80,23 @@ const logger = createLogger('hooks.server');
 // Authentication middleware
 const authHandle: Handle = async ({ event, resolve }) => {
 	try {
-		// Debug JWT_SECRET status
-		logger.debug('JWT_SECRET status:', {
-			isSet: !!process.env.JWT_SECRET
-		});
-
-		// Get token from cookies OR Authorization header
+		// Read access token from cookie (legacy path) or Authorization header
+		// (the canonical path used by api-client / authFetch).
 		let token = event.cookies.get('reborn_task_token');
-
-		// If no cookie, check Authorization header (for API requests)
 		if (!token) {
 			const authHeader = event.request.headers.get('authorization');
 			if (authHeader?.startsWith('Bearer ')) {
 				token = authHeader.slice(7);
-				logger.debug('Token found in Authorization header');
 			}
 		}
 
-		logger.debug('Token verification attempt:', {
-			tokenExists: !!token,
-			url: event.url.pathname,
-			source: event.cookies.get('reborn_task_token') ? 'cookie' : 'header'
-		});
-
 		if (token) {
-			// Verify token and extract userId
 			const tokenData = await verifyToken(token, 'access');
-
-			logger.debug('Token verification result:', {
-				success: !!tokenData,
-				userId: tokenData?.userId
-			});
-
 			if (tokenData) {
-				// Set userId in locals for use in server-side code
 				event.locals.userId = tokenData.userId;
-				logger.debug('User authenticated and locals set:', {
-					userId: tokenData.userId,
-					localsUserId: event.locals.userId
-				});
-			} else {
-				logger.debug('Invalid token - verification failed');
-				// Only clear cookie if token came from cookie, not header
-				if (event.cookies.get('reborn_task_token')) {
-					event.cookies.delete('reborn_task_token', { path: '/' });
-				}
+			} else if (event.cookies.get('reborn_task_token')) {
+				event.cookies.delete('reborn_task_token', { path: '/' });
 			}
-		} else {
-			logger.debug('No token found in cookies');
 		}
 	} catch (error: unknown) {
 		logger.error('Auth middleware error:', error);

--- a/apps/reborn-task/src/lib/auth/adapters/authApi.ts
+++ b/apps/reborn-task/src/lib/auth/adapters/authApi.ts
@@ -4,9 +4,9 @@ import type {
 	RegisterResult,
 	TwoFactorVerificationResult
 } from '@reborn/auth';
-import { withRefreshLock } from '@reborn/auth';
 import { createLogger } from '@reborn/utils';
 import { syncService } from '$lib/services/sync.service';
+import { authFetch } from '$lib/utils/auth-fetch';
 
 const logger = createLogger('AuthApiAdapter');
 
@@ -186,81 +186,30 @@ export class AuthApiAdapter implements IAuthApiClient {
 	}
 
 	async refreshToken(_refreshToken?: string): Promise<LoginResult> {
-		// Serialize refresh across every tab/app on this origin so concurrent
-		// calls from reborn-task + reborn-notes cannot both hit /api/auth/refresh
-		// with the same refresh-token cookie (which would trip the server's
-		// token-reuse detector and invalidate the entire family). Inside the
-		// lock, first check whether another tab already produced a fresh token
-		// so we can skip the redundant fetch.
-		const tokenBeforeLock =
-			typeof localStorage !== 'undefined' ? localStorage.getItem('access_token') : null;
+		// Delegate to the app's shared authFetch.refresh() — it owns the
+		// in-tab single-flight promise and the cross-tab Web Locks coordination,
+		// so this caller (bootstrap checkSession + 10-min background interval)
+		// shares one refresh path with sync's onUnauthorized handler. The
+		// _refreshToken parameter is kept for interface compatibility but
+		// ignored: the refresh token rides exclusively on the httpOnly cookie.
+		void _refreshToken;
 
-		return withRefreshLock(async () => {
-			const current =
-				typeof localStorage !== 'undefined' ? localStorage.getItem('access_token') : null;
-			if (current && current !== tokenBeforeLock) {
-				// Another tab refreshed for us while we were queued — use that token,
-				// don't call the server again.
-				syncService.setAuthToken(current);
-				return { success: true, accessToken: current };
+		try {
+			const accessToken = await authFetch.refresh();
+			if (!accessToken) {
+				return { success: false, message: 'Token refresh failed' };
 			}
 
-			try {
-				// Refresh token is sent automatically via httpOnly cookie.
-				// The _refreshToken parameter is kept for interface compatibility but ignored.
-				const response = await fetch(`${this.apiUrl}/auth/refresh`, {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json'
-					},
-					body: JSON.stringify({})
-				});
+			syncService.setAuthToken(accessToken);
+			logger.debug('Auth token refreshed via shared authFetch');
 
-				const data = await response.json();
-
-				if (!response.ok || !data.success) {
-					// DIAGNOSTIC (temporary): surface server-side refresh failure reason so we can
-					// distinguish "Token reuse detected" vs "Invalid or expired" vs "No refresh token".
-					// Remove once the session-expiry root cause is identified.
-					logger.warn('/api/auth/refresh failed', {
-						status: response.status,
-						body: data,
-						hasDocumentCookie: typeof document !== 'undefined' && document.cookie.length > 0,
-						time: new Date().toISOString()
-					});
-					return {
-						success: false,
-						message: data.error || 'Token refresh failed'
-					};
-				}
-
-				const result: LoginResult = {
-					success: true,
-					user: data.data.user,
-					accessToken: data.data.access_token,
-					// refresh_token is managed exclusively via httpOnly cookie (set by server)
-					encryptedMasterKey: data.data.encryptedMasterKey,
-					masterKeySalt: data.data.masterKeySalt
-				};
-
-				// Set token in sync service immediately
-				if (result.accessToken) {
-					// Save to localStorage
-					localStorage.setItem('access_token', result.accessToken);
-					// Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
-					// Then set in sync service
-					syncService.setAuthToken(result.accessToken);
-					logger.debug('Auth token set in sync service immediately after refresh API call');
-				}
-
-				return result;
-			} catch (error: unknown) {
-				logger.error('Token refresh API error:', error);
-				return {
-					success: false,
-					message: error instanceof Error ? error.message : 'Network error'
-				};
-			}
-		});
+			return { success: true, accessToken };
+		} catch (error: unknown) {
+			logger.error('Token refresh error:', error);
+			return {
+				success: false,
+				message: error instanceof Error ? error.message : 'Network error'
+			};
+		}
 	}
 }

--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -487,7 +487,13 @@ export class AuthOperationsService {
 	}
 
 	/**
-	 * Check if session is valid and restore it
+	 * Check if session is valid and restore it.
+	 *
+	 * Always performs a refresh on the access token when one is present in
+	 * localStorage — even if `sessionManager.isAuthenticated()` is already true
+	 * after restoring persisted credentials. The previously-stored token may
+	 * have expired (15 min TTL) while the user was away; without a proactive
+	 * refresh, the first sync after a cold start would 401 and silently fail.
 	 */
 	async checkSession(): Promise<boolean> {
 		if (!browser) return false;
@@ -502,14 +508,8 @@ export class AuthOperationsService {
 				return false;
 			}
 
-			// Check if we already have a valid session
 			const sessionManager = this.getSessionManager();
-			if (sessionManager.isAuthenticated()) {
-				logger.debug('Already authenticated');
-				return true;
-			}
-
-			logger.debug('Attempting to refresh token...');
+			logger.debug('Refreshing access token on bootstrap...');
 
 			// Create a promise that resolves after timeout
 			const timeoutPromise = new Promise<never>((_, reject) =>

--- a/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
@@ -2,6 +2,7 @@ import { ApiClient } from '@reborn/api-client';
 import { PUBLIC_BASE_PATH } from '$env/static/public';
 import { createLogger } from '@reborn/utils';
 import type { Logger } from '@reborn/utils';
+import { authFetch } from '$lib/utils/auth-fetch';
 
 /**
  * Base class for sync services with common functionality
@@ -17,12 +18,16 @@ export abstract class SyncBaseService {
 		const baseUrl = `${PUBLIC_BASE_PATH}/api`;
 		this.logger.debug('Initializing sync service with base URL:', baseUrl);
 
-		// Create API client - AuthInterceptor will handle auth headers.
-		// Shorter timeout so a VPN black hole (navigator.onLine=true but no
-		// upstream) doesn't hang a sync for the default 30 s.
+		// Create API client. AuthInterceptor adds the Bearer header on each
+		// request; `onUnauthorized` plugs into the shared `authFetch.refresh()`
+		// so a 401 here transparently triggers a single-flight refresh + retry
+		// (cross-tab serialized via Web Locks API). Shorter timeout so a VPN
+		// black hole (navigator.onLine=true but no upstream) doesn't hang a
+		// sync for the default 30 s.
 		this.apiClient = new ApiClient({
 			baseUrl,
-			timeout: 15_000
+			timeout: 15_000,
+			onUnauthorized: async () => (await authFetch.refresh()) !== null
 		});
 	}
 
@@ -83,8 +88,12 @@ export abstract class SyncBaseService {
 		if (!response.success) {
 			const errorMessage = response.error || response.message;
 			if (this.isAuthError(errorMessage) || response.status === 401 || response.status === 403) {
-				this.logger.warn(
-					`Authentication error during ${entityType} sync. Session-expired flag is managed by auth bootstrap/refresh flow.`
+				// ApiClient already attempted a refresh + retry via `onUnauthorized`,
+				// and `authFetch` flipped `sessionExpired` on failure. If we still see
+				// a 401/403 here, the user must re-authenticate — give up the entity
+				// pull silently so the SessionExpiredBanner is the only signal.
+				this.logger.info(
+					`${entityType} sync skipped — session refresh failed, awaiting re-authentication.`
 				);
 				return;
 			}

--- a/apps/reborn-task/src/lib/utils/auth-fetch.ts
+++ b/apps/reborn-task/src/lib/utils/auth-fetch.ts
@@ -1,0 +1,22 @@
+import { base } from '$app/paths';
+import { createAuthFetch } from '@reborn/auth';
+import { sessionExpired } from '$lib/stores/session-expired.store';
+
+/**
+ * App-level singleton of the authenticated fetch wrapper.
+ *
+ * - Sends `Authorization: Bearer <access_token>` from `localStorage`.
+ * - On 401 from any non-auth endpoint, single-flight refresh (cross-tab via
+ *   Web Locks API) and retry the original request once with the new token.
+ * - On refresh failure, marks `sessionExpired` so the SessionExpiredBanner
+ *   prompts the user to re-authenticate (master key is preserved).
+ *
+ * Use this wrapper for any direct `fetch()` to the app's API. The same
+ * `refresh()` instance is also wired into the `@reborn/api-client` used by
+ * sync services (`onUnauthorized`) and into `AuthApiAdapter.refreshToken()`,
+ * so all refresh paths share one in-tab single-flight promise.
+ */
+export const authFetch = createAuthFetch({
+  refreshUrl: `${base}/api/auth/refresh`,
+  onSessionExpired: () => sessionExpired.set(true)
+});

--- a/packages/api-client/src/__tests__/client-401-refresh.spec.ts
+++ b/packages/api-client/src/__tests__/client-401-refresh.spec.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiClient } from '../core/client';
+
+// In Node 22+ `navigator` and `localStorage` exist; in older runners we need
+// to provide minimal shims. The api-client only reads `navigator.onLine` and
+// (via AuthInterceptor) `localStorage.access_token` during request().
+function ensureBrowserGlobals() {
+  if (typeof (globalThis as { navigator?: unknown }).navigator === 'undefined') {
+    (globalThis as { navigator: { onLine: boolean } }).navigator = { onLine: true };
+  } else {
+    (globalThis as { navigator: { onLine?: boolean } }).navigator.onLine = true;
+  }
+
+  if (typeof (globalThis as { localStorage?: unknown }).localStorage === 'undefined') {
+    const store = new Map<string, string>();
+    (globalThis as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, String(v));
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0
+    } as Storage;
+  }
+
+  // AuthInterceptor checks `typeof window !== 'undefined' && window.localStorage`,
+  // and ApiClient registers online/offline listeners on `window` — so we shim
+  // both the storage and the addEventListener no-op.
+  if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
+    (globalThis as {
+      window: { localStorage: Storage; addEventListener: () => void; removeEventListener: () => void };
+    }).window = {
+      localStorage: (globalThis as { localStorage: Storage }).localStorage,
+      addEventListener: () => {},
+      removeEventListener: () => {}
+    };
+  }
+}
+
+describe('ApiClient — 401 refresh + retry', () => {
+  beforeEach(() => {
+    ensureBrowserGlobals();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('retries the original request once after onUnauthorized returns true', async () => {
+    localStorage.setItem('access_token', 'expired');
+
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const headers = init?.headers;
+      const auth =
+        headers instanceof Headers
+          ? headers.get('Authorization')
+          : (headers as Record<string, string> | undefined)?.['Authorization'];
+      if (auth === 'Bearer fresh') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: true, data: { ok: true } }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+          })
+        );
+      }
+      return Promise.resolve(new Response('expired', { status: 401 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn().mockImplementation(async () => {
+      localStorage.setItem('access_token', 'fresh');
+      return true;
+    });
+
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    const res = await client.get<{ ok: boolean }>('/things');
+
+    expect(res.success).toBe(true);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Initial used expired, retry used fresh
+    expect(
+      (fetchMock.mock.calls[0][1].headers as Record<string, string>)['Authorization']
+    ).toBe('Bearer expired');
+    expect(
+      (fetchMock.mock.calls[1][1].headers as Record<string, string>)['Authorization']
+    ).toBe('Bearer fresh');
+  });
+
+  it('returns the original 401 when onUnauthorized returns false (no retry)', async () => {
+    localStorage.setItem('access_token', 'expired');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn().mockResolvedValue(false);
+
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    const res = await client.get('/things');
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(401);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call onUnauthorized for /auth/refresh itself (no recursive loop)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: false, error: 'expired' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' }
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn();
+
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    await client.post('/auth/refresh', {});
+
+    expect(onUnauthorized).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call onUnauthorized when skipAuth is set', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: false }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' }
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn();
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    await client.get('/things', { skipAuth: true });
+
+    expect(onUnauthorized).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api-client/src/core/client.ts
+++ b/packages/api-client/src/core/client.ts
@@ -44,7 +44,8 @@ export class ApiClient {
       headers: config.headers || {},
       onRequest: config.onRequest || ((c) => c),
       onResponse: config.onResponse || ((r) => r),
-      onError: config.onError || (() => {})
+      onError: config.onError || (() => {}),
+      onUnauthorized: config.onUnauthorized || (async () => false)
     };
 
     // Initialize utilities
@@ -109,17 +110,7 @@ export class ApiClient {
       };
     }
 
-    // Merge configs
-    let requestConfig: RequestConfig = {
-      ...config,
-      headers: {
-        'Content-Type': 'application/json',
-        ...this.config.headers,
-        ...config.headers
-      }
-    };
-
-    // Set URL for interceptors
+    // Set URL for interceptors (stable for both initial and retry attempts)
     if (this.authInterceptor) {
       this.authInterceptor.setCurrentUrl(fullUrl);
     }
@@ -127,13 +118,27 @@ export class ApiClient {
       this.encryptionInterceptor.setCurrentUrl(fullUrl);
     }
 
-    // Apply request interceptors
-    for (const interceptor of this.requestInterceptors) {
-      requestConfig = await interceptor.onRequest(requestConfig);
-    }
+    // Build the final RequestInit through the interceptor pipeline. Re-runs on
+    // refresh-retry so AuthInterceptor picks up the new access token from
+    // localStorage on the second attempt.
+    const buildRequestConfig = async (): Promise<RequestConfig> => {
+      let requestConfig: RequestConfig = {
+        ...config,
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.config.headers,
+          ...config.headers
+        }
+      };
 
-    // Apply global onRequest hook
-    requestConfig = await this.config.onRequest(requestConfig);
+      for (const interceptor of this.requestInterceptors) {
+        requestConfig = await interceptor.onRequest(requestConfig);
+      }
+      requestConfig = await this.config.onRequest(requestConfig);
+      return requestConfig;
+    };
+
+    let requestConfig = await buildRequestConfig();
 
     // Handle offline mode
     if (!navigator.onLine && this.shouldQueueOffline(requestConfig)) {
@@ -146,11 +151,32 @@ export class ApiClient {
       const timeoutId = setTimeout(() => controller.abort(), this.config.timeout);
 
       // Make the request
-      const response = await fetch(fullUrl, {
+      let response = await fetch(fullUrl, {
         ...requestConfig,
         signal: controller.signal,
         credentials: 'include' // Important: include cookies in requests
       });
+
+      // Refresh-on-401: if a non-auth endpoint returns 401, give the caller a
+      // chance to refresh the access token, then retry the request once with
+      // the new token. The retry rebuilds the request config so AuthInterceptor
+      // re-reads the rotated token. Auth endpoints are skipped to avoid
+      // infinite recursion (the refresh endpoint itself can return 401).
+      if (
+        response.status === 401 &&
+        !this.isAuthEndpoint(fullUrl) &&
+        !requestConfig.skipAuth
+      ) {
+        const refreshed = await this.config.onUnauthorized();
+        if (refreshed) {
+          requestConfig = await buildRequestConfig();
+          response = await fetch(fullUrl, {
+            ...requestConfig,
+            signal: controller.signal,
+            credentials: 'include'
+          });
+        }
+      }
 
       clearTimeout(timeoutId);
 
@@ -370,6 +396,19 @@ export class ApiClient {
         status: response.status
       };
     }
+  }
+
+  private isAuthEndpoint(fullUrl: string): boolean {
+    // Mirror AuthInterceptor's auth-endpoint list — these must never trigger
+    // the refresh-on-401 path (the refresh endpoint itself returning 401 would
+    // otherwise loop).
+    return (
+      fullUrl.includes('/auth/login') ||
+      fullUrl.includes('/auth/register') ||
+      fullUrl.includes('/auth/logout') ||
+      fullUrl.includes('/auth/verify') ||
+      fullUrl.includes('/auth/refresh')
+    );
   }
 
   private shouldQueueOffline(config: RequestConfig): boolean {

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -66,6 +66,14 @@ export interface ApiClientConfig {
   onRequest?: (config: RequestConfig) => RequestConfig | Promise<RequestConfig>;
   onResponse?: <T>(response: ApiResponse<T>) => ApiResponse<T> | Promise<ApiResponse<T>>;
   onError?: (error: ApiError) => void | Promise<void>;
+  /**
+   * Called when a non-auth endpoint returns 401. Implementations should
+   * single-flight refresh the access token (typically `authFetch.refresh()`)
+   * and return `true` if a new token is now available — the client will
+   * re-run request interceptors and retry the original request once. Return
+   * `false` (or throw) to surface the original 401 to the caller.
+   */
+  onUnauthorized?: () => Promise<boolean>;
 }
 
 /**

--- a/packages/auth/src/__tests__/auth-fetch.spec.ts
+++ b/packages/auth/src/__tests__/auth-fetch.spec.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAuthFetch, type AuthFetchTokenStorage } from '../utils/auth-fetch';
+
+function makeStorage(initial: string | null = null): AuthFetchTokenStorage & { value: string | null } {
+  const state = { value: initial };
+  return {
+    value: state.value,
+    getAccessToken: () => state.value,
+    setAccessToken: (t: string) => {
+      state.value = t;
+    }
+  } as never;
+}
+
+describe('createAuthFetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('attaches Bearer header from storage on the initial request', async () => {
+    const storage = makeStorage('access-1');
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl
+    });
+
+    await authFetch('/api/things');
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0];
+    const headers = init.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer access-1');
+  });
+
+  it('does not overwrite caller-provided Authorization header', async () => {
+    const storage = makeStorage('access-from-storage');
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl
+    });
+
+    await authFetch('/api/things', {
+      headers: { Authorization: 'Bearer caller-token' }
+    });
+
+    const [, init] = fetchImpl.mock.calls[0];
+    const headers = init.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer caller-token');
+  });
+
+  it('refreshes on 401 and retries with the new token', async () => {
+    const storage = makeStorage('expired');
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('expired', { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { access_token: 'fresh' } }), {
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl
+    });
+
+    const response = await authFetch('/api/things');
+
+    expect(response.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+    // Initial request used expired token
+    expect((fetchImpl.mock.calls[0][1].headers as Headers).get('Authorization')).toBe(
+      'Bearer expired'
+    );
+
+    // Refresh call to refreshUrl
+    expect(fetchImpl.mock.calls[1][0]).toBe('/api/auth/refresh');
+    expect((fetchImpl.mock.calls[1][1] as RequestInit).method).toBe('POST');
+
+    // Retry request used fresh token
+    expect((fetchImpl.mock.calls[2][1].headers as Headers).get('Authorization')).toBe(
+      'Bearer fresh'
+    );
+
+    expect(storage.getAccessToken()).toBe('fresh');
+  });
+
+  it('invokes onSessionExpired and returns the original 401 when refresh fails', async () => {
+    const storage = makeStorage('expired');
+    const onSessionExpired = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('expired', { status: 401 }))
+      .mockResolvedValueOnce(new Response('refresh failed', { status: 401 }));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl,
+      onSessionExpired
+    });
+
+    const response = await authFetch('/api/things');
+
+    expect(response.status).toBe(401);
+    expect(onSessionExpired).toHaveBeenCalledOnce();
+    // No retry happened — only initial + refresh attempt
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // Storage left untouched
+    expect(storage.getAccessToken()).toBe('expired');
+  });
+
+  it('serializes concurrent 401s through a single in-flight refresh', async () => {
+    const storage = makeStorage('expired');
+
+    let resolveRefresh!: (value: Response) => void;
+    const refreshPending = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    const fetchImpl = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/auth/refresh') return refreshPending;
+      const tokenHeader = (init?.headers as Headers | undefined)?.get('Authorization');
+      if (tokenHeader === 'Bearer fresh')
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      return Promise.resolve(new Response('expired', { status: 401 }));
+    });
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl
+    });
+
+    const calls = [authFetch('/api/things/a'), authFetch('/api/things/b'), authFetch('/api/things/c')];
+
+    // Allow microtasks to flush so all three are blocked on the refresh
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveRefresh(
+      new Response(JSON.stringify({ success: true, data: { access_token: 'fresh' } }), {
+        status: 200
+      })
+    );
+
+    const responses = await Promise.all(calls);
+    expect(responses.every((r) => r.status === 200)).toBe(true);
+
+    const refreshCalls = fetchImpl.mock.calls.filter((c) => c[0] === '/api/auth/refresh');
+    expect(refreshCalls).toHaveLength(1);
+  });
+
+  it('exposes refresh() for proactive refresh', async () => {
+    const storage = makeStorage('old');
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { access_token: 'new' } }), {
+        status: 200
+      })
+    );
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl
+    });
+
+    const newToken = await authFetch.refresh();
+
+    expect(newToken).toBe('new');
+    expect(storage.getAccessToken()).toBe('new');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0][0]).toBe('/api/auth/refresh');
+  });
+
+  it('returns null from refresh() when server rejects', async () => {
+    const storage = makeStorage('old');
+    const onSessionExpired = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: false, error: 'invalid' }), { status: 401 })
+    );
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl,
+      onSessionExpired
+    });
+
+    const newToken = await authFetch.refresh();
+
+    expect(newToken).toBeNull();
+    expect(storage.getAccessToken()).toBe('old'); // unchanged
+    // refresh() itself does NOT call onSessionExpired — that's the wrapper's job on 401-driven refresh.
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -38,6 +38,10 @@ export type { PowChallengeData } from './utils/pow-solver';
 // Cross-tab/cross-app refresh-token coordination
 export { withRefreshLock } from './utils/refresh-lock';
 
+// Authenticated fetch wrapper with single-flight 401 refresh + retry
+export { createAuthFetch } from './utils/auth-fetch';
+export type { AuthFetch, AuthFetchConfig, AuthFetchTokenStorage } from './utils/auth-fetch';
+
 // Export guards
 export {
   createAuthGuard,

--- a/packages/auth/src/utils/auth-fetch.ts
+++ b/packages/auth/src/utils/auth-fetch.ts
@@ -1,0 +1,140 @@
+import { withRefreshLock } from './refresh-lock';
+
+/**
+ * Authenticated fetch wrapper with single-flight token refresh.
+ *
+ * On 401 from any non-auth endpoint, attempts to refresh the access token
+ * (single-flight per tab + cross-tab serialized via Web Locks API), then
+ * retries the original request once with the new token. If refresh fails,
+ * invokes `onSessionExpired` so the app can surface the session-expired UI.
+ *
+ * The cross-tab lock prevents two tabs (or two apps on the same origin) from
+ * both POSTing /api/auth/refresh with the same refresh-token cookie, which
+ * would trip the server's token-reuse detector and revoke the entire family.
+ *
+ * Usage:
+ *   const authFetch = createAuthFetch({
+ *     refreshUrl: '/task/api/auth/refresh',
+ *     onSessionExpired: () => sessionExpired.set(true)
+ *   });
+ *
+ *   await authFetch('/task/api/tasks');           // GET with Bearer header
+ *   await authFetch.refresh();                    // proactive refresh
+ */
+
+export interface AuthFetchTokenStorage {
+  getAccessToken: () => string | null;
+  setAccessToken: (token: string) => void;
+}
+
+export interface AuthFetchConfig {
+  /** Absolute or relative URL of the POST /auth/refresh endpoint. */
+  refreshUrl: string;
+  /** Default per-request timeout in ms. Caller-provided `init.signal` overrides. */
+  defaultTimeoutMs?: number;
+  /** Callback when refresh fails — typically marks session expired. */
+  onSessionExpired?: () => void;
+  /** Token storage adapter — defaults to localStorage 'access_token'. */
+  storage?: AuthFetchTokenStorage;
+  /** Override fetch impl (tests). Defaults to globalThis.fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface AuthFetch {
+  (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+  /** Force a refresh now, returning the new access token or null on failure. */
+  refresh: () => Promise<string | null>;
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+const defaultStorage: AuthFetchTokenStorage = {
+  getAccessToken: () =>
+    typeof localStorage !== 'undefined' ? localStorage.getItem('access_token') : null,
+  setAccessToken: (token: string) => {
+    if (typeof localStorage !== 'undefined') localStorage.setItem('access_token', token);
+  }
+};
+
+export function createAuthFetch(config: AuthFetchConfig): AuthFetch {
+  const storage = config.storage ?? defaultStorage;
+  const timeoutMs = config.defaultTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const fetchImpl = config.fetchImpl ?? ((...args: Parameters<typeof fetch>) => fetch(...args));
+
+  // In-tab single-flight: concurrent 401 handlers share one refresh promise so
+  // they don't all hit the server. Cross-tab is serialized via withRefreshLock.
+  let refreshPromise: Promise<string | null> | null = null;
+
+  async function doRefresh(tokenBeforeLock: string | null): Promise<string | null> {
+    // Inside the cross-tab lock another tab may have already refreshed for us.
+    // If the stored access token changed while we were queued, skip the
+    // redundant fetch and use the fresh one.
+    const current = storage.getAccessToken();
+    if (current && current !== tokenBeforeLock) return current;
+
+    const refreshRes = await fetchImpl(config.refreshUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    });
+
+    if (!refreshRes.ok) return null;
+
+    const data = (await refreshRes.json()) as {
+      success?: boolean;
+      data?: { access_token?: string };
+    };
+    if (!data.success || !data.data?.access_token) return null;
+
+    const newToken = data.data.access_token;
+    storage.setAccessToken(newToken);
+    return newToken;
+  }
+
+  function refresh(): Promise<string | null> {
+    if (!refreshPromise) {
+      const tokenBeforeLock = storage.getAccessToken();
+      refreshPromise = withRefreshLock(() => doRefresh(tokenBeforeLock)).finally(() => {
+        refreshPromise = null;
+      });
+    }
+    return refreshPromise;
+  }
+
+  function buildSignal(init?: RequestInit): AbortSignal {
+    if (init?.signal) return init.signal;
+    return AbortSignal.timeout(timeoutMs);
+  }
+
+  const authFetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    const accessToken = storage.getAccessToken();
+
+    const headers = new Headers(init?.headers);
+    if (accessToken && !headers.has('Authorization')) {
+      headers.set('Authorization', `Bearer ${accessToken}`);
+    }
+
+    const signal = buildSignal(init);
+    const response = await fetchImpl(input, { ...init, headers, signal });
+
+    if (response.status !== 401) return response;
+
+    const newToken = await refresh();
+    if (!newToken) {
+      config.onSessionExpired?.();
+      return response;
+    }
+
+    // Retry original request with the new token. Reuse the same signal so the
+    // retry inherits the caller's cancellation / timeout budget.
+    const retryHeaders = new Headers(init?.headers);
+    retryHeaders.set('Authorization', `Bearer ${newToken}`);
+    return fetchImpl(input, { ...init, headers: retryHeaders, signal });
+  }) as AuthFetch;
+
+  authFetch.refresh = refresh;
+  return authFetch;
+}


### PR DESCRIPTION
Sync requests in reborn-task were silently failing with 401 after login because (a) ApiClient had no response handler that could refresh the access token on 401, (b) checkSession() proactively skipped refresh once persisted credentials had marked the session authenticated, and (c) the two refresh implementations (reborn-notes auth-fetch and reborn-task AuthApiAdapter) didn't share an in-tab single-flight promise.

Extract createAuthFetch into @reborn/auth as the single canonical implementation: Bearer header from localStorage, 401 -> single-flight refresh -> retry once, with cross-tab serialization through Web Locks. Add onUnauthorized to ApiClientConfig so api-client delegates 401 recovery to the shared singleton, with auth endpoints excluded from the retry path. Both apps now instantiate one authFetch and route every refresh path (sync, bootstrap checkSession, background interval, direct UI fetches) through it, so reborn-task and reborn-notes coordinate via the same lock.

Drop the misleading "session-expired flag is managed by auth bootstrap" log in SyncBaseService -- it described a flow that didn't exist. Drop checkSession()'s early-return on isAuthenticated so cold starts always refresh the access token instead of waiting on a 401. Drop the temporary diagnostic refresh-failure logs and the JWT_SECRET / token verification debug noise from reborn-task hooks.server.ts.

Tests: 7 new in @reborn/auth (createAuthFetch), 4 new in @reborn/api-client (401 retry + auth endpoint exclusion). Existing suites stay green; both apps build and svelte-check report 0 errors / 0 warnings.