### PR TITLE
fix(notes): restore scrolling in preview, settings, auth, and error pages

### DIFF
--- a/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
@@ -54,9 +54,9 @@
   } = $props();
 
   // Split view always uses independent scrolls per pane — sticky+100dvh inside a
-  // flex container caused reflow loops on iOS Safari. Only single-pane edit
-  // honors parentScroll (parent grows with content, toolbar sticks to parent).
-  const isParentScrollActive = $derived(parentScroll && effectiveViewMode === 'edit');
+  // flex container caused reflow loops on iOS Safari. Edit and preview both let
+  // the parent scroll (parent grows with content, sticky toolbar/header work).
+  const isParentScrollActive = $derived(parentScroll && effectiveViewMode !== 'split');
 </script>
 
 <div class="relative {isParentScrollActive ? '' : 'flex min-h-0 flex-1 overflow-hidden'}">

--- a/apps/reborn-notes/src/routes/+error.svelte
+++ b/apps/reborn-notes/src/routes/+error.svelte
@@ -46,7 +46,8 @@
   </title>
 </svelte:head>
 
-<div class="min-h-screen bg-background text-foreground flex items-center justify-center px-4">
+<div class="h-dvh overflow-y-auto bg-background text-foreground">
+<div class="min-h-dvh flex items-center justify-center px-4 py-8">
   <div class="max-w-md w-full text-center space-y-6">
     {#if showOffline}
       <!-- Offline error view -->
@@ -123,4 +124,5 @@
       </div>
     {/if}
   </div>
+</div>
 </div>

--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -112,7 +112,8 @@
 	<title>{$t('auth.two_factor.title')} — re/notes</title>
 </svelte:head>
 
-<div class="flex min-h-screen items-center justify-center px-4 py-12">
+<div class="h-dvh overflow-y-auto">
+<div class="flex min-h-dvh items-center justify-center px-4 py-12">
 	<div class="w-full max-w-md space-y-6">
 		<!-- Header -->
 		<div class="text-center space-y-2">
@@ -242,4 +243,5 @@
 			</a>
 		</div>
 	</div>
+</div>
 </div>

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -107,7 +107,7 @@
   <title>{$t('settings_page.title')} — re/notes</title>
 </svelte:head>
 
-<div class="min-h-screen bg-background">
+<div class="h-dvh overflow-y-auto bg-background">
   <div class="sticky top-0 z-10 bg-background border-b">
     <div class="container mx-auto max-w-4xl px-4 sm:px-6">
       <div class="flex items-center gap-2 h-14">

--- a/packages/ui/src/components/auth/AuthLayout.svelte
+++ b/packages/ui/src/components/auth/AuthLayout.svelte
@@ -26,48 +26,50 @@
   }>();
 </script>
 
-<div class="min-h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8 relative">
-  {#if showLocaleSwitcher || showThemeSwitcher}
-    <div class="absolute top-4 right-4 flex items-center gap-2">
-      {#if showThemeSwitcher}
-        <AuthThemeSwitcher {themeStorageKey} />
+<div class="h-dvh overflow-y-auto">
+  <div class="min-h-dvh flex items-center justify-center px-4 sm:px-6 lg:px-8 py-8 relative">
+    {#if showLocaleSwitcher || showThemeSwitcher}
+      <div class="absolute top-4 right-4 flex items-center gap-2">
+        {#if showThemeSwitcher}
+          <AuthThemeSwitcher {themeStorageKey} />
+        {/if}
+        {#if showLocaleSwitcher}
+          <AuthLocaleSwitcher />
+        {/if}
+      </div>
+    {/if}
+
+    <div class="max-w-md w-full space-y-8">
+      {#if header || title || subtitle}
+        <div class="text-center">
+          {#if header}
+            <div class="flex justify-center mb-2">
+              {@render header()}
+            </div>
+          {:else if title}
+            <h2 class="text-3xl font-bold tracking-tight">
+              {title}
+            </h2>
+          {/if}
+          {#if subtitle}
+            <p class="mt-2 text-sm text-muted-foreground">
+              {subtitle}
+            </p>
+          {/if}
+        </div>
       {/if}
-      {#if showLocaleSwitcher}
-        <AuthLocaleSwitcher />
+
+      <Card>
+        <CardContent class="p-6 sm:p-8">
+          {@render children()}
+        </CardContent>
+      </Card>
+
+      {#if footer}
+        <div class="text-center">
+          {@render footer()}
+        </div>
       {/if}
     </div>
-  {/if}
-
-  <div class="max-w-md w-full space-y-8">
-    {#if header || title || subtitle}
-      <div class="text-center">
-        {#if header}
-          <div class="flex justify-center mb-2">
-            {@render header()}
-          </div>
-        {:else if title}
-          <h2 class="text-3xl font-bold tracking-tight">
-            {title}
-          </h2>
-        {/if}
-        {#if subtitle}
-          <p class="mt-2 text-sm text-muted-foreground">
-            {subtitle}
-          </p>
-        {/if}
-      </div>
-    {/if}
-
-    <Card>
-      <CardContent class="p-6 sm:p-8">
-        {@render children()}
-      </CardContent>
-    </Card>
-
-    {#if footer}
-      <div class="text-center">
-        {@render footer()}
-      </div>
-    {/if}
   </div>
 </div>

--- a/packages/ui/src/components/settings/settings-layout.svelte
+++ b/packages/ui/src/components/settings/settings-layout.svelte
@@ -26,7 +26,7 @@
   );
 </script>
 
-<div class={cn('min-h-screen bg-background', className)}>
+<div class={cn('h-dvh overflow-y-auto bg-background', className)}>
   <div class="sticky top-0 z-10 bg-background border-b">
     <div class="container mx-auto max-w-4xl px-4 sm:px-6">
       <div class="flex items-center gap-2 h-14">


### PR DESCRIPTION
PR #105 locked <html>/<body> with position:fixed to stop iOS Safari from scrolling the document when the keyboard opens. Side effect: every route that relied on document-level scroll silently lost it — content past the viewport was clipped.

- NoteContentArea: split-only the per-pane scroll constraint. Preview now lets the parent (desktopEditorScrollContainer / mobile wrapper) scroll, same as edit mode. Split keeps independent per-pane scrolls (the actual reason the constraint was introduced).
- SettingsLayout, settings/+page: replace min-h-screen with h-dvh overflow-y-auto so the layout owns its scroll container.
- AuthLayout, auth/2fa, +error: wrap with h-dvh overflow-y-auto outer and min-h-dvh flex inner — preserves vertical centering for short forms and allows scrolling when the form exceeds the viewport (avoids the flex+items-center+overflow centering trap).

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>