### PR TITLE
fix(auth): treat transient refresh failures as retryable, not session expiry

### DIFF
--- a/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
@@ -24,10 +24,23 @@ export abstract class SyncBaseService {
 		// (cross-tab serialized via Web Locks API). Shorter timeout so a VPN
 		// black hole (navigator.onLine=true but no upstream) doesn't hang a
 		// sync for the default 30 s.
+		//
+		// `authFetch.refresh()` throws `TransientRefreshError` when the server
+		// is briefly unreachable (e.g. 5xx from nginx during a Docker rebuild
+		// on the production VPS). Swallow it and return `false` so the caller
+		// gets the original 401 — sync will treat it as a transient sync error
+		// and retry on the next tick instead of falsely flagging the session
+		// as expired.
 		this.apiClient = new ApiClient({
 			baseUrl,
 			timeout: 15_000,
-			onUnauthorized: async () => (await authFetch.refresh()) !== null
+			onUnauthorized: async () => {
+				try {
+					return (await authFetch.refresh()) !== null;
+				} catch {
+					return false;
+				}
+			}
 		});
 	}
 

--- a/packages/auth/src/__tests__/auth-fetch.spec.ts
+++ b/packages/auth/src/__tests__/auth-fetch.spec.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createAuthFetch, type AuthFetchTokenStorage } from '../utils/auth-fetch';
+import {
+  createAuthFetch,
+  TransientRefreshError,
+  type AuthFetchTokenStorage
+} from '../utils/auth-fetch';
 
 function makeStorage(initial: string | null = null): AuthFetchTokenStorage & { value: string | null } {
   const state = { value: initial };
@@ -207,5 +211,110 @@ describe('createAuthFetch', () => {
     expect(storage.getAccessToken()).toBe('old'); // unchanged
     // refresh() itself does NOT call onSessionExpired — that's the wrapper's job on 401-driven refresh.
     expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  // --- Transient vs definitive refresh failure ---
+  //
+  // Regression coverage for the production-deploy bug: nginx returns 5xx for
+  // a few seconds during `docker compose up -d --build`, which used to flip
+  // the session-expired banner on mobile (where the access token had expired
+  // in the background and the very first post-resume sync hit the deploy
+  // window). The session is still valid — the server is just briefly down.
+
+  it('does NOT call onSessionExpired when refresh hits a 5xx (transient)', async () => {
+    const storage = makeStorage('expired');
+    const onSessionExpired = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('expired', { status: 401 }))
+      .mockResolvedValueOnce(new Response('Bad Gateway', { status: 502 }));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl,
+      onSessionExpired
+    });
+
+    const response = await authFetch('/api/things');
+
+    // Original 401 surfaces to caller; sync layer treats as transient and retries.
+    expect(response.status).toBe(401);
+    expect(onSessionExpired).not.toHaveBeenCalled();
+    expect(storage.getAccessToken()).toBe('expired');
+  });
+
+  it('does NOT call onSessionExpired when refresh fetch throws (network/timeout)', async () => {
+    const storage = makeStorage('expired');
+    const onSessionExpired = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('expired', { status: 401 }))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl,
+      onSessionExpired
+    });
+
+    const response = await authFetch('/api/things');
+
+    expect(response.status).toBe(401);
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('still calls onSessionExpired on a definitive 401 from refresh', async () => {
+    // Regression guard: the transient-error change must not weaken the
+    // signal for an actually-expired refresh token (token reuse → entire
+    // family revoked → 401 from /auth/refresh).
+    const storage = makeStorage('expired');
+    const onSessionExpired = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('expired', { status: 401 }))
+      .mockResolvedValueOnce(new Response('refresh denied', { status: 401 }));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl,
+      onSessionExpired
+    });
+
+    const response = await authFetch('/api/things');
+
+    expect(response.status).toBe(401);
+    expect(onSessionExpired).toHaveBeenCalledOnce();
+  });
+
+  it('refresh() throws TransientRefreshError on 5xx', async () => {
+    const storage = makeStorage('old');
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response('Service Unavailable', { status: 503 }));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl
+    });
+
+    await expect(authFetch.refresh()).rejects.toBeInstanceOf(TransientRefreshError);
+    expect(storage.getAccessToken()).toBe('old');
+  });
+
+  it('refresh() throws TransientRefreshError on network error', async () => {
+    const storage = makeStorage('old');
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh',
+      storage,
+      fetchImpl
+    });
+
+    await expect(authFetch.refresh()).rejects.toBeInstanceOf(TransientRefreshError);
   });
 });

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -39,7 +39,7 @@ export type { PowChallengeData } from './utils/pow-solver';
 export { withRefreshLock } from './utils/refresh-lock';
 
 // Authenticated fetch wrapper with single-flight 401 refresh + retry
-export { createAuthFetch } from './utils/auth-fetch';
+export { createAuthFetch, TransientRefreshError } from './utils/auth-fetch';
 export type { AuthFetch, AuthFetchConfig, AuthFetchTokenStorage } from './utils/auth-fetch';
 
 // Export guards

--- a/packages/auth/src/utils/auth-fetch.ts
+++ b/packages/auth/src/utils/auth-fetch.ts
@@ -42,8 +42,29 @@ export interface AuthFetchConfig {
 
 export interface AuthFetch {
   (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
-  /** Force a refresh now, returning the new access token or null on failure. */
+  /**
+   * Force a refresh now. Resolves to the new access token, or `null` when the
+   * server reports a definitive expiry (401/403, or 200 with `success:false`).
+   * Throws {@link TransientRefreshError} for transient failures (5xx, network
+   * error, timeout) so the caller can distinguish "session is gone" from
+   * "server is briefly unreachable" (e.g. nginx returning 502 during a Docker
+   * rebuild on the production VPS).
+   */
   refresh: () => Promise<string | null>;
+}
+
+/**
+ * Thrown by {@link AuthFetch.refresh} when `/auth/refresh` failed for a reason
+ * that does *not* indicate the session has expired — typically 5xx from nginx
+ * during a deploy, a network error, or a timeout. Callers should treat this
+ * as a transient sync error (try again later) and **must not** surface the
+ * session-expired banner.
+ */
+export class TransientRefreshError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'TransientRefreshError';
+  }
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
@@ -72,18 +93,49 @@ export function createAuthFetch(config: AuthFetchConfig): AuthFetch {
     const current = storage.getAccessToken();
     if (current && current !== tokenBeforeLock) return current;
 
-    const refreshRes = await fetchImpl(config.refreshUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({})
-    });
+    let refreshRes: Response;
+    try {
+      refreshRes = await fetchImpl(config.refreshUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+    } catch (err) {
+      // Network error / DNS / timeout — server is unreachable, not an expiry.
+      throw new TransientRefreshError(
+        err instanceof Error ? err.message : 'Refresh network error',
+        err
+      );
+    }
 
-    if (!refreshRes.ok) return null;
+    // 401/403 = definitive expiry (refresh token revoked, family invalidated,
+    // or expired beyond the 7-day sliding window). Caller should mark the
+    // session as expired and prompt for re-auth.
+    if (refreshRes.status === 401 || refreshRes.status === 403) {
+      return null;
+    }
 
-    const data = (await refreshRes.json()) as {
-      success?: boolean;
-      data?: { access_token?: string };
-    };
+    // Any other non-OK status (5xx from nginx during a rebuild, 429 rate
+    // limiting, 502/503/504 upstream unavailable) is transient — the refresh
+    // token is probably still valid, the server just can't service the
+    // request right now. Do NOT trigger the session-expired banner.
+    if (!refreshRes.ok) {
+      throw new TransientRefreshError(
+        `Refresh endpoint returned HTTP ${refreshRes.status}`
+      );
+    }
+
+    let data: { success?: boolean; data?: { access_token?: string } };
+    try {
+      data = (await refreshRes.json()) as typeof data;
+    } catch (err) {
+      // 200 OK but body is not JSON — almost certainly a misbehaving proxy
+      // serving a maintenance page. Treat as transient.
+      throw new TransientRefreshError('Refresh response was not valid JSON', err);
+    }
+
+    // 200 OK with `success:false` is a deliberate expiry signal from the
+    // server (e.g. invalid_grant). Treat as definitive.
     if (!data.success || !data.data?.access_token) return null;
 
     const newToken = data.data.access_token;
@@ -122,7 +174,19 @@ export function createAuthFetch(config: AuthFetchConfig): AuthFetch {
 
     if (response.status !== 401) return response;
 
-    const newToken = await refresh();
+    let newToken: string | null;
+    try {
+      newToken = await refresh();
+    } catch (err) {
+      // Transient refresh failure (5xx from nginx during deploy, network
+      // hiccup, timeout). Return the original 401 so the caller can treat it
+      // as a regular sync error and retry later. Crucially: do NOT call
+      // onSessionExpired — the session is probably still valid, the server
+      // is just briefly unreachable.
+      if (err instanceof TransientRefreshError) return response;
+      throw err;
+    }
+
     if (!newToken) {
       config.onSessionExpired?.();
       return response;


### PR DESCRIPTION
`/api/auth/refresh` returning 5xx (e.g. nginx 502 during a Docker rebuild on the production VPS) used to flip the session-expired banner because `createAuthFetch.doRefresh()` returned `null` for every non-OK status, and the wrapper unconditionally invoked `onSessionExpired` on a `null` result. Mobile PWAs hit this path much more often than desktop: the access token is typically expired after the app spends time in the background, so the very first sync after resume returns 401, triggers a refresh, and that refresh lands inside the deploy window.

Distinguish definitive expiry (401/403, or 200 with success:false) from transient failures (5xx, network error, timeout, non-JSON 200). The former still resolves to `null` and surfaces the banner; the latter throws a new `TransientRefreshError`, which `authFetch` catches and propagates as the original 401 so sync treats it as a regular transient error and retries on the next tick. Master key was already preserved in both paths — only the UX changes.

`sync-base.service.ts` now wraps `authFetch.refresh()` in try/catch so the throw doesn't propagate into `ApiClient.onUnauthorized`'s boolean contract. `AuthApiAdapter.refreshToken()` already had try/catch and already classifies transient failures as non-definitive via `isDefinitiveSessionExpiry()`, so no change needed there.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>