### PR TITLE
fix(notes): activate edit view when picking editor mode from toolbar

### DIFF
--- a/apps/reborn-notes/src/lib/components/editor/EditorModeButton.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/EditorModeButton.svelte
@@ -18,12 +18,12 @@
   import { appSettings, editorMode } from '$lib/stores/app-settings.store';
 
   let {
-    isActive,
+    viewMode,
     isMobile,
     label,
     onActivate
   }: {
-    isActive: boolean;
+    viewMode: 'edit' | 'split' | 'preview';
     isMobile: boolean;
     label: string;
     onActivate: () => void;
@@ -31,12 +31,15 @@
 
   let sheetOpen = $state(false);
 
+  const isActive = $derived(viewMode === 'edit');
   const FaceIcon = $derived($editorMode === 'live' ? PencilLine : Pencil);
 
   async function setEditorMode(value: 'markdown' | 'live') {
     sheetOpen = false;
-    if ($editorMode === value) return;
-    await appSettings.update('editorMode', value);
+    if ($editorMode !== value) {
+      await appSettings.update('editorMode', value);
+    }
+    onActivate();
   }
 </script>
 

--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -175,7 +175,7 @@
           {@const isActive = effectiveViewMode === mode}
           {#if mode === 'edit'}
             <EditorModeButton
-              {isActive}
+              viewMode={effectiveViewMode}
               {isMobile}
               {label}
               onActivate={() => {


### PR DESCRIPTION
Choosing Markdown source or Live preview from the split-button menu on the "Edit" segment now always switches viewMode to 'edit', regardless of whether the user was in split or preview. The three view-mode segments are visually distinct, so any interaction with the Edit segment (face icon or chevron) signals intent to enter edit view; leaving the user in preview after a sub-mode pick was confusing.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>