### PR TITLE
fix(notes): keep editor panel sized to visual viewport on mobile keyboard

### DIFF
--- a/apps/reborn-notes/src/app.html
+++ b/apps/reborn-notes/src/app.html
@@ -3,7 +3,10 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg?v=2026-04-26" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<!-- interactive-widget=resizes-content shrinks the layout viewport when the
+		     soft keyboard opens (Chromium 108+, Safari iOS 17.4+). Older engines
+		     fall back to the JS visual-viewport tracker in +layout.svelte. -->
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
 		<meta name="theme-color" content="#FFD43B" />
 		<title>re/notes</title>

--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -427,11 +427,34 @@
     });
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
+    // Mobile: when the soft keyboard opens (visualViewport shrinks), pull the
+    // caret into the visible area. The mobile root in +page.svelte is already
+    // sized to vv.height, so the parent scroll container's bounds match the
+    // visible viewport — this dispatch just nudges the scroll so the line under
+    // the caret is comfortably visible above the keyboard. Only fires when the
+    // editor has focus to avoid scrolling unfocused panes (split view RHS, etc.).
+    let prevVvHeight = window.visualViewport?.height ?? 0;
+    const handleVvResize = () => {
+      if (!isMobile || !view) return;
+      const vv = window.visualViewport;
+      if (!vv) return;
+      const next = vv.height;
+      const shrank = next + 1 < prevVvHeight; // tolerate 1px rounding jitter
+      prevVvHeight = next;
+      if (!shrank) return;
+      if (!view.hasFocus) return;
+      view.dispatch({
+        effects: EditorView.scrollIntoView(view.state.selection.main.head, { y: 'center' })
+      });
+    };
+    window.visualViewport?.addEventListener('resize', handleVvResize);
+
     return () => {
       if (hasIdleCallback && typeof cancelIdleCallback === 'function') cancelIdleCallback(idleId);
       else clearTimeout(idleId);
       observer.disconnect();
       unregisterCodeBlock();
+      window.visualViewport?.removeEventListener('resize', handleVvResize);
     };
   });
 

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -206,22 +206,49 @@
     }
   });
 
-  // iOS Safari safety net: app.css locks <html>/<body> with position:fixed, but
-  // if Safari ever ends up with non-zero scrollTop on the document element
-  // (race during font load, focus before stylesheet apply, …), the app header
-  // would slide off-screen. Reset the document scroll on every window scroll
-  // and visualViewport resize.
+  // iOS Safari safety net + visual-viewport tracker.
+  //
+  // Safety net: app.css locks <html>/<body> with position:fixed, but if Safari
+  // ever ends up with non-zero scrollTop on the document element (race during
+  // font load, focus before stylesheet apply, …), the app header would slide
+  // off-screen. Reset document scroll on every window scroll / vv resize.
+  //
+  // Visual-viewport tracker: when the soft keyboard opens on iOS Safari, the
+  // layout viewport doesn't shrink (100dvh stays full size) and Safari may
+  // "page-shift" the layout viewport upward to keep the focused contenteditable
+  // visible — pushing our sticky header above the visible area. Mirror the
+  // current visualViewport state into CSS vars so the mobile note panel can
+  // size itself to vv.height and counter-translate by vv.offsetTop, keeping
+  // the header anchored to the top of the visible area regardless of caret
+  // position. Used in apps/reborn-notes/src/routes/+page.svelte (mobile root).
   $effect(() => {
     if (!browser) return;
-    const reset = () => {
-      if (document.documentElement.scrollTop !== 0) document.documentElement.scrollTop = 0;
+    const root = document.documentElement;
+    const vv = window.visualViewport;
+
+    const update = () => {
+      if (root.scrollTop !== 0) root.scrollTop = 0;
       if (document.body.scrollTop !== 0) document.body.scrollTop = 0;
+
+      if (!vv) return;
+      // Round to integers — sub-pixel jitter from iOS during scroll causes
+      // useless reflows.
+      const h = Math.round(vv.height);
+      const offsetTop = Math.round(vv.offsetTop);
+      const inset = Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop));
+      root.style.setProperty('--rn-vv-height', `${h}px`);
+      root.style.setProperty('--rn-vv-offset-top', `${offsetTop}px`);
+      root.style.setProperty('--rn-keyboard-inset', `${inset}px`);
     };
-    window.addEventListener('scroll', reset, { passive: true });
-    window.visualViewport?.addEventListener('resize', reset);
+
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    vv?.addEventListener('resize', update);
+    vv?.addEventListener('scroll', update);
     return () => {
-      window.removeEventListener('scroll', reset);
-      window.visualViewport?.removeEventListener('resize', reset);
+      window.removeEventListener('scroll', update);
+      vv?.removeEventListener('resize', update);
+      vv?.removeEventListener('scroll', update);
     };
   });
 

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -902,7 +902,16 @@
      MOBILE: Master-Detail with two full-screen panels
      ══════════════════════════════════════════════════════════════════ -->
   <Tooltip.Provider delayDuration={0}>
-    <div class="relative h-[100dvh] overflow-hidden bg-sidebar">
+    <!-- Mobile root sized to the *visual* viewport (height shrinks when the soft
+         keyboard opens), and counter-translated by visualViewport.offsetTop to
+         neutralise iOS Safari "page-shift" — so the editor header stays anchored
+         to the top of the visible area regardless of caret position. CSS vars are
+         emitted in +layout.svelte; fallback `100dvh` covers SSR + browsers
+         without visualViewport. -->
+    <div
+      class="relative overflow-hidden bg-sidebar"
+      style="height: var(--rn-vv-height, 100dvh); transform: translateY(var(--rn-vv-offset-top, 0px));"
+    >
       <!-- ── Panel 1: Icon Rail + List ──────────────────────────────── -->
       <div
         class="absolute inset-0 flex transition-transform duration-300 ease-in-out"


### PR DESCRIPTION
iOS Safari's layout viewport doesn't shrink when the soft keyboard opens — 100dvh stays full size — and Safari "page-shifts" the layout viewport upward to keep the focused contenteditable visible. This pushed the note header above the visible area when the caret was near the bottom, and made the last few lines of a note unreachable behind the keyboard.

Track visualViewport in +layout.svelte and mirror state into CSS vars (--rn-vv-height, --rn-vv-offset-top, --rn-keyboard-inset) on <html>. The mobile root in +page.svelte sizes itself to vv.height and counter-translates by vv.offsetTop so the header stays anchored to the top of the visible strip and the scroll container's bottom lands exactly above the keyboard. NoteEditor dispatches EditorView.scrollIntoView when vv shrinks and the editor has focus, nudging the caret comfortably above the keyboard.

Add interactive-widget=resizes-content viewport meta — Chromium 108+ and Safari iOS 17.4+ shrink the layout viewport natively, the JS tracker is the fallback for older engines.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>