### PR TITLE
fix(notes): editor mode dialog icon, dark popover contrast, missing register title

### DIFF
--- a/apps/reborn-notes/src/lib/components/editor/EditorModeIntroDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/EditorModeIntroDialog.svelte
@@ -116,7 +116,9 @@
     </div>
 
     <p class="text-xs text-muted-foreground">
-      {$t('editor_mode_intro.hint_switch_later')}
+      {$t('editor_mode_intro.hint_switch_before_icon')}
+      <PencilLine class="inline-block h-3.5 w-3.5 align-text-bottom" />
+      {$t('editor_mode_intro.hint_switch_after_icon')}
     </p>
 
     <DialogFooter>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -457,7 +457,8 @@
     "option_markdown_label": "Markdown-Quelle",
     "option_markdown_description": "Rohe Marker wie ** # [Text](Link) bleiben sichtbar. Für Nutzer, die volle Kontrolle über die Syntax wollen.",
     "recommended": "Empfohlen",
-    "hint_switch_later": "Du kannst den Modus jederzeit über die ✏️-Schaltfläche in der Notiz-Kopfzeile oder in Einstellungen → Darstellung wechseln.",
+    "hint_switch_before_icon": "Du kannst den Modus jederzeit über die",
+    "hint_switch_after_icon": "Schaltfläche in der Notiz-Kopfzeile oder in Einstellungen → Darstellung wechseln.",
     "continue_button": "Loslegen"
   },
   "save_status": {
@@ -682,6 +683,7 @@
       "back_to_login": "Zurück zur Anmeldung"
     },
     "register": {
+      "title": "Erstellen Sie Ihr re/notes-Konto",
       "subtitle": "Erstellen Sie Ihr Konto, um loszulegen",
       "already_have_account": "Haben Sie bereits ein Konto?",
       "sign_in": "Anmelden",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -457,7 +457,8 @@
     "option_markdown_label": "Markdown source",
     "option_markdown_description": "Raw markers like ** # [text](link) stay visible. For users who prefer full control over the syntax.",
     "recommended": "Recommended",
-    "hint_switch_later": "You can switch modes any time using the ✏️ button in the note header or in Settings → Appearance.",
+    "hint_switch_before_icon": "You can switch modes any time using the",
+    "hint_switch_after_icon": "button in the note header or in Settings → Appearance.",
     "continue_button": "Get started"
   },
   "save_status": {
@@ -682,6 +683,7 @@
       "back_to_login": "Back to sign in"
     },
     "register": {
+      "title": "Create your re/notes account",
       "subtitle": "Create your account to get started",
       "already_have_account": "Already have an account?",
       "sign_in": "Sign in",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -457,7 +457,8 @@
     "option_markdown_label": "Fuente Markdown",
     "option_markdown_description": "Los marcadores en bruto como ** # [texto](enlace) permanecen visibles. Para usuarios que prefieren control total sobre la sintaxis.",
     "recommended": "Recomendado",
-    "hint_switch_later": "Puedes cambiar el modo en cualquier momento con el botón ✏️ en el encabezado de la nota o en Ajustes → Apariencia.",
+    "hint_switch_before_icon": "Puedes cambiar el modo en cualquier momento con el botón",
+    "hint_switch_after_icon": "en el encabezado de la nota o en Ajustes → Apariencia.",
     "continue_button": "Empezar"
   },
   "save_status": {
@@ -682,6 +683,7 @@
       "back_to_login": "Volver a iniciar sesión"
     },
     "register": {
+      "title": "Cree su cuenta en re/notes",
       "subtitle": "Cree su cuenta para comenzar",
       "already_have_account": "¿Ya tiene una cuenta?",
       "sign_in": "Iniciar sesión",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -457,7 +457,8 @@
     "option_markdown_label": "Source Markdown",
     "option_markdown_description": "Les marqueurs bruts comme ** # [texte](lien) restent visibles. Pour les utilisateurs qui préfèrent un contrôle total sur la syntaxe.",
     "recommended": "Recommandé",
-    "hint_switch_later": "Vous pouvez changer de mode à tout moment via le bouton ✏️ dans l'en-tête de la note ou dans Paramètres → Apparence.",
+    "hint_switch_before_icon": "Vous pouvez changer de mode à tout moment via le bouton",
+    "hint_switch_after_icon": "dans l'en-tête de la note ou dans Paramètres → Apparence.",
     "continue_button": "Commencer"
   },
   "save_status": {
@@ -682,6 +683,7 @@
       "back_to_login": "Retour à la connexion"
     },
     "register": {
+      "title": "Créez votre compte re/notes",
       "subtitle": "Créez votre compte pour commencer",
       "already_have_account": "Vous avez déjà un compte ?",
       "sign_in": "Se connecter",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -457,7 +457,8 @@
     "option_markdown_label": "Markdown (źródło)",
     "option_markdown_description": "Surowe znaczniki ** # [tekst](link) pozostają widoczne. Dla osób, które wolą pełną kontrolę nad składnią.",
     "recommended": "Polecane",
-    "hint_switch_later": "Tryb przełączysz w każdej chwili przyciskiem ✏️ w nagłówku notatki lub w Ustawieniach → Wygląd.",
+    "hint_switch_before_icon": "Tryb przełączysz w każdej chwili przyciskiem",
+    "hint_switch_after_icon": "w nagłówku notatki lub w Ustawieniach → Wygląd.",
     "continue_button": "Zaczynaj"
   },
   "save_status": {
@@ -682,6 +683,7 @@
       "back_to_login": "Powrót do logowania"
     },
     "register": {
+      "title": "Utwórz konto re/notes",
       "subtitle": "Utwórz konto, aby rozpocząć",
       "already_have_account": "Masz już konto?",
       "sign_in": "Zaloguj się",

--- a/packages/ui/src/components/dialog/dialog-content.svelte
+++ b/packages/ui/src/components/dialog/dialog-content.svelte
@@ -25,7 +25,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[calc(var(--rn-vv-offset-top,0px)+var(--rn-vv-height,100vh)/2)] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(var(--rn-vv-height,100vh)-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+			"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[calc(var(--rn-vv-offset-top,0px)+var(--rn-vv-height,100vh)/2)] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(var(--rn-vv-height,100vh)-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 			className
 		)}
 		{...restProps}

--- a/packages/ui/src/components/drawer/drawer-content.svelte
+++ b/packages/ui/src/components/drawer/drawer-content.svelte
@@ -20,7 +20,7 @@
 		bind:ref
 		data-slot="drawer-content"
 		class={cn(
-			"group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+			"group/drawer-content bg-popover text-popover-foreground fixed z-50 flex h-auto flex-col",
 			"data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
 			"data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
 			"data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/packages/ui/src/components/sheet/sheet-content.svelte
+++ b/packages/ui/src/components/sheet/sheet-content.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from "tailwind-variants";
 	export const sheetVariants = tv({
-		base: "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 gap-4 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+		base: "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 gap-4 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
 		variants: {
 			side: {
 				top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 border-b",


### PR DESCRIPTION
- Replace pencil emoji with inline Lucide PencilLine icon in editor mode intro dialog hint, matching the actual toolbar button. Split the i18n string into before/after-icon parts across all 5 locales.
- Use bg-popover instead of bg-background for Dialog, Sheet and Drawer content so floating surfaces stand out from the page in dark mode (popover oklch 0.269 vs background oklch 0.145). No visual change in light mode where both tokens resolve to white.
- Add missing auth.register.title key to notes translations (pl, en, de, es, fr); the registration page referenced it in <title> and svelte-i18n warned about the missing key.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>