### PR TITLE
fix(notes): position dialogs in visual viewport so iPad keyboard does not cover them

### DIFF
--- a/packages/ui/src/components/dialog/dialog-content.svelte
+++ b/packages/ui/src/components/dialog/dialog-content.svelte
@@ -25,7 +25,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[calc(var(--rn-vv-offset-top,0px)+var(--rn-vv-height,100vh)/2)] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(var(--rn-vv-height,100vh)-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 			className
 		)}
 		{...restProps}


### PR DESCRIPTION
Editor toolbar popups (Insert Image, Insert Table) were centered in the layout viewport, hiding their inputs behind the iPad virtual keyboard. Reuse the existing --rn-vv-offset-top / --rn-vv-height CSS variables to center the dialog inside the visible area, with a max-height that keeps tall content scrollable instead of clipped. Falls back to 100vh when the variables are not set, so reborn-task and desktop browsers are unaffected.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>