### PR TITLE
feat(notes): render inline images in Live Preview with click-to-load

### DIFF
--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { marked, type Tokens } from 'marked';
+  import { Marked, type Tokens, type RendererObject } from 'marked';
   import DOMPurify from 'dompurify';
 
   import { t } from '$lib/stores/i18n.store';
@@ -29,7 +29,10 @@
   });
 
   function sanitize(html: string): string {
-    return DOMPurify.sanitize(html, { USE_PROFILES: { html: true }, ALLOWED_URI_REGEXP: ALLOWED_URI });
+    return DOMPurify.sanitize(html, {
+      USE_PROFILES: { html: true, svg: true },
+      ALLOWED_URI_REGEXP: ALLOWED_URI
+    });
   }
 
   let {
@@ -85,8 +88,29 @@
     };
   });
 
-  // Configure marked renderer
-  const renderer = new marked.Renderer();
+  // Per-instance marked: avoids the global `marked.use` singleton being
+  // stomped when multiple MarkdownPreview components are mounted (e.g. mobile
+  // + desktop layouts, or version-history previews).
+  const md = new Marked({ gfm: true, breaks: true });
+  const renderer: RendererObject = {};
+
+  // "Pinned" snapshot of the prop, synced at the start of every $derived html
+  // recomputation. The renderer.image closure reads this regular variable
+  // instead of `imageLoadMode` directly because:
+  //   1. Reading a Svelte 5 prop at script init (outside any reactive scope)
+  //      captures only the *initial* value, not the reactive binding —
+  //      svelte-check explicitly warns about this. The renderer is set up at
+  //      script init, so a direct closure over `imageLoadMode` would freeze
+  //      to 'ask' forever (the bug fixed in this commit).
+  //   2. `marked.parser()` calls renderer.image from a third-party call stack
+  //      with no reactive context; there's nothing for Svelte to attach the
+  //      read to even if it happened lazily.
+  // Initial value is a literal placeholder; the real value is assigned inside
+  // the `$derived html` block before each parse.
+  let imageModeSnapshot: ImageLoadMode = 'ask';
+
+  const IMAGE_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>';
+  const BLOCKED_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>';
 
   renderer.image = ({ href, title, text }: Tokens.Image) => {
     const isDataUri = href.startsWith('data:');
@@ -96,19 +120,18 @@
 
     if (isDataUri) {
       return `<div class="image-placeholder image-placeholder--blocked">
-      <div class="image-placeholder-icon">⚠️</div>
+      <div class="image-placeholder-icon">${BLOCKED_ICON_SVG}</div>
       <div class="image-placeholder-url">${$t('editor.image_base64_blocked')}</div>
     </div>`;
     }
 
-    // External URL — behavior depends on imageLoadMode
-    if (imageLoadMode === 'always') {
+    if (imageModeSnapshot === 'always') {
       return `<img src="${escapedHref}" alt="${escapedAlt}" title="${escapedTitle}" loading="lazy" />`;
     }
 
-    const showLoadBtn = imageLoadMode === 'ask';
+    const showLoadBtn = imageModeSnapshot === 'ask';
     return `<div class="image-placeholder" data-src="${escapedHref}" data-alt="${escapedAlt}" data-title="${escapedTitle}">
-      <div class="image-placeholder-icon">🖼️</div>
+      <div class="image-placeholder-icon">${IMAGE_ICON_SVG}</div>
       <div class="image-placeholder-url">${escapedHref}</div>
       ${showLoadBtn ? `<button class="image-placeholder-load" type="button">${$t('editor.image_load')}</button>` : ''}
     </div>`;
@@ -131,24 +154,33 @@
     return highlightCodeToHtml(text, info);
   };
 
-  marked.use({ renderer, gfm: true, breaks: true });
+  md.use({ renderer });
 
   // Tokens of the latest render — kept so we can stamp `data-source-line`
   // on the matching DOM children after `{@html}` commits the new HTML.
   let lastTokens: import('marked').Token[] = [];
 
   const html = $derived.by(() => {
-    // Reactive dep: re-run when a fenced-code language chunk has loaded so
-    // we can replace the plaintext fallback with highlighted spans.
+    // Reactive deps:
+    //  - `langLoadTick` re-runs the derivation when a fenced-code language
+    //    chunk has loaded so plaintext fallbacks get replaced with
+    //    highlighted spans.
+    //  - `imageLoadMode` is read explicitly via assignment. The assignment
+    //    can't be DCE'd (it has a side effect), guaranteeing the prop is
+    //    tracked as a dep even if the compiler ever optimises plain reads.
+    //    The snapshot is consumed by `renderer.image` via the regular
+    //    variable `imageModeSnapshot`, sidestepping any uncertainty about
+    //    whether Svelte tracks reads inside a closure invoked from marked.
     void langLoadTick;
+    imageModeSnapshot = imageLoadMode;
     if (!content) {
       lastTokens = [];
       return '';
     }
-    const tokens = marked.lexer(content);
+    const tokens = md.lexer(content);
     annotateTopLevelLines(tokens);
     lastTokens = tokens;
-    const raw = sanitize(marked.parser(tokens) as string);
+    const raw = sanitize(md.parser(tokens) as string);
     if (!resolveNoteTitle) return raw;
     return raw.replace(
       /<a ([^>]*?)href="note:([0-9a-f-]{36})"([^>]*?)>([^<]*)<\/a>/gi,
@@ -546,15 +578,22 @@
     accent-color: var(--primary);
   }
 
-  /* ── Image placeholders ───────────────────────────────────── */
+  /* ── Image placeholders ─────────────────────────────────────
+     Inline-flex layout shared with Live Preview (theme.ts) for visual
+     parity. URL wraps on long paths so the user can audit the full
+     destination before deciding to load. */
   .preview :global(.image-placeholder) {
-    margin: 1em 0;
-    padding: 1em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.4em 0.75em;
+    margin: 0.25em 0;
     border: 2px dashed var(--border);
     border-radius: 0.5em;
     background: var(--muted);
-    text-align: center;
     font-size: 0.875rem;
+    max-width: 100%;
+    vertical-align: middle;
   }
 
   .preview :global(.image-placeholder--blocked) {
@@ -563,27 +602,29 @@
   }
 
   .preview :global(.image-placeholder-icon) {
-    font-size: 2rem;
-    margin-bottom: 0.5em;
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    color: var(--muted-foreground);
   }
 
   .preview :global(.image-placeholder-url) {
     color: var(--muted-foreground);
     word-break: break-all;
-    margin-bottom: 0.75em;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .preview :global(.image-placeholder-load) {
-    padding: 0.4em 1em;
+    padding: 0.25em 0.75em;
     border-radius: 0.375em;
     background: var(--primary);
     color: var(--primary-foreground);
     border: none;
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
+    flex: 0 0 auto;
+    white-space: nowrap;
   }
 
   .preview :global(.image-placeholder-load:hover) {

--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -18,6 +18,7 @@
     registerCodeBlockView
   } from '$lib/editor/live-preview';
   import { editorMode } from '$lib/stores/app-settings.store';
+  import type { ImageLoadMode } from '@reborn/storage';
   import { isDataUri } from '$lib/utils/markdown-sanitizer';
   import { toastStore } from '@reborn/ui';
   import {
@@ -54,7 +55,8 @@
     onnotelinkrequest,
     onnotelinkclick,
     availableNotes = [],
-    currentNoteId = null
+    currentNoteId = null,
+    imageLoadMode = 'ask' as ImageLoadMode
   }: {
     content?: string;
     placeholder?: string;
@@ -83,6 +85,8 @@
     availableNotes?: NoteLinkItem[];
     /** Current note id (excluded from autocomplete suggestions) */
     currentNoteId?: string | null;
+    /** User preference for external image loading — drives `ImageWidget` rendering. */
+    imageLoadMode?: ImageLoadMode;
   } = $props();
 
   let editorRootEl: HTMLDivElement;
@@ -96,6 +100,25 @@
 
   function isDark(): boolean {
     return document.documentElement.classList.contains('dark');
+  }
+
+  /**
+   * Builds the Live Preview options bag from an explicit mode argument + i18n.
+   *
+   * Mode is passed in (rather than read from the closure) so the `$effect`
+   * below can read `imageLoadMode` directly into a `const` — that read is the
+   * reactive dep, and an explicit assignment can't be silently DCE'd. The
+   * helper itself stays a plain function; calling it from inside or outside
+   * a reactive context is equally safe.
+   */
+  function livePreviewOptions(mode: ImageLoadMode) {
+    return {
+      imageLoadMode: mode,
+      imageLabels: {
+        load: $t('editor.image_load'),
+        base64Blocked: $t('editor.image_base64_blocked')
+      }
+    };
   }
 
   // ── Formatting helpers ──────────────────────────────────────────
@@ -328,7 +351,11 @@
         readonlyCompartment.of(EditorState.readOnly.of(readonly)),
         placeholderExt(placeholder),
         autocompleteCompartment.of(noteLinkAutocomplete(() => availableNotes, currentNoteId)),
-        livePreviewCompartment.of($editorMode === 'live' && !splitView ? createLivePreviewExtension() : []),
+        livePreviewCompartment.of(
+          $editorMode === 'live' && !splitView
+            ? createLivePreviewExtension(livePreviewOptions(imageLoadMode))
+            : []
+        ),
         noteLinkDecoration,
         EditorView.domEventHandlers({
           click(e) {
@@ -490,15 +517,21 @@
     });
   });
 
-  // Sync editor mode (markdown ↔ live preview).
-  // In split view the right pane already renders the rendered preview,
-  // so the editor pane always shows raw Markdown regardless of editorMode.
+  // Sync editor mode (markdown ↔ live preview) AND image-loading preference.
+  // Both `$editorMode` and `imageLoadMode` are read into local consts before
+  // the dispatch — explicit reads with side-effecting bindings can't be
+  // optimised out, guaranteeing Svelte tracks them as deps. Toggling either
+  // setting reconfigures the compartment and `ImageWidget` re-renders
+  // without a remount. In split view the right pane already renders the
+  // preview, so the editor pane always shows raw Markdown regardless of
+  // editorMode.
   $effect(() => {
     const mode = $editorMode;
+    const currentImageMode = imageLoadMode;
     const live = mode === 'live' && !splitView;
     view?.dispatch({
       effects: livePreviewCompartment.reconfigure(
-        live ? createLivePreviewExtension() : []
+        live ? createLivePreviewExtension(livePreviewOptions(currentImageMode)) : []
       )
     });
   });

--- a/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
@@ -104,6 +104,7 @@
           currentNoteId={noteId}
           parentScroll={parentScroll}
           {isMobile}
+          {imageLoadMode}
         />
       {:else if effectiveViewMode === 'split'}
         <!-- Split: each pane owns its scroll; sync handled by scroll-sync.ts.
@@ -123,6 +124,7 @@
               parentScroll={false}
               splitView
               {isMobile}
+              {imageLoadMode}
             />
           </div>
           <div class="flex min-w-0 flex-1 flex-col overflow-hidden">

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
@@ -5,6 +5,7 @@ import { Strikethrough, Table } from '@lezer/markdown';
 import type { DecorationSet } from '@codemirror/view';
 import { buildDecorations, isAnySelectionInRange } from './decorations';
 import { TableWidget } from './table-widget';
+import { ImageWidget } from './image-widget';
 
 interface DecoSpec {
   class?: string;
@@ -397,5 +398,107 @@ describe('buildDecorations — tables', () => {
     expect(
       ranges.filter((r) => r.hasWidget && r.spec.widget instanceof TableWidget)
     ).toHaveLength(0);
+  });
+});
+
+describe('buildDecorations — inline images', () => {
+  const LABELS = { load: 'Load image', base64Blocked: 'Embedded images blocked' };
+  const OPTS_ASK = { imageLoadMode: 'ask' as const, imageLabels: LABELS };
+  const OPTS_ALWAYS = { imageLoadMode: 'always' as const, imageLabels: LABELS };
+  const OPTS_NEVER = { imageLoadMode: 'never' as const, imageLabels: LABELS };
+
+  it('replaces an image with an ImageWidget when cursor is outside', () => {
+    const doc = 'before ![alt](https://example.com/img.png) after';
+    const cursor = doc.indexOf('after');
+    const state = makeState(doc, cursor);
+    const ranges = asRanges(buildDecorations(state, OPTS_ASK));
+
+    const widgets = ranges.filter(
+      (r) => r.hasWidget && r.spec.widget instanceof ImageWidget
+    );
+    expect(widgets).toHaveLength(1);
+    const widget = widgets[0].spec.widget as ImageWidget;
+    expect(widget.href).toBe('https://example.com/img.png');
+    expect(widget.alt).toBe('alt');
+    expect(widget.title).toBe('');
+    expect(widget.loadMode).toBe('ask');
+  });
+
+  it('keeps raw markdown (no widget) when cursor is inside the image range', () => {
+    const doc = 'before ![alt](https://example.com/img.png) after';
+    const cursor = doc.indexOf('alt');
+    const state = makeState(doc, cursor);
+    const ranges = asRanges(buildDecorations(state, OPTS_ASK));
+    expect(
+      ranges.filter((r) => r.hasWidget && r.spec.widget instanceof ImageWidget)
+    ).toHaveLength(0);
+  });
+
+  it('threads imageLoadMode through to the widget', () => {
+    const doc = '![a](https://example.com/x.png)\n\nbody';
+    const cursor = doc.length - 1;
+    const state = makeState(doc, cursor);
+
+    for (const [opts, expected] of [
+      [OPTS_ALWAYS, 'always'],
+      [OPTS_NEVER, 'never'],
+      [OPTS_ASK, 'ask']
+    ] as const) {
+      const ranges = asRanges(buildDecorations(state, opts));
+      const widget = ranges.find(
+        (r) => r.hasWidget && r.spec.widget instanceof ImageWidget
+      )?.spec.widget as ImageWidget | undefined;
+      expect(widget?.loadMode).toBe(expected);
+    }
+  });
+
+  it('extracts the optional title from `![alt](url "title")`', () => {
+    const doc = '![a](https://example.com/x.png "hover text")\n\nbody';
+    const cursor = doc.length - 1;
+    const state = makeState(doc, cursor);
+    const ranges = asRanges(buildDecorations(state, OPTS_ASK));
+    const widget = ranges.find(
+      (r) => r.hasWidget && r.spec.widget instanceof ImageWidget
+    )?.spec.widget as ImageWidget | undefined;
+    expect(widget?.title).toBe('hover text');
+  });
+
+  it('passes through data: URIs (widget itself decides how to render)', () => {
+    // The widget renders a blocked-warning placeholder for data: URIs, but
+    // buildDecorations must still emit a widget so the raw markdown stays
+    // hidden (consistent with all other image branches).
+    const doc = '![a](data:image/png;base64,abc)\n\nbody';
+    const cursor = doc.length - 1;
+    const state = makeState(doc, cursor);
+    const ranges = asRanges(buildDecorations(state, OPTS_ASK));
+    const widget = ranges.find(
+      (r) => r.hasWidget && r.spec.widget instanceof ImageWidget
+    )?.spec.widget as ImageWidget | undefined;
+    expect(widget?.href).toBe('data:image/png;base64,abc');
+  });
+
+  it('falls back to raw markdown when the image is nested inside a link', () => {
+    // `[![alt](img)](url)` — Lezer parses this as Link > Image. We don't
+    // want overlapping LinkWidget + ImageWidget on the same range, so the
+    // image case bails out and the link widget takes over.
+    const doc = '[![alt](https://example.com/x.png)](https://example.com/page)\n\nbody';
+    const cursor = doc.length - 1;
+    const state = makeState(doc, cursor);
+    const ranges = asRanges(buildDecorations(state, OPTS_ASK));
+    expect(
+      ranges.filter((r) => r.hasWidget && r.spec.widget instanceof ImageWidget)
+    ).toHaveLength(0);
+  });
+
+  it('uses fallback options when none are provided', () => {
+    // Backwards-compat path: callers (tests, future call sites) that don't
+    // pass options still get a working ImageWidget with sensible defaults.
+    const doc = '![a](https://example.com/x.png)\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+    const widget = ranges.find(
+      (r) => r.hasWidget && r.spec.widget instanceof ImageWidget
+    )?.spec.widget as ImageWidget | undefined;
+    expect(widget?.loadMode).toBe('ask');
   });
 });

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
@@ -13,9 +13,26 @@ import { Decoration, type DecorationSet, EditorView } from '@codemirror/view';
 import { type EditorState, type Range, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state';
 import type { SyntaxNode } from '@lezer/common';
 import type { Text } from '@codemirror/state';
+import type { ImageLoadMode } from '@reborn/storage';
 import { CodeBlockWidget, LinkWidget } from './widgets';
+import { ImageWidget, type ImageWidgetLabels, getLoadedImages } from './image-widget';
 import { TableWidget } from './table-widget';
 import { parseTable } from './table-parse';
+
+/**
+ * Options threaded into `buildDecorations` from `createLivePreviewExtension`.
+ * Currently only carries image-related preferences; structured as an object
+ * so future runtime-configurable knobs can join without churning the API.
+ */
+export interface BuildDecorationsOptions {
+  imageLoadMode: ImageLoadMode;
+  imageLabels: ImageWidgetLabels;
+}
+
+const DEFAULT_OPTIONS: BuildDecorationsOptions = {
+  imageLoadMode: 'ask',
+  imageLabels: { load: 'Load image', base64Blocked: 'Embedded images are not supported' }
+};
 
 /**
  * Effect that forces `livePreviewField` to re-run `buildDecorations` outside
@@ -125,10 +142,63 @@ function extractLinkParts(node: SyntaxNode, doc: Text): { text: string; url: str
   return { text, url };
 }
 
-export function buildDecorations(state: EditorState): DecorationSet {
+/**
+ * Pulls alt text + URL + optional title out of a Lezer `Image` node.
+ *
+ * Image layout from `@lezer/markdown`:
+ *   Image
+ *     ImageMark "!"
+ *     LinkMark  "["
+ *     (alt text inline content)
+ *     LinkMark  "]"
+ *     LinkMark  "("
+ *     URL
+ *     [LinkTitle]   ← optional, e.g. `"hover title"`
+ *     LinkMark  ")"
+ *
+ * Returns null for malformed nodes (parser still emits Image even if the
+ * source is incomplete during typing).
+ */
+function extractImageParts(
+  node: SyntaxNode,
+  doc: Text
+): { alt: string; url: string; title: string } | null {
+  let openBracket = -1;
+  let closeBracket = -1;
+  let url: string | null = null;
+  let title = '';
+  let child = node.firstChild;
+  while (child) {
+    const n = child.type.name;
+    if (n === 'LinkMark') {
+      // Image's opening LinkMark is "![" (two chars), not just "[" — match
+      // by suffix so we tolerate that without a separate ImageMark child.
+      const ch = doc.sliceString(child.from, child.to);
+      if (ch.endsWith('[') && openBracket === -1) openBracket = child.to;
+      else if (ch === ']' && closeBracket === -1) closeBracket = child.from;
+    } else if (n === 'URL') {
+      url = doc.sliceString(child.from, child.to);
+    } else if (n === 'LinkTitle') {
+      // Includes surrounding quotes — strip them to match the Markdown semantics.
+      const raw = doc.sliceString(child.from, child.to);
+      title = raw.replace(/^["'(]/, '').replace(/["')]$/, '');
+    }
+    child = child.nextSibling;
+  }
+  if (openBracket === -1 || closeBracket === -1 || closeBracket < openBracket) return null;
+  if (url === null) return null;
+  const alt = doc.sliceString(openBracket, closeBracket);
+  return { alt, url, title };
+}
+
+export function buildDecorations(
+  state: EditorState,
+  options: BuildDecorationsOptions = DEFAULT_OPTIONS
+): DecorationSet {
   const ranges: Range<Decoration>[] = [];
   const tree = syntaxTree(state);
   const doc = state.doc;
+  const loaded = getLoadedImages(state);
 
   tree.iterate({
     enter(nodeRef) {
@@ -257,6 +327,42 @@ export function buildDecorations(state: EditorState): DecorationSet {
         return false;
       }
 
+      // ─── Inline images ![alt](url) ───────────────────────────────
+      // Cursor outside the image range → render via ImageWidget.
+      // Cursor inside → fall through (no widget), CM6 shows raw markdown
+      // so the user can edit `![alt](url)` in place — same Live Preview
+      // pattern as links/headings.
+      //
+      // Images nested inside links (`[![alt](img)](url)`) keep raw markdown
+      // either way: emitting both a Link widget AND an Image widget would
+      // collide, and the nested case is rare enough that "edit as raw" is
+      // the simplest correct behaviour.
+      if (name === 'Image') {
+        const parent = nodeRef.node.parent;
+        if (parent && parent.type.name === 'Link') {
+          return false;
+        }
+        if (!isAnySelectionInRange(state, from, to)) {
+          const parts = extractImageParts(nodeRef.node, doc);
+          if (parts) {
+            const effectiveMode = loaded.has(parts.url) ? 'always' : options.imageLoadMode;
+            ranges.push(
+              Decoration.replace({
+                widget: new ImageWidget(
+                  parts.url,
+                  parts.alt,
+                  parts.title,
+                  effectiveMode,
+                  options.imageLabels
+                )
+              }).range(from, to)
+            );
+            return false;
+          }
+        }
+        return false;
+      }
+
       // ─── Links [text](url) ───────────────────────────────────────
       if (name === 'Link') {
         if (!isAnySelectionInRange(state, from, to)) {
@@ -314,29 +420,47 @@ export function buildDecorations(state: EditorState): DecorationSet {
 }
 
 /**
- * State field owning the live-preview decoration set. Must be a `StateField`
- * (not a `ViewPlugin`) because the FencedCode widget uses
- * `Decoration.replace({ block: true })` and CM6 requires block decorations
- * to come from a state-derived source — they affect the height map.
+ * Factory for the StateField owning the live-preview decoration set.
+ *
+ * A field-per-extension lets us close over per-instance options
+ * (`imageLoadMode`, i18n labels) without smuggling them through CM6
+ * facets. `createLivePreviewExtension` calls this once and the
+ * `Compartment` in NoteEditor reconfigures the whole extension whenever
+ * the options change, replacing the field as a side effect.
+ *
+ * Must be a `StateField` (not a `ViewPlugin`) because the FencedCode and
+ * Image widgets use `Decoration.replace({ block: true })` (or are emitted
+ * alongside block-replace ranges) and CM6 requires block decorations to
+ * come from a state-derived source — they affect the height map.
  *
  * Rebuild on `tr.docChanged`, `tr.selection`, or a `rebuildLivePreview` effect.
  * Tree-progress detection lives in a sibling `updateListener`
  * (`livePreviewSyncListener`) which dispatches the effect when the parser
  * finishes a step between transactions.
  */
-export const livePreviewField = StateField.define<DecorationSet>({
-  create(state) {
-    return buildDecorations(state);
-  },
-  update(value, tr) {
-    const forced = tr.effects.some((e) => e.is(rebuildLivePreview));
-    if (tr.docChanged || tr.selection || forced) {
-      return buildDecorations(tr.state);
-    }
-    return value;
-  },
-  provide: (f) => EditorView.decorations.from(f)
-});
+export function createLivePreviewField(
+  options: BuildDecorationsOptions = DEFAULT_OPTIONS
+): StateField<DecorationSet> {
+  return StateField.define<DecorationSet>({
+    create(state) {
+      return buildDecorations(state, options);
+    },
+    update(value, tr) {
+      const forced = tr.effects.some((e) => e.is(rebuildLivePreview));
+      if (tr.docChanged || tr.selection || forced) {
+        return buildDecorations(tr.state, options);
+      }
+      return value;
+    },
+    provide: (f) => EditorView.decorations.from(f)
+  });
+}
+
+/**
+ * Default field with sensible fallback options. Kept for tests and any
+ * legacy callers that don't need per-instance configuration.
+ */
+export const livePreviewField = createLivePreviewField();
 
 /**
  * Detects incremental parser progress between transactions and dispatches

--- a/apps/reborn-notes/src/lib/editor/live-preview/image-widget.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/image-widget.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeImageSrc, isDataImageUri } from './image-widget';
+
+describe('sanitizeImageSrc', () => {
+  it.each([
+    ['https://example.com/img.png'],
+    ['http://example.com/img.png'],
+    ['HTTPS://EXAMPLE.COM/IMG.PNG'],
+    ['/relative/img.png'],
+    ['./img.png'],
+    ['#anchor']
+  ])('allows %s', (url) => {
+    expect(sanitizeImageSrc(url)).toBe(url.trim());
+  });
+
+  it.each([
+    ['javascript:alert(1)'],
+    ['JAVASCRIPT:alert(1)'],
+    ['data:image/png;base64,abc'],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['vbscript:msgbox(1)'],
+    ['file:///etc/passwd'],
+    ['mailto:user@example.com'],
+    ['tel:+48123456789'],
+    ['note:00000000-0000-0000-0000-000000000000'],
+    ['ftp://example.com/img.png']
+  ])('blocks %s', (url) => {
+    expect(sanitizeImageSrc(url)).toBeNull();
+  });
+
+  it('rejects empty/whitespace', () => {
+    expect(sanitizeImageSrc('')).toBeNull();
+    expect(sanitizeImageSrc('   ')).toBeNull();
+    expect(sanitizeImageSrc('\t\n')).toBeNull();
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(sanitizeImageSrc('  https://example.com/img.png  ')).toBe(
+      'https://example.com/img.png'
+    );
+  });
+});
+
+describe('isDataImageUri', () => {
+  it.each([
+    ['data:image/png;base64,abc'],
+    ['DATA:image/jpeg;base64,xyz'],
+    ['data:text/plain,hello'],
+    ['  data:image/png;base64,abc']
+  ])('detects %s as data URI', (url) => {
+    expect(isDataImageUri(url)).toBe(true);
+  });
+
+  it.each([
+    ['https://example.com/img.png'],
+    ['/relative/img.png'],
+    [''],
+    ['data-uri-but-not-really']
+  ])('rejects %s', (url) => {
+    expect(isDataImageUri(url)).toBe(false);
+  });
+});

--- a/apps/reborn-notes/src/lib/editor/live-preview/image-widget.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/image-widget.ts
@@ -1,0 +1,263 @@
+/**
+ * Live Preview widget for inline images (`![alt](url)`).
+ *
+ * Three render branches selected by the user's `imageLoadMode` preference:
+ *   - `'always'` → real `<img loading="lazy">` (after `sanitizeImageSrc`).
+ *   - `'ask'`    → click-to-load placeholder with URL + Load button.
+ *   - `'never'`  → placeholder with URL only, no button.
+ *
+ * `data:` URIs always render the blocked-warning placeholder regardless of
+ * mode, mirroring `MarkdownPreview.svelte`'s renderer.image and the policy
+ * documented in `docs/development/guidelines/40-mermaid-image-preview.md`.
+ *
+ * Visual parity with the regular Preview is intentional: when the cursor
+ * leaves the image's markdown range, the editor and the rendered preview
+ * show the same placeholder/image. When the cursor is INSIDE the range,
+ * `decorations.ts` skips this widget and the user sees raw markdown
+ * (`![alt](url)`) editable in place — the standard Live Preview pattern.
+ */
+import { WidgetType, type EditorView } from '@codemirror/view';
+import { StateEffect, StateField } from '@codemirror/state';
+import type { ImageLoadMode } from '@reborn/storage';
+import { rebuildLivePreview } from './decorations';
+
+const HTTP_LIKE = /^https?:\/\//i;
+const RELATIVE = /^[/.#]/;
+
+/**
+ * Allowlist for `<img src>`. Stricter than `sanitizeLinkUrl`: no `mailto:`,
+ * `tel:`, `note:` (these are not loadable as images), and `data:` is blocked
+ * unconditionally — base64 inline images are out of scope per project
+ * security policy.
+ */
+export function sanitizeImageSrc(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  if (HTTP_LIKE.test(trimmed)) return trimmed;
+  if (RELATIVE.test(trimmed)) return trimmed;
+  return null;
+}
+
+export function isDataImageUri(url: string): boolean {
+  return /^data:/i.test(url.trim());
+}
+
+export type ImageWidgetLabels = {
+  /** Button text in 'ask' mode. */
+  load: string;
+  /** Inline notice for blocked data: URIs. */
+  base64Blocked: string;
+};
+
+// ── Per-click image loading via CM6 state (no DOM mutation) ──────────
+
+export const loadImageEffect = StateEffect.define<string>();
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+export const loadedImagesField = StateField.define<ReadonlySet<string>>({
+  create: () => new Set(),
+  update(value, tr) {
+    let next: Set<string> | null = null;
+    for (const e of tr.effects) {
+      if (e.is(loadImageEffect) && !value.has(e.value)) {
+        if (!next) next = new Set(value);
+        next.add(e.value);
+      }
+    }
+    return next ?? value;
+  }
+});
+
+export function getLoadedImages(
+  state: { field: <T>(f: StateField<T>, required?: boolean) => T | undefined }
+): ReadonlySet<string> {
+  return (state.field(loadedImagesField, false) as ReadonlySet<string> | undefined) ?? EMPTY_SET;
+}
+
+// ── SVG icon path for the image placeholder (lucide "image" icon) ────
+
+const IMAGE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="cm-lp-img-placeholder-icon-svg"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>`;
+
+const BLOCKED_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="cm-lp-img-placeholder-icon-svg"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>`;
+
+// ── Widget ────────────────────────────────────────────────────────────
+
+export class ImageWidget extends WidgetType {
+  constructor(
+    readonly href: string,
+    readonly alt: string,
+    readonly title: string,
+    readonly loadMode: ImageLoadMode,
+    readonly labels: ImageWidgetLabels
+  ) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    return (
+      other instanceof ImageWidget &&
+      other.href === this.href &&
+      other.alt === this.alt &&
+      other.title === this.title &&
+      other.loadMode === this.loadMode &&
+      other.labels.load === this.labels.load &&
+      other.labels.base64Blocked === this.labels.base64Blocked
+    );
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    if (isDataImageUri(this.href)) {
+      const blocked = buildBlockedPlaceholder(this.labels.base64Blocked);
+      attachEditOnClick(blocked, view);
+      return blocked;
+    }
+
+    const safeSrc = sanitizeImageSrc(this.href);
+    if (!safeSrc) {
+      const ph = buildPlaceholder(this.href, this.alt, this.title, false, this.labels.load);
+      attachEditOnClick(ph, view);
+      return ph;
+    }
+
+    if (this.loadMode === 'always') {
+      const img = buildImage(safeSrc, this.alt, this.title);
+      attachEditOnClick(img, view);
+      return img;
+    }
+
+    const placeholder = buildPlaceholder(
+      safeSrc,
+      this.alt,
+      this.title,
+      this.loadMode === 'ask',
+      this.labels.load
+    );
+
+    if (this.loadMode === 'ask') {
+      const btn = placeholder.querySelector('.cm-lp-img-placeholder-load') as HTMLButtonElement | null;
+      if (btn) {
+        attachLoadHandler(btn, safeSrc, view);
+      }
+    }
+    attachEditOnClick(placeholder, view);
+
+    return placeholder;
+  }
+
+  /**
+   * Treat the widget as opaque to CM6 — `true` for every event.
+   *
+   * CM6's default mousedown handler uses `posAtCoords` to set the caret,
+   * which for an `<img>` widget lands the cursor at the widget boundary
+   * (just before or just after the markdown range). That leaves the
+   * widget rendered and prevents in-place editing.
+   *
+   * Instead, our own `click` listeners (`attachLoadHandler`,
+   * `attachEditOnClick`) dispatch the right state change explicitly:
+   * Load → `loadImageEffect`, anywhere else on the widget → selection
+   * inside the markdown range so Live Preview hides the widget.
+   */
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+function buildImage(src: string, alt: string, title: string): HTMLImageElement {
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = alt;
+  if (title) img.title = title;
+  img.loading = 'lazy';
+  img.classList.add('cm-lp-img');
+  return img;
+}
+
+function buildPlaceholder(
+  href: string,
+  alt: string,
+  title: string,
+  showLoadBtn: boolean,
+  loadLabel: string
+): HTMLElement {
+  const wrap = document.createElement('span');
+  wrap.classList.add('cm-lp-img-placeholder');
+  if (alt) wrap.dataset.alt = alt;
+  if (title) wrap.dataset.title = title;
+  wrap.dataset.src = href;
+
+  const icon = document.createElement('span');
+  icon.classList.add('cm-lp-img-placeholder-icon');
+  icon.innerHTML = IMAGE_ICON_SVG;
+  wrap.appendChild(icon);
+
+  const url = document.createElement('span');
+  url.classList.add('cm-lp-img-placeholder-url');
+  url.textContent = href;
+  wrap.appendChild(url);
+
+  if (showLoadBtn) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.classList.add('cm-lp-img-placeholder-load');
+    btn.textContent = loadLabel;
+    wrap.appendChild(btn);
+  }
+
+  return wrap;
+}
+
+function buildBlockedPlaceholder(notice: string): HTMLElement {
+  const wrap = document.createElement('span');
+  wrap.classList.add('cm-lp-img-placeholder', 'cm-lp-img-placeholder--blocked');
+
+  const icon = document.createElement('span');
+  icon.classList.add('cm-lp-img-placeholder-icon');
+  icon.innerHTML = BLOCKED_ICON_SVG;
+  wrap.appendChild(icon);
+
+  const msg = document.createElement('span');
+  msg.classList.add('cm-lp-img-placeholder-url');
+  msg.textContent = notice;
+  wrap.appendChild(msg);
+
+  return wrap;
+}
+
+function attachLoadHandler(btn: HTMLButtonElement, href: string, view: EditorView): void {
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    view.dispatch({
+      effects: [loadImageEffect.of(href), rebuildLivePreview.of(null)]
+    });
+  });
+}
+
+/**
+ * Move the editor caret inside the widget's markdown range on click.
+ *
+ * Without this, clicking an `<img>` (or a placeholder area where CM6
+ * doesn't naturally land the caret — e.g. on top of the image bitmap)
+ * leaves the cursor outside the `![alt](url)` range, so the widget
+ * stays rendered and the user can't switch to raw markdown for editing.
+ *
+ * `view.posAtDOM(el)` returns the doc position of the widget's start.
+ * Adding `+1` lands the caret one char inside the range, which makes
+ * `isAnySelectionInRange(state, from, to)` return true and the next
+ * `buildDecorations` skips this image — raw `![alt](url)` becomes
+ * editable in place.
+ */
+function attachEditOnClick(el: HTMLElement, view: EditorView): void {
+  el.addEventListener('click', (e) => {
+    // The Load button has its own handler that stops propagation; don't
+    // treat its click as an "edit this image" intent.
+    if (e.defaultPrevented) return;
+    if ((e.target as Element | null)?.closest('.cm-lp-img-placeholder-load')) return;
+    const pos = view.posAtDOM(el);
+    if (pos < 0) return;
+    e.preventDefault();
+    view.focus();
+    view.dispatch({ selection: { anchor: pos + 1, head: pos + 1 } });
+  });
+}

--- a/apps/reborn-notes/src/lib/editor/live-preview/index.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/index.ts
@@ -7,27 +7,45 @@
  *
  * Scope: ATX headings, **bold**, *italic*, `inline code`, links (incl. note:UUID),
  * blockquote, bullet/ordered lists, fenced code blocks (```lang ... ```),
- * GFM tables (always rendered as an editable widget — Obsidian-style).
- * Inline images stay as raw markdown.
+ * GFM tables (always rendered as an editable widget — Obsidian-style),
+ * and inline images (`![alt](url)` — placeholder/auto-load per user
+ * preference, raw markdown when the cursor is inside the image range).
  */
 import type { Extension } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
 import { Strikethrough, Table } from '@lezer/markdown';
+import type { ImageLoadMode } from '@reborn/storage';
 import {
-  livePreviewField,
+  createLivePreviewField,
   livePreviewSyncListener,
   livePreviewAtomicRanges
 } from './decorations';
 import { livePreviewTheme } from './theme';
 import { codeLanguages } from './code-languages';
+import { loadedImagesField, type ImageWidgetLabels } from './image-widget';
 
-export function createLivePreviewExtension(): Extension {
-  return [
-    livePreviewField,
-    livePreviewSyncListener,
-    livePreviewAtomicRanges,
-    livePreviewTheme
-  ];
+/**
+ * Runtime options for the Live Preview extension. The Compartment in
+ * NoteEditor reconfigures the whole extension whenever any option changes.
+ */
+export interface LivePreviewOptions {
+  /** User preference for external image loading. */
+  imageLoadMode?: ImageLoadMode;
+  /** i18n labels used inside DOM widgets (cannot read Svelte stores there). */
+  imageLabels?: ImageWidgetLabels;
+}
+
+const DEFAULT_LABELS: ImageWidgetLabels = {
+  load: 'Load image',
+  base64Blocked: 'Embedded images are not supported'
+};
+
+export function createLivePreviewExtension(options: LivePreviewOptions = {}): Extension {
+  const field = createLivePreviewField({
+    imageLoadMode: options.imageLoadMode ?? 'ask',
+    imageLabels: options.imageLabels ?? DEFAULT_LABELS
+  });
+  return [field, loadedImagesField, livePreviewSyncListener, livePreviewAtomicRanges, livePreviewTheme];
 }
 
 /**
@@ -42,10 +60,12 @@ export function getMarkdownExtension(): Extension {
 export {
   buildDecorations,
   isAnySelectionInRange,
+  createLivePreviewField,
   livePreviewField,
   livePreviewSyncListener,
   livePreviewAtomicRanges,
-  rebuildLivePreview
+  rebuildLivePreview,
+  type BuildDecorationsOptions
 } from './decorations';
 export {
   CodeBlockWidget,
@@ -55,6 +75,15 @@ export {
   sanitizeInfoClass,
   sanitizeLinkUrl
 } from './widgets';
+export {
+  ImageWidget,
+  sanitizeImageSrc,
+  isDataImageUri,
+  loadImageEffect,
+  loadedImagesField,
+  getLoadedImages,
+  type ImageWidgetLabels
+} from './image-widget';
 export { TableWidget, tableCellEditAnnotation } from './table-widget';
 export {
   highlightCodeToHtml,

--- a/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
@@ -256,6 +256,61 @@ export const livePreviewTheme = EditorView.theme({
   '.cm-lp-table th:focus, .cm-lp-table td:focus': {
     boxShadow: 'inset 0 0 0 2px var(--ring, var(--primary))',
     backgroundColor: 'color-mix(in srgb, var(--primary) 8%, transparent)'
+  },
+
+  // ─── Inline images & placeholders ─────────────────────────────
+  // Image widgets are emitted as inline replacements (no `block: true`),
+  // so they live inside `.cm-line` flow. Margin must stay 0 — same height-map
+  // rule as line/block decorations. Visual parity with `.image-placeholder`
+  // in MarkdownPreview.svelte is intentional, but the layout adapts to the
+  // inline context (inline-flex instead of block + text-align).
+  '.cm-lp-img': {
+    maxWidth: '100%',
+    height: 'auto',
+    borderRadius: '0.375em',
+    verticalAlign: 'middle'
+  },
+  '.cm-lp-img-placeholder': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5em',
+    padding: '0.4em 0.75em',
+    margin: '0',
+    border: '2px dashed var(--border)',
+    borderRadius: '0.5em',
+    background: 'var(--muted)',
+    fontSize: '0.875rem',
+    maxWidth: '100%',
+    verticalAlign: 'middle'
+  },
+  '.cm-lp-img-placeholder--blocked': {
+    borderColor: 'var(--destructive)',
+    background: 'color-mix(in srgb, var(--destructive) 8%, var(--muted))'
+  },
+  '.cm-lp-img-placeholder-icon': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    flex: '0 0 auto',
+    color: 'var(--muted-foreground)'
+  },
+  '.cm-lp-img-placeholder-url': {
+    color: 'var(--muted-foreground)',
+    wordBreak: 'break-all',
+    flex: '1 1 auto',
+    minWidth: '0'
+  },
+  '.cm-lp-img-placeholder-load': {
+    padding: '0.25em 0.75em',
+    borderRadius: '0.375em',
+    background: 'var(--primary)',
+    color: 'var(--primary-foreground)',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '0.8125rem',
+    flex: '0 0 auto'
+  },
+  '.cm-lp-img-placeholder-load:hover': {
+    opacity: '0.9'
   }
 
   // Dark-mode token overrides live in NoteEditor.svelte's `<style>`

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -1389,6 +1389,7 @@
             onnotelinkrequest={openNotePicker}
             onnotelink={handleNoteLink}
             {resolveNoteTitle}
+            imageLoadMode={$imageLoadMode}
           />
         {:else}
           <NoteEditorHeader
@@ -1467,6 +1468,7 @@
               onnotelinkrequest={openNotePicker}
               onnotelink={handleNoteLink}
               {resolveNoteTitle}
+              imageLoadMode={$imageLoadMode}
             />
           </div>
         {/if}


### PR DESCRIPTION
Images (`![alt](url)`) now render as widgets in Live Preview when the cursor is outside their range, mirroring the regular Preview's three load modes (always / ask / never) and the data: URI block. Clicking the widget moves the caret into the markdown range so the user can edit `![alt](url)` in place.

Click-to-load uses a CM6 StateField (`loadedImagesField`) to track manually-loaded URLs instead of mutating widget DOM directly — the previous DOM swap was interpreted by CM6 as user input and deleted the markdown source on click.

Placeholder visuals are unified across Preview and Live Preview: inline-flex layout with a lucide SVG icon (Image / AlertTriangle for blocked data: URIs) and full URL wrapping so the user can audit the destination before loading.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>