### PR TITLE
fix(notes): defer all imports to pushPendingItems to satisfy folder FK

### DIFF
--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -44,7 +44,7 @@ import { createLogger } from '@reborn/utils';
 import * as NoteService from './note.service';
 import * as FolderService from './folder.service';
 import * as TagService from './tag.service';
-import { pushNote, pushFolder, pushTag, pushPendingItems } from './notes-sync.service';
+import { pushNote, pushPendingItems } from './notes-sync.service';
 import { noteIndex } from './note-index.svelte';
 import {
   parseMarkdownFile,
@@ -860,7 +860,14 @@ export async function importJsonBackup(
         updated_at: now
       };
       await folderStore.save(toSave);
-      pushFolder(toSave);
+      // Push is deferred to pushPendingItems() at the end of the import.
+      // Firing per-element pushes here would race against the parallel note
+      // pushes below — the server's POST /api/notes FK-checks folder_id
+      // and 404s when a note's parent folder hasn't landed yet. The end-of-
+      // import pushPendingItems() runs `Promise.allSettled([folders + tags])
+      // → Promise.allSettled(notes)` so the FK relationship is satisfied
+      // before any note POST fires. See guideline 44 + the regression test
+      // "importJsonBackup defers all pushes to pushPendingItems".
       result.folders++;
       restoredOrCreatedFolderIds.add(validated.id);
       if (restoring) result.restoredFromTrash++;
@@ -905,7 +912,7 @@ export async function importJsonBackup(
         updated_at: now
       };
       await tagStore.save(toSave);
-      pushTag(toSave);
+      // Push deferred to pushPendingItems() — see folder loop above.
       result.tags++;
     } catch (e: unknown) {
       result.errors.push(`Tag ${tag.id}: ${e instanceof Error ? e.message : 'błąd'}`);
@@ -983,8 +990,7 @@ export async function importJsonBackup(
           updated_at: now
         };
         await noteStore.save(toSave);
-        const wireForPush = stripNoteShadowIndexes(toSave);
-        pushNote(wireForPush);
+        // Push deferred to pushPendingItems() — see folder loop above.
         result.relinkedToFolder++;
         continue;
       }
@@ -1071,7 +1077,7 @@ export async function importJsonBackup(
         ]);
       }
 
-      pushNote(wire);
+      // Push deferred to pushPendingItems() — see folder loop above.
       result.notes++;
       if (restoring) result.restoredFromTrash++;
     } catch (e: unknown) {
@@ -1116,7 +1122,13 @@ export async function importJsonBackup(
   }
   onProgress?.({ phase: 'indexing', current: 1, total: 1 });
 
-  // Trigger background sync for any items that didn't get pushed inline
+  // Push every imported entity through one ordered batch. pushPendingItems()
+  // uses buildFolderLayers (BFS by parent depth) and runs
+  //   Promise.allSettled([folders + tags]) → Promise.allSettled(notes)
+  // so the server's POST /api/notes FK check on `folder_id` always sees the
+  // parent folder by the time a note POST fires. Per-loop fire-and-forget
+  // pushes raced against this — see fix(notes): import-push-ordering and
+  // guideline 44.
   void pushPendingItems();
 
   logger.info('Import complete', {

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -276,6 +276,32 @@ describe('notes-sync — regression (offline data loss)', () => {
     expect(between).toMatch(/await\s+Promise\.allSettled/);
   });
 
+  it('importJsonBackup defers all pushes to pushPendingItems (ordering)', () => {
+    // Production reproduction: backup with 7 folders + 85 notes triggered ~25
+    // simultaneous "POST /api/notes 404 Folder not found" errors during import
+    // because per-loop fire-and-forget pushFolder/pushNote raced — notes POST
+    // reached the server before their parent folder POST completed, the
+    // server's FK check missed the folder, and 404 came back. pushPendingItems
+    // already runs `Promise.allSettled([folders + tags]) → Promise.allSettled
+    // (notes)` so it's the safe single push path. Mirrors the importFolder
+    // fix below.
+    const src = readSource('./export-import.service.ts');
+
+    const importStart = src.indexOf('export async function importJsonBackup');
+    const importEnd = src.indexOf('\n/**', importStart);
+    expect(importStart).toBeGreaterThan(-1);
+    expect(importEnd).toBeGreaterThan(importStart);
+    const importBody = src.slice(importStart, importEnd);
+
+    // No per-element pushFolder/pushTag/pushNote in importJsonBackup — all
+    // imports save with sync_status='pending' and rely on pushPendingItems.
+    expect(importBody).not.toMatch(/\bpushFolder\s*\(/);
+    expect(importBody).not.toMatch(/\bpushTag\s*\(/);
+    expect(importBody).not.toMatch(/\bpushNote\s*\(/);
+    // pushPendingItems must still fire at the tail.
+    expect(importBody).toMatch(/pushPendingItems\s*\(/);
+  });
+
   it('importFolder bulk-pushes via pushPendingItems, not per-note pushNote', () => {
     // Without ordering, notes POST before their just-created folders land,
     // and the server's folder_id FK check returns 404. The fix routes every


### PR DESCRIPTION
Production import of an 85-note / 7-folder backup logged ~25 simultaneous "POST /api/notes 404 Not Found" errors during the import phase. The server's POST /api/notes FK-checks `folder_id` against the user's folder table and returns 404 ("Folder not found") when the parent isn't there yet — that's exactly what happened: per-loop fire-and-forget pushes raced between entity types. pushFolder() POST and pushNote() POST started roughly together, the note request reached the server first, the folder hadn't been written yet, FK check missed, 404.

The retry path eventually papered over it (pushPendingItems on the tail runs `Promise.allSettled([folders + tags]) → Promise.allSettled(notes)` via buildFolderLayers, so notes ultimately landed), but the noisy 404s during import look like real failures and slow the path to consistency.

The fix mirrors what importFolder() (Obsidian vault) already does — and already has a regression test for. importJsonBackup now saves every imported entity to IDB with sync_status='pending' and lets the existing end-of-import pushPendingItems() do the ordered push as the single push path:

- Drop pushFolder/pushTag/pushNote calls from the three loops + the relinking branch in importJsonBackup.
- Remove pushFolder/pushTag from the import statement (no longer used in this file). pushNote stays — importMarkdownFiles still calls it for single .md imports, where there's no folder being created in parallel and the FK race doesn't apply.
- Update the end-of-import comment to call out the FK ordering guarantee and reference the regression test.
- New regression test "importJsonBackup defers all pushes to pushPendingItems": asserts no push{Folder,Tag,Note} appears in the importJsonBackup body and that pushPendingItems still fires at the tail.

importMarkdownFiles is unchanged — single .md imports target an existing (or undefined/root) folder, so there's no parallel folder push to race against. importFolder is also unchanged — it already follows this pattern.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>