### PR TITLE
fix(notes): accept null in folder_id/parent_id when importing JSON backup

### DIFF
--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -62,6 +62,13 @@ import {
 } from './import-dedup-utils';
 import { sanitizeMarkdownContent, sanitizeTags } from '$lib/utils/markdown-sanitizer';
 import { shouldRestoreFromTrash, shouldRelinkToBackupFolder } from './export-import-trash-utils';
+import {
+  normalizeNullToUndefined,
+  formatZodIssues,
+  FOLDER_OPTIONAL_FIELDS,
+  NOTE_OPTIONAL_FIELDS,
+  TAG_OPTIONAL_FIELDS
+} from './import-normalize-utils';
 
 const logger = createLogger('ExportImport');
 
@@ -121,6 +128,7 @@ function fixEntityUuids(
   }
   return { fixed, repairedFields };
 }
+
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -515,28 +523,43 @@ function stripNoteShadowIndexes(note: NoteStoredLocal): NoteEncrypted {
   return rest;
 }
 
-/** Normalize UUID fields in exported entities (fix corrupted IndexedDB data). */
+/**
+ * Sanitize records before serializing to a backup file:
+ *  1. Repair corrupted UUIDs (legacy IDB data with stripped leading zeros).
+ *  2. Convert `null` → `undefined` for optional-but-not-nullable fields so
+ *     `JSON.stringify` drops them. Without this step, legacy IDB records that
+ *     stored e.g. `folder_id: null` would emit `"folder_id": null` in the file,
+ *     and a later import (or a third-party importer) might reject the value
+ *     because the schema expects `string | undefined`. See guideline 44.
+ */
 function normalizeExportUuids<T extends { id: string }>(
   items: T[],
-  uuidFields: string[]
+  uuidFields: string[],
+  optionalFields: readonly string[] = []
 ): T[] {
   return items.map((item) => {
     let modified = false;
-    const copy = { ...item };
+    const copy = { ...item } as Record<string, unknown>;
     for (const field of uuidFields) {
-      const val = (copy as Record<string, unknown>)[field];
+      const val = copy[field];
       if (typeof val === 'string' && !UUID_RE.test(val)) {
         const repaired = tryFixUuid(val);
         if (repaired) {
-          (copy as Record<string, unknown>)[field] = repaired;
+          copy[field] = repaired;
           modified = true;
         }
       }
     }
-    if (modified) {
-      logger.warn(`Export: naprawiono UUID dla elementu ${copy.id}`);
+    for (const field of optionalFields) {
+      if (copy[field] === null) {
+        copy[field] = undefined;
+        modified = true;
+      }
     }
-    return copy;
+    if (modified) {
+      logger.warn(`Export: znormalizowano dane elementu ${copy.id as string}`);
+    }
+    return copy as T;
   });
 }
 
@@ -557,10 +580,15 @@ export async function exportJsonBackup(): Promise<void> {
 
   const sanitizedNotes: NoteEncrypted[] = normalizeExportUuids(
     notes.map(stripNoteShadowIndexes),
-    ['id', 'user_id', 'folder_id']
+    ['id', 'user_id', 'folder_id'],
+    NOTE_OPTIONAL_FIELDS
   );
-  const sanitizedFolders = normalizeExportUuids(folders, ['id', 'user_id', 'parent_id']);
-  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id']);
+  const sanitizedFolders = normalizeExportUuids(
+    folders,
+    ['id', 'user_id', 'parent_id'],
+    FOLDER_OPTIONAL_FIELDS
+  );
+  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id'], TAG_OPTIONAL_FIELDS);
 
   const backup = {
     version: 1,
@@ -594,10 +622,15 @@ export async function exportEncryptedBackup(password: string): Promise<void> {
 
   const sanitizedNotes: NoteEncrypted[] = normalizeExportUuids(
     notes.map(stripNoteShadowIndexes),
-    ['id', 'user_id', 'folder_id']
+    ['id', 'user_id', 'folder_id'],
+    NOTE_OPTIONAL_FIELDS
   );
-  const sanitizedFolders = normalizeExportUuids(folders, ['id', 'user_id', 'parent_id']);
-  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id']);
+  const sanitizedFolders = normalizeExportUuids(
+    folders,
+    ['id', 'user_id', 'parent_id'],
+    FOLDER_OPTIONAL_FIELDS
+  );
+  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id'], TAG_OPTIONAL_FIELDS);
 
   const backup = {
     exported_at: new Date().toISOString(),
@@ -762,8 +795,12 @@ export async function importJsonBackup(
   // Import folders first (notes reference them)
   for (const folder of backupData.folders ?? []) {
     try {
-      const { fixed: fixedFolder, repairedFields: repairedFolderFields } = fixEntityUuids(
+      const normalized = normalizeNullToUndefined(
         folder as Record<string, unknown>,
+        FOLDER_OPTIONAL_FIELDS
+      );
+      const { fixed: fixedFolder, repairedFields: repairedFolderFields } = fixEntityUuids(
+        normalized,
         ['id', 'user_id', 'parent_id']
       );
       if (repairedFolderFields.length > 0) {
@@ -771,7 +808,7 @@ export async function importJsonBackup(
       }
       const parsed = schemas.FolderEncryptedSchema.safeParse(fixedFolder);
       if (!parsed.success) {
-        result.errors.push(`Folder ${fixedFolder.id}: walidacja nie powiodła się — ${parsed.error.issues[0]?.message}`);
+        result.errors.push(`Folder ${fixedFolder.id}: walidacja nie powiodła się — ${formatZodIssues(parsed.error)}`);
         continue;
       }
       const validated = parsed.data;
@@ -805,8 +842,12 @@ export async function importJsonBackup(
   // Import tags
   for (const tag of backupData.tags ?? []) {
     try {
-      const { fixed: fixedTag, repairedFields: repairedTagFields } = fixEntityUuids(
+      const normalized = normalizeNullToUndefined(
         tag as Record<string, unknown>,
+        TAG_OPTIONAL_FIELDS
+      );
+      const { fixed: fixedTag, repairedFields: repairedTagFields } = fixEntityUuids(
+        normalized,
         ['id', 'user_id']
       );
       if (repairedTagFields.length > 0) {
@@ -814,7 +855,7 @@ export async function importJsonBackup(
       }
       const parsed = schemas.TagEncryptedSchema.safeParse(fixedTag);
       if (!parsed.success) {
-        result.errors.push(`Tag ${fixedTag.id}: walidacja nie powiodła się — ${parsed.error.issues[0]?.message}`);
+        result.errors.push(`Tag ${fixedTag.id}: walidacja nie powiodła się — ${formatZodIssues(parsed.error)}`);
         continue;
       }
       const validated = parsed.data;
@@ -856,8 +897,9 @@ export async function importJsonBackup(
       // strips unknowns, so this is mostly defensive — it makes the intent
       // explicit and tolerates legacy files.
       const wireCandidate = stripUnknownNoteShadowIndexes(note) as Record<string, unknown>;
+      const normalized = normalizeNullToUndefined(wireCandidate, NOTE_OPTIONAL_FIELDS);
       const { fixed: fixedNote, repairedFields: repairedNoteFields } = fixEntityUuids(
-        wireCandidate,
+        normalized,
         ['id', 'user_id', 'folder_id']
       );
       if (repairedNoteFields.length > 0) {
@@ -865,7 +907,7 @@ export async function importJsonBackup(
       }
       const parsed = schemas.NoteEncryptedSchema.safeParse(fixedNote);
       if (!parsed.success) {
-        result.errors.push(`Note ${(fixedNote as { id?: string }).id ?? '?'}: walidacja nie powiodła się — ${parsed.error.issues[0]?.message}`);
+        result.errors.push(`Note ${(fixedNote as { id?: string }).id ?? '?'}: walidacja nie powiodła się — ${formatZodIssues(parsed.error)}`);
         continue;
       }
       const validated = parsed.data;
@@ -1014,7 +1056,7 @@ export async function importJsonBackup(
     try {
       const parsed = schemas.NoteTagSchema.safeParse(rel);
       if (!parsed.success) {
-        result.errors.push(`NoteTag: walidacja nie powiodła się — ${parsed.error.issues[0]?.message}`);
+        result.errors.push(`NoteTag: walidacja nie powiodła się — ${formatZodIssues(parsed.error)}`);
         continue;
       }
       const rawId = (rel as Record<string, unknown>).id;

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -824,6 +824,7 @@ export async function importJsonBackup(
       }
       const toSave = {
         ...validated,
+        parent_id: validated.parent_id ?? undefined,
         user_id: userId,
         sync_status: 'pending' as const,
         sync_version: 0,
@@ -941,7 +942,7 @@ export async function importJsonBackup(
         // override folder_id and bump sync metadata so the move propagates.
         const toSave: NoteStoredLocal = {
           ...existing,
-          folder_id: validated.folder_id,
+          folder_id: validated.folder_id ?? undefined,
           sync_status: 'pending',
           sync_version: 0,
           updated_at: now
@@ -999,6 +1000,7 @@ export async function importJsonBackup(
 
       const wire: NoteEncrypted = {
         ...validated,
+        folder_id: validated.folder_id ?? undefined,
         ...(sanitizedContentEncrypted !== undefined
           ? { content_encrypted: sanitizedContentEncrypted }
           : {}),

--- a/apps/reborn-notes/src/lib/services/idb-cleanup.service.ts
+++ b/apps/reborn-notes/src/lib/services/idb-cleanup.service.ts
@@ -1,0 +1,94 @@
+/**
+ * One-shot IndexedDB cleanup migration.
+ *
+ * Historical reborn-notes builds occasionally wrote `null` (instead of
+ * `undefined`) to optional-but-not-nullable fields on notes and folders —
+ * most commonly `folder_id` (root notes) and `parent_id` (root folders).
+ * The shape was tolerated locally but caused the JSON backup importer to
+ * reject affected entries with "Invalid input" once Zod 4 tightened
+ * `optional()` semantics.
+ *
+ * Schemas now accept null and the importer normalizes inputs, but local
+ * IDB still carries the pollution — every fresh export would re-emit the
+ * nulls. This helper rewrites those records in place so the next backup
+ * comes out clean. It is idempotent and runs at most once per browser
+ * profile (gated by a localStorage flag).
+ */
+import { noteStore, folderStore } from '@reborn/storage';
+import type { FolderEncrypted, NoteStoredLocal } from '@reborn/types';
+import { createLogger } from '@reborn/utils';
+
+const logger = createLogger('IdbCleanup');
+
+const FLAG_KEY = 'reborn-notes:idb-null-fk-cleanup-v1';
+
+/** Optional-but-not-nullable fields that may have been written as `null`. */
+const NOTE_FIELDS_TO_CLEAN = [
+  'folder_id',
+  'metadata_encrypted',
+  'device_id',
+  'is_archived'
+] as const;
+const FOLDER_FIELDS_TO_CLEAN = ['parent_id', 'metadata_encrypted', 'device_id'] as const;
+
+function dropNullFields<T extends object>(record: T, fields: readonly string[]): { cleaned: T; changed: boolean } {
+  const out = { ...record } as Record<string, unknown>;
+  let changed = false;
+  for (const field of fields) {
+    if (out[field] === null) {
+      delete out[field];
+      changed = true;
+    }
+  }
+  return { cleaned: out as T, changed };
+}
+
+/**
+ * Rewrite locally-stored notes and folders that hold `null` in
+ * optional-but-not-nullable fields. Runs at most once per browser profile.
+ *
+ * Safe to call before sync — the rewrite only touches local IDB and does
+ * not change `sync_status` or `sync_version`, so it doesn't trigger an
+ * unnecessary push.
+ */
+export async function cleanupNullFkFields(): Promise<void> {
+  if (typeof localStorage === 'undefined') return;
+  if (localStorage.getItem(FLAG_KEY)) return;
+
+  try {
+    const [notes, folders] = await Promise.all([
+      noteStore.getAll() as Promise<NoteStoredLocal[]>,
+      folderStore.getAll() as Promise<FolderEncrypted[]>
+    ]);
+
+    let notesCleaned = 0;
+    let foldersCleaned = 0;
+
+    for (const note of notes) {
+      const { cleaned, changed } = dropNullFields(note, NOTE_FIELDS_TO_CLEAN);
+      if (changed) {
+        await noteStore.save(cleaned);
+        notesCleaned++;
+      }
+    }
+
+    for (const folder of folders) {
+      const { cleaned, changed } = dropNullFields(folder, FOLDER_FIELDS_TO_CLEAN);
+      if (changed) {
+        await folderStore.save(cleaned);
+        foldersCleaned++;
+      }
+    }
+
+    localStorage.setItem(FLAG_KEY, new Date().toISOString());
+    if (notesCleaned > 0 || foldersCleaned > 0) {
+      logger.info('Cleaned null FK fields from local IDB', {
+        notes: notesCleaned,
+        folders: foldersCleaned
+      });
+    }
+  } catch (error) {
+    // Don't block app startup — leave the flag unset so we retry next boot.
+    logger.warn('IDB null-FK cleanup failed; will retry next boot', error);
+  }
+}

--- a/apps/reborn-notes/src/lib/services/import-normalize-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/import-normalize-utils.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  normalizeNullToUndefined,
+  formatZodIssues,
+  FOLDER_OPTIONAL_FIELDS,
+  NOTE_OPTIONAL_FIELDS,
+  TAG_OPTIONAL_FIELDS
+} from './import-normalize-utils';
+
+describe('normalizeNullToUndefined', () => {
+  it('replaces null with undefined for listed fields', () => {
+    const out = normalizeNullToUndefined(
+      { a: null, b: 'keep', c: null, d: 0 },
+      ['a', 'c']
+    );
+    expect(out.a).toBeUndefined();
+    expect(out.b).toBe('keep');
+    expect(out.c).toBeUndefined();
+    expect(out.d).toBe(0);
+  });
+
+  it('does not touch fields that are not in the list', () => {
+    const out = normalizeNullToUndefined({ a: null, b: null }, ['a']);
+    expect(out.a).toBeUndefined();
+    expect(out.b).toBeNull();
+  });
+
+  it('leaves undefined as undefined', () => {
+    const out = normalizeNullToUndefined({ a: undefined }, ['a']);
+    expect(out.a).toBeUndefined();
+  });
+
+  it('leaves valid string values intact', () => {
+    const out = normalizeNullToUndefined(
+      { folder_id: 'abc-123' },
+      ['folder_id']
+    );
+    expect(out.folder_id).toBe('abc-123');
+  });
+
+  it('does not mutate the input object', () => {
+    const input = { folder_id: null, title: 'x' };
+    const out = normalizeNullToUndefined(input, ['folder_id']);
+    expect(input.folder_id).toBeNull();
+    expect(out.folder_id).toBeUndefined();
+  });
+
+  it('produces output where JSON.stringify drops the cleared field', () => {
+    // The end-to-end value: a normalized record re-emitted via JSON should
+    // not carry the null forward. This is the property that ensures
+    // round-trip exports stay clean.
+    const out = normalizeNullToUndefined(
+      { folder_id: null, title: 't' },
+      ['folder_id']
+    );
+    expect(JSON.parse(JSON.stringify(out))).toEqual({ title: 't' });
+  });
+});
+
+describe('formatZodIssues', () => {
+  it('includes the field path and message for a single issue', () => {
+    const schema = z.object({ folder_id: z.string().uuid() });
+    const result = schema.safeParse({ folder_id: 'not-a-uuid' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const formatted = formatZodIssues(result.error);
+      expect(formatted).toContain('folder_id');
+      // Don't assert on Zod's exact wording — just that it surfaces *something*
+      // beyond the bare "Invalid input" the default extractor would return.
+      expect(formatted.length).toBeGreaterThan('folder_id'.length + 2);
+    }
+  });
+
+  it('joins multiple issues with "; "', () => {
+    const schema = z.object({
+      a: z.string(),
+      b: z.number()
+    });
+    const result = schema.safeParse({ a: 1, b: 'x' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const formatted = formatZodIssues(result.error);
+      expect(formatted).toContain('; ');
+      expect(formatted).toContain('a');
+      expect(formatted).toContain('b');
+    }
+  });
+
+  it('handles top-level errors (empty path)', () => {
+    const schema = z.string();
+    const result = schema.safeParse(123);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const formatted = formatZodIssues(result.error);
+      // Should produce a message (no leading "."), not "Invalid input" alone.
+      expect(formatted.length).toBeGreaterThan(0);
+      expect(formatted).not.toMatch(/^\./);
+    }
+  });
+});
+
+describe('field lists stay in sync with schema expectations', () => {
+  it('lists every field that legacy IDB might hold as null', () => {
+    expect(FOLDER_OPTIONAL_FIELDS).toContain('parent_id');
+    expect(NOTE_OPTIONAL_FIELDS).toContain('folder_id');
+    expect(NOTE_OPTIONAL_FIELDS).toContain('metadata_encrypted');
+    expect(TAG_OPTIONAL_FIELDS).toContain('color_encrypted');
+  });
+});

--- a/apps/reborn-notes/src/lib/services/import-normalize-utils.ts
+++ b/apps/reborn-notes/src/lib/services/import-normalize-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helpers for the import/export pipeline. Extracted so they can be unit
+ * tested without dragging in IndexedDB / cryptoManager / Svelte stores.
+ *
+ * - `normalizeNullToUndefined` — defensive conversion for fields that the
+ *   schemas treat as optional-but-not-nullable (legacy IDB or strict
+ *   third-party producers may emit `null`).
+ * - `formatZodIssues` — turns a `safeParse` failure into a single human
+ *   readable string with field paths included (the default
+ *   `error.issues[0]?.message` is just "Invalid input" — useless for triage).
+ */
+
+export function normalizeNullToUndefined(
+  raw: Record<string, unknown>,
+  fields: readonly string[]
+): Record<string, unknown> {
+  const out = { ...raw };
+  for (const field of fields) {
+    if (out[field] === null) {
+      out[field] = undefined;
+    }
+  }
+  return out;
+}
+
+export function formatZodIssues(error: {
+  issues: Array<{ path: PropertyKey[]; message: string }>;
+}): string {
+  return error.issues
+    .map((i) => {
+      const path = i.path.join('.');
+      return path ? `${path}: ${i.message}` : i.message;
+    })
+    .join('; ');
+}
+
+/** Optional-but-not-nullable fields per entity type. Single source of truth so
+ * the import normalizer and the export sanitizer stay in sync. */
+export const FOLDER_OPTIONAL_FIELDS = [
+  'parent_id',
+  'metadata_encrypted',
+  'device_id'
+] as const;
+export const NOTE_OPTIONAL_FIELDS = [
+  'folder_id',
+  'metadata_encrypted',
+  'device_id',
+  'is_archived'
+] as const;
+export const TAG_OPTIONAL_FIELDS = ['color_encrypted', 'device_id'] as const;

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
   import { authStore } from '$lib/stores/auth.store';
   import { pullFromServer, pushPendingItems, refreshStoresAfterPull } from '$lib/services/notes-sync.service';
   import { noteIndex } from '$lib/services/note-index.svelte';
+  import { cleanupNullFkFields } from '$lib/services/idb-cleanup.service';
   import { refreshPendingCount, isOnline, sessionExpired } from '$lib/stores/sync-status.store';
   import { initI18n, setLocale, locale } from '$lib/stores/i18n.store';
   import { reAuthenticate, verifyTotpForReauth } from '$lib/services/notes-auth.service';
@@ -115,6 +116,12 @@
           logger.error('Failed to initialize storage:', e);
         }
       }
+
+      // 2a. One-shot cleanup of legacy null FK fields in IDB. Idempotent and
+      //     gated by a localStorage flag — runs only once per browser profile,
+      //     no-op afterwards. Awaited so it completes before sync touches the
+      //     same records. Bounded by local IDB size (typically <1s).
+      await cleanupNullFkFields();
 
       // 3. Initialize SSO auth state AFTER storage is ready
       //    (reads shared localStorage from reborn-task if same origin)

--- a/apps/reborn-task/src/lib/services/data-export.service.ts
+++ b/apps/reborn-task/src/lib/services/data-export.service.ts
@@ -17,6 +17,23 @@ import type {
 const logger = createLogger('DataExportService');
 
 /**
+ * Drop the listed fields if their value is exactly `null`, returning a new
+ * object. Used at export time so optional-but-not-nullable fields don't leak
+ * `null` into the backup file (where they'd persist through `JSON.stringify`
+ * and trip strict Zod schemas on a future import).
+ */
+function stripNullOptionalFields(
+	raw: Record<string, unknown>,
+	fields: readonly string[]
+): Record<string, unknown> {
+	const out = { ...raw };
+	for (const field of fields) {
+		if (out[field] === null) delete out[field];
+	}
+	return out;
+}
+
+/**
  * Encrypted export format version.
  *
  * - 1.0 (legacy): emitted local-only shadow indexes (is_completed, is_starred,
@@ -141,7 +158,9 @@ export class DataExportService {
 						is_starred: meta.is_starred ?? task.is_starred,
 						is_recurring: meta.is_recurring ?? task.is_recurring ?? false,
 						recurrence_rule,
-						parent_task_id: task.parent_task_id,
+						// Normalize null → undefined so it drops from the JSON file.
+						// Strict importers (TaskDecryptedSchema before relaxation) reject null.
+						parent_task_id: task.parent_task_id ?? undefined,
 						is_template: task.is_template,
 						recurrence_base_date: meta.recurrence_base_date,
 						completed_at: meta.completed_at,
@@ -225,7 +244,15 @@ export class DataExportService {
 			subtaskStore.getAll()
 		]);
 
-		const lists: ListEncrypted[] = allLists.filter((l) => !l.deleted_at);
+		const lists: ListEncrypted[] = allLists
+			.filter((l) => !l.deleted_at)
+			.map(
+				(l) =>
+					stripNullOptionalFields(l as unknown as Record<string, unknown>, [
+						'metadata_encrypted',
+						'device_id'
+					]) as unknown as ListEncrypted
+			);
 
 		const tasks: TaskEncrypted[] = allTasks
 			.filter((t) => !t.deleted_at)
@@ -255,12 +282,23 @@ export class DataExportService {
 	/**
 	 * Drop local-only shadow indexes from a task before persisting outside
 	 * the device. Mirrors the strip done before sending to the server.
+	 *
+	 * Also normalizes `null` → `undefined` for optional-but-not-nullable fields
+	 * so `JSON.stringify` drops them entirely. Without this, legacy IDB records
+	 * that hold e.g. `parent_task_id: null` would emit `"parent_task_id": null`
+	 * in the file and a strict importer would reject them. See guideline 44.
 	 */
 	private stripTaskShadowIndexes(task: TaskEncryptedBooleans): TaskEncrypted {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const { is_completed, is_starred, is_recurring, due_date, ...rest } = task;
+		const out = stripNullOptionalFields(rest as unknown as Record<string, unknown>, [
+			'parent_task_id',
+			'description_encrypted',
+			'recurrence_rule_encrypted',
+			'device_id'
+		]);
 		return {
-			...rest,
+			...(out as unknown as Omit<TaskEncrypted, 'is_template'>),
 			is_template: (task.is_template ? 1 : 0) as 0 | 1
 		};
 	}
@@ -272,7 +310,10 @@ export class DataExportService {
 	private stripSubtaskShadowIndexes(subtask: SubtaskStoredLocal): SubtaskEncrypted {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const { is_completed, ...rest } = subtask;
-		return rest;
+		return stripNullOptionalFields(rest as unknown as Record<string, unknown>, [
+			'metadata_encrypted',
+			'device_id'
+		]) as unknown as SubtaskEncrypted;
 	}
 
 	private triggerDownload(data: ExportData, filename: string): void {

--- a/apps/reborn-task/src/lib/services/data-import.service.ts
+++ b/apps/reborn-task/src/lib/services/data-import.service.ts
@@ -22,6 +22,54 @@ const logger = createLogger('DataImportService');
 /** Max import file size: 100 MB (aligned with per-user storage quota). */
 const MAX_IMPORT_FILE_SIZE = 100 * 1024 * 1024;
 
+/**
+ * Normalize `null` → `undefined` for fields that are optional-but-not-nullable
+ * downstream. Server (Prisma) and legacy local IDB records may carry `null` for
+ * "no parent / no metadata"; the rest of the client code uses `undefined` as
+ * the canonical absence marker. Without this, Zod's optional() rejects null
+ * and otherwise-valid backups fail validation. Mirrors the helper of the same
+ * name in reborn-notes export-import.service.ts.
+ */
+function normalizeNullToUndefined(
+	raw: Record<string, unknown>,
+	fields: readonly string[]
+): Record<string, unknown> {
+	const out = { ...raw };
+	for (const field of fields) {
+		if (out[field] === null) {
+			out[field] = undefined;
+		}
+	}
+	return out;
+}
+
+/** Optional-but-not-nullable fields per entity type. */
+const LIST_OPTIONAL_FIELDS = ['metadata_encrypted', 'device_id'] as const;
+const TASK_OPTIONAL_FIELDS = [
+	'parent_task_id',
+	'description_encrypted',
+	'recurrence_rule_encrypted',
+	'device_id'
+] as const;
+const SUBTASK_OPTIONAL_FIELDS = ['metadata_encrypted', 'device_id'] as const;
+
+/**
+ * Format a Zod safeParse failure into a single human-readable message.
+ * `issues[0]?.message` on its own returns "Invalid input" with no field
+ * context — useless for triage. Concatenating path + message per issue
+ * makes the UI report actionable. Mirrors `formatZodIssues` in reborn-notes.
+ */
+function formatZodIssues(error: {
+	issues: Array<{ path: PropertyKey[]; message: string }>;
+}): string {
+	return error.issues
+		.map((i) => {
+			const path = i.path.join('.');
+			return path ? `${path}: ${i.message}` : i.message;
+		})
+		.join('; ');
+}
+
 export interface ImportResult {
 	listsImported: number;
 	tasksImported: number;
@@ -105,9 +153,13 @@ export class DataImportService {
 
 		for (const list of exportData.data.lists) {
 			try {
-				const parsed = schemas.ListEncryptedSchema.safeParse(list);
+				const normalized = normalizeNullToUndefined(
+					list as unknown as Record<string, unknown>,
+					LIST_OPTIONAL_FIELDS
+				);
+				const parsed = schemas.ListEncryptedSchema.safeParse(normalized);
 				if (!parsed.success) {
-					result.errors.push(`Lista ${list.id}: walidacja — ${parsed.error.issues[0]?.message}`);
+					result.errors.push(`Lista ${list.id}: walidacja — ${formatZodIssues(parsed.error)}`);
 					continue;
 				}
 				const existing = await listStore.get(parsed.data.id);
@@ -144,7 +196,7 @@ export class DataImportService {
 				const parsed = schemas.TaskEncryptedSchema.safeParse(wireCandidate);
 				if (!parsed.success) {
 					result.errors.push(
-						`Zadanie ${(rawTask as { id?: string }).id ?? '?'}: walidacja — ${parsed.error.issues[0]?.message}`
+						`Zadanie ${(rawTask as { id?: string }).id ?? '?'}: walidacja — ${formatZodIssues(parsed.error)}`
 					);
 					continue;
 				}
@@ -186,7 +238,7 @@ export class DataImportService {
 				const parsed = schemas.SubtaskEncryptedSchema.safeParse(wireCandidate);
 				if (!parsed.success) {
 					result.errors.push(
-						`Podzadanie ${(rawSubtask as { id?: string }).id ?? '?'}: walidacja — ${parsed.error.issues[0]?.message}`
+						`Podzadanie ${(rawSubtask as { id?: string }).id ?? '?'}: walidacja — ${formatZodIssues(parsed.error)}`
 					);
 					continue;
 				}
@@ -231,7 +283,7 @@ export class DataImportService {
 			try {
 				const parsed = schemas.ListDecryptedSchema.safeParse(list);
 				if (!parsed.success) {
-					result.errors.push(`Lista ${list.id}: walidacja — ${parsed.error.issues[0]?.message}`);
+					result.errors.push(`Lista ${list.id}: walidacja — ${formatZodIssues(parsed.error)}`);
 					continue;
 				}
 				const validList = parsed.data;
@@ -280,7 +332,7 @@ export class DataImportService {
 			try {
 				const parsed = schemas.TaskDecryptedSchema.safeParse(task);
 				if (!parsed.success) {
-					result.errors.push(`Zadanie ${task.id}: walidacja — ${parsed.error.issues[0]?.message}`);
+					result.errors.push(`Zadanie ${task.id}: walidacja — ${formatZodIssues(parsed.error)}`);
 					continue;
 				}
 				const validTask = parsed.data;
@@ -348,7 +400,7 @@ export class DataImportService {
 			try {
 				const parsed = schemas.SubtaskSchema.safeParse(subtask);
 				if (!parsed.success) {
-					result.errors.push(`Podzadanie ${subtask.id}: walidacja — ${parsed.error.issues[0]?.message}`);
+					result.errors.push(`Podzadanie ${subtask.id}: walidacja — ${formatZodIssues(parsed.error)}`);
 					continue;
 				}
 				const validSub = parsed.data;
@@ -406,7 +458,7 @@ export class DataImportService {
 		if (typeof out.is_template === 'boolean') {
 			out.is_template = out.is_template ? 1 : 0;
 		}
-		return out;
+		return normalizeNullToUndefined(out, TASK_OPTIONAL_FIELDS);
 	}
 
 	/**
@@ -418,7 +470,7 @@ export class DataImportService {
 		const r = raw as Record<string, unknown>;
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const { is_completed, ...rest } = r;
-		return rest;
+		return normalizeNullToUndefined(rest, SUBTASK_OPTIONAL_FIELDS);
 	}
 
 	/**

--- a/apps/reborn-task/src/lib/services/data-import.service.ts
+++ b/apps/reborn-task/src/lib/services/data-import.service.ts
@@ -210,6 +210,7 @@ export class DataImportService {
 				// shadow indexes are local-only and never trusted from a file).
 				const wire: TaskEncrypted = {
 					...parsed.data,
+					parent_task_id: parsed.data.parent_task_id ?? undefined,
 					user_id: userId,
 					sync_status: 'pending',
 					sync_version: 0,
@@ -373,7 +374,7 @@ export class DataImportService {
 					description_encrypted,
 					metadata_encrypted,
 					recurrence_rule_encrypted,
-					parent_task_id: validTask.parent_task_id,
+					parent_task_id: validTask.parent_task_id ?? undefined,
 					is_template: (validTask.is_template ? 1 : 0) as 0 | 1,
 					position: validTask.position,
 					created_at: validTask.created_at,

--- a/packages/types/src/schemas/__tests__/note.spec.ts
+++ b/packages/types/src/schemas/__tests__/note.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { NoteDecryptedSchema, NoteEncryptedSchema } from '../entities/note';
-import { FolderDecryptedSchema } from '../entities/folder';
+import { FolderDecryptedSchema, FolderEncryptedSchema } from '../entities/folder';
 import { TagDecryptedSchema } from '../entities/tag';
 
 describe('Note Schemas', () => {
@@ -93,6 +93,90 @@ describe('Note Schemas', () => {
       };
 
       const result = FolderDecryptedSchema.safeParse(invalidFolder);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('null tolerance for FK fields (regression)', () => {
+    // Server (Prisma) returns `null` for absent foreign keys; client code uses
+    // `undefined`. Both must be accepted so JSON backups round-trip cleanly
+    // regardless of which producer wrote the file. See guideline 44.
+    const baseEncryptedNote = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      user_id: '123e4567-e89b-12d3-a456-426614174001',
+      title_encrypted: 'iv:cipher',
+      content_encrypted: 'iv:cipher',
+      sync_version: 0,
+      sync_status: 'synced' as const,
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z'
+    };
+
+    const baseEncryptedFolder = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      user_id: '123e4567-e89b-12d3-a456-426614174001',
+      name_encrypted: 'iv:cipher',
+      order_index: 0,
+      is_archived: false,
+      sync_version: 0,
+      sync_status: 'synced' as const,
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z'
+    };
+
+    it('accepts NoteEncryptedSchema with folder_id=null (root note from server)', () => {
+      const result = NoteEncryptedSchema.safeParse({ ...baseEncryptedNote, folder_id: null });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts NoteEncryptedSchema with folder_id absent (client-created)', () => {
+      const result = NoteEncryptedSchema.safeParse(baseEncryptedNote);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts NoteDecryptedSchema with folder_id=null', () => {
+      const result = NoteDecryptedSchema.safeParse({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        title: 'Test',
+        content: 'Body',
+        folder_id: null,
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts FolderEncryptedSchema with parent_id=null (root folder)', () => {
+      const result = FolderEncryptedSchema.safeParse({ ...baseEncryptedFolder, parent_id: null });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts FolderDecryptedSchema with parent_id=null', () => {
+      const result = FolderDecryptedSchema.safeParse({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        parent_id: null,
+        name: 'Inbox',
+        order_index: 0,
+        is_archived: false,
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z'
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('still rejects malformed UUID in folder_id', () => {
+      const result = NoteEncryptedSchema.safeParse({
+        ...baseEncryptedNote,
+        folder_id: 'not-a-uuid'
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('still rejects malformed UUID in parent_id', () => {
+      const result = FolderEncryptedSchema.safeParse({
+        ...baseEncryptedFolder,
+        parent_id: 'not-a-uuid'
+      });
       expect(result.success).toBe(false);
     });
   });

--- a/packages/types/src/schemas/entities/folder.ts
+++ b/packages/types/src/schemas/entities/folder.ts
@@ -3,7 +3,9 @@ import { SyncableEncryptedEntitySchema } from '../base';
 
 export const FolderDecryptedSchema = z.object({
   id: z.string().uuid(),
-  parent_id: z.string().uuid().optional(),
+  // Server (Prisma) returns `null` for root folders; client code uses `undefined`.
+  // Both are valid wire representations of "no parent".
+  parent_id: z.string().uuid().nullable().optional(),
   name: z.string().min(1).max(255),
   color: z.string().regex(/^#[0-9A-F]{6}$/i).optional(),
   icon: z.string().optional(),
@@ -15,7 +17,9 @@ export const FolderDecryptedSchema = z.object({
 });
 
 export const FolderEncryptedSchema = SyncableEncryptedEntitySchema.extend({
-  parent_id: z.string().uuid().optional(),
+  // Server (Prisma) returns `null` for root folders; client code uses `undefined`.
+  // Both are valid wire representations of "no parent".
+  parent_id: z.string().uuid().nullable().optional(),
   name_encrypted: z.string(),
   metadata_encrypted: z.string().optional(), // color, icon etc.
   order_index: z.number().int().min(0),

--- a/packages/types/src/schemas/entities/note.ts
+++ b/packages/types/src/schemas/entities/note.ts
@@ -15,7 +15,9 @@ export const NoteSensitiveMetadataSchema = z.object({
  */
 export const NoteDecryptedSchema = z.object({
   id: z.string().uuid(),
-  folder_id: z.string().uuid().optional(),
+  // Server (Prisma) returns `null` for root-level notes; client code uses `undefined`.
+  // Both are valid wire representations of "no folder".
+  folder_id: z.string().uuid().nullable().optional(),
   title: z.string().min(1),
   content: z.string(),
   tags: z.array(z.string()).optional(),
@@ -31,7 +33,9 @@ export const NoteDecryptedSchema = z.object({
  * Schema for encrypted note (wire format — no plaintext sensitive data)
  */
 export const NoteEncryptedSchema = SyncableEncryptedEntitySchema.extend({
-  folder_id: z.string().uuid().optional(),
+  // Server (Prisma) returns `null` for root-level notes; client code uses `undefined`.
+  // Both are valid wire representations of "no folder".
+  folder_id: z.string().uuid().nullable().optional(),
   title_encrypted: z.string().min(1),
   content_encrypted: z.string(),
   metadata_encrypted: z.string().optional(), // Contains NoteSensitiveMetadata

--- a/packages/types/src/schemas/entities/task.ts
+++ b/packages/types/src/schemas/entities/task.ts
@@ -51,7 +51,9 @@ export const TaskDecryptedSchema = z.object({
   is_starred: z.boolean(),
   is_recurring: z.boolean().optional(),
   recurrence_rule: z.string().optional(),
-  parent_task_id: z.string().uuid().optional(),
+  // Server (Prisma) returns `null` for top-level tasks; client code uses `undefined`.
+  // Both are valid wire representations of "no parent".
+  parent_task_id: z.string().uuid().nullable().optional(),
   is_template: z.boolean(),
   recurrence_base_date: z.string().nullable().optional(),
   completed_at: z.string().nullable().optional(),
@@ -75,7 +77,9 @@ export const TaskEncryptedSchema = SyncableEncryptedEntitySchema.extend({
   description_encrypted: z.string().optional(),
   metadata_encrypted: z.string(),  // Required — contains TaskSensitiveMetadata
   recurrence_rule_encrypted: z.string().optional(),
-  parent_task_id: z.string().uuid().optional(),
+  // Server (Prisma) returns `null` for top-level tasks; client code uses `undefined`.
+  // Both are valid wire representations of "no parent".
+  parent_task_id: z.string().uuid().nullable().optional(),
   is_template: BooleanIntSchema,
   position: z.number().min(0)
 });


### PR DESCRIPTION
Backups created before deleting folders + emptying trash failed to restore the deleted entries: every note/folder where Prisma had stored `null` in folder_id/parent_id (root-level items) tripped Zod 4's `optional()` rule, which only accepts `string | undefined`. Same shape was also reachable via legacy IDB writes that persisted across versions.

- Schemas: parent_id (folder), folder_id (note), parent_task_id (task) now `.nullable().optional()` — Prisma and legacy local IDB are both legal producers of null for absent FKs.
- Import: normalizeNullToUndefined() runs before safeParse for the optional-but-not-nullable fields per entity type, so freshly-imported records arrive in IDB with the canonical `undefined` shape regardless of which producer wrote the file. Applied to both v1 (plaintext envelope) and v2 (password-encrypted) backup formats — they share the post-decrypt validation loop.
- Export: null is dropped before JSON.stringify so future backups stay clean and don't propagate the pollution.
- IDB cleanup: one-shot cleanupNullFkFields() rewrites locally-stored notes/folders that hold null in optional fields. Idempotent (gated by localStorage flag) and awaited before sync push so the server doesn't see the legacy shape.
- Errors: formatZodIssues() replaces `issues[0]?.message` (which is just "Invalid input" in Zod 4 — useless for triage) with field path + every issue concatenated.
- Tests: 7 schema regression cases (null FK accepted, malformed UUID still rejected) + 10 unit tests for the helpers.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>