### PR TITLE
chore: gitignore nginx/staging.conf alongside prod.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ docker-compose.prod.yml
 docker-compose.staging.yml
 docker-compose.localprod.yml
 nginx/prod.conf
+nginx/staging.conf
 
 # Dev Container (Claude Code specific mounts)
 .devcontainer/


### PR DESCRIPTION
Staging nginx vhost is now managed via the same SCP flow as prod — edited locally in nginx/staging.conf, deployed to VPS, copied into /etc/nginx/sites-available/staging.reapps.eu. Symmetric to prod.conf (already gitignored), so changes go through git diff review before hitting the server.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>