### PR TITLE
chore(security): audit 008 quickfixes — O22, O27, O28

### DIFF
--- a/apps/reborn-notes/src/routes/api/auth/sessions/current/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/sessions/current/+server.ts
@@ -6,6 +6,8 @@ import { getUserFromToken } from '$lib/server/auth';
 
 const logger = createLogger('Notes-SessionPatchCurrent');
 
+const MAX_DEVICE_INFO_ENCRYPTED_BYTES = 512;
+
 /**
  * PATCH /api/auth/sessions/current
  * Update the current session's device_info_encrypted field.
@@ -23,6 +25,9 @@ export const PATCH: RequestHandler = async ({ request, cookies }) => {
     const deviceInfoEncrypted = body?.device_info_encrypted;
     if (!deviceInfoEncrypted || typeof deviceInfoEncrypted !== 'string') {
       return json({ success: false, error: 'Missing device_info_encrypted' }, { status: 400 });
+    }
+    if (deviceInfoEncrypted.length > MAX_DEVICE_INFO_ENCRYPTED_BYTES) {
+      return json({ success: false, error: 'device_info_encrypted too large' }, { status: 400 });
     }
 
     // Verify session belongs to user and is active

--- a/apps/reborn-notes/src/routes/api/notes/[id]/versions/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/[id]/versions/+server.ts
@@ -123,15 +123,17 @@ export const POST: RequestHandler = async ({ request, params }) => {
     });
 
     // Prune: keep only the most recent MAX_NOTE_VERSIONS
+    // user_id filter is defense-in-depth — current ownership model guarantees one
+    // user per note, but a future share/transfer feature must not delete other users' versions.
     const allVersions = await prisma.noteVersion.findMany({
-      where: { note_id: params.id },
+      where: { note_id: params.id, user_id: userId },
       orderBy: { created_at: 'desc' },
       select: { id: true }
     });
 
     if (allVersions.length > MAX_NOTE_VERSIONS) {
       const toDelete = allVersions.slice(MAX_NOTE_VERSIONS).map((v) => v.id);
-      await prisma.noteVersion.deleteMany({ where: { id: { in: toDelete } } });
+      await prisma.noteVersion.deleteMany({ where: { id: { in: toDelete }, user_id: userId } });
     }
 
     return json({ success: true });

--- a/apps/reborn-task/src/routes/api/auth/sessions/current/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/sessions/current/+server.ts
@@ -6,6 +6,8 @@ import { prisma } from '@reborn/database';
 
 const logger = createLogger('SessionPatchCurrent');
 
+const MAX_DEVICE_INFO_ENCRYPTED_BYTES = 512;
+
 /**
  * PATCH /api/auth/sessions/current
  * Update the current session's device_info_encrypted field.
@@ -26,6 +28,9 @@ export const PATCH: RequestHandler = async ({ request, cookies }) => {
 		const deviceInfoEncrypted = body?.device_info_encrypted;
 		if (!deviceInfoEncrypted || typeof deviceInfoEncrypted !== 'string') {
 			return json({ success: false, error: 'Missing device_info_encrypted' }, { status: 400 });
+		}
+		if (deviceInfoEncrypted.length > MAX_DEVICE_INFO_ENCRYPTED_BYTES) {
+			return json({ success: false, error: 'device_info_encrypted too large' }, { status: 400 });
 		}
 
 		// Verify session belongs to user and is active

--- a/packages/types/src/schemas/api/crud-requests.ts
+++ b/packages/types/src/schemas/api/crud-requests.ts
@@ -125,12 +125,6 @@ export const UpdateTagRequestSchema = z.object({
   color_encrypted: z.string().max(MAX_ENCRYPTED_TAG_COLOR_BYTES).optional().nullable()
 });
 
-// ─── reborn-notes: Note Tags ─────────────────────────────────────────
-
-export const SetNoteTagsRequestSchema = z.object({
-  tag_ids: z.array(z.string().uuid())
-});
-
 // ─── Inferred types ──────────────────────────────────────────────────
 
 export type CreateTaskRequest = z.infer<typeof CreateTaskRequestSchema>;
@@ -146,4 +140,3 @@ export type CreateFolderRequest = z.infer<typeof CreateFolderRequestSchema>;
 export type UpdateFolderRequest = z.infer<typeof UpdateFolderRequestSchema>;
 export type CreateTagRequest = z.infer<typeof CreateTagRequestSchema>;
 export type UpdateTagRequest = z.infer<typeof UpdateTagRequestSchema>;
-export type SetNoteTagsRequest = z.infer<typeof SetNoteTagsRequestSchema>;


### PR DESCRIPTION
Defense-in-depth fixes from security audit 008:

- O22: remove dead SetNoteTagsRequestSchema/Type (relic from NoteTag DROP)
- O27: filter NoteVersion prune by user_id (theoretical, future-proof for share/transfer)
- O28: cap device_info_encrypted at 512 B in PATCH /api/auth/sessions/current

No behaviour change for current users; not exploitable in current data model.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>