### PR TITLE
fix(notes): make backup import resilient to legacy/null user_id

### DIFF
--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -531,11 +531,17 @@ function stripNoteShadowIndexes(note: NoteStoredLocal): NoteEncrypted {
  *     stored e.g. `folder_id: null` would emit `"folder_id": null` in the file,
  *     and a later import (or a third-party importer) might reject the value
  *     because the schema expects `string | undefined`. See guideline 44.
+ *  3. Stamp the current account's UUID into `user_id` when the stored value
+ *     is null/missing/non-UUID. The local IDB cleanup migration repairs the
+ *     same pollution, but this is a belt-and-suspenders pass — without it,
+ *     a backup taken before the next boot's cleanup would still emit
+ *     `"user_id": null`.
  */
 function normalizeExportUuids<T extends { id: string }>(
   items: T[],
   uuidFields: string[],
-  optionalFields: readonly string[] = []
+  optionalFields: readonly string[] = [],
+  userIdReplacement?: string
 ): T[] {
   return items.map((item) => {
     let modified = false;
@@ -553,6 +559,13 @@ function normalizeExportUuids<T extends { id: string }>(
     for (const field of optionalFields) {
       if (copy[field] === null) {
         copy[field] = undefined;
+        modified = true;
+      }
+    }
+    if (userIdReplacement && UUID_RE.test(userIdReplacement)) {
+      const stored = copy.user_id;
+      if (typeof stored !== 'string' || !UUID_RE.test(stored)) {
+        copy.user_id = userIdReplacement;
         modified = true;
       }
     }
@@ -578,17 +591,21 @@ export async function exportJsonBackup(): Promise<void> {
     tagStore.getAll()
   ]);
 
+  const userId = get(authStore).userId ?? undefined;
+
   const sanitizedNotes: NoteEncrypted[] = normalizeExportUuids(
     notes.map(stripNoteShadowIndexes),
     ['id', 'user_id', 'folder_id'],
-    NOTE_OPTIONAL_FIELDS
+    NOTE_OPTIONAL_FIELDS,
+    userId
   );
   const sanitizedFolders = normalizeExportUuids(
     folders,
     ['id', 'user_id', 'parent_id'],
-    FOLDER_OPTIONAL_FIELDS
+    FOLDER_OPTIONAL_FIELDS,
+    userId
   );
-  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id'], TAG_OPTIONAL_FIELDS);
+  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id'], TAG_OPTIONAL_FIELDS, userId);
 
   const backup = {
     version: 1,
@@ -620,17 +637,21 @@ export async function exportEncryptedBackup(password: string): Promise<void> {
     tagStore.getAll()
   ]);
 
+  const userId = get(authStore).userId ?? undefined;
+
   const sanitizedNotes: NoteEncrypted[] = normalizeExportUuids(
     notes.map(stripNoteShadowIndexes),
     ['id', 'user_id', 'folder_id'],
-    NOTE_OPTIONAL_FIELDS
+    NOTE_OPTIONAL_FIELDS,
+    userId
   );
   const sanitizedFolders = normalizeExportUuids(
     folders,
     ['id', 'user_id', 'parent_id'],
-    FOLDER_OPTIONAL_FIELDS
+    FOLDER_OPTIONAL_FIELDS,
+    userId
   );
-  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id'], TAG_OPTIONAL_FIELDS);
+  const sanitizedTags = normalizeExportUuids(tags, ['id', 'user_id'], TAG_OPTIONAL_FIELDS, userId);
 
   const backup = {
     exported_at: new Date().toISOString(),
@@ -799,6 +820,14 @@ export async function importJsonBackup(
         folder as Record<string, unknown>,
         FOLDER_OPTIONAL_FIELDS
       );
+      // The current account is authoritative for `user_id`; the value carried
+      // in the file is irrelevant (we overwrite it on save anyway). Set it
+      // before validation so legacy backups with null/missing/invalid user_id
+      // — produced by older client builds or by a sync pull racing auth
+      // restoration — don't fail Zod's `z.string().uuid()` check. Same
+      // behavior on cross-account imports: ownership transfers to the
+      // importing user. See guideline 44.
+      normalized.user_id = userId;
       const { fixed: fixedFolder, repairedFields: repairedFolderFields } = fixEntityUuids(
         normalized,
         ['id', 'user_id', 'parent_id']
@@ -847,6 +876,9 @@ export async function importJsonBackup(
         tag as Record<string, unknown>,
         TAG_OPTIONAL_FIELDS
       );
+      // user_id from file is ignored — set authoritative value before
+      // validation. See folder loop above for rationale.
+      normalized.user_id = userId;
       const { fixed: fixedTag, repairedFields: repairedTagFields } = fixEntityUuids(
         normalized,
         ['id', 'user_id']
@@ -899,6 +931,9 @@ export async function importJsonBackup(
       // explicit and tolerates legacy files.
       const wireCandidate = stripUnknownNoteShadowIndexes(note) as Record<string, unknown>;
       const normalized = normalizeNullToUndefined(wireCandidate, NOTE_OPTIONAL_FIELDS);
+      // user_id from file is ignored — set authoritative value before
+      // validation. See folder loop above for rationale.
+      normalized.user_id = userId;
       const { fixed: fixedNote, repairedFields: repairedNoteFields } = fixEntityUuids(
         normalized,
         ['id', 'user_id', 'folder_id']

--- a/apps/reborn-notes/src/lib/services/idb-cleanup.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/idb-cleanup.service.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { repairUserId } from './idb-cleanup.service';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const OTHER_UUID = '11111111-2222-3333-4444-555555555555';
+
+describe('repairUserId', () => {
+  it('replaces null user_id with currentUserId', () => {
+    const input: { user_id: unknown; x: number } = { user_id: null, x: 1 };
+    const result = repairUserId(input, VALID_UUID);
+    expect(result.changed).toBe(true);
+    expect(result.cleaned.user_id).toBe(VALID_UUID);
+  });
+
+  it('replaces missing user_id with currentUserId', () => {
+    const input: { user_id?: unknown; x: number } = { x: 1 };
+    const result = repairUserId(input, VALID_UUID);
+    expect(result.changed).toBe(true);
+    expect(result.cleaned.user_id).toBe(VALID_UUID);
+  });
+
+  it('replaces empty-string user_id with currentUserId', () => {
+    const result = repairUserId({ user_id: '' }, VALID_UUID);
+    expect(result.changed).toBe(true);
+    expect(result.cleaned.user_id).toBe(VALID_UUID);
+  });
+
+  it('replaces non-UUID string user_id with currentUserId', () => {
+    const result = repairUserId({ user_id: 'not-a-uuid' }, VALID_UUID);
+    expect(result.changed).toBe(true);
+    expect(result.cleaned.user_id).toBe(VALID_UUID);
+  });
+
+  it('replaces non-string user_id (number) with currentUserId', () => {
+    const result = repairUserId({ user_id: 123 }, VALID_UUID);
+    expect(result.changed).toBe(true);
+    expect(result.cleaned.user_id).toBe(VALID_UUID);
+  });
+
+  it('keeps a valid UUID user_id even when currentUserId is different', () => {
+    // We don't transfer ownership of legacy local records that already
+    // carry a valid UUID — that would silently rewrite multi-account IDB
+    // history. Only invalid values get repaired.
+    const result = repairUserId({ user_id: OTHER_UUID }, VALID_UUID);
+    expect(result.changed).toBe(false);
+    expect(result.cleaned.user_id).toBe(OTHER_UUID);
+  });
+
+  it('does nothing when currentUserId is null (auth not ready)', () => {
+    const result = repairUserId({ user_id: null }, null);
+    expect(result.changed).toBe(false);
+    expect(result.cleaned.user_id).toBeNull();
+  });
+
+  it('does nothing when currentUserId itself is invalid', () => {
+    // Defensive: never propagate a malformed currentUserId into local data.
+    const result = repairUserId({ user_id: null }, 'not-a-uuid');
+    expect(result.changed).toBe(false);
+    expect(result.cleaned.user_id).toBeNull();
+  });
+
+  it('does not mutate the input record', () => {
+    const input = { user_id: null, title: 'x' };
+    const result = repairUserId(input, VALID_UUID);
+    expect(input.user_id).toBeNull();
+    expect(result.cleaned.user_id).toBe(VALID_UUID);
+    expect(result.cleaned).not.toBe(input);
+  });
+
+  it('preserves other fields untouched', () => {
+    const result = repairUserId(
+      { user_id: null, title: 't', folder_id: undefined, sync_version: 3 },
+      VALID_UUID
+    );
+    expect(result.cleaned).toEqual({
+      user_id: VALID_UUID,
+      title: 't',
+      folder_id: undefined,
+      sync_version: 3
+    });
+  });
+});

--- a/apps/reborn-notes/src/lib/services/idb-cleanup.service.ts
+++ b/apps/reborn-notes/src/lib/services/idb-cleanup.service.ts
@@ -8,11 +8,18 @@
  * reject affected entries with "Invalid input" once Zod 4 tightened
  * `optional()` semantics.
  *
- * Schemas now accept null and the importer normalizes inputs, but local
- * IDB still carries the pollution — every fresh export would re-emit the
- * nulls. This helper rewrites those records in place so the next backup
- * comes out clean. It is idempotent and runs at most once per browser
- * profile (gated by a localStorage flag).
+ * A subsequent regression also surfaced via `user_id`: if the auth store
+ * hadn't hydrated by the time a sync pull ran, `get(authStore).userId!`
+ * (non-null assertion) silently produced `undefined` and the local IDB
+ * record carried that value forward. Once exported, every backup repeated
+ * the pollution and import refused the entries.
+ *
+ * Schemas now accept null FKs and the importer overrides user_id from the
+ * current account, but local IDB still carries the legacy values — every
+ * fresh export would re-emit them. This helper rewrites those records in
+ * place so the next backup comes out clean. Idempotent and runs at most
+ * once per browser profile per migration version (gated by a localStorage
+ * flag with the version baked into the key).
  */
 import { noteStore, folderStore } from '@reborn/storage';
 import type { FolderEncrypted, NoteStoredLocal } from '@reborn/types';
@@ -20,7 +27,16 @@ import { createLogger } from '@reborn/utils';
 
 const logger = createLogger('IdbCleanup');
 
-const FLAG_KEY = 'reborn-notes:idb-null-fk-cleanup-v1';
+/**
+ * Bumped from v1 → v2 when user_id repair was added. v1 ran before this
+ * change and only handled null FK fields; v2 re-runs everywhere so user_id
+ * pollution gets cleaned up too. The flag for v1 is intentionally left
+ * behind — it costs nothing and avoids re-running v1 logic on profiles
+ * that already migrated.
+ */
+const FLAG_KEY = 'reborn-notes:idb-null-fk-cleanup-v2';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Optional-but-not-nullable fields that may have been written as `null`. */
 const NOTE_FIELDS_TO_CLEAN = [
@@ -44,14 +60,46 @@ function dropNullFields<T extends object>(record: T, fields: readonly string[]):
 }
 
 /**
+ * Repair `user_id` on a record if the stored value is null, undefined,
+ * empty, or anything other than a valid UUID. We only attempt repair when
+ * the caller supplies a known-good `currentUserId`. Returning the record
+ * untouched is safe — the importer will override user_id at validation
+ * time anyway. Repairing locally just stops every fresh export from
+ * propagating the legacy garbage to a new backup file.
+ *
+ * Exported for unit testing.
+ */
+export function repairUserId<T extends { user_id?: unknown }>(
+  record: T,
+  currentUserId: string | null
+): { cleaned: T; changed: boolean } {
+  const stored = record.user_id;
+  const validStored = typeof stored === 'string' && UUID_RE.test(stored);
+  if (validStored) return { cleaned: record, changed: false };
+  if (!currentUserId || !UUID_RE.test(currentUserId)) {
+    return { cleaned: record, changed: false };
+  }
+  return { cleaned: { ...record, user_id: currentUserId }, changed: true };
+}
+
+/**
  * Rewrite locally-stored notes and folders that hold `null` in
- * optional-but-not-nullable fields. Runs at most once per browser profile.
+ * optional-but-not-nullable fields, and repair `user_id` when it is
+ * missing or malformed. Runs at most once per browser profile per
+ * migration version.
  *
  * Safe to call before sync — the rewrite only touches local IDB and does
  * not change `sync_status` or `sync_version`, so it doesn't trigger an
- * unnecessary push.
+ * unnecessary push. Repaired user_id is local-only repair; the server
+ * already knows the correct user_id from the request session.
+ *
+ * @param currentUserId Current user's UUID (from authStore). When provided,
+ *   records with invalid/missing user_id are repaired in place. When null
+ *   (e.g. cleanup runs before authentication completes), the user_id pass
+ *   is skipped — the next boot will run cleanup again because the migration
+ *   flag is only set on completion.
  */
-export async function cleanupNullFkFields(): Promise<void> {
+export async function cleanupNullFkFields(currentUserId: string | null = null): Promise<void> {
   if (typeof localStorage === 'undefined') return;
   if (localStorage.getItem(FLAG_KEY)) return;
 
@@ -63,32 +111,64 @@ export async function cleanupNullFkFields(): Promise<void> {
 
     let notesCleaned = 0;
     let foldersCleaned = 0;
+    let userIdRepaired = 0;
 
     for (const note of notes) {
-      const { cleaned, changed } = dropNullFields(note, NOTE_FIELDS_TO_CLEAN);
+      let working = note;
+      let changed = false;
+      const nullPass = dropNullFields(working, NOTE_FIELDS_TO_CLEAN);
+      if (nullPass.changed) {
+        working = nullPass.cleaned;
+        changed = true;
+      }
+      const uidPass = repairUserId(working, currentUserId);
+      if (uidPass.changed) {
+        working = uidPass.cleaned;
+        changed = true;
+        userIdRepaired++;
+      }
       if (changed) {
-        await noteStore.save(cleaned);
+        await noteStore.save(working);
         notesCleaned++;
       }
     }
 
     for (const folder of folders) {
-      const { cleaned, changed } = dropNullFields(folder, FOLDER_FIELDS_TO_CLEAN);
+      let working = folder;
+      let changed = false;
+      const nullPass = dropNullFields(working, FOLDER_FIELDS_TO_CLEAN);
+      if (nullPass.changed) {
+        working = nullPass.cleaned;
+        changed = true;
+      }
+      const uidPass = repairUserId(working, currentUserId);
+      if (uidPass.changed) {
+        working = uidPass.cleaned;
+        changed = true;
+        userIdRepaired++;
+      }
       if (changed) {
-        await folderStore.save(cleaned);
+        await folderStore.save(working);
         foldersCleaned++;
       }
     }
 
-    localStorage.setItem(FLAG_KEY, new Date().toISOString());
+    // Only mark the migration done if we actually had a chance to repair
+    // user_id (i.e. caller supplied a userId). If currentUserId was null
+    // we stopped short of the user_id pass, so re-run on next boot when
+    // auth is hopefully ready.
+    if (currentUserId) {
+      localStorage.setItem(FLAG_KEY, new Date().toISOString());
+    }
     if (notesCleaned > 0 || foldersCleaned > 0) {
-      logger.info('Cleaned null FK fields from local IDB', {
+      logger.info('Cleaned local IDB', {
         notes: notesCleaned,
-        folders: foldersCleaned
+        folders: foldersCleaned,
+        userIdRepaired
       });
     }
   } catch (error) {
     // Don't block app startup — leave the flag unset so we retry next boot.
-    logger.warn('IDB null-FK cleanup failed; will retry next boot', error);
+    logger.warn('IDB cleanup failed; will retry next boot', error);
   }
 }

--- a/apps/reborn-notes/src/lib/services/import-normalize-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/import-normalize-utils.spec.ts
@@ -108,3 +108,71 @@ describe('field lists stay in sync with schema expectations', () => {
     expect(TAG_OPTIONAL_FIELDS).toContain('color_encrypted');
   });
 });
+
+describe('user_id override sequence (regression — production import failure)', () => {
+  // Production exports surfaced records with `user_id: null` (sync race) or
+  // missing user_id (legacy IDB). The importer overrides user_id with the
+  // current account's id on save, so we set it BEFORE safeParse — value
+  // from the file is unused. These tests pin the contract that the schema
+  // accepts the prepared input regardless of what shape user_id had.
+  const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+  const VALID_UUID_2 = '11111111-2222-4333-8444-555555555555';
+  const NOTE_BASE = {
+    id: VALID_UUID_2,
+    title_encrypted: 'iv:cipher',
+    content_encrypted: 'iv:cipher',
+    sync_version: 0,
+    sync_status: 'synced' as const,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z'
+  };
+
+  function prepare(raw: Record<string, unknown>, userId: string): Record<string, unknown> {
+    // Mirrors the pre-validation pipeline used in export-import.service.ts:
+    //   normalizeNullToUndefined → set user_id → safeParse
+    const out = normalizeNullToUndefined(raw, NOTE_OPTIONAL_FIELDS);
+    out.user_id = userId;
+    return out;
+  }
+
+  it('accepts a backup record with user_id=null after the override', () => {
+    const prepared = prepare({ ...NOTE_BASE, user_id: null }, VALID_UUID);
+    const result = z
+      .object({
+        id: z.string().uuid(),
+        user_id: z.string().uuid()
+      })
+      .safeParse(prepared);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.user_id).toBe(VALID_UUID);
+  });
+
+  it('accepts a backup record with user_id missing after the override', () => {
+    const prepared = prepare({ ...NOTE_BASE }, VALID_UUID);
+    const result = z
+      .object({ user_id: z.string().uuid() })
+      .safeParse(prepared);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a backup record with non-UUID user_id (e.g. empty string) after the override', () => {
+    const prepared = prepare({ ...NOTE_BASE, user_id: '' }, VALID_UUID);
+    const result = z
+      .object({ user_id: z.string().uuid() })
+      .safeParse(prepared);
+    expect(result.success).toBe(true);
+  });
+
+  it('without the override, the schema still rejects user_id=null (pre-fix behavior)', () => {
+    // Sanity: confirm we are testing a real previously-broken case. If this
+    // ever flips to `success: true` it means someone relaxed the schema —
+    // the importer override should be the only thing accepting bad user_id,
+    // not the validator itself.
+    const onlyNormalized = normalizeNullToUndefined(
+      { ...NOTE_BASE, user_id: null },
+      NOTE_OPTIONAL_FIELDS
+    );
+    const result = z.object({ user_id: z.string().uuid() }).safeParse(onlyNormalized);
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -306,4 +306,127 @@ describe('notes-sync — regression (offline data loss)', () => {
     expect(importFolder).not.toMatch(/\bpushTag\s*\(/);
     expect(importFolder).toMatch(/pushPendingItems\s*\(/);
   });
+
+  // ── user_id resilience (regression: production imports failing with
+  //    "user_id: Invalid input" because legacy IDB / sync race wrote null)
+  it('importJsonBackup overrides user_id BEFORE safeParse in folder/tag/note loops', () => {
+    // The schema requires user_id to be a UUID; the importer always
+    // overwrites it with the current account's userId on save. Setting it
+    // before validation (instead of after) makes legacy backups with
+    // null/missing/invalid user_id pass — the value from the file is dead
+    // weight we don't use. See guideline 44.
+    const src = readSource('./export-import.service.ts');
+
+    const folderLoopStart = src.indexOf("for (const folder of backupData.folders");
+    const folderSafeParseIdx = src.indexOf('FolderEncryptedSchema.safeParse', folderLoopStart);
+    expect(folderSafeParseIdx).toBeGreaterThan(folderLoopStart);
+    const folderPreValidate = src.slice(folderLoopStart, folderSafeParseIdx);
+    expect(folderPreValidate).toMatch(/normalized\.user_id\s*=\s*userId/);
+
+    const tagLoopStart = src.indexOf("for (const tag of backupData.tags");
+    const tagSafeParseIdx = src.indexOf('TagEncryptedSchema.safeParse', tagLoopStart);
+    expect(tagSafeParseIdx).toBeGreaterThan(tagLoopStart);
+    const tagPreValidate = src.slice(tagLoopStart, tagSafeParseIdx);
+    expect(tagPreValidate).toMatch(/normalized\.user_id\s*=\s*userId/);
+
+    const noteLoopStart = src.indexOf('for (let i = 0; i < notes.length; i++)');
+    const noteSafeParseIdx = src.indexOf('NoteEncryptedSchema.safeParse', noteLoopStart);
+    expect(noteSafeParseIdx).toBeGreaterThan(noteLoopStart);
+    const notePreValidate = src.slice(noteLoopStart, noteSafeParseIdx);
+    expect(notePreValidate).toMatch(/normalized\.user_id\s*=\s*userId/);
+  });
+
+  it('pull helpers capture userId once at the top instead of `userId!` in each save', () => {
+    // Non-null assertions on `get(authStore).userId` silently produced
+    // `undefined` when sync raced auth hydration / logout, polluting the
+    // local user_id. The guard returns early if userId isn't present and
+    // every save uses the captured value. See guideline 44.
+    const src = readSource('./notes-sync.service.ts');
+
+    for (const fnName of ['pullFolders', 'pullTags', 'pullNotes']) {
+      const start = src.indexOf(`async function ${fnName}`);
+      expect(start, `${fnName} not found`).toBeGreaterThan(-1);
+      // Bound the function body — stop at the next top-level `async function`
+      // or the push-helpers section header.
+      const after = src.slice(start);
+      const nextFnIdx = after.indexOf('\nasync function ', 1);
+      const sectionEndIdx = after.indexOf('// ── Push helpers');
+      const candidates = [nextFnIdx, sectionEndIdx].filter((i) => i > 0);
+      const end = candidates.length > 0 ? Math.min(...candidates) : after.length;
+      const body = after.slice(0, end);
+
+      // userId is captured at the top.
+      expect(body, `${fnName} must capture userId at top`).toMatch(
+        /const\s+userId\s*=\s*get\(authStore\)\.userId/
+      );
+      // Bail out when userId is absent.
+      expect(body, `${fnName} must early-return on missing userId`).toMatch(
+        /if\s*\(\s*!userId\s*\)\s*return\s*;/
+      );
+      // No more non-null assertions on authStore.userId inside the body.
+      expect(body, `${fnName} must not use \`get(authStore).userId!\``).not.toMatch(
+        /get\(authStore\)\.userId!/
+      );
+    }
+  });
+
+  it('cleanup migration is awaited before pull and receives the current userId', () => {
+    const src = readSource('../../routes/+layout.svelte');
+    expect(src).toMatch(/await\s+cleanupNullFkFields\s*\(\s*get\(authStore\)\.userId\s*\)/);
+    // The flag was bumped to v2 to re-run the cleanup with user_id repair
+    // included. Ensure we never silently re-use the v1 flag.
+    const cleanupSrc = readSource('./idb-cleanup.service.ts');
+    expect(cleanupSrc).toMatch(/idb-null-fk-cleanup-v2/);
+    expect(cleanupSrc).not.toMatch(/^const\s+FLAG_KEY\s*=\s*'reborn-notes:idb-null-fk-cleanup-v1'/m);
+  });
+
+  it('export sanitizer stamps current userId into records with invalid user_id', () => {
+    // normalizeExportUuids gets a userIdReplacement parameter; both
+    // exportJsonBackup and exportEncryptedBackup must pass the current
+    // account's userId so legacy IDB pollution (user_id: null/missing)
+    // doesn't propagate into freshly-emitted backup files.
+    const src = readSource('./export-import.service.ts');
+    expect(src).toMatch(
+      /function\s+normalizeExportUuids[\s\S]{0,300}?userIdReplacement\?:\s*string/
+    );
+
+    const fullExport = src.slice(
+      src.indexOf('export async function exportJsonBackup'),
+      src.indexOf('export async function exportEncryptedBackup')
+    );
+    expect(fullExport).toMatch(/get\(authStore\)\.userId/);
+    // All three normalize calls in this function must thread userId through.
+    expect(fullExport.match(/normalizeExportUuids\s*\(/g)?.length).toBe(3);
+    // Walk each call manually with paren-balancing so nested calls in the
+    // first argument (e.g. `notes.map(stripNoteShadowIndexes)`) don't fool
+    // a naive `slice(0, indexOf(')'))`.
+    function* eachCall(text: string, fnName: string): Generator<string> {
+      const re = new RegExp(`${fnName}\\s*\\(`, 'g');
+      let match: RegExpExecArray | null;
+      while ((match = re.exec(text)) !== null) {
+        let depth = 1;
+        let i = match.index + match[0].length;
+        while (i < text.length && depth > 0) {
+          const ch = text[i];
+          if (ch === '(') depth++;
+          else if (ch === ')') depth--;
+          i++;
+        }
+        yield text.slice(match.index + match[0].length, i - 1);
+      }
+    }
+    for (const argList of eachCall(fullExport, 'normalizeExportUuids')) {
+      expect(argList, `normalizeExportUuids call must thread userId: ${argList}`).toMatch(
+        /userId/
+      );
+    }
+
+    const encExport = src.slice(src.indexOf('export async function exportEncryptedBackup'));
+    expect(encExport).toMatch(/get\(authStore\)\.userId/);
+    for (const argList of eachCall(encExport, 'normalizeExportUuids')) {
+      expect(argList, `normalizeExportUuids call must thread userId: ${argList}`).toMatch(
+        /userId/
+      );
+    }
+  });
 });

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -191,6 +191,14 @@ export async function pullFromServer(): Promise<boolean> {
 }
 
 async function pullFolders(): Promise<void> {
+  // Capture userId once at the top. Without this guard, a logout (or auth
+  // store hydration race) mid-pull would let a non-null assertion on the
+  // store's userId evaluate to undefined further down — silently writing
+  // user_id=undefined to IDB, which then propagates to every fresh export
+  // and trips the import validator for that account. See guideline 44 +
+  // `idb-cleanup.service.ts`.
+  const userId = get(authStore).userId;
+  if (!userId) return;
   const res = await authFetch(`${PUBLIC_BASE_PATH}/api/folders`);
   if (!res.ok) throw new Error(`GET /api/folders: ${res.status}`);
   const { data } = await res.json();
@@ -234,7 +242,7 @@ async function pullFolders(): Promise<void> {
 
       const folder: FolderEncrypted = {
         id: f.id,
-        user_id: get(authStore).userId!,
+        user_id: userId,
         parent_id: f.parent_id ?? undefined,
         name_encrypted: f.name_encrypted,
         order_index: f.order_index,
@@ -262,6 +270,9 @@ async function pullFolders(): Promise<void> {
 }
 
 async function pullTags(): Promise<void> {
+  // See pullFolders() for rationale on the userId guard.
+  const userId = get(authStore).userId;
+  if (!userId) return;
   const res = await authFetch(`${PUBLIC_BASE_PATH}/api/tags`);
   if (!res.ok) throw new Error(`GET /api/tags: ${res.status}`);
   const { data } = await res.json();
@@ -301,7 +312,7 @@ async function pullTags(): Promise<void> {
 
       await tagStore.save({
         id: t.id,
-        user_id: get(authStore).userId!,
+        user_id: userId,
         name_encrypted: t.name_encrypted,
         color_encrypted: t.color_encrypted ?? undefined,
         usage_count: localTag?.usage_count ?? 0,
@@ -326,6 +337,9 @@ async function pullTags(): Promise<void> {
 }
 
 async function pullNotes(): Promise<void> {
+  // See pullFolders() for rationale on the userId guard.
+  const userId = get(authStore).userId;
+  if (!userId) return;
   const res = await authFetch(`${PUBLIC_BASE_PATH}/api/notes?include_archived=true`);
   if (!res.ok) throw new Error(`GET /api/notes: ${res.status}`);
   const { data } = await res.json();
@@ -415,7 +429,7 @@ async function pullNotes(): Promise<void> {
 
       const note: NoteStoredLocal = {
         id: n.id,
-        user_id: get(authStore).userId!,
+        user_id: userId,
         folder_id: n.folder_id ?? undefined,
         title_encrypted: n.title_encrypted,
         content_encrypted: n.content_encrypted,

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import '../app.css';
   import { onMount, untrack } from 'svelte';
+  import { get } from 'svelte/store';
   import { Toaster } from '@reborn/ui';
   import { browser } from '$app/environment';
   import type { Snippet } from 'svelte';
@@ -117,15 +118,19 @@
         }
       }
 
-      // 2a. One-shot cleanup of legacy null FK fields in IDB. Idempotent and
-      //     gated by a localStorage flag — runs only once per browser profile,
-      //     no-op afterwards. Awaited so it completes before sync touches the
-      //     same records. Bounded by local IDB size (typically <1s).
-      await cleanupNullFkFields();
-
-      // 3. Initialize SSO auth state AFTER storage is ready
-      //    (reads shared localStorage from reborn-task if same origin)
+      // 2a. Initialize SSO auth state AFTER storage is ready and BEFORE the
+      //     cleanup migration — cleanup repairs malformed user_id in legacy
+      //     local records, which needs the current account's UUID.
+      //     (reads shared localStorage from reborn-task if same origin)
       authStore.initialize();
+
+      // 2b. One-shot cleanup of legacy null FK fields + malformed user_id in
+      //     IDB. Idempotent and gated by a versioned localStorage flag — runs
+      //     once per browser profile per migration version. Awaited so it
+      //     completes before sync touches the same records. Bounded by local
+      //     IDB size (typically <1s). Re-runs on next boot if user_id repair
+      //     was skipped because auth wasn't ready.
+      await cleanupNullFkFields(get(authStore).userId);
 
       // 4. Mark app as ready — unblocks auth guard $effect
       appReady = true;

--- a/apps/reborn-task/src/lib/services/data-import.regression.spec.ts
+++ b/apps/reborn-task/src/lib/services/data-import.regression.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression: production exports occasionally carried `user_id: null` (or a
+ * missing user_id) due to legacy IDB writes / sync racing auth restoration.
+ * The importer overwrites user_id with the current account's id on save —
+ * validating the file value first is dead weight. The fix sets user_id
+ * BEFORE `safeParse` so legacy backups get accepted. Mirrors the same fix
+ * in reborn-notes (`export-import.service.ts`). See guideline 44.
+ */
+function readSource(relative: string): string {
+	return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+describe('reborn-task data-import — user_id resilience (regression)', () => {
+	it('exposes a withUserId helper that sets user_id on record inputs', () => {
+		const src = readSource('./data-import.service.ts');
+		expect(src).toMatch(/function\s+withUserId\s*\(\s*raw:\s*unknown\s*,\s*userId:\s*string\s*\)/);
+		// Returns a fresh record with user_id stamped in.
+		expect(src).toMatch(/user_id:\s*userId/);
+	});
+
+	it('encrypted import wraps each entity through withUserId before safeParse', () => {
+		const src = readSource('./data-import.service.ts');
+		const encStart = src.indexOf('private async importEncrypted');
+		const encEnd = src.indexOf('private async importDecrypted');
+		expect(encStart).toBeGreaterThan(-1);
+		expect(encEnd).toBeGreaterThan(encStart);
+		const enc = src.slice(encStart, encEnd);
+
+		// Three loops (lists, tasks, subtasks). Each must thread withUserId
+		// through whatever pre-processing it does, BEFORE safeParse runs.
+		const safeParseLines = enc.match(/safeParse\(/g) ?? [];
+		expect(safeParseLines.length).toBe(3);
+
+		// List loop: withUserId wraps the normalizeNullToUndefined output.
+		expect(enc).toMatch(
+			/withUserId\s*\(\s*\n?\s*normalizeNullToUndefined\s*\([\s\S]*?\)\s*,\s*userId\s*\)/
+		);
+		// Task loop: withUserId wraps normalizeTaskToWire(rawTask).
+		expect(enc).toMatch(/withUserId\s*\(\s*this\.normalizeTaskToWire\s*\(\s*rawTask\s*\)\s*,\s*userId\s*\)/);
+		// Subtask loop: same wrap.
+		expect(enc).toMatch(
+			/withUserId\s*\(\s*this\.normalizeSubtaskToWire\s*\(\s*rawSubtask\s*\)\s*,\s*userId\s*\)/
+		);
+	});
+});

--- a/apps/reborn-task/src/lib/services/data-import.service.ts
+++ b/apps/reborn-task/src/lib/services/data-import.service.ts
@@ -54,6 +54,22 @@ const TASK_OPTIONAL_FIELDS = [
 const SUBTASK_OPTIONAL_FIELDS = ['metadata_encrypted', 'device_id'] as const;
 
 /**
+ * The current account is authoritative for `user_id`; the value carried in the
+ * file is irrelevant (we overwrite it on save anyway). Setting it before
+ * `safeParse` lets legacy backups with null/missing/invalid user_id — produced
+ * by older client builds or by a sync pull racing auth restoration — pass
+ * Zod's `z.string().uuid()` check. Same behavior on cross-account imports:
+ * ownership transfers to the importing user. See guideline 44.
+ *
+ * Returns the input unchanged for non-record inputs; the subsequent
+ * `safeParse` will reject those with its own type error.
+ */
+function withUserId(raw: unknown, userId: string): unknown {
+	if (typeof raw !== 'object' || raw === null) return raw;
+	return { ...(raw as Record<string, unknown>), user_id: userId };
+}
+
+/**
  * Format a Zod safeParse failure into a single human-readable message.
  * `issues[0]?.message` on its own returns "Invalid input" with no field
  * context — useless for triage. Concatenating path + message per issue
@@ -153,9 +169,12 @@ export class DataImportService {
 
 		for (const list of exportData.data.lists) {
 			try {
-				const normalized = normalizeNullToUndefined(
-					list as unknown as Record<string, unknown>,
-					LIST_OPTIONAL_FIELDS
+				const normalized = withUserId(
+					normalizeNullToUndefined(
+						list as unknown as Record<string, unknown>,
+						LIST_OPTIONAL_FIELDS
+					),
+					userId
 				);
 				const parsed = schemas.ListEncryptedSchema.safeParse(normalized);
 				if (!parsed.success) {
@@ -192,7 +211,7 @@ export class DataImportService {
 				// Normalize legacy v1.0 fields (boolean is_template, shadow indexes)
 				// to wire-format before validation. Both stripped shadow indexes
 				// and is_template normalized to 0|1 for TaskEncryptedSchema.
-				const wireCandidate = this.normalizeTaskToWire(rawTask);
+				const wireCandidate = withUserId(this.normalizeTaskToWire(rawTask), userId);
 				const parsed = schemas.TaskEncryptedSchema.safeParse(wireCandidate);
 				if (!parsed.success) {
 					result.errors.push(
@@ -235,7 +254,7 @@ export class DataImportService {
 		for (const rawSubtask of exportData.data.subtasks) {
 			try {
 				// Strip legacy shadow index before validating against wire schema.
-				const wireCandidate = this.normalizeSubtaskToWire(rawSubtask);
+				const wireCandidate = withUserId(this.normalizeSubtaskToWire(rawSubtask), userId);
 				const parsed = schemas.SubtaskEncryptedSchema.safeParse(wireCandidate);
 				if (!parsed.success) {
 					result.errors.push(


### PR DESCRIPTION
Production exports surfaced records the importer rejected with "user_id: Invalid input". Better Zod 4 error formatting from #120 made the failing field visible — local IDB on production accounts carried records where user_id was null (or missing entirely) and the schema's strict z.string().uuid() refused to validate them.

Two stacked sources of pollution:

1. Sync pull race. pullFolders/pullTags/pullNotes did `user_id: get(authStore).userId!` with a non-null assertion; if a pull ran before auth-store hydration completed (PWA cold start, service worker restart) the assertion silently produced undefined, IDB stored undefined, JSON.stringify emitted null on next export.
2. Older client builds wrote `user_id: ''` as an "API will fill it in" placeholder; if the API call failed mid-flow, the empty string stuck around and propagated through every subsequent backup.

The importer always overwrites user_id with the current account's id on save anyway, so validating the file value was pure dead-code verification. Setting it BEFORE safeParse makes legacy backups pass without weakening the schema (it stays strict for every other code path: API push, server validation, etc.).

Changes:

- Importer (notes + task): override user_id with the current userId before safeParse. Notes does it inline in folder/tag/note loops; task uses a small `withUserId` helper that handles the wire pre-processor wrapper.
- IDB cleanup migration: extended to repair user_id when stored value is null/missing/empty/non-UUID. Flag bumped v1 → v2 so it re-runs everywhere. Gated on currentUserId being a valid UUID itself — never propagates a malformed userId into local data. The flag is only set after a run that actually had a chance to do the user_id pass; if auth wasn't ready we re-run on next boot.
- Layout init order: storage → auth.initialize() → cleanup → sync, so cleanup sees the userId from the auth store.
- Sync pull guard: pullFolders/pullTags/pullNotes capture userId once at the top and bail early if it's missing. All `userId!` non-null assertions in their bodies are gone.
- Export sanitizer: normalizeExportUuids takes a userIdReplacement parameter; when a record's user_id is invalid, the current account's id is stamped in before JSON.stringify. Belt-and- suspenders against an export that fires before the cleanup runs.

Tests:

- 9 unit tests for repairUserId (null/missing/empty/non-UUID input, gating on valid currentUserId, no-mutation, valid UUIDs preserved even cross-account).
- 4 source-level regression tests in notes-sync.regression.spec.ts (importer override before safeParse, pull guard pattern in all three pull helpers, cleanup wired with userId in layout, export sanitizer threading userId through every normalize call).
- 4 behavior tests in import-normalize-utils.spec.ts exercising the full pipeline (normalize → set user_id → safeParse) for null / missing / empty-string / non-UUID inputs, plus a sanity test that the schema still rejects bad user_id without the override.
- 2 regression tests in reborn-task data-import.regression.spec.ts for the withUserId helper threading.

The schema (z.string().uuid() on user_id) is intentionally NOT relaxed — only the importer ignores the file value. Other code paths that validate against SyncableEncryptedEntitySchema still enforce a real UUID.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>