### PR TITLE
feat(notes): make Live Preview the default editor mode with first-run intro

### DIFF
--- a/apps/reborn-notes/src/lib/components/editor/EditorModeButton.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/EditorModeButton.svelte
@@ -109,12 +109,7 @@
             {$t('editor_mode.markdown')}
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="live">
-            <span>{$t('editor_mode.live')}</span>
-            <span
-              class="ml-auto inline-flex items-center rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400"
-            >
-              {$t('editor_mode.beta')}
-            </span>
+            {$t('editor_mode.live')}
           </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
@@ -138,15 +133,10 @@
         </Button>
         <Button
           variant={$editorMode === 'live' ? 'secondary' : 'ghost'}
-          class="w-full justify-start gap-2"
+          class="w-full justify-start"
           onclick={() => setEditorMode('live')}
         >
-          <span>{$t('editor_mode.live')}</span>
-          <span
-            class="inline-flex items-center rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400"
-          >
-            {$t('editor_mode.beta')}
-          </span>
+          {$t('editor_mode.live')}
         </Button>
       </div>
     </SheetContent>

--- a/apps/reborn-notes/src/lib/components/editor/EditorModeIntroDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/EditorModeIntroDialog.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import { Pencil, PencilLine, Check } from '@lucide/svelte';
+  import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Button
+  } from '@reborn/ui';
+  import { t } from '$lib/stores/i18n.store';
+  import { editorMode } from '$lib/stores/app-settings.store';
+  import type { EditorMode } from '@reborn/storage';
+
+  let {
+    open = $bindable(false),
+    onclose
+  }: {
+    open: boolean;
+    onclose: (chosenMode: EditorMode | null) => void;
+  } = $props();
+
+  let chosen = $state<EditorMode>($editorMode);
+  let completed = false;
+
+  $effect(() => {
+    if (open) {
+      chosen = $editorMode;
+      completed = false;
+    }
+  });
+
+  function handleContinue() {
+    completed = true;
+    open = false;
+    onclose(chosen);
+  }
+
+  function handleOpenChange(v: boolean) {
+    open = v;
+    if (!v && !completed) onclose(null);
+  }
+</script>
+
+<Dialog {open} onOpenChange={handleOpenChange}>
+  <DialogContent class="sm:max-w-[480px]">
+    <DialogHeader>
+      <DialogTitle>{$t('editor_mode_intro.title')}</DialogTitle>
+      <DialogDescription>{$t('editor_mode_intro.description')}</DialogDescription>
+    </DialogHeader>
+
+    <div class="grid gap-3 py-2">
+      <button
+        type="button"
+        class="group flex items-start gap-3 rounded-lg border-2 p-4 text-left transition-colors {chosen ===
+        'live'
+          ? 'border-primary bg-primary/5'
+          : 'border-border hover:border-muted-foreground/40 hover:bg-accent/30'}"
+        onclick={() => (chosen = 'live')}
+        aria-pressed={chosen === 'live'}
+      >
+        <div
+          class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md {chosen ===
+          'live'
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-muted text-muted-foreground'}"
+        >
+          <PencilLine class="h-5 w-5" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <span class="font-medium">{$t('editor_mode_intro.option_live_label')}</span>
+            <span
+              class="inline-flex items-center rounded bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400"
+            >
+              {$t('editor_mode_intro.recommended')}
+            </span>
+          </div>
+          <p class="mt-1 text-sm text-muted-foreground">
+            {$t('editor_mode_intro.option_live_description')}
+          </p>
+        </div>
+        {#if chosen === 'live'}
+          <Check class="mt-1 h-5 w-5 shrink-0 text-primary" />
+        {/if}
+      </button>
+
+      <button
+        type="button"
+        class="group flex items-start gap-3 rounded-lg border-2 p-4 text-left transition-colors {chosen ===
+        'markdown'
+          ? 'border-primary bg-primary/5'
+          : 'border-border hover:border-muted-foreground/40 hover:bg-accent/30'}"
+        onclick={() => (chosen = 'markdown')}
+        aria-pressed={chosen === 'markdown'}
+      >
+        <div
+          class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md {chosen ===
+          'markdown'
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-muted text-muted-foreground'}"
+        >
+          <Pencil class="h-5 w-5" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="font-medium">{$t('editor_mode_intro.option_markdown_label')}</div>
+          <p class="mt-1 text-sm text-muted-foreground">
+            {$t('editor_mode_intro.option_markdown_description')}
+          </p>
+        </div>
+        {#if chosen === 'markdown'}
+          <Check class="mt-1 h-5 w-5 shrink-0 text-primary" />
+        {/if}
+      </button>
+    </div>
+
+    <p class="text-xs text-muted-foreground">
+      {$t('editor_mode_intro.hint_switch_later')}
+    </p>
+
+    <DialogFooter>
+      <Button onclick={handleContinue}>
+        {$t('editor_mode_intro.continue_button')}
+      </Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>

--- a/apps/reborn-notes/src/lib/stores/app-settings.store.ts
+++ b/apps/reborn-notes/src/lib/stores/app-settings.store.ts
@@ -203,7 +203,12 @@ export const firstDayOfWeek = derived(appSettings, ($settings) => $settings?.fir
 
 export const imageLoadMode = derived(appSettings, ($settings) => $settings?.imageLoadMode ?? 'ask');
 
-export const editorMode = derived(appSettings, ($settings) => $settings?.editorMode ?? 'markdown');
+export const editorMode = derived(appSettings, ($settings) => $settings?.editorMode ?? 'live');
+
+export const editorModeIntroSeen = derived(
+  appSettings,
+  ($settings) => $settings?.editorModeIntroSeen ?? false
+);
 
 if (browser) {
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -49,7 +49,9 @@
   import { foldersStore } from '$lib/stores/folders.store';
   import { tagsStore } from '$lib/stores/tags.store';
   import { getSettings } from '$lib/utils/app-settings';
-  import { imageLoadMode } from '$lib/stores/app-settings.store';
+  import { appSettings, imageLoadMode, editorModeIntroSeen } from '$lib/stores/app-settings.store';
+  import EditorModeIntroDialog from '$lib/components/editor/EditorModeIntroDialog.svelte';
+  import type { EditorMode } from '@reborn/storage';
   import { t } from '$lib/stores/i18n.store';
   import { noteDetailService } from '$lib/services/note-detail.service.svelte';
   import { noteIndex } from '$lib/services/note-index.svelte';
@@ -490,7 +492,14 @@
   });
 
   // ── New note ─────────────────────────────────────────────────────
+  let editorModeIntroOpen = $state(false);
+
   async function handleNewNote() {
+    if (!$editorModeIntroSeen) {
+      editorModeIntroOpen = true;
+      return;
+    }
+
     // Trash/starred/tags filter out a freshly created note (no deletion / star /
     // tag yet), so the user would create a note and see nothing. Switch to "All
     // notes" first and await tick so the section $effect drives the store filter
@@ -507,6 +516,15 @@
     const id = await notesStore.create(`${prefix} ${date}`, '');
     noteDetailService.setNewNote();
     activeNoteId.set(id);
+  }
+
+  async function handleEditorModeIntroClose(chosen: EditorMode | null) {
+    if (chosen) {
+      await appSettings.update('editorMode', chosen);
+    }
+    await appSettings.update('editorModeIntroSeen', true);
+    editorModeIntroOpen = false;
+    await handleNewNote();
   }
 
   // ── Folder management ────────────────────────────────────────────
@@ -1618,4 +1636,9 @@
   confirmText={$t('notes.delete_note')}
   destructive
   onConfirm={confirmDetailDelete}
+/>
+
+<EditorModeIntroDialog
+  bind:open={editorModeIntroOpen}
+  onclose={handleEditorModeIntroClose}
 />

--- a/apps/reborn-notes/src/routes/settings/appearance/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/appearance/+page.svelte
@@ -332,11 +332,6 @@
             <SelectItem value="live">{$t('settings_page.appearance.editor_mode_live')}</SelectItem>
           </SelectContent>
         </Select>
-        {#if editorModeValue === 'live'}
-          <p class="text-xs text-muted-foreground">
-            {$t('settings_page.appearance.editor_mode_live_note')}
-          </p>
-        {/if}
       </CardContent>
     </Card>
 

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -447,8 +447,18 @@
     "label": "Editor-Modus",
     "markdown": "Markdown-Quelle",
     "live": "Live-Vorschau",
-    "beta": "Beta",
     "open_menu": "Editor-Modus wählen"
+  },
+  "editor_mode_intro": {
+    "title": "Wie möchtest du deine Notizen bearbeiten?",
+    "description": "Wähle einen Editor-Modus. Du kannst ihn jederzeit ändern.",
+    "option_live_label": "Live-Vorschau",
+    "option_live_description": "Markdown wird beim Tippen formatiert — die Notiz sieht aus wie das fertige Ergebnis. Empfohlen, wenn du Markdown nicht kennst.",
+    "option_markdown_label": "Markdown-Quelle",
+    "option_markdown_description": "Rohe Marker wie ** # [Text](Link) bleiben sichtbar. Für Nutzer, die volle Kontrolle über die Syntax wollen.",
+    "recommended": "Empfohlen",
+    "hint_switch_later": "Du kannst den Modus jederzeit über die ✏️-Schaltfläche in der Notiz-Kopfzeile oder in Einstellungen → Darstellung wechseln.",
+    "continue_button": "Loslegen"
   },
   "save_status": {
     "unsaved": "Nicht gespeicherte Änderungen",
@@ -504,8 +514,7 @@
       "editor_mode_desc": "Wie Markdown beim Bearbeiten einer Notiz angezeigt wird",
       "editor_mode_markdown": "Markdown (gesamte Syntax anzeigen)",
       "editor_mode_live": "Live-Vorschau (Syntax außerhalb des Cursors ausblenden)",
-      "editor_mode_updated": "Bearbeitungsmodus aktualisiert",
-      "editor_mode_live_note": "Beta — funktioniert am besten am Desktop. Tabellen und Codeblöcke bleiben in rohem Markdown."
+      "editor_mode_updated": "Bearbeitungsmodus aktualisiert"
     },
     "security": {
       "title": "Sicherheit",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -447,8 +447,18 @@
     "label": "Editor mode",
     "markdown": "Markdown source",
     "live": "Live preview",
-    "beta": "Beta",
     "open_menu": "Choose editor mode"
+  },
+  "editor_mode_intro": {
+    "title": "How would you like to edit your notes?",
+    "description": "Pick an editor mode. You can change it any time.",
+    "option_live_label": "Live preview",
+    "option_live_description": "Markdown is rendered as you type — your note looks like the finished result. Recommended if you don't know Markdown.",
+    "option_markdown_label": "Markdown source",
+    "option_markdown_description": "Raw markers like ** # [text](link) stay visible. For users who prefer full control over the syntax.",
+    "recommended": "Recommended",
+    "hint_switch_later": "You can switch modes any time using the ✏️ button in the note header or in Settings → Appearance.",
+    "continue_button": "Get started"
   },
   "save_status": {
     "unsaved": "Unsaved changes",
@@ -504,8 +514,7 @@
       "editor_mode_desc": "How Markdown is shown while you edit a note",
       "editor_mode_markdown": "Markdown (show all syntax)",
       "editor_mode_live": "Live preview (hide syntax outside cursor)",
-      "editor_mode_updated": "Editor mode updated",
-      "editor_mode_live_note": "Beta — works best on desktop. Tables and code blocks still show raw Markdown."
+      "editor_mode_updated": "Editor mode updated"
     },
     "security": {
       "title": "Security",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -447,8 +447,18 @@
     "label": "Modo de editor",
     "markdown": "Fuente Markdown",
     "live": "Vista previa en vivo",
-    "beta": "Beta",
     "open_menu": "Elegir modo de editor"
+  },
+  "editor_mode_intro": {
+    "title": "¿Cómo quieres editar tus notas?",
+    "description": "Elige un modo de editor. Puedes cambiarlo en cualquier momento.",
+    "option_live_label": "Vista previa en vivo",
+    "option_live_description": "Markdown se formatea mientras escribes — la nota se ve como el resultado final. Recomendado si no conoces Markdown.",
+    "option_markdown_label": "Fuente Markdown",
+    "option_markdown_description": "Los marcadores en bruto como ** # [texto](enlace) permanecen visibles. Para usuarios que prefieren control total sobre la sintaxis.",
+    "recommended": "Recomendado",
+    "hint_switch_later": "Puedes cambiar el modo en cualquier momento con el botón ✏️ en el encabezado de la nota o en Ajustes → Apariencia.",
+    "continue_button": "Empezar"
   },
   "save_status": {
     "unsaved": "Cambios sin guardar",
@@ -504,8 +514,7 @@
       "editor_mode_desc": "Cómo se muestra Markdown mientras editas una nota",
       "editor_mode_markdown": "Markdown (mostrar toda la sintaxis)",
       "editor_mode_live": "Vista previa en vivo (ocultar sintaxis fuera del cursor)",
-      "editor_mode_updated": "Modo de edición actualizado",
-      "editor_mode_live_note": "Beta — funciona mejor en escritorio. Las tablas y bloques de código permanecen en Markdown sin procesar."
+      "editor_mode_updated": "Modo de edición actualizado"
     },
     "security": {
       "title": "Seguridad",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -447,8 +447,18 @@
     "label": "Mode d'éditeur",
     "markdown": "Source Markdown",
     "live": "Aperçu en direct",
-    "beta": "Bêta",
     "open_menu": "Choisir le mode d'éditeur"
+  },
+  "editor_mode_intro": {
+    "title": "Comment souhaitez-vous éditer vos notes ?",
+    "description": "Choisissez un mode d'éditeur. Vous pouvez le changer à tout moment.",
+    "option_live_label": "Aperçu en direct",
+    "option_live_description": "Le Markdown est formaté pendant que vous tapez — la note ressemble au résultat final. Recommandé si vous ne connaissez pas Markdown.",
+    "option_markdown_label": "Source Markdown",
+    "option_markdown_description": "Les marqueurs bruts comme ** # [texte](lien) restent visibles. Pour les utilisateurs qui préfèrent un contrôle total sur la syntaxe.",
+    "recommended": "Recommandé",
+    "hint_switch_later": "Vous pouvez changer de mode à tout moment via le bouton ✏️ dans l'en-tête de la note ou dans Paramètres → Apparence.",
+    "continue_button": "Commencer"
   },
   "save_status": {
     "unsaved": "Modifications non enregistrées",
@@ -504,8 +514,7 @@
       "editor_mode_desc": "Comment le Markdown est affiché pendant l'édition d'une note",
       "editor_mode_markdown": "Markdown (afficher toute la syntaxe)",
       "editor_mode_live": "Aperçu en direct (masquer la syntaxe hors du curseur)",
-      "editor_mode_updated": "Mode d'édition mis à jour",
-      "editor_mode_live_note": "Bêta — fonctionne mieux sur ordinateur. Les tableaux et blocs de code restent en Markdown brut."
+      "editor_mode_updated": "Mode d'édition mis à jour"
     },
     "security": {
       "title": "Sécurité",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -447,8 +447,18 @@
     "label": "Tryb edytora",
     "markdown": "Markdown (źródło)",
     "live": "Podgląd na żywo",
-    "beta": "Beta",
     "open_menu": "Wybierz tryb edytora"
+  },
+  "editor_mode_intro": {
+    "title": "Jak chcesz edytować notatki?",
+    "description": "Wybierz tryb edytora. Zawsze możesz to zmienić.",
+    "option_live_label": "Podgląd na żywo",
+    "option_live_description": "Markdown formatuje się w trakcie pisania — notatka wygląda jak gotowa. Polecane, jeśli nie znasz Markdown.",
+    "option_markdown_label": "Markdown (źródło)",
+    "option_markdown_description": "Surowe znaczniki ** # [tekst](link) pozostają widoczne. Dla osób, które wolą pełną kontrolę nad składnią.",
+    "recommended": "Polecane",
+    "hint_switch_later": "Tryb przełączysz w każdej chwili przyciskiem ✏️ w nagłówku notatki lub w Ustawieniach → Wygląd.",
+    "continue_button": "Zaczynaj"
   },
   "save_status": {
     "unsaved": "Niezapisane zmiany",
@@ -504,8 +514,7 @@
       "editor_mode_desc": "Jak Markdown jest wyświetlany podczas edycji notatki",
       "editor_mode_markdown": "Markdown (pokaż całą składnię)",
       "editor_mode_live": "Podgląd na żywo (ukryj składnię poza kursorem)",
-      "editor_mode_updated": "Tryb edycji zaktualizowany",
-      "editor_mode_live_note": "Beta — działa najlepiej na komputerze. Tabele i bloki kodu pozostają w surowym Markdown."
+      "editor_mode_updated": "Tryb edycji zaktualizowany"
     },
     "security": {
       "title": "Bezpieczeństwo",

--- a/packages/storage/src/stores/settings.store.ts
+++ b/packages/storage/src/stores/settings.store.ts
@@ -22,6 +22,7 @@ export interface AppSettings {
   sync_interval_minutes: number;
   imageLoadMode: ImageLoadMode;
   editorMode: EditorMode;
+  editorModeIntroSeen: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -97,7 +98,8 @@ export const settingsOperations = {
           auto_sync_enabled: true,
           sync_interval_minutes: 5,
           imageLoadMode: 'ask',
-          editorMode: 'markdown',
+          editorMode: 'live',
+          editorModeIntroSeen: false,
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
         };


### PR DESCRIPTION
Promote Live Preview from opt-in to default after enough maturity (parser-progress detection, atomic ranges, editable GFM tables). Existing users keep their saved editorMode — initializeDefaults only runs for fresh records.

Show a one-time intro dialog (EditorModeIntroDialog.svelte) before the user's first new-note creation after this rollout. New editorModeIntroSeen flag in AppSettings; the derived store treats undefined as false, so existing users see the dialog once as well. Pre-selected option mirrors the user's current mode so an accidental "Get started" click never silently changes their setting. Dismiss (Esc/X/backdrop) keeps the current mode but still flips the flag.

Drop the "Beta" label everywhere: removed editor_mode.beta and settings_page.appearance.editor_mode_live_note keys from all 5 locales together with their consumers in EditorModeButton.svelte and settings/appearance.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>