### PR TITLE
fix(notes): make folder and tag DELETE endpoints idempotent

### DIFF
--- a/apps/reborn-notes/src/routes/api/folders/[id]/+server.ts
+++ b/apps/reborn-notes/src/routes/api/folders/[id]/+server.ts
@@ -66,14 +66,30 @@ export const PATCH: RequestHandler = async ({ request, params }) => {
   }
 };
 
-/** DELETE /api/folders/[id] — delete folder and cascade to children. */
+/**
+ * DELETE /api/folders/[id] — delete folder and cascade to children.
+ *
+ * Idempotent: if the folder does not exist (or belongs to another user) we
+ * return 200 with `success: true` instead of 404. The client treats folder
+ * deletes as fire-and-forget with a short 4-attempt retry window
+ * (see `pushFolderDelete` in `notes-sync.service.ts`). A 404 — e.g. when the
+ * folder was never synced because an earlier `pushFolder` was abandoned, or
+ * the row was already removed by an earlier successful DELETE the client did
+ * not record — would be retried 4× and then dropped permanently, even though
+ * the desired end state (folder absent server-side) already holds. Returning
+ * 200 on a missing row keeps the server view authoritative without leaking
+ * existence: an unauthorised caller cannot distinguish "folder absent" from
+ * "folder belongs to someone else".
+ */
 export const DELETE: RequestHandler = async ({ request, params }) => {
   try {
     const userId = await getUserFromToken(request.headers.get('authorization'));
     if (!userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
+    // Ownership-scoped lookup. If the row is missing OR owned by a different
+    // user, treat as a no-op success — same shape as DELETE /api/notes/[id].
     const existing = await prisma.folder.findFirst({ where: { id: params.id, user_id: userId } });
-    if (!existing) return json({ success: false, error: 'Not found' }, { status: 404 });
+    if (!existing) return json({ success: true });
 
     // Prisma cascade (onDelete: Cascade) handles child folders and notes
     await prisma.folder.delete({ where: { id: params.id } });

--- a/apps/reborn-notes/src/routes/api/folders/[id]/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/folders/[id]/server.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  folder: {
+    findFirst: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn()
+  }
+};
+
+vi.mock('@reborn/database', () => ({ prisma: mockPrisma }));
+
+const mockGetUserFromToken = vi.fn();
+vi.mock('$lib/server/auth', () => ({
+  getUserFromToken: (...args: unknown[]) => mockGetUserFromToken(...args)
+}));
+
+vi.mock('@reborn/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+}));
+
+vi.mock('@reborn/types', () => ({
+  validateBody: vi.fn(),
+  schemas: { UpdateFolderRequestSchema: {} }
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const FOLDER_ID = '4591259b-5201-4c5a-b174-6d73a71049b8';
+
+function createDeleteEvent(folderId: string) {
+  return {
+    request: new Request(`http://localhost/api/folders/${folderId}`, {
+      method: 'DELETE',
+      headers: { authorization: 'Bearer mock-token' }
+    }),
+    params: { id: folderId }
+  };
+}
+
+async function callDelete(folderId: string) {
+  const { DELETE } = await import('./+server');
+  const event = createDeleteEvent(folderId);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response = await (DELETE as any)(event);
+  const data = await response.json();
+  return { status: response.status, data };
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserFromToken.mockResolvedValue(USER_ID);
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('DELETE /api/folders/[id] (idempotency)', () => {
+  // (a) Existing folder → 200 + actual delete
+  it('deletes an existing folder owned by the caller', async () => {
+    mockPrisma.folder.findFirst.mockResolvedValue({ id: FOLDER_ID, user_id: USER_ID });
+    mockPrisma.folder.delete.mockResolvedValue({});
+
+    const { status, data } = await callDelete(FOLDER_ID);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockPrisma.folder.findFirst).toHaveBeenCalledWith({
+      where: { id: FOLDER_ID, user_id: USER_ID }
+    });
+    expect(mockPrisma.folder.delete).toHaveBeenCalledWith({ where: { id: FOLDER_ID } });
+  });
+
+  // (b) Folder absent server-side → 200, no delete attempted (idempotent no-op)
+  // This is the regression case: client-side `pushFolderDelete` would otherwise
+  // burn its 4-attempt retry window on a folder that was never synced or was
+  // already removed.
+  it('returns 200 (no-op) when the folder does not exist', async () => {
+    mockPrisma.folder.findFirst.mockResolvedValue(null);
+
+    const { status, data } = await callDelete(FOLDER_ID);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockPrisma.folder.delete).not.toHaveBeenCalled();
+  });
+
+  // (c) Folder owned by a different user → 200, but no delete (no existence leak)
+  it('returns 200 (no-op) for a folder owned by another user, without deleting it', async () => {
+    // findFirst is scoped by user_id, so foreign rows look identical to absent rows.
+    mockPrisma.folder.findFirst.mockResolvedValue(null);
+
+    const { status, data } = await callDelete(FOLDER_ID);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockPrisma.folder.findFirst).toHaveBeenCalledWith({
+      where: { id: FOLDER_ID, user_id: USER_ID }
+    });
+    expect(mockPrisma.folder.delete).not.toHaveBeenCalled();
+  });
+
+  // (d) No auth → 401 (unchanged behavior)
+  it('returns 401 when the caller is unauthenticated', async () => {
+    mockGetUserFromToken.mockResolvedValue(null);
+
+    const { status, data } = await callDelete(FOLDER_ID);
+
+    expect(status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(mockPrisma.folder.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.folder.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/reborn-notes/src/routes/api/tags/[id]/+server.ts
+++ b/apps/reborn-notes/src/routes/api/tags/[id]/+server.ts
@@ -49,14 +49,23 @@ export const PATCH: RequestHandler = async ({ request, params }) => {
   }
 };
 
-/** DELETE /api/tags/[id] — delete tag and all its note associations. */
+/**
+ * DELETE /api/tags/[id] — delete tag and all its note associations.
+ *
+ * Idempotent: missing tag returns 200 instead of 404. Same rationale as
+ * `DELETE /api/folders/[id]` — `pushTagDelete` is fire-and-forget with a
+ * 4-attempt retry budget, and a 404 on a tag that was never synced (or was
+ * already removed) would burn that budget for nothing. Ownership check still
+ * applies; a tag owned by another user is also treated as no-op success so
+ * we don't leak existence.
+ */
 export const DELETE: RequestHandler = async ({ request, params }) => {
   try {
     const userId = await getUserFromToken(request.headers.get('authorization'));
     if (!userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
     const existing = await prisma.tag.findFirst({ where: { id: params.id, user_id: userId } });
-    if (!existing) return json({ success: false, error: 'Not found' }, { status: 404 });
+    if (!existing) return json({ success: true });
 
     // Tag-note associations are in metadata_encrypted (client-side) — no server-side join table
     await prisma.tag.delete({ where: { id: params.id } });

--- a/apps/reborn-notes/src/routes/api/tags/[id]/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/tags/[id]/server.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  tag: {
+    findFirst: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn()
+  }
+};
+
+vi.mock('@reborn/database', () => ({ prisma: mockPrisma }));
+
+const mockGetUserFromToken = vi.fn();
+vi.mock('$lib/server/auth', () => ({
+  getUserFromToken: (...args: unknown[]) => mockGetUserFromToken(...args)
+}));
+
+vi.mock('@reborn/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+}));
+
+vi.mock('@reborn/types', () => ({
+  validateBody: vi.fn(),
+  schemas: { UpdateTagRequestSchema: {} }
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const TAG_ID = 'b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e';
+
+function createDeleteEvent(tagId: string) {
+  return {
+    request: new Request(`http://localhost/api/tags/${tagId}`, {
+      method: 'DELETE',
+      headers: { authorization: 'Bearer mock-token' }
+    }),
+    params: { id: tagId }
+  };
+}
+
+async function callDelete(tagId: string) {
+  const { DELETE } = await import('./+server');
+  const event = createDeleteEvent(tagId);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response = await (DELETE as any)(event);
+  const data = await response.json();
+  return { status: response.status, data };
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserFromToken.mockResolvedValue(USER_ID);
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('DELETE /api/tags/[id] (idempotency)', () => {
+  // (a) Existing tag → 200 + actual delete
+  it('deletes an existing tag owned by the caller', async () => {
+    mockPrisma.tag.findFirst.mockResolvedValue({ id: TAG_ID, user_id: USER_ID });
+    mockPrisma.tag.delete.mockResolvedValue({});
+
+    const { status, data } = await callDelete(TAG_ID);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockPrisma.tag.findFirst).toHaveBeenCalledWith({
+      where: { id: TAG_ID, user_id: USER_ID }
+    });
+    expect(mockPrisma.tag.delete).toHaveBeenCalledWith({ where: { id: TAG_ID } });
+  });
+
+  // (b) Tag absent server-side → 200, no delete attempted (idempotent no-op).
+  // Same regression class as folder DELETE: avoids burning the fire-and-forget
+  // retry budget on tags that were never synced.
+  it('returns 200 (no-op) when the tag does not exist', async () => {
+    mockPrisma.tag.findFirst.mockResolvedValue(null);
+
+    const { status, data } = await callDelete(TAG_ID);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockPrisma.tag.delete).not.toHaveBeenCalled();
+  });
+
+  // (c) Tag owned by another user → 200, but no delete (no existence leak)
+  it('returns 200 (no-op) for a tag owned by another user, without deleting it', async () => {
+    mockPrisma.tag.findFirst.mockResolvedValue(null);
+
+    const { status, data } = await callDelete(TAG_ID);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockPrisma.tag.findFirst).toHaveBeenCalledWith({
+      where: { id: TAG_ID, user_id: USER_ID }
+    });
+    expect(mockPrisma.tag.delete).not.toHaveBeenCalled();
+  });
+
+  // (d) No auth → 401 (unchanged behavior)
+  it('returns 401 when the caller is unauthenticated', async () => {
+    mockGetUserFromToken.mockResolvedValue(null);
+
+    const { status, data } = await callDelete(TAG_ID);
+
+    expect(status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(mockPrisma.tag.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.tag.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Missing resource on DELETE now returns 200 instead of 404, matching the existing notes endpoint behavior. Eliminates spurious 4x retry errors when fire-and-forget pushFolderDelete or pushTagDelete fires for a resource that was never synced or was already removed server-side. Ownership scoping is preserved — foreign rows are treated as no-op success to avoid leaking existence.

Adds spec coverage for both endpoints: existing row, missing row, foreign-user row, and unauthenticated caller.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>