### PR TITLE
fix(notes): prevent wide code blocks/tables from stretching live preview on mobile

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -881,10 +881,18 @@
   }
 
   :global(.cm-host .cm-content) {
+    width: 100%;
     max-width: 48rem; /* max-w-3xl */
     margin: 0 auto;
     font-size: 1rem; /* 16px — prevents iOS auto-zoom on focus */
     line-height: 1.7;
+    box-sizing: border-box;
+    /* Belt-and-braces: even if some descendant widget tries to push intrinsic
+       min-content (a wide <pre>/<table>), this lets `.cm-content` shrink to
+       its parent rather than overflow the viewport. The widgets themselves
+       carry their own scroll containers (`.cm-lp-codeblock-wrap`,
+       `.cm-lp-table-wrap`). */
+    min-width: 0;
   }
 
   @media (min-width: 768px) {

--- a/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
@@ -135,9 +135,21 @@ export const livePreviewTheme = EditorView.theme({
   },
 
   // ─── Fenced code blocks ──────────────────────────────────────
-  // Cursor outside: replaced with <pre class="cm-lp-codeblock">.
-  // Margin must stay 0 so the block sits flush — same height-map rule
-  // as line decorations.
+  // Cursor outside: replaced with <div class="cm-lp-codeblock-wrap"><pre>.
+  // The wrapper is the horizontal scroll container; its `overflow-x: auto`
+  // creates a new BFC that prevents the <pre>'s `white-space: pre` intrinsic
+  // width from propagating up to `.cm-content` and overflowing the viewport
+  // on mobile (sibling paragraphs/headings would otherwise stretch with it).
+  // Margin must stay 0 — same height-map rule as line decorations.
+  '.cm-lp-codeblock-wrap': {
+    margin: '0',
+    maxWidth: '100%',
+    overflowX: 'auto',
+    borderRadius: '0.5em',
+    // Improves single-finger horizontal swipe on touch devices without
+    // hijacking vertical page scroll.
+    touchAction: 'pan-x pan-y'
+  },
   '.cm-lp-codeblock': {
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
     fontSize: '0.875em',
@@ -147,8 +159,13 @@ export const livePreviewTheme = EditorView.theme({
     padding: '0.75em 1em',
     margin: '0',
     borderRadius: '0.5em',
-    overflowX: 'auto',
-    whiteSpace: 'pre'
+    whiteSpace: 'pre',
+    // `width: max-content` lets the <pre> grow to its longest line so the
+    // wrapper's `overflow-x: auto` actually engages. `min-width: 100%` keeps
+    // the muted background filling the wrapper width when code is short.
+    width: 'max-content',
+    minWidth: '100%',
+    boxSizing: 'border-box'
   },
   '.cm-lp-codeblock code': {
     fontFamily: 'inherit',
@@ -227,6 +244,11 @@ export const livePreviewTheme = EditorView.theme({
   '.cm-lp-table-wrap': {
     margin: '0',
     padding: '0.25em 0',
+    // `max-width: 100%` keeps the wrapper inside `.cm-content` on mobile —
+    // without it, a wide table's intrinsic min-content can push `.cm-content`
+    // past the viewport, dragging headings/paragraphs along (same failure
+    // mode as the code-block widget).
+    maxWidth: '100%',
     overflowX: 'auto'
   },
   '.cm-lp-table': {

--- a/apps/reborn-notes/src/lib/editor/live-preview/widgets.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/widgets.ts
@@ -133,6 +133,15 @@ export class CodeBlockWidget extends WidgetType {
   }
 
   toDOM(): HTMLElement {
+    // Outer wrapper is the horizontal scroll container.
+    // Without this, the <pre>'s `white-space: pre` propagates a min-content
+    // width up to `.cm-content`, expanding it past the viewport on mobile and
+    // forcing sibling lines (paragraphs, headings) to overflow the screen.
+    // The wrapper's `overflow-x: auto` (set in theme.ts) creates a new BFC
+    // that contains the intrinsic width of the code so only the code scrolls.
+    const wrap = document.createElement('div');
+    wrap.classList.add('cm-lp-codeblock-wrap');
+
     const pre = document.createElement('pre');
     pre.classList.add('cm-lp-codeblock');
 
@@ -151,7 +160,8 @@ export class CodeBlockWidget extends WidgetType {
     }
 
     pre.appendChild(codeEl);
-    return pre;
+    wrap.appendChild(pre);
+    return wrap;
   }
 
   ignoreEvent(): boolean {


### PR DESCRIPTION
In Live Preview on mobile, a code block (or table) wider than the viewport expanded the entire `.cm-content` — sibling paragraphs and headings overflowed the screen too. Root cause: a `<pre>` with `white-space: pre` propagates its intrinsic min-content width up through CM6's content measurement, even with `overflow-x: auto` on the `<pre>` itself.

Fix: wrap `CodeBlockWidget` DOM in a dedicated `<div class="cm-lp-codeblock-wrap">` whose `overflow-x: auto` creates a new BFC and isolates the inner `<pre>`'s intrinsic width from `.cm-content`. The `<pre>` gets `width: max-content; min-width: 100%` so the muted background fills the wrapper for short snippets and scrolls horizontally for long ones. Same `max-width: 100%` added to the existing `.cm-lp-table-wrap`. Belt-and-braces `min-width: 0; width: 100%; box-sizing: border-box` on `.cm-content` in `NoteEditor.svelte` lets the content area shrink even if a future widget forgets its own scroll container.

Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>