### PR TITLE
fix(notes): stabilize editor header, split view, and toolbar on iPadOS Safari

### DIFF
--- a/apps/reborn-notes/src/app.css
+++ b/apps/reborn-notes/src/app.css
@@ -41,6 +41,23 @@
 @source "./routes/**/*.{svelte,js,ts}";
 @source "../../../packages/ui/src/**/*.{svelte,js,ts}";
 
+/* iOS Safari body scroll-lock — prevents Safari from scrolling the window when
+ * a contenteditable (CodeMirror) gains focus and the virtual keyboard opens.
+ * Without this, Safari scrolls <html>/<body> to keep the caret visible, which
+ * pushes the app header off-screen. position:fixed neutralizes window-level
+ * scrolling so the app's own overflow containers stay in control. */
+@layer base {
+  html,
+  body {
+    overflow: hidden;
+    overscroll-behavior: none;
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
 /* Dark mode scrollbar */
 @layer base {
   .dark * {

--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -39,25 +39,21 @@
     readonly = false,
     parentScroll = false,
     isMobile = false,
-    panelReady = true,
     splitView = false,
     onchange,
     onscrollerinit,
     onnotelinkrequest,
     onnotelinkclick,
     availableNotes = [],
-    currentNoteId = null,
-    externalDialogOpen = false
+    currentNoteId = null
   }: {
     content?: string;
     placeholder?: string;
     readonly?: boolean;
     /** When true, the editor grows to content height (no own scroll) and toolbar becomes sticky + centered. */
     parentScroll?: boolean;
-    /** When true, enables mobile-specific toolbar behavior (sticky over virtual keyboard). */
+    /** When true, the editor renders the mobile toolbar (sticky on top of editor). */
     isMobile?: boolean;
-    /** When true, the parent panel transition has completed (safe for position:fixed). Defaults to true for non-mobile contexts. */
-    panelReady?: boolean;
     /** When true, indicates editor is in split view context (toolbar full-width, no max-w centering). */
     splitView?: boolean;
     onchange?: (content: string) => void;
@@ -71,8 +67,6 @@
     availableNotes?: NoteLinkItem[];
     /** Current note id (excluded from autocomplete suggestions) */
     currentNoteId?: string | null;
-    /** When true, an external dialog (e.g. NotePicker) is open — hides mobile toolbar. */
-    externalDialogOpen?: boolean;
   } = $props();
 
   let editorRootEl: HTMLDivElement;
@@ -239,9 +233,6 @@
   let showTableDialog = $state(false);
   let tableCols = $state(3);
   let tableRows = $state(2);
-
-  /** When any popup dialog is open, hide the mobile toolbar to avoid z-index conflicts. */
-  const anyDialogOpen = $derived(showImageDialog || showTableDialog || externalDialogOpen);
 
   function openTableDialog() {
     if (isMobile) view?.contentDOM.blur();
@@ -432,112 +423,6 @@
   onDestroy(() => {
     view?.destroy();
   });
-
-  // ── Mobile virtual keyboard tracking ────────────────────────────
-  let mobileKeyboardOpen = $state(false);
-  let toolbarBottomPx = $state(0);
-  const KEYBOARD_THRESHOLD = 0.85;
-  const KEYBOARD_MIN_DIFF_PX = 150;
-
-  $effect(() => {
-    if (!isMobile) return;
-    if (typeof window === 'undefined') return;
-
-    const vv = window.visualViewport ?? null;
-    let layoutHeight = window.innerHeight;
-    let vvDetected = false;
-    let focusDetected = false;
-    let focusTimer: ReturnType<typeof setTimeout> | undefined;
-
-    function recalcLayout() {
-      // Update layoutHeight only when keyboard is likely closed
-      const currentHeight = vv ? vv.height : window.innerHeight;
-      if (currentHeight / window.innerHeight > 0.9) {
-        layoutHeight = window.innerHeight;
-      }
-    }
-
-    function applyState() {
-      mobileKeyboardOpen = vvDetected || focusDetected;
-      if (!mobileKeyboardOpen) toolbarBottomPx = 0;
-    }
-
-    // ── Strategy 1: visualViewport (primary) ──
-    function onVVResize() {
-      if (!vv) return;
-      const visibleHeight = vv.height;
-      vvDetected =
-        visibleHeight < layoutHeight * KEYBOARD_THRESHOLD &&
-        layoutHeight - visibleHeight > KEYBOARD_MIN_DIFF_PX;
-      // Without interactive-widget=resizes-content the layout viewport stays
-      // full-size when the keyboard opens (default resizes-visual behaviour).
-      // position:fixed bottom:0 would land behind the keyboard, so we compute
-      // the real offset from the visualViewport API.
-      if (vvDetected) {
-        toolbarBottomPx = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
-      } else {
-        toolbarBottomPx = 0;
-        recalcLayout();
-      }
-      applyState();
-    }
-
-    // ── Strategy 2: focus-based fallback ──
-    // Scoped to editorRootEl so toolbar button clicks don't trigger focusout→hide.
-    function onFocusIn(e: FocusEvent) {
-      const target = e.target;
-      if (!(target instanceof HTMLElement)) return;
-      const isEditable =
-        target.isContentEditable ||
-        target.tagName === 'TEXTAREA' ||
-        target.tagName === 'INPUT';
-      if (!isEditable) return;
-
-      clearTimeout(focusTimer);
-      // Delay to let visualViewport fire first
-      focusTimer = setTimeout(() => {
-        if (!vvDetected) {
-          focusDetected = true;
-          applyState();
-        }
-      }, 300);
-    }
-
-    function onFocusOut(e: FocusEvent) {
-      clearTimeout(focusTimer);
-      // If focus moves to another element inside this component (e.g. toolbar button),
-      // keep focusDetected — the keyboard is still open.
-      const related = e.relatedTarget as Node | null;
-      if (related && editorRootEl?.contains(related)) return;
-      focusTimer = setTimeout(() => {
-        focusDetected = false;
-        if (!vvDetected) applyState();
-      }, 200);
-    }
-
-    // ── Bind events ──
-    const rootEl = editorRootEl;
-    if (vv) {
-      vv.addEventListener('resize', onVVResize);
-      vv.addEventListener('scroll', onVVResize);
-    }
-    rootEl?.addEventListener('focusin', onFocusIn);
-    rootEl?.addEventListener('focusout', onFocusOut);
-    window.addEventListener('orientationchange', recalcLayout);
-
-    return () => {
-      if (vv) {
-        vv.removeEventListener('resize', onVVResize);
-        vv.removeEventListener('scroll', onVVResize);
-      }
-      rootEl?.removeEventListener('focusin', onFocusIn);
-      rootEl?.removeEventListener('focusout', onFocusOut);
-      window.removeEventListener('orientationchange', recalcLayout);
-      clearTimeout(focusTimer);
-      mobileKeyboardOpen = false;
-      toolbarBottomPx = 0;
-    };
-  });
 </script>
 
 <div bind:this={editorRootEl} class="flex flex-col" class:h-full={!parentScroll}>
@@ -716,18 +601,15 @@
       </button>
     {/snippet}
 
-    {#if isMobile && mobileKeyboardOpen && panelReady && !anyDialogOpen}
-      <!-- Mobile: fixed toolbar above virtual keyboard with slide-up animation -->
-      <div
-        class="mobile-keyboard-toolbar"
-        style:bottom="{toolbarBottomPx}px"
-      >
-        <div class="flex items-center gap-0.5 px-2 py-1.5">
+    {#if isMobile}
+      <!-- Mobile: sticky toolbar at top of editor.
+           Position is deterministic — independent of virtual keyboard state
+           and Stage Manager edge-cases on iPad. -->
+      <div class="mobile-toolbar sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b">
+        <div class="flex flex-nowrap items-center gap-0.5 overflow-x-auto px-2 py-1.5">
           {@render toolbarButtons()}
         </div>
       </div>
-    {:else if isMobile}
-      <!-- Mobile: toolbar hidden when keyboard is closed (no-op) -->
     {:else if parentScroll && !splitView}
       <div class="sticky top-0 z-10 bg-background/95 backdrop-blur-sm px-5">
         <div class="mx-auto max-w-3xl">
@@ -859,11 +741,6 @@
     class:cm-parent-scroll={parentScroll}
     aria-label={$t('editor.note_editor')}
   ></div>
-
-  {#if isMobile && mobileKeyboardOpen && panelReady && !anyDialogOpen}
-    <!-- Spacer so content isn't hidden behind the fixed toolbar -->
-    <div class="h-13 shrink-0"></div>
-  {/if}
 </div>
 
 <style>
@@ -948,35 +825,8 @@
     color: var(--accent-foreground);
   }
 
-  /* ── Mobile keyboard toolbar ─────────────────────────────── */
-  .mobile-keyboard-toolbar {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-    width: 100vw;
-    z-index: 9999;
-    background-color: var(--background);
-    border-top: 1px solid var(--border);
-    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
-    overflow-x: auto;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-    white-space: nowrap;
-    animation: toolbar-slide-up 0.2s ease-out;
-  }
-
-  @keyframes toolbar-slide-up {
-    from {
-      opacity: 0;
-      transform: translateY(1rem);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  .mobile-keyboard-toolbar .toolbar-btn {
+  /* ── Mobile toolbar (sticky at top of editor) ────────────── */
+  .mobile-toolbar .toolbar-btn {
     flex-shrink: 0;
     min-width: 2.5rem;
     height: 2.5rem;
@@ -984,13 +834,13 @@
   }
 
   /* Enlarge icons inside mobile toolbar for better touch targets */
-  .mobile-keyboard-toolbar .toolbar-btn :global(svg) {
+  .mobile-toolbar .toolbar-btn :global(svg) {
     width: 1.25rem;
     height: 1.25rem;
   }
 
-  /* Hide separators inside the fixed mobile toolbar to save space */
-  .mobile-keyboard-toolbar [role='separator'] {
+  /* Hide separators inside the mobile toolbar to save horizontal space */
+  .mobile-toolbar [role='separator'] {
     display: none;
   }
 </style>

--- a/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
@@ -23,13 +23,11 @@
     imageLoadMode = 'ask' as ImageLoadMode,
     parentScroll = false,
     isMobile = false,
-    panelReady = true,
     oncontentchange,
     onscrollerinit,
     onnotelinkrequest,
     onnotelink,
-    resolveNoteTitle,
-    externalDialogOpen = false
+    resolveNoteTitle
   }: {
     noteId: string;
     effectiveViewMode: ViewMode;
@@ -42,22 +40,23 @@
     previewScrollEl: HTMLElement | null;
     autocompleteNotes: { id: string; title: string }[];
     imageLoadMode?: ImageLoadMode;
-    /** When true (desktop edit mode), the parent scrolls and editor grows to content. */
+    /** When true (desktop edit mode), the parent scrolls and editor grows to content.
+     *  Effective only in single-pane edit mode — split view always uses independent
+     *  scrolls per pane. */
     parentScroll?: boolean;
-    /** When true, enables mobile-specific toolbar behavior (sticky over virtual keyboard). */
+    /** When true, the editor renders the mobile toolbar (sticky on top of editor). */
     isMobile?: boolean;
-    /** When true, the panel slide-in transition has completed (safe for position:fixed toolbar). */
-    panelReady?: boolean;
     oncontentchange: (content: string) => void;
     onscrollerinit: (el: HTMLElement) => void;
     onnotelinkrequest: () => void;
     onnotelink: (noteId: string) => void;
     resolveNoteTitle: (noteId: string) => string | undefined;
-    /** When true, an external dialog (e.g. NotePicker) is open — hides mobile toolbar. */
-    externalDialogOpen?: boolean;
   } = $props();
 
-  const isParentScrollActive = $derived(parentScroll);
+  // Split view always uses independent scrolls per pane — sticky+100dvh inside a
+  // flex container caused reflow loops on iOS Safari. Only single-pane edit
+  // honors parentScroll (parent grows with content, toolbar sticks to parent).
+  const isParentScrollActive = $derived(parentScroll && effectiveViewMode === 'edit');
 </script>
 
 <div class="relative {isParentScrollActive ? '' : 'flex min-h-0 flex-1 overflow-hidden'}">
@@ -95,13 +94,12 @@
           currentNoteId={noteId}
           parentScroll={parentScroll}
           {isMobile}
-          {panelReady}
-          {externalDialogOpen}
         />
       {:else if effectiveViewMode === 'split'}
-        <!-- Split: parent scroll drives left column; right column is sticky with own scroll -->
-        <div class="flex divide-x divide-border">
-          <div class="min-w-0 flex-1">
+        <!-- Split: each pane owns its scroll; sync handled by scroll-sync.ts.
+             Avoids sticky+100dvh reflow loop that caused auto-scroll-to-top on iOS. -->
+        <div class="flex divide-x divide-border h-full min-h-0">
+          <div class="min-w-0 flex-1 overflow-hidden">
             <NoteEditor
               bind:this={editorRef}
               content={noteDetailService.content}
@@ -111,11 +109,13 @@
               {onnotelinkrequest}
               availableNotes={autocompleteNotes}
               currentNoteId={noteId}
-              parentScroll={parentScroll}
-              splitView              {externalDialogOpen}            />
+              parentScroll={false}
+              splitView
+              {isMobile}
+            />
           </div>
-          <div class="sticky -top-px flex min-w-0 flex-1 flex-col" style="height: calc(100dvh - 4rem + 1px);">
-            <div class="flex shrink-0 items-center border-t border-b bg-background/95 backdrop-blur-sm px-4 py-1.5">
+          <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
+            <div class="flex shrink-0 items-center border-b bg-background/95 backdrop-blur-sm px-4 py-1.5">
               <span class="flex h-7 items-center text-xs font-medium text-muted-foreground">{$t('editor.preview')}</span>
             </div>
             <MarkdownPreview

--- a/apps/reborn-notes/src/lib/utils/scroll-sync.ts
+++ b/apps/reborn-notes/src/lib/utils/scroll-sync.ts
@@ -1,6 +1,13 @@
 /**
  * Scroll-sync helper for split view (editor ↔ preview).
  *
+ * Strategy: soft sync (post-gesture). Each pane stamps `lastUserScroll` on its
+ * own scroll event; the cross-pane sync only runs after a short pause (≥ 80 ms)
+ * when no fresh user input is arriving. This eliminates the iOS Safari ping-pong
+ * caused by momentum scrolling, where every frame triggered a programmatic
+ * counter-scroll on the other pane and asymmetric ratio drift pulled both panes
+ * toward scrollTop=0.
+ *
  * Usage in a Svelte component:
  *   const scrollSync = createScrollSync();
  *   // pass scrollSync.initEditorScroller to NoteEditor's onscrollerinit
@@ -26,39 +33,78 @@ export interface ScrollSync {
   destroy: () => void;
 }
 
+const USER_SCROLL_QUIET_MS = 80;
+const SYNC_RELEASE_MS = 120;
+
 export function createScrollSync(): ScrollSync {
   let editorScroller: HTMLElement | null = null;
   let scrollContainer: HTMLElement | null = null;
   let syncing = false;
+  let lastUserScroll = 0;
+  let releaseTimer: ReturnType<typeof setTimeout> | null = null;
+  let editorPendingTimer: ReturnType<typeof setTimeout> | null = null;
+  let previewPendingTimer: ReturnType<typeof setTimeout> | null = null;
 
-  /** The element whose scroll position drives sync. */
+  /** The element whose scroll position drives editor→preview sync. */
   function activeSource(): HTMLElement | null {
     return scrollContainer ?? editorScroller;
   }
 
-  function syncEditorToPreview() {
+  function scheduleRelease() {
+    if (releaseTimer) clearTimeout(releaseTimer);
+    releaseTimer = setTimeout(() => {
+      syncing = false;
+      releaseTimer = null;
+    }, SYNC_RELEASE_MS);
+  }
+
+  function applyRatio(target: HTMLElement, ratio: number) {
+    target.scrollTop = ratio * (target.scrollHeight - target.clientHeight);
+  }
+
+  function syncEditorToPreviewNow() {
     const source = activeSource();
-    if (syncing || !source || !sync.previewScrollEl) return;
+    if (!source || !sync.previewScrollEl) return;
     syncing = true;
     const { scrollTop, scrollHeight, clientHeight } = source;
     const ratio = scrollHeight > clientHeight ? scrollTop / (scrollHeight - clientHeight) : 0;
-    sync.previewScrollEl.scrollTop =
-      ratio * (sync.previewScrollEl.scrollHeight - sync.previewScrollEl.clientHeight);
-    requestAnimationFrame(() => {
-      syncing = false;
-    });
+    applyRatio(sync.previewScrollEl, ratio);
+    scheduleRelease();
   }
 
-  function syncPreviewToEditor() {
+  function syncPreviewToEditorNow() {
     const target = activeSource();
-    if (syncing || !target || !sync.previewScrollEl) return;
+    if (!target || !sync.previewScrollEl) return;
     syncing = true;
     const { scrollTop, scrollHeight, clientHeight } = sync.previewScrollEl;
     const ratio = scrollHeight > clientHeight ? scrollTop / (scrollHeight - clientHeight) : 0;
-    target.scrollTop = ratio * (target.scrollHeight - target.clientHeight);
-    requestAnimationFrame(() => {
-      syncing = false;
-    });
+    applyRatio(target, ratio);
+    scheduleRelease();
+  }
+
+  function syncEditorToPreview() {
+    if (syncing) return;
+    lastUserScroll = performance.now();
+    if (editorPendingTimer) clearTimeout(editorPendingTimer);
+    editorPendingTimer = setTimeout(() => {
+      editorPendingTimer = null;
+      // Only run if no newer user-driven scroll arrived in the meantime
+      if (performance.now() - lastUserScroll >= USER_SCROLL_QUIET_MS - 1) {
+        syncEditorToPreviewNow();
+      }
+    }, USER_SCROLL_QUIET_MS);
+  }
+
+  function syncPreviewToEditor() {
+    if (syncing) return;
+    lastUserScroll = performance.now();
+    if (previewPendingTimer) clearTimeout(previewPendingTimer);
+    previewPendingTimer = setTimeout(() => {
+      previewPendingTimer = null;
+      if (performance.now() - lastUserScroll >= USER_SCROLL_QUIET_MS - 1) {
+        syncPreviewToEditorNow();
+      }
+    }, USER_SCROLL_QUIET_MS);
   }
 
   function initEditorScroller(el: HTMLElement) {
@@ -91,6 +137,12 @@ export function createScrollSync(): ScrollSync {
   }
 
   function destroy() {
+    if (releaseTimer) clearTimeout(releaseTimer);
+    if (editorPendingTimer) clearTimeout(editorPendingTimer);
+    if (previewPendingTimer) clearTimeout(previewPendingTimer);
+    releaseTimer = null;
+    editorPendingTimer = null;
+    previewPendingTimer = null;
     if (scrollContainer) {
       scrollContainer.removeEventListener('scroll', syncEditorToPreview);
       scrollContainer = null;

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -206,6 +206,25 @@
     }
   });
 
+  // iOS Safari safety net: app.css locks <html>/<body> with position:fixed, but
+  // if Safari ever ends up with non-zero scrollTop on the document element
+  // (race during font load, focus before stylesheet apply, …), the app header
+  // would slide off-screen. Reset the document scroll on every window scroll
+  // and visualViewport resize.
+  $effect(() => {
+    if (!browser) return;
+    const reset = () => {
+      if (document.documentElement.scrollTop !== 0) document.documentElement.scrollTop = 0;
+      if (document.body.scrollTop !== 0) document.body.scrollTop = 0;
+    };
+    window.addEventListener('scroll', reset, { passive: true });
+    window.visualViewport?.addEventListener('resize', reset);
+    return () => {
+      window.removeEventListener('scroll', reset);
+      window.visualViewport?.removeEventListener('resize', reset);
+    };
+  });
+
   function applyTheme(theme: 'light' | 'dark' | 'system') {
     const root = document.documentElement;
     if (theme === 'system') {

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -259,8 +259,6 @@
   let isMobile = $state(false);
   let closeSidebarSignal = $state(0);
   const effectiveViewMode = $derived(isMobile && viewMode === 'split' ? 'edit' : viewMode);
-  /** True after the editor panel slide-in transition completes (prevents broken position:fixed during transform). */
-  let mobilePanelReady = $state(false);
 
   // Mobile drill-down navigation state
   type MobileView = 'list' | 'folder-tree' | 'tag-list';
@@ -336,30 +334,6 @@
     }
     prevMobileView = view;
   });
-
-  // Reset panelReady only when panel visibility changes (null ↔ non-null).
-  // Switching between two notes doesn't trigger a slide — skip reset.
-  let prevNoteIdForPanel: string | null | undefined;
-  $effect(() => {
-    const currentId = $activeNoteId;
-    const hadNote = prevNoteIdForPanel != null;
-    const hasNote = currentId != null;
-    prevNoteIdForPanel = currentId;
-    if (hadNote !== hasNote) {
-      mobilePanelReady = false;
-    }
-  });
-
-  function handleMobilePanelTransitionEnd(e: TransitionEvent) {
-    // Tailwind v4 uses individual `translate` property (not composed `transform`).
-    // Ignore bubbled events from children — only react to this element's transition.
-    if (
-      (e.propertyName === 'translate' || e.propertyName === 'transform') &&
-      e.target === e.currentTarget
-    ) {
-      mobilePanelReady = !!$activeNoteId;
-    }
-  }
 
   function handleMobileBack() {
     if (isMobile && mobileHistoryDepth > 0) {
@@ -687,14 +661,6 @@
     return () => previewScrollEl?.removeEventListener('scroll', scrollSync.syncPreviewToEditor);
   });
 
-  // When in split view with parentScroll, use the parent scroll container instead of .cm-scroller
-  $effect(() => {
-    if (effectiveViewMode === 'split' && desktopEditorScrollContainer) {
-      scrollSync.setScrollContainer(desktopEditorScrollContainer);
-      return () => scrollSync.setScrollContainer(null);
-    }
-  });
-
   // ── Folder breadcrumb navigation ──────────────────────────────────
   function navigateToNoteFolder() {
     activeSection = 'folders';
@@ -1015,7 +981,6 @@
         class:translate-x-full={!$activeNoteId}
         ontouchstart={handleSwipeStart}
         ontouchend={handleSwipeEnd}
-        ontransitionend={handleMobilePanelTransitionEnd}
         role="region"
         aria-label="Note editor"
       >
@@ -1062,7 +1027,6 @@
               imageLoadMode={$imageLoadMode}
             />
           {:else}
-            <!-- Sticky header stays above scroll -->
             <NoteEditorHeader
               {isMobile}
               {activeTrash}
@@ -1133,7 +1097,6 @@
                 bind:previewScrollEl
                 {autocompleteNotes}
                 {isMobile}
-                panelReady={mobilePanelReady}
                 parentScroll={true}
                 oncontentchange={handleContentChange}
                 onscrollerinit={scrollSync.initEditorScroller}
@@ -1141,7 +1104,6 @@
                 onnotelink={handleNoteLink}
                 {resolveNoteTitle}
                 imageLoadMode={$imageLoadMode}
-                externalDialogOpen={notePickerOpen}
               />
             </div>
           {/if}


### PR DESCRIPTION
Three bugs surfaced on iPad Pro 11" in Safari (PWA, Stage Manager) — fixed with the same root-cause pass:

- Header escape: Safari programmatically scrolls the window to keep the CodeMirror caret in view when the virtual keyboard opens, pushing the app header off-screen. Lock <html>/<body> with position:fixed so Safari has nothing to scroll on the document level. Add a +layout safety net that resets documentElement.scrollTop on scroll/visualViewport.resize.

- Split view auto-scroll-to-top: sticky right column with calc(100dvh) triggered reflow loops on iOS, while the rAF-released scroll-sync flag let momentum-scroll events ping-pong between panes. Restructure split so each pane owns its scroll (drop parentScroll for split, drop sticky
  + 100dvh). Rewrite scroll-sync as soft sync: defer cross-pane updates until 80 ms of input quiet, release with setTimeout(120) instead of rAF.

- Toolbar missing in narrow iPad windows: position:fixed bottom + toolbarBottomPx broke when vv.offsetTop != 0 (Stage Manager) or when the slide-in animation didn't fire (deep-link to active note left panelReady=false). Move the mobile toolbar to sticky top-of-editor — deterministic position, independent of keyboard state, vv.offsetTop, and panel-ready timing. Drop ~120 lines of visualViewport keyboard detection and mobilePanelReady wiring that became unnecessary.

Verified: build, vitest (165/165), svelte-check (0/0), and browser preview on desktop + mobile viewport. Final PASS requires a physical iPad — Chrome DevTools doesn't reproduce resizes-visual or Stage Manager edge-cases.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>