### PR TITLE
docs: revert Mastodon rel=me link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,5 +250,3 @@ Reborn Apps is built by a non-profit foundation — no investors, no ads, no tra
 ---
 
 Built with privacy in mind by [Reborn Foundation](https://reborn.org.pl) (Poland).
-
-Follow us on the Fediverse: <a rel="me" href="https://mastodon.social/@reapps_eu">@reapps_eu@mastodon.social</a>


### PR DESCRIPTION
GitHub strips rel="me" from rendered HTML and auto-links the @user@domain text as a mailto link, breaking the original intent. Mastodon profile verification is now handled via the Website field on the GitHub org profile, which preserves rel="me".

This reverts commit 6fa708b85f4d3d1e5b16f4f9e0d6c2c5e9c8a4b1 (PR #118).