### PR TITLE
feat(search): freetext negation and quoted phrases (Tier 1.5)

### DIFF
--- a/apps/reborn-notes/src/lib/stores/notes.store.ts
+++ b/apps/reborn-notes/src/lib/stores/notes.store.ts
@@ -4,6 +4,7 @@ import { browser } from '$app/environment';
 import type { NoteDecrypted } from '@reborn/types';
 import {
   evaluate,
+  freetextIsEmpty,
   isEmpty as isAstEmpty,
   parseQuery,
   requiresContent,
@@ -92,14 +93,14 @@ function createNotesStore() {
   /**
    * Refresh the list from the in-memory NoteIndex.
    *
-   * Pure freetext (no operators) takes the fast title-substring path via
-   * `noteIndex.getFiltered({ search })`. As soon as the parser recognizes any
-   * operator (e.g. `tag:`, `created:`), we switch to AST evaluation against
-   * the index. Operators that need note content (`has:link`, freetext-in-body
-   * when the user enabled "search in content") delegate entirely to
-   * `triggerContentSearch()` — the title-only intermediate is skipped to
-   * avoid flashing wrong results, and the previous `_raw` stays visible
-   * until the body-aware pass completes.
+   * Single-word freetext with no operators and no excludes takes the fast
+   * title-substring path via `noteIndex.getFiltered({ search })`. Anything
+   * else (multi-word AND, quoted phrase, `-exclude`, or any operator) goes
+   * through AST evaluation. Operators that need note content (`has:link`,
+   * freetext-in-body when the user enabled "search in content") delegate
+   * entirely to `triggerContentSearch()` — the title-only intermediate is
+   * skipped to avoid flashing wrong results, and the previous `_raw` stays
+   * visible until the body-aware pass completes.
    */
   function refresh() {
     if (!browser) return;
@@ -132,16 +133,36 @@ function createNotesStore() {
     }
   }
 
-  /** Synchronous AST/freetext evaluation against the in-memory NoteIndex (no body). */
+  /**
+   * Synchronous AST/freetext evaluation against the in-memory NoteIndex (no body).
+   *
+   * Three routing cases:
+   *   1. Empty AST (no filters, no freetext) — return the visible scope as-is.
+   *   2. Single-word freetext, no operators — fast title-substring path through
+   *      `getFiltered({ search })`. Bypasses building a SearchContext.
+   *   3. Anything else (multi-word, phrase, exclude, or operators) — full AST
+   *      evaluation via `getFilteredByAst`, which handles include/exclude
+   *      semantics consistently.
+   */
   function evaluateAgainstIndex(
     ast: QueryAST,
     filterOpts: ReturnType<typeof buildFilterOptions>
   ): NoteListItem[] {
-    if (ast.filters.length === 0) {
-      // Fast path — pure freetext (or empty) goes through the legacy title-substring filter.
+    if (ast.filters.length === 0 && freetextIsEmpty(ast.freetext)) {
       const { items } = noteIndex.getFiltered({
         ...filterOpts,
-        search: ast.freetext || undefined,
+        pageSize: Number.MAX_SAFE_INTEGER
+      });
+      return items;
+    }
+    if (
+      ast.filters.length === 0 &&
+      ast.freetext.exclude.length === 0 &&
+      ast.freetext.include.length === 1
+    ) {
+      const { items } = noteIndex.getFiltered({
+        ...filterOpts,
+        search: ast.freetext.include[0],
         pageSize: Number.MAX_SAFE_INTEGER
       });
       return items;
@@ -184,7 +205,7 @@ function createNotesStore() {
     try {
       // 1. Pre-filter: structural operators only.
       const liteAst: QueryAST = {
-        freetext: '',
+        freetext: { include: [], exclude: [] },
         filters: ast.filters.filter((f) => f.kind !== 'has')
       };
       const ctx = buildSearchContext();

--- a/apps/reborn-task/src/lib/stores/search-results.store.ts
+++ b/apps/reborn-task/src/lib/stores/search-results.store.ts
@@ -6,9 +6,11 @@
  *
  * Routing rules (`search(query)`):
  *   - Empty query                                 → clear results.
- *   - No operators AND no body needed             → instant title-substring path
+ *   - Single freetext word/phrase, no operators,
+ *     no exclude, no body needed                  → instant title-substring path
  *                                                   via `taskTitleIndex.search`.
- *   - Operators present AND no body needed        → AST-on-index path via
+ *   - Multi-word/phrase/exclude/operator AND no
+ *     body needed                                 → AST-on-index path via
  *                                                   `taskTitleIndex.getFilteredByAst`.
  *   - `requiresContent(ast)` OR (`searchInDescription` toggle on AND
  *      non-empty freetext)                        → body-aware path via
@@ -27,6 +29,7 @@ import { buildTaskSearchContext } from '$lib/services/task-search-context';
 import {
 	createLogger,
 	evaluate,
+	freetextIsEmpty,
 	parseQuery,
 	requiresContent,
 	type SearchEntity
@@ -90,14 +93,17 @@ function createSearchStore() {
 		const ctx = buildTaskSearchContext();
 		const currentState = get({ subscribe });
 		const wantsContent =
-			requiresContent(ast) || (currentState.searchInDescription && ast.freetext.length > 0);
+			requiresContent(ast) || (currentState.searchInDescription && !freetextIsEmpty(ast.freetext));
 
 		// Title-only path — no decryption required
 		if (!wantsContent) {
-			const titleMatches =
-				ast.filters.length === 0
-					? taskTitleIndex.search(query)
-					: taskTitleIndex.getFilteredByAst(ast, ctx, { excludeTemplates: true }).items;
+			const isSingleWordOnly =
+				ast.filters.length === 0 &&
+				ast.freetext.exclude.length === 0 &&
+				ast.freetext.include.length === 1;
+			const titleMatches = isSingleWordOnly
+				? taskTitleIndex.search(ast.freetext.include[0])
+				: taskTitleIndex.getFilteredByAst(ast, ctx, { excludeTemplates: true }).items;
 
 			const results: TaskListItem[] = titleMatches.slice(0, MAX_RESULTS);
 
@@ -129,7 +135,10 @@ function createSearchStore() {
 			const predicate = (task: TaskDecrypted) =>
 				evaluate(ast, mapTaskToSearchEntity(task), ctx);
 
-			for await (const task of searchService.searchTasksInBatches(ast.freetext, {
+			// Pass an empty query — the predicate (full AST evaluator) is
+			// authoritative for both freetext and operators. searchTasksInBatches
+			// recognizes the predicate-only mode and scans every active task.
+			for await (const task of searchService.searchTasksInBatches('', {
 				maxResults: MAX_RESULTS + 1, // Fetch one extra to detect hasMore
 				batchSize: 10,
 				searchInDescription: true,

--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -26,17 +26,19 @@ All search runs **client-side** over already-decrypted data — the server never
 **Modifiers**
 
 - `-OPERATOR` — negate the operator. Example: `-tag:archived` (exclude tag), `-is:completed` (only incomplete).
-- `"quoted value"` — preserve whitespace and colons inside an operator value. Example: `tag:"in progress"`, `list:"Q2 planning"`.
+- `-WORD` — exclude items whose title (or body, in the description/content path) contains *WORD*. Example: `cat -mouse` matches items mentioning *cat* but never *mouse*.
+- `"quoted value"` — preserve whitespace and colons. Inside an operator: `tag:"in progress"`, `list:"Q2 planning"`. As plain text: `"meeting prep"` matches the literal phrase including whitespace, instead of *meeting* AND *prep* independently.
+- `-"quoted value"` — exclude a phrase. Example: `cat -"angry mouse"`.
 
 **Combining**
 
-All operators are AND-combined with each other and with any plain-text words. Example:
+All operators are AND-combined with each other and with any plain-text words. Plain-text excludes are AND-combined too — every excluded substring must be absent. Example:
 
 ```
-meeting tag:work -is:completed modified:<14d
+meeting tag:work -is:completed modified:<14d -draft
 ```
 
-…matches items containing the word *meeting*, tagged `work`, not yet completed, modified within the last 14 days.
+…matches items containing the word *meeting*, tagged `work`, not yet completed, modified within the last 14 days, and not containing *draft*.
 
 ---
 
@@ -88,9 +90,11 @@ Plain-text words (anything that's not an operator) match by substring against:
 
 Operators that need note/task body — currently only `has:link` — automatically force the body-aware path even when the toggle is off.
 
-Multiple plain-text words are AND-combined: `meeting prep` requires both *meeting* and *prep* to appear in the searched fields.
+Multiple plain-text words are AND-combined: `meeting prep` requires both *meeting* and *prep* to appear independently in the searched fields. To require the literal phrase including whitespace, wrap it in quotes: `"meeting prep"` matches only items where the two words appear next to each other in that order.
 
-To search for a phrase containing whitespace as a single substring, wrap operator values in quotes (`tag:"side projects"`). Plain-text quoting is not supported — `meeting prep` and `"meeting prep"` behave the same.
+To exclude a substring, prefix it with `-`: `cat -mouse` keeps items mentioning *cat* and drops any that also mention *mouse*. Excludes work on phrases too: `cat -"angry mouse"`.
+
+Quoting also works inside operator values: `tag:"side projects"`, `list:"Q2 planning"`.
 
 ---
 

--- a/packages/utils/src/search-query/ast.ts
+++ b/packages/utils/src/search-query/ast.ts
@@ -1,7 +1,7 @@
 /**
  * AST for the search query language used in reborn-task and reborn-notes search boxes.
  *
- * Supported operators (Tier 1):
+ * Supported operators (Tier 1 + 1.5):
  *   tag:work             — match by tag name
  *   folder:projects/active (notes only) / list:Inbox (task only)
  *   created:>2026-01-01  / created:<7d / created:2026-01-01..2026-02-01
@@ -9,9 +9,15 @@
  *   due:<7d              (task only)
  *   has:link             (forces content-search path)
  *   is:starred | pinned | completed | overdue | trashed
- *   -OPERATOR            negation prefix
+ *   -OPERATOR            negation prefix on operators (-tag:archived, -is:completed)
  *   "quoted value"       allows whitespace and colons in operator values
- *   freetext             everything else; AND-combined as substring match against title
+ *
+ * Freetext (Tier 1.5):
+ *   foo bar              — AND-combined word substrings (each word must appear)
+ *   "foo bar"            — phrase: single substring including the whitespace
+ *   -mouse               — exclude: tokens prefixed with `-` whose body is not a
+ *                          recognized operator are subtractive (must NOT appear)
+ *   -"foo bar"           — exclude phrase
  */
 
 export type DateField = 'created' | 'modified' | 'due';
@@ -49,9 +55,23 @@ export type Filter =
   | { kind: 'has'; value: HasFlag; negated: boolean }
   | { kind: 'is'; value: IsFlag; negated: boolean };
 
+/**
+ * Plain-text portion of the query. Each item in `include` and `exclude` is a
+ * pre-split, lowercased substring; phrases (`"foo bar"`) keep their internal
+ * whitespace as one item, while bare words (`foo bar`) become two items.
+ *
+ * Evaluator semantics:
+ *   - All `include` items must appear in the haystack (title, plus body when
+ *     the body-aware path populates it). AND-combined.
+ *   - No `exclude` item may appear in the haystack.
+ */
+export interface FreetextSpec {
+  include: string[];
+  exclude: string[];
+}
+
 export interface QueryAST {
-  /** Lowercased, space-joined non-operator tokens. Empty string when query has only operators. */
-  freetext: string;
+  freetext: FreetextSpec;
   /** All recognized operators. AND-combined. */
   filters: Filter[];
 }
@@ -64,9 +84,14 @@ export function requiresContent(ast: QueryAST): boolean {
   return ast.filters.some((f) => f.kind === 'has' && f.value === 'link');
 }
 
+/** True when the freetext portion has no include and no exclude items. */
+export function freetextIsEmpty(ft: FreetextSpec): boolean {
+  return ft.include.length === 0 && ft.exclude.length === 0;
+}
+
 /**
  * Returns true when the AST has neither operators nor freetext — i.e. an empty query.
  */
 export function isEmpty(ast: QueryAST): boolean {
-  return ast.freetext.length === 0 && ast.filters.length === 0;
+  return freetextIsEmpty(ast.freetext) && ast.filters.length === 0;
 }

--- a/packages/utils/src/search-query/evaluator.test.ts
+++ b/packages/utils/src/search-query/evaluator.test.ts
@@ -67,6 +67,76 @@ describe('evaluate — freetext', () => {
   });
 });
 
+describe('evaluate — Tier 1.5 freetext phrases and excludes', () => {
+  it('quoted phrase requires the literal substring including whitespace', () => {
+    const ast = parseQuery('"meeting prep"');
+    expect(
+      evaluate(ast, makeEntity({ title: 'Q3 meeting prep agenda' }), makeCtx())
+    ).toBe(true);
+    expect(
+      evaluate(ast, makeEntity({ title: 'meeting agenda — prep notes' }), makeCtx())
+    ).toBe(false);
+  });
+
+  it('plain `-word` excludes entities containing word', () => {
+    const ast = parseQuery('cat -mouse');
+    expect(evaluate(ast, makeEntity({ title: 'a fat cat' }), makeCtx())).toBe(true);
+    expect(
+      evaluate(ast, makeEntity({ title: 'cat and mouse' }), makeCtx())
+    ).toBe(false);
+  });
+
+  it('exclude phrase ignores its substring even if individual words match', () => {
+    const ast = parseQuery('cat -"angry mouse"');
+    expect(evaluate(ast, makeEntity({ title: 'cat with angry mouse' }), makeCtx())).toBe(false);
+    expect(
+      evaluate(ast, makeEntity({ title: 'cat with angry dog and mouse' }), makeCtx())
+    ).toBe(true);
+  });
+
+  it('exclude also looks at body when populated', () => {
+    const ast = parseQuery('-secret');
+    expect(
+      evaluate(ast, makeEntity({ title: 'public', body: 'this is secret' }), makeCtx())
+    ).toBe(false);
+    expect(
+      evaluate(ast, makeEntity({ title: 'public', body: 'nothing here' }), makeCtx())
+    ).toBe(true);
+  });
+
+  it('only-exclude query (no include) matches everything except hits', () => {
+    const ast = parseQuery('-spam');
+    expect(evaluate(ast, makeEntity({ title: 'inbox' }), makeCtx())).toBe(true);
+    expect(evaluate(ast, makeEntity({ title: 'spam folder' }), makeCtx())).toBe(false);
+  });
+
+  it('include and exclude combine with operator filters (all AND)', () => {
+    const ctx = makeCtx({ tagIdByName: new Map([['work', 'tag-w']]) });
+    const ast = parseQuery('tag:work meeting -draft');
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ tagIds: ['tag-w'], title: 'meeting agenda' }),
+        ctx
+      )
+    ).toBe(true);
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ tagIds: ['tag-w'], title: 'meeting draft v2' }),
+        ctx
+      )
+    ).toBe(false);
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ tagIds: ['tag-w'], title: 'lunch' }),
+        ctx
+      )
+    ).toBe(false);
+  });
+});
+
 describe('evaluate — tag filter', () => {
   it('matches when tag id resolves and entity has it', () => {
     const ctx = makeCtx({ tagIdByName: new Map([['work', 'tag-1']]) });

--- a/packages/utils/src/search-query/evaluator.ts
+++ b/packages/utils/src/search-query/evaluator.ts
@@ -1,4 +1,4 @@
-import type { DateExpression, Filter, QueryAST } from './ast';
+import type { DateExpression, Filter, FreetextSpec, QueryAST } from './ast';
 import { resolveDateRef } from './date-parser';
 
 /**
@@ -50,13 +50,18 @@ export function evaluate(ast: QueryAST, entity: SearchEntity, ctx: SearchContext
   return true;
 }
 
-function matchFreetext(needle: string, entity: SearchEntity): boolean {
-  if (!needle) return true;
+function matchFreetext(ft: FreetextSpec, entity: SearchEntity): boolean {
+  if (ft.include.length === 0 && ft.exclude.length === 0) return true;
   const haystack =
     entity.title.toLowerCase() +
     (entity.body !== undefined ? '\n' + entity.body.toLowerCase() : '');
-  const words = needle.split(/\s+/).filter((w) => w.length > 0);
-  return words.every((w) => haystack.includes(w));
+  for (const needle of ft.include) {
+    if (!haystack.includes(needle)) return false;
+  }
+  for (const needle of ft.exclude) {
+    if (haystack.includes(needle)) return false;
+  }
+  return true;
 }
 
 function checkFilter(filter: Filter, entity: SearchEntity, ctx: SearchContext): boolean {

--- a/packages/utils/src/search-query/index.ts
+++ b/packages/utils/src/search-query/index.ts
@@ -3,11 +3,12 @@ export type {
   DateRef,
   DateExpression,
   Filter,
+  FreetextSpec,
   HasFlag,
   IsFlag,
   QueryAST
 } from './ast';
-export { isEmpty, requiresContent } from './ast';
+export { freetextIsEmpty, isEmpty, requiresContent } from './ast';
 export { parseDateExpression, resolveDateRef } from './date-parser';
 export { parseQuery } from './parser';
 export type { SearchContext, SearchEntity } from './evaluator';

--- a/packages/utils/src/search-query/parser.test.ts
+++ b/packages/utils/src/search-query/parser.test.ts
@@ -1,22 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import { parseQuery } from './parser';
 
+const EMPTY_FT = { include: [], exclude: [] };
+
 describe('parseQuery — empty and freetext', () => {
   it('returns empty AST for empty input', () => {
-    expect(parseQuery('')).toEqual({ freetext: '', filters: [] });
-    expect(parseQuery('   ')).toEqual({ freetext: '', filters: [] });
+    expect(parseQuery('')).toEqual({ freetext: EMPTY_FT, filters: [] });
+    expect(parseQuery('   ')).toEqual({ freetext: EMPTY_FT, filters: [] });
   });
 
-  it('lowercases and joins plain freetext', () => {
+  it('lowercases and splits plain freetext into AND-words', () => {
     expect(parseQuery('Hello World')).toEqual({
-      freetext: 'hello world',
+      freetext: { include: ['hello', 'world'], exclude: [] },
       filters: []
     });
   });
 
-  it('preserves quoted whitespace in freetext', () => {
+  it('preserves quoted whitespace as a single phrase', () => {
     expect(parseQuery('"hello world" foo')).toEqual({
-      freetext: 'hello world foo',
+      freetext: { include: ['hello world', 'foo'], exclude: [] },
       filters: []
     });
   });
@@ -26,7 +28,7 @@ describe('parseQuery — operators', () => {
   it('parses tag operator', () => {
     const ast = parseQuery('tag:work');
     expect(ast.filters).toEqual([{ kind: 'tag', value: 'work', negated: false }]);
-    expect(ast.freetext).toBe('');
+    expect(ast.freetext).toEqual(EMPTY_FT);
   });
 
   it('parses negated tag', () => {
@@ -91,7 +93,7 @@ describe('parseQuery — operators', () => {
 
   it('combines operators with freetext', () => {
     const ast = parseQuery('tag:work meeting notes -is:trashed');
-    expect(ast.freetext).toBe('meeting notes');
+    expect(ast.freetext).toEqual({ include: ['meeting', 'notes'], exclude: [] });
     expect(ast.filters).toEqual([
       { kind: 'tag', value: 'work', negated: false },
       { kind: 'is', value: 'trashed', negated: true }
@@ -106,59 +108,112 @@ describe('parseQuery — quoted operator values', () => {
     ]);
   });
 
-  it('treats fully quoted token as freetext', () => {
+  it('treats fully quoted token as a freetext phrase, not as operator', () => {
     const ast = parseQuery('"tag:work"');
-    expect(ast.freetext).toBe('tag:work');
+    expect(ast.freetext).toEqual({ include: ['tag:work'], exclude: [] });
     expect(ast.filters).toEqual([]);
+  });
+});
+
+describe('parseQuery — Tier 1.5 freetext negation', () => {
+  it('plain dashed token becomes an exclude', () => {
+    expect(parseQuery('-broken')).toEqual({
+      freetext: { include: [], exclude: ['broken'] },
+      filters: []
+    });
+  });
+
+  it('mixes include words and excludes', () => {
+    expect(parseQuery('cat dog -mouse')).toEqual({
+      freetext: { include: ['cat', 'dog'], exclude: ['mouse'] },
+      filters: []
+    });
+  });
+
+  it('exclude works with quoted phrase', () => {
+    expect(parseQuery('cat -"angry mouse"')).toEqual({
+      freetext: { include: ['cat'], exclude: ['angry mouse'] },
+      filters: []
+    });
+  });
+
+  it('combines freetext exclude with operator filters', () => {
+    const ast = parseQuery('meeting tag:work -draft');
+    expect(ast.freetext).toEqual({ include: ['meeting'], exclude: ['draft'] });
+    expect(ast.filters).toEqual([{ kind: 'tag', value: 'work', negated: false }]);
+  });
+
+  it('lone dash stays as a freetext include item', () => {
+    expect(parseQuery('-')).toEqual({
+      freetext: { include: ['-'], exclude: [] },
+      filters: []
+    });
+  });
+
+  it('only the leading dash is a negator — extra dashes stay literal', () => {
+    expect(parseQuery('--foo')).toEqual({
+      freetext: { include: [], exclude: ['-foo'] },
+      filters: []
+    });
+  });
+
+  it('hyphenated word in the middle of a token stays as one substring', () => {
+    expect(parseQuery('multi-word-thing')).toEqual({
+      freetext: { include: ['multi-word-thing'], exclude: [] },
+      filters: []
+    });
+  });
+
+  it('lowercases excludes', () => {
+    expect(parseQuery('-FOO')).toEqual({
+      freetext: { include: [], exclude: ['foo'] },
+      filters: []
+    });
   });
 });
 
 describe('parseQuery — graceful degradation', () => {
   it('treats unknown operator as freetext', () => {
     const ast = parseQuery('foo:bar baz');
-    expect(ast.freetext).toBe('foo:bar baz');
+    expect(ast.freetext).toEqual({ include: ['foo:bar', 'baz'], exclude: [] });
     expect(ast.filters).toEqual([]);
   });
 
   it('treats malformed date as freetext', () => {
     const ast = parseQuery('created:tomorrow');
-    expect(ast.freetext).toBe('created:tomorrow');
+    expect(ast.freetext).toEqual({ include: ['created:tomorrow'], exclude: [] });
     expect(ast.filters).toEqual([]);
   });
 
   it('treats unknown is: flag as freetext', () => {
     const ast = parseQuery('is:fancy');
-    expect(ast.freetext).toBe('is:fancy');
+    expect(ast.freetext).toEqual({ include: ['is:fancy'], exclude: [] });
     expect(ast.filters).toEqual([]);
   });
 
   it('treats unknown has: value as freetext', () => {
     const ast = parseQuery('has:image');
-    expect(ast.freetext).toBe('has:image');
+    expect(ast.freetext).toEqual({ include: ['has:image'], exclude: [] });
     expect(ast.filters).toEqual([]);
   });
 
   it('treats empty operator value as freetext', () => {
     const ast = parseQuery('tag:');
-    expect(ast.freetext).toBe('tag:');
+    expect(ast.freetext).toEqual({ include: ['tag:'], exclude: [] });
     expect(ast.filters).toEqual([]);
   });
 
   it('treats colon-only token as freetext', () => {
     const ast = parseQuery(':foo');
-    expect(ast.freetext).toBe(':foo');
+    expect(ast.freetext).toEqual({ include: [':foo'], exclude: [] });
     expect(ast.filters).toEqual([]);
   });
 
-  it('keeps the dash when degraded freetext was negated', () => {
+  it('a `-key:value` with unknown key degrades into a freetext exclude', () => {
+    // The dash is a meaningful negator (Tier 1.5) when the body is not an
+    // operator — `-foo:bar` excludes the substring `foo:bar`.
     const ast = parseQuery('-foo:bar');
-    expect(ast.freetext).toBe('-foo:bar');
-    expect(ast.filters).toEqual([]);
-  });
-
-  it('plain dashed token stays as freetext (no Tier 1 freetext negation)', () => {
-    const ast = parseQuery('-broken');
-    expect(ast.freetext).toBe('-broken');
+    expect(ast.freetext).toEqual({ include: [], exclude: ['foo:bar'] });
     expect(ast.filters).toEqual([]);
   });
 });
@@ -168,7 +223,7 @@ describe('parseQuery — multiple filters', () => {
     const ast = parseQuery(
       'tag:reading -tag:archived folder:inbox created:>2026-01-01 has:link foo bar'
     );
-    expect(ast.freetext).toBe('foo bar');
+    expect(ast.freetext).toEqual({ include: ['foo', 'bar'], exclude: [] });
     expect(ast.filters).toHaveLength(5);
     expect(ast.filters[0]).toMatchObject({ kind: 'tag', value: 'reading', negated: false });
     expect(ast.filters[1]).toMatchObject({ kind: 'tag', value: 'archived', negated: true });

--- a/packages/utils/src/search-query/parser.ts
+++ b/packages/utils/src/search-query/parser.ts
@@ -1,4 +1,4 @@
-import type { DateField, Filter, IsFlag, QueryAST } from './ast';
+import type { DateField, Filter, FreetextSpec, IsFlag, QueryAST } from './ast';
 import { parseDateExpression } from './date-parser';
 
 const IS_FLAGS: ReadonlySet<IsFlag> = new Set([
@@ -33,31 +33,37 @@ interface RawToken {
  * Tokenization rules:
  *   - Whitespace separates tokens; quoted segments (`"..."`) preserve internal whitespace.
  *   - A `:` that is inside quotes does not split key from value.
- *   - A token starting with `-` is tentatively negated; if the key:value combination
- *     is unknown or malformed, the `-` is kept as part of the freetext fallback.
+ *   - A token starting with `-` is tentatively negated:
+ *       - If the rest forms a recognized operator → negated operator filter.
+ *       - Otherwise → freetext exclude (Tier 1.5; the leading `-` is stripped).
  *   - Unknown operator keys, malformed dates, or `is:` flags outside the supported
  *     set degrade the entire token to freetext (no errors, no warnings — the user
  *     simply gets a substring search). This matters because users mid-typing should
  *     never see a hard failure.
+ *   - Multi-word phrases inside quotes stay as a single freetext item, so
+ *     `"meeting prep"` matches the literal substring with whitespace.
  */
 export function parseQuery(input: string): QueryAST {
   const tokens = tokenize(input);
   const filters: Filter[] = [];
-  const textTokens: string[] = [];
+  const include: string[] = [];
+  const exclude: string[] = [];
 
   for (const tok of tokens) {
     const classified = classify(tok);
-    if (classified.kind === 'text') {
-      textTokens.push(classified.value);
+    if (classified.kind === 'filter') {
+      filters.push(classified.filter);
+      continue;
+    }
+    if (classified.kind === 'exclude') {
+      exclude.push(classified.value);
     } else {
-      filters.push(classified);
+      include.push(classified.value);
     }
   }
 
-  return {
-    freetext: textTokens.join(' ').toLowerCase().trim(),
-    filters
-  };
+  const freetext: FreetextSpec = { include, exclude };
+  return { freetext, filters };
 }
 
 function tokenize(input: string): RawToken[] {
@@ -92,30 +98,37 @@ function tokenize(input: string): RawToken[] {
   return tokens;
 }
 
-type TextResult = { kind: 'text'; value: string };
+type ClassifyResult =
+  | { kind: 'filter'; filter: Filter }
+  | { kind: 'include'; value: string }
+  | { kind: 'exclude'; value: string };
 
-function classify(token: RawToken): Filter | TextResult {
+function classify(token: RawToken): ClassifyResult {
   const { text, unquotedColonIdx } = token;
   const negated = text.startsWith('-');
   const keyStart = negated ? 1 : 0;
 
-  // Need a non-empty key before the colon and a colon past `keyStart`.
-  if (unquotedColonIdx <= keyStart) {
-    return { kind: 'text', value: text };
+  // Try operator first (with or without `-` prefix). Need a non-empty key
+  // before the colon and a colon past `keyStart`.
+  if (unquotedColonIdx > keyStart) {
+    const key = text.slice(keyStart, unquotedColonIdx).toLowerCase();
+    if (KNOWN_KEYS.has(key)) {
+      const value = text.slice(unquotedColonIdx + 1);
+      if (value) {
+        const filter = parseOperator(key, value, negated);
+        if (filter) return { kind: 'filter', filter };
+      }
+    }
   }
 
-  const key = text.slice(keyStart, unquotedColonIdx).toLowerCase();
-  if (!KNOWN_KEYS.has(key)) {
-    return { kind: 'text', value: text };
+  // Not an operator — treat as freetext. A leading `-` on a non-operator token
+  // means "exclude this substring", but only when there's something after it
+  // (a bare `-` stays as include). Lowercase for case-insensitive matching;
+  // empty results are dropped by the caller.
+  if (negated && text.length > 1) {
+    return { kind: 'exclude', value: text.slice(1).toLowerCase() };
   }
-
-  const value = text.slice(unquotedColonIdx + 1);
-  if (!value) {
-    return { kind: 'text', value: text };
-  }
-
-  const filter = parseOperator(key, value, negated);
-  return filter ?? { kind: 'text', value: text };
+  return { kind: 'include', value: text.toLowerCase() };
 }
 
 function parseOperator(key: string, value: string, negated: boolean): Filter | null {


### PR DESCRIPTION
Extends the search-query parser/evaluator with two fast-follow modifiers on top of Tier 1 operators:

- `-WORD` / `-"phrase"` — exclude a substring from the haystack. Plain dashed tokens whose body is not a recognized operator now subtract from results instead of being kept literally as freetext.
- `"meeting prep"` — quoted plain-text becomes a phrase: a single substring including whitespace, instead of AND-combined words.

Aligns with Gmail/GitHub/Linear conventions (implicit AND, `-` for NOT, quotes for phrase). Operator negation (`-tag:archived`) was already in Tier 1 and stays unchanged.

AST shape: replaces the flat `freetext: string` with a structured `FreetextSpec { include: string[]; exclude: string[] }`. The evaluator AND-checks every include and ensures every exclude is absent. Helper `freetextIsEmpty(spec)` exported for the per-app routing layers.

Per-app routing keeps the cheap title-substring fast path for the common single-word case (no excludes, no operators); anything else goes through `getFilteredByAst`, which now handles include/exclude semantics consistently. The body-aware path in re/task drops the redundant freetext substring filter inside searchTasksInBatches and relies on the AST predicate as the sole authority — passing an empty query and letting the predicate decide both freetext and operators.

Tests: 81/81 in @reborn/utils (was 68; +13 new for negation, phrases, and edge cases like bare \`-\`, \`--foo\`, hyphenated middle, lowercased excludes, exclude with operators). Both apps stay green: reborn-notes 366/366, reborn-task 25/25, both typecheck 0/0.

Travis (computrav, 2026-05-07) flagged this as P0/P1 fast-follow after Tier 1 landed — implicit AND with phrase quoting and freetext negation were the two visible gaps relative to the conventions users already know.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>