### PR TITLE
fix(notes): force raw markdown in split view editor pane

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -315,7 +315,7 @@
         readonlyCompartment.of(EditorState.readOnly.of(readonly)),
         placeholderExt(placeholder),
         autocompleteCompartment.of(noteLinkAutocomplete(() => availableNotes, currentNoteId)),
-        livePreviewCompartment.of($editorMode === 'live' ? createLivePreviewExtension() : []),
+        livePreviewCompartment.of($editorMode === 'live' && !splitView ? createLivePreviewExtension() : []),
         noteLinkDecoration,
         EditorView.domEventHandlers({
           click(e) {
@@ -416,12 +416,15 @@
     });
   });
 
-  // Sync editor mode (markdown ↔ live preview)
+  // Sync editor mode (markdown ↔ live preview).
+  // In split view the right pane already renders the rendered preview,
+  // so the editor pane always shows raw Markdown regardless of editorMode.
   $effect(() => {
     const mode = $editorMode;
+    const live = mode === 'live' && !splitView;
     view?.dispatch({
       effects: livePreviewCompartment.reconfigure(
-        mode === 'live' ? createLivePreviewExtension() : []
+        live ? createLivePreviewExtension() : []
       )
     });
   });


### PR DESCRIPTION
In split view the right pane already renders the rendered preview, so the editor pane now ignores editorMode='live' and always shows raw Markdown. User preference is preserved — live preview returns when switching back to the Edit-only view.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>