### PR TITLE
fix(notes): also size desktop layout to visual viewport for iPad keyboard

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -427,21 +427,23 @@
     });
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
-    // Mobile: when the soft keyboard opens (visualViewport shrinks), pull the
-    // caret into the visible area. The mobile root in +page.svelte is already
-    // sized to vv.height, so the parent scroll container's bounds match the
-    // visible viewport — this dispatch just nudges the scroll so the line under
-    // the caret is comfortably visible above the keyboard. Only fires when the
-    // editor has focus to avoid scrolling unfocused panes (split view RHS, etc.).
+    // When the soft keyboard opens (visualViewport shrinks significantly),
+    // pull the caret into the visible area. Both layouts size their scroll
+    // container to vv.height (mobile root in +page.svelte / SidebarProvider
+    // on desktop), so this dispatch nudges the scroll so the line under the
+    // caret lands comfortably above the keyboard. Threshold of 100px filters
+    // out incidental resizes (browser chrome show/hide, address bar) — only
+    // a soft keyboard moves vv.height by more than that. Only fires when the
+    // editor has focus, so split view's unfocused pane doesn't scroll.
     let prevVvHeight = window.visualViewport?.height ?? 0;
     const handleVvResize = () => {
-      if (!isMobile || !view) return;
+      if (!view) return;
       const vv = window.visualViewport;
       if (!vv) return;
       const next = vv.height;
-      const shrank = next + 1 < prevVvHeight; // tolerate 1px rounding jitter
+      const shrankByKeyboard = prevVvHeight - next > 100;
       prevVvHeight = next;
-      if (!shrank) return;
+      if (!shrankByKeyboard) return;
       if (!view.hasFocus) return;
       view.dispatch({
         effects: EditorView.scrollIntoView(view.state.selection.main.head, { y: 'center' })

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -1241,7 +1241,11 @@
   <!-- ══════════════════════════════════════════════════════════════════
      DESKTOP: Original 3-column layout
      ══════════════════════════════════════════════════════════════════ -->
-  <SidebarProvider style="height: 100vh; min-height: 0; overflow: hidden; --sidebar-width: 24rem;">
+  <!-- height tracks visualViewport so the soft keyboard (iPad PWA Safari etc.)
+       shrinks the desktop scroll container instead of leaving the bottom of
+       the note hidden behind the keyboard. CSS var emitted in +layout.svelte;
+       fallback `100vh` covers SSR + browsers without visualViewport. -->
+  <SidebarProvider style="height: var(--rn-vv-height, 100vh); min-height: 0; overflow: hidden; --sidebar-width: 24rem;">
     <Sidebar
       variant="inset"
       collapsible="offcanvas"


### PR DESCRIPTION
The mobile-branch fix in v0.12.1 only tracked --rn-vv-height for the mobile root (`<div class="relative">`), but iPad Pro 11" runs the desktop branch (width ≥ 768 px) — its SidebarProvider was still locked to 100vh, so the soft keyboard kept covering the bottom of the note in Safari/PWA.

Switch the SidebarProvider to height: var(--rn-vv-height, 100vh) so the desktop scroll container shrinks together with the visible viewport. No counter-translate needed: the sticky header in SidebarInset stays in place on its own (iPad doesn't page-shift the layout viewport here).

Drop the isMobile gate from NoteEditor's keyboard-aware scrollIntoView and swap the 1 px shrink check for a 100 px threshold — iPad in desktop view runs with isMobile=false, and 100 px reliably distinguishes a soft keyboard from incidental browser-chrome resizes.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>