### PR TITLE
chore: remove github sponsors entry from FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,4 @@
 # .github/FUNDING.yml
-github: fundacja-reborn
 custom:
   - https://reapps.eu/#support
   - https://wise.com/pay/business/fundacjareborn?description=Donation+-+statutory+purposes


### PR DESCRIPTION
The `github: fundacja-reborn` entry caused GitHub to reject the file because the org is not enrolled in GitHub Sponsors. Keep only the custom links (reapps.eu/#support, Wise) so the Sponsor button works.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>