### PR TITLE
feat(task): configurable notification lead time and date-only reminder hour

### DIFF
--- a/apps/reborn-task/src/hooks.client.ts
+++ b/apps/reborn-task/src/hooks.client.ts
@@ -139,22 +139,54 @@ initializeStorage('task')
 			try {
 				const { tasks } = await import('$lib/stores/decrypted-tasks.store');
 				const { getSetting } = await import('$lib/utils/app-settings');
+				const { appSettings } = await import('$lib/stores/app-settings.store');
 				const { get } = await import('svelte/store');
+				const {
+					DEFAULT_NOTIFICATION_LEAD_MINUTES,
+					DEFAULT_NOTIFICATION_ALL_DAY_TIME
+				} = await import('$lib/services/push-notification.service');
+
+				const readTimingOptions = async () => ({
+					leadMinutes:
+						(await getSetting('notification_lead_minutes')) ?? DEFAULT_NOTIFICATION_LEAD_MINUTES,
+					allDayTime:
+						(await getSetting('notification_all_day_time')) ?? DEFAULT_NOTIFICATION_ALL_DAY_TIME
+				});
 
 				const syncIfEnabled = async () => {
 					const enabled = await getSetting('notifications_enabled');
-					if (enabled) {
-						await pushNotificationService.syncScheduledNotifications(get(tasks));
-					}
+					if (!enabled) return;
+					const opts = await readTimingOptions();
+					await pushNotificationService.syncScheduledNotifications(get(tasks), opts);
 				};
 
 				tasks.subscribe(($tasks) => {
 					void (async () => {
 						const enabled = await getSetting('notifications_enabled');
-						if (enabled) {
-							await pushNotificationService.syncScheduledNotifications($tasks);
-						}
+						if (!enabled) return;
+						const opts = await readTimingOptions();
+						await pushNotificationService.syncScheduledNotifications($tasks, opts);
 					})();
+				});
+
+				// Re-sync when notification timing settings change so the user sees
+				// the new schedule immediately without waiting for the next trigger.
+				let lastLead: number | undefined;
+				let lastAllDay: string | undefined;
+				appSettings.subscribe(($settings) => {
+					if (!$settings) return;
+					const lead = $settings.notification_lead_minutes;
+					const allDay = $settings.notification_all_day_time;
+					if (lastLead === undefined && lastAllDay === undefined) {
+						lastLead = lead;
+						lastAllDay = allDay;
+						return;
+					}
+					if (lead !== lastLead || allDay !== lastAllDay) {
+						lastLead = lead;
+						lastAllDay = allDay;
+						void syncIfEnabled();
+					}
 				});
 
 				document.addEventListener('visibilitychange', () => {

--- a/apps/reborn-task/src/lib/services/push-notification.service.spec.ts
+++ b/apps/reborn-task/src/lib/services/push-notification.service.spec.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+	computeReminderFireAt,
+	DEFAULT_NOTIFICATION_LEAD_MINUTES,
+	DEFAULT_NOTIFICATION_ALL_DAY_TIME
+} from './push-notification.service';
+
+/**
+ * `computeReminderFireAt` decides when a task reminder should fire.
+ *
+ * - has_time: leadMinutes before the due timestamp (a moment in time, TZ-agnostic).
+ * - !has_time: due_date is UTC midnight; treat its UTC calendar day as the user's
+ *   local calendar day and fire at allDayTime in local time.
+ *
+ * Tests run with TZ=Europe/Warsaw (set in CI / local dev). To stay robust across
+ * environments we either (a) assert on TZ-agnostic invariants for has_time, or
+ * (b) reconstruct the expected local timestamp the same way the production code
+ * does, so the assertion holds in any timezone.
+ */
+
+describe('computeReminderFireAt', () => {
+	const opts = {
+		leadMinutes: DEFAULT_NOTIFICATION_LEAD_MINUTES,
+		allDayTime: DEFAULT_NOTIFICATION_ALL_DAY_TIME
+	};
+
+	describe('has_time === true', () => {
+		it('fires leadMinutes before due_date', () => {
+			const due = '2026-05-10T14:30:00.000Z';
+			const result = computeReminderFireAt({ due_date: due, has_time: true }, opts);
+			expect(result).toBe(new Date(due).getTime() - 60 * 60 * 1000);
+		});
+
+		it('respects custom leadMinutes', () => {
+			const due = '2026-05-10T14:30:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: true },
+				{ leadMinutes: 1440, allDayTime: '09:00' }
+			);
+			expect(result).toBe(new Date(due).getTime() - 24 * 60 * 60 * 1000);
+		});
+
+		it('treats leadMinutes=0 as fire at due time', () => {
+			const due = '2026-05-10T14:30:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: true },
+				{ leadMinutes: 0, allDayTime: '09:00' }
+			);
+			expect(result).toBe(new Date(due).getTime());
+		});
+	});
+
+	describe('has_time === false (date-only)', () => {
+		it('fires at allDayTime in local time on the calendar day stored in due_date', () => {
+			// due_date is UTC midnight — its UTC date components (Y/M/D) define the calendar day.
+			const due = '2026-05-10T00:00:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: false },
+				{ leadMinutes: 60, allDayTime: '09:00' }
+			);
+
+			// Expected: local 2026-05-10 09:00. Reconstruct the same way prod does
+			// so the assertion is timezone-agnostic.
+			const expected = new Date(2026, 4, 10, 9, 0, 0, 0).getTime();
+			expect(result).toBe(expected);
+		});
+
+		it('respects a custom allDayTime', () => {
+			const due = '2026-05-10T00:00:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: false },
+				{ leadMinutes: 60, allDayTime: '18:30' }
+			);
+			const expected = new Date(2026, 4, 10, 18, 30, 0, 0).getTime();
+			expect(result).toBe(expected);
+		});
+
+		it('does NOT subtract leadMinutes for date-only tasks', () => {
+			const due = '2026-05-10T00:00:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: false },
+				{ leadMinutes: 1440, allDayTime: '09:00' }
+			);
+			// Result is 09:00 local on 2026-05-10, regardless of leadMinutes.
+			const expected = new Date(2026, 4, 10, 9, 0, 0, 0).getTime();
+			expect(result).toBe(expected);
+		});
+
+		it('falls back to default allDayTime on malformed input', () => {
+			const due = '2026-05-10T00:00:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: false },
+				{ leadMinutes: 60, allDayTime: 'not-a-time' }
+			);
+			// Default is 09:00.
+			const expected = new Date(2026, 4, 10, 9, 0, 0, 0).getTime();
+			expect(result).toBe(expected);
+		});
+
+		it('uses UTC date components — does not shift calendar day across midnight TZ boundary', () => {
+			// In TZ ahead of UTC (e.g. Warsaw +1/+2), `new Date('2026-05-10T00:00:00.000Z')`
+			// would render as May 10 01:00–02:00 local. Using getDate() instead of
+			// getUTCDate() would still return 10 here, so this test is defensive: ensure
+			// we read UTC components — a regression that switched to local would still
+			// land on the same day in this case but would break for users in negative
+			// offsets (e.g. America/Los_Angeles where the same instant is May 9 17:00).
+			const due = '2026-05-10T00:00:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: false },
+				{ leadMinutes: 0, allDayTime: '09:00' }
+			);
+			const taskLocalDate = new Date(result!);
+			expect(taskLocalDate.getDate()).toBe(10);
+			expect(taskLocalDate.getMonth()).toBe(4); // May (0-indexed)
+			expect(taskLocalDate.getFullYear()).toBe(2026);
+			expect(taskLocalDate.getHours()).toBe(9);
+			expect(taskLocalDate.getMinutes()).toBe(0);
+		});
+	});
+
+	describe('invalid inputs', () => {
+		it('returns null when due_date is missing', () => {
+			expect(computeReminderFireAt({ due_date: null, has_time: false }, opts)).toBeNull();
+		});
+
+		it('returns null when due_date is unparseable', () => {
+			expect(computeReminderFireAt({ due_date: 'not-a-date', has_time: true }, opts)).toBeNull();
+		});
+	});
+
+	describe('regression: pre-fix behaviour', () => {
+		// Before the fix, all tasks (including date-only) used `dueMs - 60min`.
+		// For a date-only task in PL summer (UTC+2), midnight UTC = 02:00 local;
+		// fireAt = 01:00 local — i.e. 1 AM in the night BEFORE the user expected.
+		// After the fix, date-only tasks fire at 09:00 local (default).
+		it('date-only task fires in the morning, not at 01:00 local', () => {
+			const due = '2026-05-10T00:00:00.000Z';
+			const result = computeReminderFireAt(
+				{ due_date: due, has_time: false },
+				{ leadMinutes: 60, allDayTime: '09:00' }
+			);
+			const fired = new Date(result!);
+			expect(fired.getHours()).toBe(9); // not 0/1/2 AM
+		});
+	});
+});
+
+describe('default constants', () => {
+	it('DEFAULT_NOTIFICATION_LEAD_MINUTES is 60', () => {
+		expect(DEFAULT_NOTIFICATION_LEAD_MINUTES).toBe(60);
+	});
+
+	it('DEFAULT_NOTIFICATION_ALL_DAY_TIME is 09:00', () => {
+		expect(DEFAULT_NOTIFICATION_ALL_DAY_TIME).toBe('09:00');
+	});
+});
+

--- a/apps/reborn-task/src/lib/services/push-notification.service.ts
+++ b/apps/reborn-task/src/lib/services/push-notification.service.ts
@@ -16,8 +16,113 @@ import type { TaskListItem } from '$lib/services/task-title-index.svelte';
 
 const logger = createLogger('PushNotificationService');
 
-// How many minutes before due date to fire a reminder
-const REMINDER_MINUTES_BEFORE = 60;
+/** Default reminder lead time for tasks with `has_time === true` (minutes). */
+export const DEFAULT_NOTIFICATION_LEAD_MINUTES = 60;
+/** Default local clock time for date-only reminders (HH:MM). */
+export const DEFAULT_NOTIFICATION_ALL_DAY_TIME = '09:00';
+
+export interface ReminderTimingOptions {
+	/** Minutes before `due_date` for tasks with `has_time === true`. */
+	leadMinutes: number;
+	/** Local 'HH:MM' string used as the fire time for date-only tasks. */
+	allDayTime: string;
+}
+
+/** Pick of TaskListItem fields needed to compute reminder fire time. */
+type ReminderTask = Pick<TaskListItem, 'due_date' | 'has_time'>;
+
+/**
+ * Compute the absolute timestamp at which a task's reminder should fire.
+ *
+ * - For tasks with `has_time === true`: fire `leadMinutes` before `due_date`.
+ * - For date-only tasks (`has_time === false`): fire on the calendar day stored
+ *   in `due_date` (UTC midnight) at the user's local `allDayTime`.
+ *
+ * Exported as a pure function for unit testing.
+ */
+export function computeReminderFireAt(
+	task: ReminderTask,
+	options: ReminderTimingOptions
+): number | null {
+	if (!task.due_date) return null;
+
+	const due = new Date(task.due_date);
+	if (Number.isNaN(due.getTime())) return null;
+
+	if (task.has_time) {
+		return due.getTime() - options.leadMinutes * 60_000;
+	}
+
+	// Date-only: due_date is UTC midnight; treat its UTC date components as the
+	// user's local calendar day, then assemble a local Date at allDayTime.
+	const [hh, mm] = parseAllDayTime(options.allDayTime);
+	return new Date(
+		due.getUTCFullYear(),
+		due.getUTCMonth(),
+		due.getUTCDate(),
+		hh,
+		mm,
+		0,
+		0
+	).getTime();
+}
+
+/** Parse 'HH:MM' into [hour, minute]. Falls back to default on invalid input. */
+function parseAllDayTime(value: string): [number, number] {
+	const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+	if (!match) return parseAllDayTime(DEFAULT_NOTIFICATION_ALL_DAY_TIME);
+	const h = Number(match[1]);
+	const m = Number(match[2]);
+	if (h < 0 || h > 23 || m < 0 || m > 59) {
+		return parseAllDayTime(DEFAULT_NOTIFICATION_ALL_DAY_TIME);
+	}
+	return [h, m];
+}
+
+/**
+ * Build the notification body text using translated strings.
+ * - has_time: "scheduled for HH:MM" with the time formatted in user's locale.
+ * - date-only with calendar day == today: "scheduled for today".
+ * - date-only otherwise: "scheduled for {locale-formatted date}".
+ */
+type TranslateFn = (key: string, options?: { values?: Record<string, string | number> }) => string;
+
+function formatReminderBody(task: ReminderTask, translate: TranslateFn, locale: string): string {
+	if (!task.due_date) return translate('notifications.task_due.body_unknown');
+
+	const due = new Date(task.due_date);
+	if (Number.isNaN(due.getTime())) {
+		return translate('notifications.task_due.body_unknown');
+	}
+
+	const localeTag = locale === 'pl' ? 'pl-PL' : locale;
+
+	if (task.has_time) {
+		const time = due.toLocaleTimeString(localeTag, { hour: '2-digit', minute: '2-digit' });
+		return translate('notifications.task_due.body_time', { values: { time } });
+	}
+
+	// Date-only: compare UTC calendar day against today's local calendar day.
+	const taskYear = due.getUTCFullYear();
+	const taskMonth = due.getUTCMonth();
+	const taskDay = due.getUTCDate();
+	const today = new Date();
+	if (
+		taskYear === today.getFullYear() &&
+		taskMonth === today.getMonth() &&
+		taskDay === today.getDate()
+	) {
+		return translate('notifications.task_due.body_today');
+	}
+
+	const taskLocalDay = new Date(taskYear, taskMonth, taskDay);
+	const date = taskLocalDay.toLocaleDateString(localeTag, {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric'
+	});
+	return translate('notifications.task_due.body_date', { values: { date } });
+}
 
 export type PermissionState = 'granted' | 'denied' | 'default' | 'unsupported';
 
@@ -120,13 +225,32 @@ class PushNotificationService {
 	/**
 	 * Sync scheduled local notifications with current task list.
 	 * Cancels obsolete reminders and schedules upcoming ones.
+	 *
+	 * Timing options come from `AppSettings`:
+	 * - tasks with `has_time === true`: fire `leadMinutes` before `due_date`.
+	 * - date-only tasks: fire on the calendar day at the local `allDayTime`.
 	 */
-	async syncScheduledNotifications(tasks: TaskListItem[]): Promise<void> {
+	async syncScheduledNotifications(
+		tasks: TaskListItem[],
+		options: ReminderTimingOptions = {
+			leadMinutes: DEFAULT_NOTIFICATION_LEAD_MINUTES,
+			allDayTime: DEFAULT_NOTIFICATION_ALL_DAY_TIME
+		}
+	): Promise<void> {
 		if (!this.isSupported() || Notification.permission !== 'granted') return;
 
 		const sw = await navigator.serviceWorker.ready;
 		const now = Date.now();
 		const window24h = 24 * 60 * 60 * 1000;
+
+		// Lazy import to avoid pulling i18n into worker contexts.
+		const [{ get }, { t }, { currentLanguage }] = await Promise.all([
+			import('svelte/store'),
+			import('$lib/stores/i18n.store'),
+			import('$lib/stores/app-settings.store')
+		]);
+		const translate = get(t) as TranslateFn;
+		const locale = get(currentLanguage);
 
 		// Cancel all existing scheduled reminders first
 		sw.active?.postMessage({ type: 'CANCEL_ALL_NOTIFICATIONS' });
@@ -134,15 +258,13 @@ class PushNotificationService {
 		for (const task of tasks) {
 			if (task.is_completed || task.deleted_at || !task.due_date) continue;
 
-			const dueMs = new Date(task.due_date).getTime();
-			const fireAt = dueMs - REMINDER_MINUTES_BEFORE * 60 * 1000;
+			const fireAt = computeReminderFireAt(task, options);
+			if (fireAt === null) continue;
 
-			// Only schedule if in the future and within 24 hours
+			// Only schedule if in the future and within 24 hours (SW lifecycle limit)
 			if (fireAt <= now || fireAt > now + window24h) continue;
 
-			const body = task.has_time
-				? `Termin: ${new Date(dueMs).toLocaleTimeString('pl', { hour: '2-digit', minute: '2-digit' })}`
-				: 'Zbliża się termin zadania';
+			const body = formatReminderBody(task, translate, locale);
 
 			sw.active?.postMessage({
 				type: 'SCHEDULE_NOTIFICATION',

--- a/apps/reborn-task/src/routes/settings/notifications/+page.svelte
+++ b/apps/reborn-task/src/routes/settings/notifications/+page.svelte
@@ -10,11 +10,20 @@
 		Button,
 		Switch,
 		Label,
+		Select,
+		SelectContent,
+		SelectItem,
+		SelectTrigger,
 		toast
 	} from '@reborn/ui';
-	import { Bell, BellOff, AlertTriangle, Info, Send } from '@lucide/svelte';
+	import { Bell, BellOff, AlertTriangle, Info, Send, Clock } from '@lucide/svelte';
 	import { appSettings } from '$lib/stores/app-settings.store';
-	import { pushNotificationService, type PermissionState } from '$lib/services/push-notification.service';
+	import {
+		pushNotificationService,
+		type PermissionState,
+		DEFAULT_NOTIFICATION_LEAD_MINUTES,
+		DEFAULT_NOTIFICATION_ALL_DAY_TIME
+	} from '$lib/services/push-notification.service';
 	import { createLogger } from '@reborn/utils';
 	import { t } from '$lib/stores/i18n.store';
 
@@ -25,14 +34,37 @@
 	let permissionState = $state<PermissionState>('default');
 	let isSubscribed = $state(false);
 	let notificationsEnabled = $state($appSettings?.notifications_enabled ?? false);
+	let leadMinutes = $state<number>(
+		$appSettings?.notification_lead_minutes ?? DEFAULT_NOTIFICATION_LEAD_MINUTES
+	);
+	let allDayTime = $state<string>(
+		$appSettings?.notification_all_day_time ?? DEFAULT_NOTIFICATION_ALL_DAY_TIME
+	);
 	const isMacOS = $derived(
 		typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
+	);
+
+	const leadOptions = $derived([
+		{ value: '0', label: $t('settings.notification_lead.options.at_due') },
+		{ value: '15', label: $t('settings.notification_lead.options.15min') },
+		{ value: '30', label: $t('settings.notification_lead.options.30min') },
+		{ value: '60', label: $t('settings.notification_lead.options.1h') },
+		{ value: '120', label: $t('settings.notification_lead.options.2h') },
+		{ value: '360', label: $t('settings.notification_lead.options.6h') },
+		{ value: '720', label: $t('settings.notification_lead.options.12h') },
+		{ value: '1440', label: $t('settings.notification_lead.options.24h') }
+	]);
+
+	const leadLabel = $derived(
+		leadOptions.find((o) => Number(o.value) === leadMinutes)?.label ?? leadOptions[3].label
 	);
 
 	onMount(() => {
 		// Sync enabled state from settings store
 		const unsub = appSettings.subscribe((settings) => {
 			notificationsEnabled = settings?.notifications_enabled ?? false;
+			leadMinutes = settings?.notification_lead_minutes ?? DEFAULT_NOTIFICATION_LEAD_MINUTES;
+			allDayTime = settings?.notification_all_day_time ?? DEFAULT_NOTIFICATION_ALL_DAY_TIME;
 		});
 
 		// Detect permission and subscription state
@@ -40,6 +72,28 @@
 
 		return unsub;
 	});
+
+	async function updateLeadMinutes(value: string) {
+		const minutes = Number(value);
+		if (!Number.isFinite(minutes) || minutes < 0) return;
+		try {
+			await appSettings.update('notification_lead_minutes', minutes);
+		} catch (err: unknown) {
+			logger.error('Failed to update notification_lead_minutes', err);
+			toast.error($t('settings.notification_error.unknown_error'));
+		}
+	}
+
+	async function updateAllDayTime(value: string) {
+		// Basic HH:MM validation; native input enforces format but be defensive.
+		if (!/^\d{1,2}:\d{2}$/.test(value)) return;
+		try {
+			await appSettings.update('notification_all_day_time', value);
+		} catch (err: unknown) {
+			logger.error('Failed to update notification_all_day_time', err);
+			toast.error($t('settings.notification_error.unknown_error'));
+		}
+	}
 
 	async function refreshState() {
 		permissionState = pushNotificationService.getPermission();
@@ -199,10 +253,49 @@
 					</div>
 
 					{#if notificationsEnabled}
-						<div class="flex items-start gap-2 rounded-md bg-muted/50 p-3">
-							<Info class="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+						<!-- Lead time for tasks with a specific time -->
+						<div class="space-y-2">
+							<Label for="notification-lead" class="flex items-center gap-2">
+								<Clock class="h-4 w-4 text-muted-foreground" />
+								{$t('settings.notification_lead.label')}
+							</Label>
+							<Select
+								type="single"
+								value={String(leadMinutes)}
+								onValueChange={(value) => updateLeadMinutes(value)}
+								disabled={isLoading}
+							>
+								<SelectTrigger id="notification-lead" class="w-full">
+									{leadLabel}
+								</SelectTrigger>
+								<SelectContent>
+									{#each leadOptions as option (option.value)}
+										<SelectItem value={option.value}>{option.label}</SelectItem>
+									{/each}
+								</SelectContent>
+							</Select>
 							<p class="text-xs text-muted-foreground">
-								{$t('settings.notifications_info', { values: { hours: '1' } })}
+								{$t('settings.notification_lead.help')}
+							</p>
+						</div>
+
+						<!-- All-day time for date-only tasks -->
+						<div class="space-y-2">
+							<Label for="notification-all-day-time" class="flex items-center gap-2">
+								<Clock class="h-4 w-4 text-muted-foreground" />
+								{$t('settings.notification_all_day_time.label')}
+							</Label>
+							<input
+								id="notification-all-day-time"
+								type="time"
+								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+								value={allDayTime}
+								disabled={isLoading}
+								onchange={(e) =>
+									updateAllDayTime((e.target as HTMLInputElement).value)}
+							/>
+							<p class="text-xs text-muted-foreground">
+								{$t('settings.notification_all_day_time.help')}
 							</p>
 						</div>
 

--- a/packages/i18n/src/translations/tasks/de/settings.json
+++ b/packages/i18n/src/translations/tasks/de/settings.json
@@ -125,7 +125,24 @@
   "notification_error": {
     "unknown_error": "Ein unbekannter Fehler ist beim \u00c4ndern der Benachrichtigungseinstellungen aufgetreten."
   },
-  "notifications_info": "Sie erhalten Aufgabenerinnerungen {hours} Stunden vor der F\u00e4lligkeit.",
+  "notification_lead": {
+    "label": "Erinnerung f\u00fcr Aufgaben mit Uhrzeit",
+    "help": "Wann eine Benachrichtigung f\u00fcr eine Aufgabe mit konkreter Uhrzeit ausgel\u00f6st werden soll.",
+    "options": {
+      "at_due": "Zum F\u00e4lligkeitszeitpunkt",
+      "15min": "15 Minuten vorher",
+      "30min": "30 Minuten vorher",
+      "1h": "1 Stunde vorher",
+      "2h": "2 Stunden vorher",
+      "6h": "6 Stunden vorher",
+      "12h": "12 Stunden vorher",
+      "24h": "24 Stunden vorher"
+    }
+  },
+  "notification_all_day_time": {
+    "label": "Erinnerungszeit f\u00fcr Aufgaben ohne Uhrzeit",
+    "help": "Zu dieser Uhrzeit erhalten Sie am F\u00e4lligkeitstag eine Benachrichtigung f\u00fcr Aufgaben ohne konkrete Uhrzeit."
+  },
   "notifications_macos_info": "Unter macOS \u00fcberpr\u00fcfen Sie auch Systemeinstellungen \u2192 Mitteilungen \u2192 Ihr Browser und stellen Sie sicher, dass Benachrichtigungen erlaubt sind.",
   "send_test_notification": "Testbenachrichtigung senden",
   "test_notification_sent": "Testbenachrichtigung gesendet",

--- a/packages/i18n/src/translations/tasks/en/settings.json
+++ b/packages/i18n/src/translations/tasks/en/settings.json
@@ -125,7 +125,24 @@
   "notification_error": {
     "unknown_error": "An unknown error occurred while changing notification settings."
   },
-  "notifications_info": "You will receive task reminders {hours} hours before the due time.",
+  "notification_lead": {
+    "label": "Remind me about tasks with a time",
+    "help": "When to fire a notification for a task that has a specific time set.",
+    "options": {
+      "at_due": "At the due time",
+      "15min": "15 minutes before",
+      "30min": "30 minutes before",
+      "1h": "1 hour before",
+      "2h": "2 hours before",
+      "6h": "6 hours before",
+      "12h": "12 hours before",
+      "24h": "24 hours before"
+    }
+  },
+  "notification_all_day_time": {
+    "label": "Reminder time for date-only tasks",
+    "help": "You'll get a notification at this time on the day a task without a specific time is due."
+  },
   "notifications_macos_info": "On macOS, also check System Settings → Notifications → your browser and make sure notifications are allowed.",
   "send_test_notification": "Send test notification",
   "test_notification_sent": "Test notification sent",

--- a/packages/i18n/src/translations/tasks/es/settings.json
+++ b/packages/i18n/src/translations/tasks/es/settings.json
@@ -125,7 +125,24 @@
   "notification_error": {
     "unknown_error": "Se produjo un error desconocido al cambiar los ajustes de notificación."
   },
-  "notifications_info": "Recibirá recordatorios de tareas {hours} horas antes de la hora de vencimiento.",
+  "notification_lead": {
+    "label": "Recordatorio para tareas con hora",
+    "help": "Cuándo enviar la notificación de una tarea con hora específica.",
+    "options": {
+      "at_due": "A la hora de vencimiento",
+      "15min": "15 minutos antes",
+      "30min": "30 minutos antes",
+      "1h": "1 hora antes",
+      "2h": "2 horas antes",
+      "6h": "6 horas antes",
+      "12h": "12 horas antes",
+      "24h": "24 horas antes"
+    }
+  },
+  "notification_all_day_time": {
+    "label": "Hora de recordatorio para tareas sin hora",
+    "help": "Recibirás una notificación a esta hora el día en que vence una tarea sin hora específica."
+  },
   "notifications_macos_info": "En macOS, también verifique Ajustes del Sistema → Notificaciones → su navegador y asegúrese de que las notificaciones estén permitidas.",
   "send_test_notification": "Enviar notificación de prueba",
   "test_notification_sent": "Notificación de prueba enviada",

--- a/packages/i18n/src/translations/tasks/fr/settings.json
+++ b/packages/i18n/src/translations/tasks/fr/settings.json
@@ -125,7 +125,24 @@
   "notification_error": {
     "unknown_error": "Une erreur inconnue s'est produite lors de la modification des param\u00e8tres de notification."
   },
-  "notifications_info": "Vous recevrez des rappels de t\u00e2ches {hours} heures avant l'heure d'\u00e9ch\u00e9ance.",
+  "notification_lead": {
+    "label": "Rappel pour les t\u00e2ches avec heure",
+    "help": "Quand d\u00e9clencher la notification pour une t\u00e2che dont l'heure pr\u00e9cise est d\u00e9finie.",
+    "options": {
+      "at_due": "\u00c0 l'heure d'\u00e9ch\u00e9ance",
+      "15min": "15 minutes avant",
+      "30min": "30 minutes avant",
+      "1h": "1 heure avant",
+      "2h": "2 heures avant",
+      "6h": "6 heures avant",
+      "12h": "12 heures avant",
+      "24h": "24 heures avant"
+    }
+  },
+  "notification_all_day_time": {
+    "label": "Heure de rappel pour les t\u00e2ches sans heure",
+    "help": "Vous recevrez une notification \u00e0 cette heure le jour d'\u00e9ch\u00e9ance d'une t\u00e2che sans heure pr\u00e9cise."
+  },
   "notifications_macos_info": "Sur macOS, v\u00e9rifiez \u00e9galement R\u00e9glages Syst\u00e8me \u2192 Notifications \u2192 votre navigateur et assurez-vous que les notifications sont autoris\u00e9es.",
   "send_test_notification": "Envoyer une notification de test",
   "test_notification_sent": "Notification de test envoy\u00e9e",

--- a/packages/i18n/src/translations/tasks/pl/settings.json
+++ b/packages/i18n/src/translations/tasks/pl/settings.json
@@ -202,7 +202,24 @@
   "notification_error": {
     "unknown_error": "Wystąpił nieznany błąd podczas zmiany ustawień powiadomień."
   },
-  "notifications_info": "Otrzymasz przypomnienia o zadaniach {hours} godzin przed terminem.",
+  "notification_lead": {
+    "label": "Przypominaj zadania z czasem",
+    "help": "Kiedy wysłać powiadomienie dla zadania z konkretną godziną.",
+    "options": {
+      "at_due": "W momencie terminu",
+      "15min": "15 minut wcześniej",
+      "30min": "30 minut wcześniej",
+      "1h": "1 godzinę wcześniej",
+      "2h": "2 godziny wcześniej",
+      "6h": "6 godzin wcześniej",
+      "12h": "12 godzin wcześniej",
+      "24h": "24 godziny wcześniej"
+    }
+  },
+  "notification_all_day_time": {
+    "label": "Pora przypomnień dla zadań bez godziny",
+    "help": "O tej porze otrzymasz powiadomienie w dniu zadania, dla którego nie ustawiono konkretnej godziny."
+  },
   "notifications_macos_info": "Na macOS dodatkowo sprawdź Ustawienia systemowe → Powiadomienia → Twoja przeglądarka i upewnij się, że powiadomienia są dozwolone.",
   "send_test_notification": "Wyślij testowe powiadomienie",
   "test_notification_sent": "Testowe powiadomienie zostało wysłane",

--- a/packages/storage/src/stores/settings.store.ts
+++ b/packages/storage/src/stores/settings.store.ts
@@ -18,6 +18,10 @@ export interface AppSettings {
   timeFormat: '12h' | '24h';
   firstDayOfWeek: number; // 0 = Sunday, 1 = Monday, etc.
   notifications_enabled: boolean;
+  /** Minutes before due_date to fire a reminder (only for tasks with has_time === true). */
+  notification_lead_minutes: number;
+  /** Local 'HH:MM' clock time to fire reminders for date-only tasks (has_time === false). */
+  notification_all_day_time: string;
   auto_sync_enabled: boolean;
   sync_interval_minutes: number;
   imageLoadMode: ImageLoadMode;
@@ -95,6 +99,8 @@ export const settingsOperations = {
           timeFormat: '24h',
           firstDayOfWeek: 1, // Monday
           notifications_enabled: false,
+          notification_lead_minutes: 60,
+          notification_all_day_time: '09:00',
           auto_sync_enabled: true,
           sync_interval_minutes: 5,
           imageLoadMode: 'ask',


### PR DESCRIPTION
Hardcoded REMINDER_MINUTES_BEFORE=60 broke date-only tasks: due_date is stored as UTC midnight, so subtracting 60 min fired the alert at ~01:00 local time in PL — either waking the user or being filtered out as past.

Split scheduling into two paths via the new pure helper computeReminderFireAt:
- has_time: due_date − leadMinutes
- date-only: extract UTC calendar day, fire at allDayTime in local time

Two new AppSettings (per-device, IndexedDB):
- notification_lead_minutes (default 60; UI: 0/15/30/60/120/360/720/1440)
- notification_all_day_time (default 09:00)

UI in /settings/notifications adds a Select for lead time and a time input for the date-only fire hour. hooks.client.ts re-syncs scheduled reminders when either setting changes. Notification body text now goes through i18n (notifications.task_due.body_*) with today / future-day / has_time variants across PL/EN/DE/FR/ES.

Tests: 13 cases in push-notification.service.spec.ts, written TZ-agnostic by reconstructing expected local timestamps.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>