### PR TITLE
feat(search): tier 2 boolean or grouping

### DIFF
--- a/apps/reborn-notes/src/lib/stores/notes.store.ts
+++ b/apps/reborn-notes/src/lib/stores/notes.store.ts
@@ -3,8 +3,8 @@ import { untrack } from 'svelte';
 import { browser } from '$app/environment';
 import type { NoteDecrypted } from '@reborn/types';
 import {
+  buildLiteAst,
   evaluate,
-  freetextIsEmpty,
   isEmpty as isAstEmpty,
   parseQuery,
   requiresContent,
@@ -134,21 +134,19 @@ function createNotesStore() {
   }
 
   /**
-   * Synchronous AST/freetext evaluation against the in-memory NoteIndex (no body).
+   * Synchronous AST evaluation against the in-memory NoteIndex (no body).
    *
    * Three routing cases:
-   *   1. Empty AST (no filters, no freetext) — return the visible scope as-is.
-   *   2. Single-word freetext, no operators — fast title-substring path through
+   *   1. Empty AST — return the visible scope as-is.
+   *   2. Single positive leaf-text — fast title-substring path through
    *      `getFiltered({ search })`. Bypasses building a SearchContext.
-   *   3. Anything else (multi-word, phrase, exclude, or operators) — full AST
-   *      evaluation via `getFilteredByAst`, which handles include/exclude
-   *      semantics consistently.
+   *   3. Anything else — full AST evaluation via `getFilteredByAst`.
    */
   function evaluateAgainstIndex(
     ast: QueryAST,
     filterOpts: ReturnType<typeof buildFilterOptions>
   ): NoteListItem[] {
-    if (ast.filters.length === 0 && freetextIsEmpty(ast.freetext)) {
+    if (isAstEmpty(ast)) {
       const { items } = noteIndex.getFiltered({
         ...filterOpts,
         pageSize: Number.MAX_SAFE_INTEGER
@@ -156,13 +154,13 @@ function createNotesStore() {
       return items;
     }
     if (
-      ast.filters.length === 0 &&
-      ast.freetext.exclude.length === 0 &&
-      ast.freetext.include.length === 1
+      ast.root !== null &&
+      ast.root.kind === 'leaf-text' &&
+      !ast.root.negated
     ) {
       const { items } = noteIndex.getFiltered({
         ...filterOpts,
-        search: ast.freetext.include[0],
+        search: ast.root.value,
         pageSize: Number.MAX_SAFE_INTEGER
       });
       return items;
@@ -203,23 +201,22 @@ function createNotesStore() {
     const myVersion = ++contentSearchVersion;
     loading.set(true);
     try {
-      // 1. Pre-filter: structural operators only.
-      const liteAst: QueryAST = {
-        freetext: { include: [], exclude: [] },
-        filters: ast.filters.filter((f) => f.kind !== 'has')
-      };
+      // 1. Pre-filter: lite-AST drops body-dependent leaves (leaf-text,
+      //    has:*) so the candidate set isn't pruned by predicates that need
+      //    the decrypted body. Polarity-aware — `-(cat) tag:work` keeps
+      //    tag:work, doesn't collapse to FALSE.
+      const liteAst = buildLiteAst(ast);
       const ctx = buildSearchContext();
-      const candidates =
-        liteAst.filters.length === 0
-          ? noteIndex.getFiltered({
-              ...filterOpts,
-              search: undefined,
-              pageSize: Number.MAX_SAFE_INTEGER
-            }).items
-          : noteIndex.getFilteredByAst(liteAst, ctx, {
-              ...filterOpts,
-              pageSize: Number.MAX_SAFE_INTEGER
-            }).items;
+      const candidates = isAstEmpty(liteAst)
+        ? noteIndex.getFiltered({
+            ...filterOpts,
+            search: undefined,
+            pageSize: Number.MAX_SAFE_INTEGER
+          }).items
+        : noteIndex.getFilteredByAst(liteAst, ctx, {
+            ...filterOpts,
+            pageSize: Number.MAX_SAFE_INTEGER
+          }).items;
 
       // 2. Stream-decrypt: peak ≈ 1 body. `full` and the per-iteration entity
       //    drop out of scope on each loop turn → eligible for GC. Only metadata

--- a/apps/reborn-task/src/lib/stores/task-list-view.store.ts
+++ b/apps/reborn-task/src/lib/stores/task-list-view.store.ts
@@ -24,9 +24,9 @@ import { browser } from '$app/environment';
 import { taskStore } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
 import {
+	buildLiteAst,
 	createLogger,
 	evaluate,
-	freetextIsEmpty,
 	isEmpty as isAstEmpty,
 	parseQuery,
 	requiresContent,
@@ -166,27 +166,23 @@ function createTaskListViewStore() {
 	}
 
 	/**
-	 * Synchronous AST/freetext evaluation against the in-memory TaskIndex.
+	 * Synchronous AST evaluation against the in-memory TaskIndex.
 	 *
 	 * Three routing cases (mirrors Notes):
 	 *   1. Empty AST → return the visible scope as-is via `getFiltered`.
-	 *   2. Single-word freetext, no operators, no excludes → fast title-substring
-	 *      path through `getFiltered({ search })`. Bypasses building a SearchContext.
+	 *   2. Single positive leaf-text → fast title-substring path through
+	 *      `getFiltered({ search })`. Bypasses building a SearchContext.
 	 *   3. Anything else → full AST evaluation via `getFilteredByAst`.
 	 */
 	function evaluateAgainstIndex(
 		ast: QueryAST,
 		filterOpts: TaskFilterOptions & TaskFilterByAstOptions
 	): TaskListItem[] {
-		if (ast.filters.length === 0 && freetextIsEmpty(ast.freetext)) {
+		if (isAstEmpty(ast)) {
 			return taskIndex.getFiltered(filterOpts).items;
 		}
-		if (
-			ast.filters.length === 0 &&
-			ast.freetext.exclude.length === 0 &&
-			ast.freetext.include.length === 1
-		) {
-			return taskIndex.getFiltered({ ...filterOpts, search: ast.freetext.include[0] }).items;
+		if (ast.root !== null && ast.root.kind === 'leaf-text' && !ast.root.negated) {
+			return taskIndex.getFiltered({ ...filterOpts, search: ast.root.value }).items;
 		}
 		const ctx = buildTaskSearchContext();
 		return taskIndex.getFilteredByAst(ast, ctx, filterOpts).items;
@@ -218,16 +214,14 @@ function createTaskListViewStore() {
 		const myVersion = ++contentSearchVersion;
 		loading.set(true);
 		try {
-			// 1. Pre-filter: structural operators only.
-			const liteAst: QueryAST = {
-				freetext: { include: [], exclude: [] },
-				filters: ast.filters.filter((f) => f.kind !== 'has')
-			};
+			// 1. Pre-filter: lite-AST drops body-dependent leaves (leaf-text,
+			//    has:*) and is polarity-aware so NOT-of-leaf-text doesn't
+			//    collapse the candidate set.
+			const liteAst = buildLiteAst(ast);
 			const ctx = buildTaskSearchContext();
-			const candidates =
-				liteAst.filters.length === 0
-					? taskIndex.getFiltered(filterOpts).items
-					: taskIndex.getFilteredByAst(liteAst, ctx, filterOpts).items;
+			const candidates = isAstEmpty(liteAst)
+				? taskIndex.getFiltered(filterOpts).items
+				: taskIndex.getFilteredByAst(liteAst, ctx, filterOpts).items;
 
 			// Quick lookup of encrypted records for streaming decryption.
 			const encryptedById = new Map<string, TaskEncryptedBooleans>();

--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -32,13 +32,80 @@ All search runs **client-side** over already-decrypted data — the server never
 
 **Combining**
 
-All operators are AND-combined with each other and with any plain-text words. Plain-text excludes are AND-combined too — every excluded substring must be absent. Example:
+By default everything is AND-combined: operators with each other, operators with plain-text words, and excludes too — every clause must hold simultaneously. Example:
 
 ```
 meeting tag:work -is:completed modified:<14d -draft
 ```
 
 …matches items containing the word *meeting*, tagged `work`, not yet completed, modified within the last 14 days, and not containing *draft*.
+
+To express "either / or" relationships, use the `OR` operator described below.
+
+---
+
+## Boolean operators
+
+Beyond the implicit AND, the search box supports explicit `OR`, parenthesized groups, and group negation.
+
+### `OR` — alternatives
+
+```
+cat OR mouse                    # title or body contains "cat" OR "mouse"
+tag:work OR tag:personal        # either tag matches
+is:completed OR is:overdue      # finished or past due
+```
+
+`OR` must be **uppercase** with surrounding whitespace. Lowercase `or` is treated as a plain text word — same convention as Gmail, GitHub, and Linear. To search for the literal substring `OR`, quote it: `"OR"`.
+
+**Precedence — AND binds tighter than OR.** That mirrors how the operator behaves in mainstream search boxes:
+
+```
+cat dog OR mouse                # = (cat AND dog) OR mouse
+```
+
+When in doubt, parenthesize.
+
+### Grouping with `(...)`
+
+Parentheses override precedence and let you compose richer queries:
+
+```
+tag:work (is:starred OR modified:<7d)         # work items, either starred OR recently touched
+(cat OR dog) -tag:archived                    # mentions cat or dog, not archived
+(tag:reading AND has:link) OR is:starred      # reading items with a link, or anything starred
+```
+
+Empty groups `()` are ignored. Redundant nesting like `((cat))` collapses naturally.
+
+### Negating a group with `-(...)`
+
+A leading `-` before a group negates the entire group:
+
+```
+-(tag:archived OR is:trashed)   # neither archived nor trashed
+tag:work -(is:completed AND -has:link)  # active work tasks that have either an
+                                        # incomplete state or a linked reference
+```
+
+This is distinct from leaf-level negation (`-tag:archived`, `-mouse`), which negates a single operator or word.
+
+### Quoted boolean tokens
+
+Quotes always preserve characters literally — `OR`, `(`, and `)` inside quotes are treated as part of the value, not as boolean syntax:
+
+```
+"cat OR dog"     # plain phrase including the literal text "OR"
+tag:"or another" # tag value containing the substring "or another"
+"(test)"         # plain phrase, parens are part of the title to search for
+```
+
+### Graceful fallback
+
+If the parser hits a structural problem (an unmatched parenthesis, a dangling `OR`), the whole query degrades to a flat plain-text parse — the offending characters become literal substring tokens. You'll never see a red error state mid-typing; the search just becomes less specific until the syntax is balanced again. Examples:
+
+- `(cat OR ` — unmatched `(`. Searches for items literally containing `(`, `cat`, and `or`.
+- `cat OR` — trailing `OR`. Searches for items literally containing `cat` and `or`.
 
 ---
 

--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -46,7 +46,7 @@ To express "either / or" relationships, use the `OR` operator described below.
 
 ## Boolean operators
 
-Beyond the implicit AND, the search box supports explicit `OR`, parenthesized groups, and group negation.
+Beyond the implicit AND, the search box supports explicit `OR`, parenthesized groups, and group negation. Explicit `AND` is also recognized as a redundant synonym for the implicit AND.
 
 ### `OR` — alternatives
 
@@ -65,6 +65,17 @@ cat dog OR mouse                # = (cat AND dog) OR mouse
 ```
 
 When in doubt, parenthesize.
+
+### `AND` — explicit (and redundant)
+
+A space between two clauses already means AND, so `cat dog` and `cat AND dog` produce the same results. The explicit form exists for symmetry with `OR` — useful inside groups where the boolean intent is clearer when written out:
+
+```
+(cat AND dog) OR mouse          # equivalent to (cat dog) OR mouse
+tag:work AND -is:completed      # equivalent to tag:work -is:completed
+```
+
+`AND` must be **uppercase** with surrounding whitespace, exactly like `OR`. Lowercase `and` and the quoted form `"AND"` are treated as the plain text word `and`. AND has the same precedence as the implicit space — i.e. tighter than OR — so `cat AND dog OR mouse` parses as `(cat AND dog) OR mouse`.
 
 ### Grouping with `(...)`
 
@@ -92,20 +103,22 @@ This is distinct from leaf-level negation (`-tag:archived`, `-mouse`), which neg
 
 ### Quoted boolean tokens
 
-Quotes always preserve characters literally — `OR`, `(`, and `)` inside quotes are treated as part of the value, not as boolean syntax:
+Quotes always preserve characters literally — `OR`, `AND`, `(`, and `)` inside quotes are treated as part of the value, not as boolean syntax:
 
 ```
 "cat OR dog"     # plain phrase including the literal text "OR"
+"cat AND dog"    # plain phrase including the literal text "AND"
 tag:"or another" # tag value containing the substring "or another"
 "(test)"         # plain phrase, parens are part of the title to search for
 ```
 
 ### Graceful fallback
 
-If the parser hits a structural problem (an unmatched parenthesis, a dangling `OR`), the whole query degrades to a flat plain-text parse — the offending characters become literal substring tokens. You'll never see a red error state mid-typing; the search just becomes less specific until the syntax is balanced again. Examples:
+If the parser hits a structural problem (an unmatched parenthesis, a dangling `OR` or `AND`), the whole query degrades to a flat plain-text parse — the offending characters become literal substring tokens. You'll never see a red error state mid-typing; the search just becomes less specific until the syntax is balanced again. Examples:
 
 - `(cat OR ` — unmatched `(`. Searches for items literally containing `(`, `cat`, and `or`.
 - `cat OR` — trailing `OR`. Searches for items literally containing `cat` and `or`.
+- `cat AND` — trailing `AND`. Searches for items literally containing `cat` and `and`.
 
 ---
 

--- a/packages/utils/src/search-query/ast.ts
+++ b/packages/utils/src/search-query/ast.ts
@@ -1,7 +1,7 @@
 /**
  * AST for the search query language used in reborn-task and reborn-notes search boxes.
  *
- * Supported operators (Tier 1 + 1.5):
+ * Supported operators (Tier 1 + 1.5 + 2):
  *   tag:work             — match by tag name
  *   folder:projects/active (notes only) / list:Inbox (task only)
  *   created:>2026-01-01  / created:<7d / created:2026-01-01..2026-02-01
@@ -12,12 +12,22 @@
  *   -OPERATOR            negation prefix on operators (-tag:archived, -is:completed)
  *   "quoted value"       allows whitespace and colons in operator values
  *
+ * Boolean operators (Tier 2):
+ *   foo bar              — implicit AND between consecutive primaries
+ *   foo OR bar           — explicit OR (uppercase only — lowercase `or` is plain text)
+ *   (foo bar) OR baz     — grouping; precedence is AND > OR
+ *   -(tag:work OR is:trashed) — negate a group
+ *
  * Freetext (Tier 1.5):
- *   foo bar              — AND-combined word substrings (each word must appear)
+ *   foo                  — substring match against title (and body when populated)
  *   "foo bar"            — phrase: single substring including the whitespace
- *   -mouse               — exclude: tokens prefixed with `-` whose body is not a
- *                          recognized operator are subtractive (must NOT appear)
+ *   -mouse               — exclude: leaf-text with negated:true
  *   -"foo bar"           — exclude phrase
+ *
+ * Graceful degradation (Tier 2):
+ *   Unmatched parens or dangling `OR` fall back to a flat parse where the
+ *   offending characters become plain freetext — the user never sees a
+ *   hard error mid-typing.
  */
 
 export type DateField = 'created' | 'modified' | 'due';
@@ -56,42 +66,54 @@ export type Filter =
   | { kind: 'is'; value: IsFlag; negated: boolean };
 
 /**
- * Plain-text portion of the query. Each item in `include` and `exclude` is a
- * pre-split, lowercased substring; phrases (`"foo bar"`) keep their internal
- * whitespace as one item, while bare words (`foo bar`) become two items.
+ * Tree-shaped AST node. AND / OR are n-ary so a flat sequence like
+ * `cat dog mouse` becomes a single `And([…])` instead of nesting binary ANDs.
  *
- * Evaluator semantics:
- *   - All `include` items must appear in the haystack (title, plus body when
- *     the body-aware path populates it). AND-combined.
- *   - No `exclude` item may appear in the haystack.
+ * Leaf-level `negated` is preserved on `Filter` (Tier 1.5 syntax `-tag:archived`)
+ * and on `leaf-text` (`-mouse`). `Not(child)` is reserved for explicit group
+ * negation (`-(group)`), which has no leaf-level equivalent.
+ *
+ * TRUE / FALSE sentinels used by the lite-AST builder are encoded as
+ * `{ kind: 'and', children: [] }` (TRUE — `every` over empty is true) and
+ * `{ kind: 'or', children: [] }` (FALSE — `some` over empty is false). This
+ * keeps the type closed without adding sentinel kinds.
  */
-export interface FreetextSpec {
-  include: string[];
-  exclude: string[];
-}
+export type Node =
+  | { kind: 'and'; children: Node[] }
+  | { kind: 'or'; children: Node[] }
+  | { kind: 'not'; child: Node }
+  | { kind: 'leaf-filter'; filter: Filter }
+  | { kind: 'leaf-text'; value: string; negated: boolean };
 
 export interface QueryAST {
-  freetext: FreetextSpec;
-  /** All recognized operators. AND-combined. */
-  filters: Filter[];
+  /** `null` represents an empty query (matches everything). */
+  root: Node | null;
 }
 
 /**
- * Returns true if any filter requires decrypting entity body (description/content).
- * Used by the search wrapper to decide between title-instant and content-async paths.
+ * Returns true if any leaf in the AST requires decrypting entity body —
+ * currently only `has:link`. Used by the search wrapper to decide between
+ * the title-instant path and the content-async path.
  */
 export function requiresContent(ast: QueryAST): boolean {
-  return ast.filters.some((f) => f.kind === 'has' && f.value === 'link');
+  return ast.root !== null && nodeRequiresContent(ast.root);
 }
 
-/** True when the freetext portion has no include and no exclude items. */
-export function freetextIsEmpty(ft: FreetextSpec): boolean {
-  return ft.include.length === 0 && ft.exclude.length === 0;
+function nodeRequiresContent(node: Node): boolean {
+  switch (node.kind) {
+    case 'and':
+    case 'or':
+      return node.children.some(nodeRequiresContent);
+    case 'not':
+      return nodeRequiresContent(node.child);
+    case 'leaf-filter':
+      return node.filter.kind === 'has';
+    case 'leaf-text':
+      return false;
+  }
 }
 
-/**
- * Returns true when the AST has neither operators nor freetext — i.e. an empty query.
- */
+/** True when the AST has no root — i.e. the query is empty. */
 export function isEmpty(ast: QueryAST): boolean {
-  return freetextIsEmpty(ast.freetext) && ast.filters.length === 0;
+  return ast.root === null;
 }

--- a/packages/utils/src/search-query/evaluator.test.ts
+++ b/packages/utils/src/search-query/evaluator.test.ts
@@ -393,6 +393,122 @@ describe('evaluate — combinations', () => {
   });
 });
 
+describe('evaluate — Tier 2 boolean OR', () => {
+  it('OR matches when either disjunct matches', () => {
+    const ast = parseQuery('cat OR dog');
+    expect(evaluate(ast, makeEntity({ title: 'My cat is fluffy' }), makeCtx())).toBe(true);
+    expect(evaluate(ast, makeEntity({ title: 'A dog at home' }), makeCtx())).toBe(true);
+    expect(evaluate(ast, makeEntity({ title: 'A horse on the hill' }), makeCtx())).toBe(false);
+  });
+
+  it('OR across operator filters', () => {
+    const ctx = makeCtx({
+      tagIdByName: new Map([
+        ['work', 'tag-w'],
+        ['personal', 'tag-p']
+      ])
+    });
+    const ast = parseQuery('tag:work OR tag:personal');
+    expect(evaluate(ast, makeEntity({ tagIds: ['tag-w'] }), ctx)).toBe(true);
+    expect(evaluate(ast, makeEntity({ tagIds: ['tag-p'] }), ctx)).toBe(true);
+    expect(evaluate(ast, makeEntity({ tagIds: [] }), ctx)).toBe(false);
+  });
+
+  it('AND binds tighter than OR — `cat dog OR mouse`', () => {
+    const ast = parseQuery('cat dog OR mouse');
+    // Matches when (cat AND dog) OR mouse holds.
+    expect(evaluate(ast, makeEntity({ title: 'cat and dog walk' }), makeCtx())).toBe(true);
+    expect(evaluate(ast, makeEntity({ title: 'a mouse alone' }), makeCtx())).toBe(true);
+    expect(evaluate(ast, makeEntity({ title: 'cat alone' }), makeCtx())).toBe(false);
+  });
+});
+
+describe('evaluate — Tier 2 grouping', () => {
+  it('group changes precedence', () => {
+    const ctx = makeCtx({
+      tagIdByName: new Map([['work', 'tag-w']])
+    });
+    const ast = parseQuery('tag:work AND (is:starred OR is:pinned)');
+    // `AND` is not a real keyword (we only have implicit AND); Gmail-like
+    // behaviour means literal lowercase "and" is plain text. So tokens here
+    // are tag:work, AND (a literal word), and a grouped OR. The literal
+    // "and" must appear in title for the AND-arm to match — adjust title.
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ title: 'and item', tagIds: ['tag-w'], flags: { starred: true } }),
+        ctx
+      )
+    ).toBe(true);
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ title: 'and item', tagIds: ['tag-w'], flags: { pinned: true } }),
+        ctx
+      )
+    ).toBe(true);
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ title: 'and item', tagIds: ['tag-w'], flags: {} }),
+        ctx
+      )
+    ).toBe(false);
+  });
+
+  it('grouped OR with implicit AND outside', () => {
+    const ctx = makeCtx({
+      tagIdByName: new Map([['work', 'tag-w']])
+    });
+    const ast = parseQuery('tag:work (is:starred OR is:pinned)');
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ tagIds: ['tag-w'], flags: { starred: true } }),
+        ctx
+      )
+    ).toBe(true);
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ tagIds: ['tag-w'], flags: {} }),
+        ctx
+      )
+    ).toBe(false);
+    expect(
+      evaluate(
+        ast,
+        makeEntity({ tagIds: [], flags: { starred: true } }),
+        ctx
+      )
+    ).toBe(false);
+  });
+
+  it('negated group excludes any inner match', () => {
+    const ctx = makeCtx({
+      tagIdByName: new Map([['archived', 'tag-a']])
+    });
+    const ast = parseQuery('-(tag:archived OR is:trashed)');
+    // Matches entities that are neither tagged archived nor trashed.
+    expect(
+      evaluate(ast, makeEntity({ tagIds: [], flags: {} }), ctx)
+    ).toBe(true);
+    expect(
+      evaluate(ast, makeEntity({ tagIds: ['tag-a'], flags: {} }), ctx)
+    ).toBe(false);
+    expect(
+      evaluate(ast, makeEntity({ tagIds: [], flags: { trashed: true } }), ctx)
+    ).toBe(false);
+  });
+
+  it('negated group also excludes leaf-text matches inside', () => {
+    const ast = parseQuery('-(spam OR draft)');
+    expect(evaluate(ast, makeEntity({ title: 'inbox' }), makeCtx())).toBe(true);
+    expect(evaluate(ast, makeEntity({ title: 'spam folder' }), makeCtx())).toBe(false);
+    expect(evaluate(ast, makeEntity({ title: 'draft v2' }), makeCtx())).toBe(false);
+  });
+});
+
 describe('AST helpers', () => {
   it('isEmpty detects empty AST', () => {
     expect(isEmpty(parseQuery(''))).toBe(true);
@@ -405,5 +521,11 @@ describe('AST helpers', () => {
     expect(requiresContent(parseQuery('tag:work'))).toBe(false);
     expect(requiresContent(parseQuery('has:link'))).toBe(true);
     expect(requiresContent(parseQuery('tag:work has:link'))).toBe(true);
+  });
+
+  it('requiresContent walks through OR and NOT', () => {
+    expect(requiresContent(parseQuery('cat OR has:link'))).toBe(true);
+    expect(requiresContent(parseQuery('-(has:link)'))).toBe(true);
+    expect(requiresContent(parseQuery('cat OR dog'))).toBe(false);
   });
 });

--- a/packages/utils/src/search-query/evaluator.ts
+++ b/packages/utils/src/search-query/evaluator.ts
@@ -1,4 +1,4 @@
-import type { DateExpression, Filter, FreetextSpec, QueryAST } from './ast';
+import type { DateExpression, Filter, Node, QueryAST } from './ast';
 import { resolveDateRef } from './date-parser';
 
 /**
@@ -60,26 +60,49 @@ function bodyContainsLink(body: string): boolean {
   return false;
 }
 
+/**
+ * Walks the tree AST and returns true iff the entity satisfies the query.
+ *
+ * Empty AST (`root === null`) matches everything — consumers lean on this so
+ * they don't need a special `isEmpty` early-return at every call site.
+ *
+ * The haystack (lowercased title + optional body) is computed once per
+ * `evaluate()` call and shared across every leaf-text node, so a query like
+ * `cat OR dog OR mouse` doesn't rebuild the same string three times.
+ */
 export function evaluate(ast: QueryAST, entity: SearchEntity, ctx: SearchContext): boolean {
-  if (!matchFreetext(ast.freetext, entity)) return false;
-  for (const filter of ast.filters) {
-    if (!checkFilter(filter, entity, ctx)) return false;
-  }
-  return true;
+  if (ast.root === null) return true;
+  const haystack = buildHaystack(entity);
+  return evalNode(ast.root, entity, ctx, haystack);
 }
 
-function matchFreetext(ft: FreetextSpec, entity: SearchEntity): boolean {
-  if (ft.include.length === 0 && ft.exclude.length === 0) return true;
-  const haystack =
+function evalNode(
+  node: Node,
+  entity: SearchEntity,
+  ctx: SearchContext,
+  haystack: string
+): boolean {
+  switch (node.kind) {
+    case 'and':
+      return node.children.every((c) => evalNode(c, entity, ctx, haystack));
+    case 'or':
+      return node.children.some((c) => evalNode(c, entity, ctx, haystack));
+    case 'not':
+      return !evalNode(node.child, entity, ctx, haystack);
+    case 'leaf-filter':
+      return checkFilter(node.filter, entity, ctx);
+    case 'leaf-text': {
+      const present = haystack.includes(node.value);
+      return node.negated ? !present : present;
+    }
+  }
+}
+
+function buildHaystack(entity: SearchEntity): string {
+  return (
     entity.title.toLowerCase() +
-    (entity.body !== undefined ? '\n' + entity.body.toLowerCase() : '');
-  for (const needle of ft.include) {
-    if (!haystack.includes(needle)) return false;
-  }
-  for (const needle of ft.exclude) {
-    if (haystack.includes(needle)) return false;
-  }
-  return true;
+    (entity.body !== undefined ? '\n' + entity.body.toLowerCase() : '')
+  );
 }
 
 function checkFilter(filter: Filter, entity: SearchEntity, ctx: SearchContext): boolean {

--- a/packages/utils/src/search-query/index.ts
+++ b/packages/utils/src/search-query/index.ts
@@ -13,3 +13,4 @@ export { parseDateExpression, resolveDateRef } from './date-parser';
 export { parseQuery } from './parser';
 export type { SearchContext, SearchEntity } from './evaluator';
 export { emptySearchContext, evaluate } from './evaluator';
+export { buildLiteAst } from './lite-ast';

--- a/packages/utils/src/search-query/index.ts
+++ b/packages/utils/src/search-query/index.ts
@@ -3,12 +3,12 @@ export type {
   DateRef,
   DateExpression,
   Filter,
-  FreetextSpec,
   HasFlag,
   IsFlag,
+  Node,
   QueryAST
 } from './ast';
-export { freetextIsEmpty, isEmpty, requiresContent } from './ast';
+export { isEmpty, requiresContent } from './ast';
 export { parseDateExpression, resolveDateRef } from './date-parser';
 export { parseQuery } from './parser';
 export type { SearchContext, SearchEntity } from './evaluator';

--- a/packages/utils/src/search-query/lite-ast.test.ts
+++ b/packages/utils/src/search-query/lite-ast.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import type { Node, QueryAST } from './ast';
+import { isEmpty } from './ast';
+import { emptySearchContext, evaluate, type SearchEntity } from './evaluator';
+import { buildLiteAst } from './lite-ast';
+import { parseQuery } from './parser';
+
+const tag = (value: string, negated = false): Node => ({
+  kind: 'leaf-filter',
+  filter: { kind: 'tag', value, negated }
+});
+const is = (
+  value: 'starred' | 'pinned' | 'completed' | 'overdue' | 'trashed',
+  negated = false
+): Node => ({ kind: 'leaf-filter', filter: { kind: 'is', value, negated } });
+const and = (...children: Node[]): Node => ({ kind: 'and', children });
+const or = (...children: Node[]): Node => ({ kind: 'or', children });
+const not = (child: Node): Node => ({ kind: 'not', child });
+
+const TRUE_AST: QueryAST = { root: null };
+
+describe('buildLiteAst — pass-through and trivial cases', () => {
+  it('empty AST stays empty', () => {
+    expect(buildLiteAst({ root: null })).toEqual(TRUE_AST);
+  });
+
+  it('lone leaf-text collapses to empty AST (matches everything)', () => {
+    expect(buildLiteAst(parseQuery('cat'))).toEqual(TRUE_AST);
+  });
+
+  it('lone has:link collapses to empty AST', () => {
+    expect(buildLiteAst(parseQuery('has:link'))).toEqual(TRUE_AST);
+  });
+
+  it('lone structural filter passes through verbatim', () => {
+    expect(buildLiteAst(parseQuery('tag:work'))).toEqual({ root: tag('work') });
+  });
+});
+
+describe('buildLiteAst — AND simplification', () => {
+  it('drops leaf-text from AND, keeps structural', () => {
+    expect(buildLiteAst(parseQuery('cat tag:work'))).toEqual({
+      root: tag('work')
+    });
+  });
+
+  it('drops has:link from AND, keeps structural', () => {
+    expect(buildLiteAst(parseQuery('tag:work has:link'))).toEqual({
+      root: tag('work')
+    });
+  });
+
+  it('AND of two structurals stays as AND', () => {
+    expect(buildLiteAst(parseQuery('tag:work is:starred'))).toEqual({
+      root: and(tag('work'), is('starred'))
+    });
+  });
+
+  it('AND of all-TRUE collapses to empty AST', () => {
+    expect(buildLiteAst(parseQuery('cat dog has:link'))).toEqual(TRUE_AST);
+  });
+});
+
+describe('buildLiteAst — OR simplification', () => {
+  it('OR with TRUE arm collapses entire OR to empty AST', () => {
+    // `tag:work OR has:link` → over-match: pre-filter returns full scope,
+    // body-aware pass narrows down. This is the documented trade-off.
+    expect(buildLiteAst(parseQuery('tag:work OR has:link'))).toEqual(TRUE_AST);
+  });
+
+  it('OR with leaf-text arm collapses to TRUE', () => {
+    expect(buildLiteAst(parseQuery('tag:work OR cat'))).toEqual(TRUE_AST);
+  });
+
+  it('OR of two structurals stays as OR', () => {
+    expect(buildLiteAst(parseQuery('tag:work OR is:starred'))).toEqual({
+      root: or(tag('work'), is('starred'))
+    });
+  });
+
+  it('inner OR with body-dep arm under outer AND drops to outer structural', () => {
+    expect(buildLiteAst(parseQuery('tag:work (cat OR is:starred)'))).toEqual({
+      root: tag('work')
+    });
+  });
+});
+
+describe('buildLiteAst — NOT simplification (polarity-aware)', () => {
+  it('NOT(leaf-text) keeps structural AND arm — no under-match', () => {
+    // `-(cat) tag:work` should NOT collapse to FALSE. With polarity-aware
+    // strip: leaf-text under negative polarity → FALSE → NOT(FALSE) = TRUE
+    // → AND(TRUE, tag) → tag:work.
+    expect(buildLiteAst(parseQuery('-(cat) tag:work'))).toEqual({
+      root: tag('work')
+    });
+  });
+
+  it('NOT of structural filter passes through', () => {
+    expect(buildLiteAst(parseQuery('-(tag:archived)'))).toEqual({
+      root: not(tag('archived'))
+    });
+  });
+
+  it('NOT of OR(structural, leaf-text) keeps structural arm of NOT', () => {
+    // `-(tag:archived OR cat)` — under NOT we flip polarity. The 'cat' leaf
+    // becomes FALSE, the OR drops it, leaving NOT(tag:archived). The lite
+    // pre-filter still excludes archived items, and the body-aware pass
+    // applies the full -(… OR cat) check post-decryption.
+    expect(buildLiteAst(parseQuery('-(tag:archived OR cat)'))).toEqual({
+      root: not(tag('archived'))
+    });
+  });
+
+  it('Tier 1.5 leaf-level `-cat` AND structural keeps structural', () => {
+    // Leaf-level negation on a body-dependent leaf still strips polarity-
+    // correctly because the leaf is itself the unit being approximated.
+    expect(buildLiteAst(parseQuery('-cat tag:work'))).toEqual({
+      root: tag('work')
+    });
+  });
+});
+
+describe('buildLiteAst — soundness contract (lite ⊇ full)', () => {
+  // Validate the contract by sampling: for a small entity set and a few
+  // queries, every entity that matches the full AST must also match the
+  // lite AST. The body-aware pipeline relies on this — a violation means
+  // entries that should match get pre-filtered away.
+
+  function makeEntity(overrides: Partial<SearchEntity> = {}): SearchEntity {
+    return {
+      id: 'e',
+      title: '',
+      body: undefined,
+      tagIds: [],
+      folderId: null,
+      listId: null,
+      createdAt: new Date(2026, 0, 1),
+      updatedAt: new Date(2026, 0, 1),
+      dueAt: null,
+      flags: {},
+      ...overrides
+    };
+  }
+
+  const NOW = new Date(2026, 4, 6, 12, 0, 0);
+
+  function ctxWithTags(tags: Record<string, string>) {
+    return {
+      ...emptySearchContext(NOW),
+      tagIdByName: new Map(Object.entries(tags))
+    };
+  }
+
+  const ctx = ctxWithTags({ work: 'tag-w', archived: 'tag-a', personal: 'tag-p' });
+
+  // Sample entities covering the relevant axes.
+  const entities: SearchEntity[] = [
+    makeEntity({ id: 'work-cat', title: 'cat', body: 'cat in body', tagIds: ['tag-w'] }),
+    makeEntity({ id: 'work-no-cat', title: 'meeting', body: 'agenda', tagIds: ['tag-w'] }),
+    makeEntity({ id: 'archived-cat', title: 'cat', body: '', tagIds: ['tag-a'] }),
+    makeEntity({ id: 'starred', title: 'note', body: '', flags: { starred: true } }),
+    makeEntity({ id: 'plain', title: 'plain', body: '' }),
+    makeEntity({ id: 'personal', title: 'foo', body: '', tagIds: ['tag-p'] }),
+    makeEntity({
+      id: 'plain-with-link',
+      title: 'doc',
+      body: 'see https://example.com',
+      tagIds: ['tag-w']
+    })
+  ];
+
+  const queries = [
+    '-(cat) tag:work',
+    '-(tag:archived OR cat)',
+    'tag:work OR cat',
+    'tag:work has:link',
+    'tag:work OR has:link',
+    '-cat tag:work',
+    'tag:work AND (is:starred OR is:pinned)',
+    '(cat OR dog) tag:work'
+  ];
+
+  for (const q of queries) {
+    it(`lite ⊇ full for "${q}"`, () => {
+      const full = parseQuery(q);
+      const lite = buildLiteAst(full);
+      for (const e of entities) {
+        const fullMatch = evaluate(full, e, ctx);
+        const liteMatch = evaluate(lite, e, ctx);
+        if (fullMatch && !liteMatch) {
+          throw new Error(
+            `under-match for query="${q}" entity="${e.id}": full=true, lite=false`
+          );
+        }
+      }
+    });
+  }
+
+  it('isEmpty correctly detects collapsed lite ASTs', () => {
+    expect(isEmpty(buildLiteAst(parseQuery('cat dog')))).toBe(true);
+    expect(isEmpty(buildLiteAst(parseQuery('tag:work')))).toBe(false);
+  });
+});

--- a/packages/utils/src/search-query/lite-ast.ts
+++ b/packages/utils/src/search-query/lite-ast.ts
@@ -1,0 +1,144 @@
+import type { Node, QueryAST } from './ast';
+
+/**
+ * Build a "lite" version of the AST suitable for pre-filtering an in-memory
+ * index before the streaming-decrypt body-aware pass.
+ *
+ * Rationale: full evaluation needs the decrypted body for `leaf-text` (which
+ * may match against title+body) and `has:*` filters (which inspect body
+ * content). Pre-filtering with the full AST would exclude entries whose only
+ * match is in body — the regression we hit before adopting this two-pass
+ * design. The lite AST replaces those body-dependent leaves with a polarity-
+ * aware sentinel so the boolean tree simplifies to a sound over-approximation.
+ *
+ * Soundness contract: the lite AST may **over-match** (false positives,
+ * filtered out by the full evaluator after decryption). It must NEVER
+ * **under-match** — every entry that matches the full AST must also match
+ * the lite AST.
+ *
+ * Why polarity matters: replacing a body-dependent leaf with a constant only
+ * stays sound if the constant is the over-approximation of the leaf in its
+ * context. Inside an even number of NOTs (positive polarity, where `cat` acts
+ * additively) the over-approximation is TRUE — `cat` could be true, so we
+ * assume it is. Inside an odd number of NOTs (negative polarity, where `cat`
+ * subtracts), we need `cat` to be FALSE so that the surrounding NOT becomes
+ * TRUE (still permissive). Concretely:
+ *
+ *   `-(cat) tag:work` → AND(NOT(leaf 'cat'), tag:work)
+ *   With naive strip (leaf → TRUE): NOT(TRUE) = FALSE → AND collapses to FALSE,
+ *   pre-filter returns nothing — but full AST matches `tag:work` items
+ *   without "cat". That's an under-match. With polarity strip
+ *   (leaf in negative polarity → FALSE): NOT(FALSE) = TRUE, AND → tag:work. ✓
+ *
+ * Sentinel encoding: TRUE is `{ kind: 'and', children: [] }` (because
+ * `every` over an empty array is `true`); FALSE is `{ kind: 'or', children: [] }`
+ * (`some` over empty is `false`). The native evaluator handles both correctly
+ * without special-case code.
+ */
+export function buildLiteAst(ast: QueryAST): QueryAST {
+  if (ast.root === null) return { root: null };
+  const stripped = strip(ast.root, 'positive');
+  const lite = simplify(stripped);
+  if (isTrue(lite)) return { root: null }; // matches everything → empty AST
+  return { root: lite };
+}
+
+const TRUE: Node = { kind: 'and', children: [] };
+const FALSE: Node = { kind: 'or', children: [] };
+
+type Polarity = 'positive' | 'negative';
+
+function flip(p: Polarity): Polarity {
+  return p === 'positive' ? 'negative' : 'positive';
+}
+
+function isTrue(node: Node): boolean {
+  return node.kind === 'and' && node.children.length === 0;
+}
+
+function isFalse(node: Node): boolean {
+  return node.kind === 'or' && node.children.length === 0;
+}
+
+/**
+ * Replace body-dependent leaves with the polarity-correct sentinel.
+ *
+ *   - leaf-text  in positive polarity → TRUE  (over-approximate as "matches")
+ *   - leaf-text  in negative polarity → FALSE (so the surrounding NOT becomes
+ *                                              TRUE, still permissive)
+ *   - has:*      handled the same way
+ *
+ * The leaf's own `negated` flag (Tier 1.5 leaf-level negation, e.g. `-cat`)
+ * does not change the sentinel. Both the positive form and the negated form
+ * collapse to the same polarity-driven constant — the post-decryption pass
+ * is what actually checks the leaf semantics.
+ */
+function strip(node: Node, polarity: Polarity): Node {
+  switch (node.kind) {
+    case 'and':
+      return { kind: 'and', children: node.children.map((c) => strip(c, polarity)) };
+    case 'or':
+      return { kind: 'or', children: node.children.map((c) => strip(c, polarity)) };
+    case 'not':
+      return { kind: 'not', child: strip(node.child, flip(polarity)) };
+    case 'leaf-filter':
+      if (node.filter.kind === 'has') {
+        return polarity === 'positive' ? TRUE : FALSE;
+      }
+      return node;
+    case 'leaf-text':
+      return polarity === 'positive' ? TRUE : FALSE;
+  }
+}
+
+/**
+ * Collapse TRUE/FALSE sentinels through the tree:
+ *
+ *   AND(…, TRUE, …)  → drop TRUE; if all dropped → TRUE
+ *   AND(…, FALSE, …) → FALSE
+ *   OR(…, TRUE, …)   → TRUE
+ *   OR(…, FALSE, …)  → drop FALSE; if all dropped → FALSE
+ *   NOT(TRUE)        → FALSE
+ *   NOT(FALSE)       → TRUE
+ *   AND([single])    → unwrap
+ *   OR([single])     → unwrap
+ *
+ * Bottom-up: simplify children before collapsing the parent.
+ */
+function simplify(node: Node): Node {
+  switch (node.kind) {
+    case 'and': {
+      const children = node.children.map(simplify);
+      const out: Node[] = [];
+      for (const c of children) {
+        if (isFalse(c)) return FALSE;
+        if (isTrue(c)) continue;
+        out.push(c);
+      }
+      if (out.length === 0) return TRUE;
+      if (out.length === 1) return out[0];
+      return { kind: 'and', children: out };
+    }
+    case 'or': {
+      const children = node.children.map(simplify);
+      const out: Node[] = [];
+      for (const c of children) {
+        if (isTrue(c)) return TRUE;
+        if (isFalse(c)) continue;
+        out.push(c);
+      }
+      if (out.length === 0) return FALSE;
+      if (out.length === 1) return out[0];
+      return { kind: 'or', children: out };
+    }
+    case 'not': {
+      const inner = simplify(node.child);
+      if (isTrue(inner)) return FALSE;
+      if (isFalse(inner)) return TRUE;
+      return { kind: 'not', child: inner };
+    }
+    case 'leaf-filter':
+    case 'leaf-text':
+      return node;
+  }
+}

--- a/packages/utils/src/search-query/parser.test.ts
+++ b/packages/utils/src/search-query/parser.test.ts
@@ -240,6 +240,60 @@ describe('parseQuery — Tier 2 boolean OR', () => {
   });
 });
 
+describe('parseQuery — explicit AND (no-op infix)', () => {
+  it('explicit `cat AND dog` parses identically to implicit `cat dog`', () => {
+    expect(parseQuery('cat AND dog')).toEqual(parseQuery('cat dog'));
+    expect(parseQuery('cat AND dog')).toEqual({ root: and(text('cat'), text('dog')) });
+  });
+
+  it('AND is consumed inside a group — `(ale AND jaki)` matches both words only', () => {
+    // Regression: before AND was a token, this AST was AND(ale, "and", jaki)
+    // which required the literal substring "and" in the searched fields.
+    expect(parseQuery('(ale AND jaki)')).toEqual({
+      root: and(text('ale'), text('jaki'))
+    });
+  });
+
+  it('chains multiple AND operands', () => {
+    expect(parseQuery('cat AND dog AND mouse')).toEqual({
+      root: and(text('cat'), text('dog'), text('mouse'))
+    });
+  });
+
+  it('lowercase `and` stays a plain word (Gmail/GitHub convention)', () => {
+    expect(parseQuery('cat and dog')).toEqual({
+      root: and(text('cat'), text('and'), text('dog'))
+    });
+  });
+
+  it('quoted `"AND"` is a literal word, not the operator', () => {
+    expect(parseQuery('"AND"')).toEqual({ root: text('and') });
+  });
+
+  it('AND inside a value (key:AND) stays in the value', () => {
+    expect(parseQuery('tag:AND')).toEqual({ root: tag('and') });
+  });
+
+  it('mixes AND and OR — AND still binds tighter than OR', () => {
+    // `cat AND dog OR mouse` ≡ `(cat AND dog) OR mouse`
+    expect(parseQuery('cat AND dog OR mouse')).toEqual({
+      root: or(and(text('cat'), text('dog')), text('mouse'))
+    });
+  });
+
+  it('trailing AND falls back to flat parse', () => {
+    expect(parseQuery('cat AND')).toEqual({
+      root: and(text('cat'), text('and'))
+    });
+  });
+
+  it('leading AND falls back to flat parse', () => {
+    expect(parseQuery('AND cat')).toEqual({
+      root: and(text('and'), text('cat'))
+    });
+  });
+});
+
 describe('parseQuery — Tier 2 grouping', () => {
   it('parses simple parenthesized group', () => {
     expect(parseQuery('(cat dog) OR chicken')).toEqual({

--- a/packages/utils/src/search-query/parser.test.ts
+++ b/packages/utils/src/search-query/parser.test.ts
@@ -1,234 +1,347 @@
 import { describe, expect, it } from 'vitest';
+import type { Node } from './ast';
 import { parseQuery } from './parser';
 
-const EMPTY_FT = { include: [], exclude: [] };
+// Shorthand builders so tests read like the AST they describe.
+const text = (value: string, negated = false): Node =>
+  ({ kind: 'leaf-text', value, negated } as Node);
+const tag = (value: string, negated = false): Node => ({
+  kind: 'leaf-filter',
+  filter: { kind: 'tag', value, negated }
+});
+const folder = (value: string, negated = false): Node => ({
+  kind: 'leaf-filter',
+  filter: { kind: 'folder', value, negated }
+});
+const list = (value: string, negated = false): Node => ({
+  kind: 'leaf-filter',
+  filter: { kind: 'list', value, negated }
+});
+const has = (value: 'link', negated = false): Node => ({
+  kind: 'leaf-filter',
+  filter: { kind: 'has', value, negated }
+});
+const is = (
+  value: 'starred' | 'pinned' | 'completed' | 'overdue' | 'trashed',
+  negated = false
+): Node => ({ kind: 'leaf-filter', filter: { kind: 'is', value, negated } });
+const and = (...children: Node[]): Node => ({ kind: 'and', children });
+const or = (...children: Node[]): Node => ({ kind: 'or', children });
+const not = (child: Node): Node => ({ kind: 'not', child });
 
 describe('parseQuery — empty and freetext', () => {
   it('returns empty AST for empty input', () => {
-    expect(parseQuery('')).toEqual({ freetext: EMPTY_FT, filters: [] });
-    expect(parseQuery('   ')).toEqual({ freetext: EMPTY_FT, filters: [] });
+    expect(parseQuery('')).toEqual({ root: null });
+    expect(parseQuery('   ')).toEqual({ root: null });
   });
 
-  it('lowercases and splits plain freetext into AND-words', () => {
+  it('lowercases and ANDs plain freetext words', () => {
     expect(parseQuery('Hello World')).toEqual({
-      freetext: { include: ['hello', 'world'], exclude: [] },
-      filters: []
+      root: and(text('hello'), text('world'))
     });
   });
 
   it('preserves quoted whitespace as a single phrase', () => {
     expect(parseQuery('"hello world" foo')).toEqual({
-      freetext: { include: ['hello world', 'foo'], exclude: [] },
-      filters: []
+      root: and(text('hello world'), text('foo'))
     });
+  });
+
+  it('unwraps a single word into a bare leaf', () => {
+    expect(parseQuery('hello')).toEqual({ root: text('hello') });
   });
 });
 
 describe('parseQuery — operators', () => {
   it('parses tag operator', () => {
-    const ast = parseQuery('tag:work');
-    expect(ast.filters).toEqual([{ kind: 'tag', value: 'work', negated: false }]);
-    expect(ast.freetext).toEqual(EMPTY_FT);
+    expect(parseQuery('tag:work')).toEqual({ root: tag('work') });
   });
 
   it('parses negated tag', () => {
-    const ast = parseQuery('-tag:archived');
-    expect(ast.filters).toEqual([
-      { kind: 'tag', value: 'archived', negated: true }
-    ]);
+    expect(parseQuery('-tag:archived')).toEqual({ root: tag('archived', true) });
   });
 
   it('lowercases tag values', () => {
-    expect(parseQuery('tag:WORK').filters).toEqual([
-      { kind: 'tag', value: 'work', negated: false }
-    ]);
+    expect(parseQuery('tag:WORK')).toEqual({ root: tag('work') });
   });
 
   it('parses folder path normalized', () => {
-    expect(parseQuery('folder:Projects/Active').filters).toEqual([
-      { kind: 'folder', value: 'projects/active', negated: false }
-    ]);
+    expect(parseQuery('folder:Projects/Active')).toEqual({
+      root: folder('projects/active')
+    });
   });
 
   it('strips empty segments and trailing slashes in folder', () => {
-    expect(parseQuery('folder:/projects//active/').filters).toEqual([
-      { kind: 'folder', value: 'projects/active', negated: false }
-    ]);
+    expect(parseQuery('folder:/projects//active/')).toEqual({
+      root: folder('projects/active')
+    });
   });
 
   it('parses list operator', () => {
-    expect(parseQuery('list:Inbox').filters).toEqual([
-      { kind: 'list', value: 'inbox', negated: false }
-    ]);
+    expect(parseQuery('list:Inbox')).toEqual({ root: list('inbox') });
   });
 
   it('parses date operators', () => {
     const ast = parseQuery('created:>2026-01-01 modified:<7d due:today');
-    expect(ast.filters).toHaveLength(3);
-    expect(ast.filters[0]).toMatchObject({
-      kind: 'date',
-      field: 'created',
-      negated: false
-    });
-    expect(ast.filters[1]).toMatchObject({ kind: 'date', field: 'modified' });
-    expect(ast.filters[2]).toMatchObject({ kind: 'date', field: 'due' });
+    expect(ast.root?.kind).toBe('and');
+    if (ast.root?.kind !== 'and') throw new Error('expected and');
+    expect(ast.root.children).toHaveLength(3);
+    const [a, b, c] = ast.root.children;
+    expect(a.kind === 'leaf-filter' && a.filter.kind === 'date' && a.filter.field).toBe('created');
+    expect(b.kind === 'leaf-filter' && b.filter.kind === 'date' && b.filter.field).toBe('modified');
+    expect(c.kind === 'leaf-filter' && c.filter.kind === 'date' && c.filter.field).toBe('due');
   });
 
   it('parses has:link', () => {
-    expect(parseQuery('has:link').filters).toEqual([
-      { kind: 'has', value: 'link', negated: false }
-    ]);
+    expect(parseQuery('has:link')).toEqual({ root: has('link') });
   });
 
   it('parses is: flags', () => {
     const ast = parseQuery('is:starred is:pinned is:completed is:overdue is:trashed');
-    expect(ast.filters.map((f) => (f.kind === 'is' ? f.value : null))).toEqual([
-      'starred',
-      'pinned',
-      'completed',
-      'overdue',
-      'trashed'
-    ]);
+    expect(ast).toEqual({
+      root: and(is('starred'), is('pinned'), is('completed'), is('overdue'), is('trashed'))
+    });
   });
 
-  it('combines operators with freetext', () => {
-    const ast = parseQuery('tag:work meeting notes -is:trashed');
-    expect(ast.freetext).toEqual({ include: ['meeting', 'notes'], exclude: [] });
-    expect(ast.filters).toEqual([
-      { kind: 'tag', value: 'work', negated: false },
-      { kind: 'is', value: 'trashed', negated: true }
-    ]);
+  it('combines operators with freetext (implicit AND)', () => {
+    expect(parseQuery('tag:work meeting notes -is:trashed')).toEqual({
+      root: and(tag('work'), text('meeting'), text('notes'), is('trashed', true))
+    });
   });
 });
 
 describe('parseQuery — quoted operator values', () => {
   it('allows whitespace inside quoted operator value', () => {
-    expect(parseQuery('tag:"work in progress"').filters).toEqual([
-      { kind: 'tag', value: 'work in progress', negated: false }
-    ]);
+    expect(parseQuery('tag:"work in progress"')).toEqual({
+      root: tag('work in progress')
+    });
   });
 
   it('treats fully quoted token as a freetext phrase, not as operator', () => {
-    const ast = parseQuery('"tag:work"');
-    expect(ast.freetext).toEqual({ include: ['tag:work'], exclude: [] });
-    expect(ast.filters).toEqual([]);
+    expect(parseQuery('"tag:work"')).toEqual({ root: text('tag:work') });
   });
 });
 
 describe('parseQuery — Tier 1.5 freetext negation', () => {
   it('plain dashed token becomes an exclude', () => {
-    expect(parseQuery('-broken')).toEqual({
-      freetext: { include: [], exclude: ['broken'] },
-      filters: []
-    });
+    expect(parseQuery('-broken')).toEqual({ root: text('broken', true) });
   });
 
   it('mixes include words and excludes', () => {
     expect(parseQuery('cat dog -mouse')).toEqual({
-      freetext: { include: ['cat', 'dog'], exclude: ['mouse'] },
-      filters: []
+      root: and(text('cat'), text('dog'), text('mouse', true))
     });
   });
 
   it('exclude works with quoted phrase', () => {
     expect(parseQuery('cat -"angry mouse"')).toEqual({
-      freetext: { include: ['cat'], exclude: ['angry mouse'] },
-      filters: []
+      root: and(text('cat'), text('angry mouse', true))
     });
   });
 
   it('combines freetext exclude with operator filters', () => {
-    const ast = parseQuery('meeting tag:work -draft');
-    expect(ast.freetext).toEqual({ include: ['meeting'], exclude: ['draft'] });
-    expect(ast.filters).toEqual([{ kind: 'tag', value: 'work', negated: false }]);
+    expect(parseQuery('meeting tag:work -draft')).toEqual({
+      root: and(text('meeting'), tag('work'), text('draft', true))
+    });
   });
 
-  it('lone dash stays as a freetext include item', () => {
-    expect(parseQuery('-')).toEqual({
-      freetext: { include: ['-'], exclude: [] },
-      filters: []
-    });
+  it('lone dash stays as a freetext include leaf', () => {
+    expect(parseQuery('-')).toEqual({ root: text('-') });
   });
 
   it('only the leading dash is a negator — extra dashes stay literal', () => {
-    expect(parseQuery('--foo')).toEqual({
-      freetext: { include: [], exclude: ['-foo'] },
-      filters: []
-    });
+    expect(parseQuery('--foo')).toEqual({ root: text('-foo', true) });
   });
 
   it('hyphenated word in the middle of a token stays as one substring', () => {
-    expect(parseQuery('multi-word-thing')).toEqual({
-      freetext: { include: ['multi-word-thing'], exclude: [] },
-      filters: []
-    });
+    expect(parseQuery('multi-word-thing')).toEqual({ root: text('multi-word-thing') });
   });
 
   it('lowercases excludes', () => {
-    expect(parseQuery('-FOO')).toEqual({
-      freetext: { include: [], exclude: ['foo'] },
-      filters: []
+    expect(parseQuery('-FOO')).toEqual({ root: text('foo', true) });
+  });
+});
+
+describe('parseQuery — graceful degradation (Tier 1)', () => {
+  it('treats unknown operator as freetext', () => {
+    expect(parseQuery('foo:bar baz')).toEqual({
+      root: and(text('foo:bar'), text('baz'))
+    });
+  });
+
+  it('treats malformed date as freetext', () => {
+    expect(parseQuery('created:tomorrow')).toEqual({
+      root: text('created:tomorrow')
+    });
+  });
+
+  it('treats unknown is: flag as freetext', () => {
+    expect(parseQuery('is:fancy')).toEqual({ root: text('is:fancy') });
+  });
+
+  it('treats unknown has: value as freetext', () => {
+    expect(parseQuery('has:image')).toEqual({ root: text('has:image') });
+  });
+
+  it('treats empty operator value as freetext', () => {
+    expect(parseQuery('tag:')).toEqual({ root: text('tag:') });
+  });
+
+  it('treats colon-only token as freetext', () => {
+    expect(parseQuery(':foo')).toEqual({ root: text(':foo') });
+  });
+
+  it('a `-key:value` with unknown key degrades into a freetext exclude', () => {
+    expect(parseQuery('-foo:bar')).toEqual({ root: text('foo:bar', true) });
+  });
+});
+
+describe('parseQuery — Tier 2 boolean OR', () => {
+  it('parses uppercase OR between two leaves', () => {
+    expect(parseQuery('cat OR mouse')).toEqual({
+      root: or(text('cat'), text('mouse'))
+    });
+  });
+
+  it('lowercase `or` is treated as a plain word', () => {
+    expect(parseQuery('cat or mouse')).toEqual({
+      root: and(text('cat'), text('or'), text('mouse'))
+    });
+  });
+
+  it('AND binds tighter than OR — `cat dog OR mouse` is `(cat AND dog) OR mouse`', () => {
+    expect(parseQuery('cat dog OR mouse')).toEqual({
+      root: or(and(text('cat'), text('dog')), text('mouse'))
+    });
+  });
+
+  it('combines operators across OR', () => {
+    expect(parseQuery('tag:work OR tag:personal')).toEqual({
+      root: or(tag('work'), tag('personal'))
+    });
+  });
+
+  it('chains multiple OR operands at the same level', () => {
+    expect(parseQuery('cat OR dog OR mouse')).toEqual({
+      root: or(text('cat'), text('dog'), text('mouse'))
+    });
+  });
+
+  it('quoted OR is a literal word, not the operator (lowercased like all freetext)', () => {
+    // Quoted segments preserve whitespace and disable structural tokenization,
+    // but per Tier 1.5 freetext is always lowercased for case-insensitive
+    // matching — so `"OR"` becomes the leaf-text `or`. The point of this case
+    // is that `OR` does NOT promote to the boolean operator.
+    expect(parseQuery('"OR"')).toEqual({ root: text('or') });
+  });
+
+  it('OR inside a value (key:OR) stays in the value', () => {
+    expect(parseQuery('tag:OR')).toEqual({ root: tag('or') });
+  });
+});
+
+describe('parseQuery — Tier 2 grouping', () => {
+  it('parses simple parenthesized group', () => {
+    expect(parseQuery('(cat dog) OR chicken')).toEqual({
+      root: or(and(text('cat'), text('dog')), text('chicken'))
+    });
+  });
+
+  it('mixes operator with grouped OR', () => {
+    expect(parseQuery('tag:work (is:starred OR modified:<7d)')).toMatchObject({
+      root: { kind: 'and' }
+    });
+    const ast = parseQuery('tag:work (is:starred OR modified:<7d)');
+    if (ast.root?.kind !== 'and') throw new Error('expected and');
+    expect(ast.root.children[0]).toEqual(tag('work'));
+    expect(ast.root.children[1].kind).toBe('or');
+  });
+
+  it('flattens redundant parens around a single leaf', () => {
+    expect(parseQuery('((cat))')).toEqual({ root: text('cat') });
+  });
+
+  it('empty group `()` is dropped (TRUE) — only-empty-group becomes empty AST', () => {
+    // `()` → TRUE sentinel `{ kind: 'and', children: [] }` at root.
+    // Practically equivalent to empty input from the evaluator's perspective.
+    expect(parseQuery('()')).toEqual({ root: and() });
+  });
+
+  it('empty group inside an AND drops out of the parent', () => {
+    // `() cat` → AND(TRUE, cat). The lite-AST builder simplifies this; for
+    // the parser we just preserve the structure.
+    const ast = parseQuery('() cat');
+    if (ast.root?.kind !== 'and') throw new Error('expected and');
+    expect(ast.root.children).toHaveLength(2);
+    expect(ast.root.children[1]).toEqual(text('cat'));
+  });
+
+  it('parses negated group', () => {
+    expect(parseQuery('-(tag:archived OR is:trashed)')).toEqual({
+      root: not(or(tag('archived'), is('trashed')))
+    });
+  });
+
+  it('quoted parens are literal characters in the phrase', () => {
+    expect(parseQuery('"(test)"')).toEqual({ root: text('(test)') });
+  });
+});
+
+describe('parseQuery — Tier 2 graceful fallback', () => {
+  it('unmatched opening paren falls back to flat parse', () => {
+    // `(cat OR` — unmatched `(`, dangling `OR`. Flat: tokens become
+    // `(`, `cat`, `OR` (literals).
+    expect(parseQuery('(cat OR')).toEqual({
+      root: and(text('('), text('cat'), text('or'))
+    });
+  });
+
+  it('trailing OR falls back to flat parse', () => {
+    expect(parseQuery('cat OR')).toEqual({
+      root: and(text('cat'), text('or'))
+    });
+  });
+
+  it('leading OR falls back to flat parse', () => {
+    expect(parseQuery('OR cat')).toEqual({
+      root: and(text('or'), text('cat'))
+    });
+  });
+
+  it('unmatched closing paren falls back to flat parse', () => {
+    expect(parseQuery('cat) dog')).toEqual({
+      root: and(text('cat'), text(')'), text('dog'))
+    });
+  });
+
+  it('negated unmatched group falls back to flat parse', () => {
+    // `-(tag:work` — `-` followed by `(` would start Not(group), but the
+    // group never closes → ParseError → flat fallback. Tokens are
+    // WORD `-`, LPAREN, WORD `tag:work`. In flat fallback the bare `-`
+    // becomes a literal leaf, the `(` becomes the literal char `(`, and
+    // `tag:work` resolves through parseAtom into a tag filter.
+    expect(parseQuery('-(tag:work')).toEqual({
+      root: and(text('-'), text('('), tag('work'))
     });
   });
 });
 
-describe('parseQuery — graceful degradation', () => {
-  it('treats unknown operator as freetext', () => {
-    const ast = parseQuery('foo:bar baz');
-    expect(ast.freetext).toEqual({ include: ['foo:bar', 'baz'], exclude: [] });
-    expect(ast.filters).toEqual([]);
-  });
-
-  it('treats malformed date as freetext', () => {
-    const ast = parseQuery('created:tomorrow');
-    expect(ast.freetext).toEqual({ include: ['created:tomorrow'], exclude: [] });
-    expect(ast.filters).toEqual([]);
-  });
-
-  it('treats unknown is: flag as freetext', () => {
-    const ast = parseQuery('is:fancy');
-    expect(ast.freetext).toEqual({ include: ['is:fancy'], exclude: [] });
-    expect(ast.filters).toEqual([]);
-  });
-
-  it('treats unknown has: value as freetext', () => {
-    const ast = parseQuery('has:image');
-    expect(ast.freetext).toEqual({ include: ['has:image'], exclude: [] });
-    expect(ast.filters).toEqual([]);
-  });
-
-  it('treats empty operator value as freetext', () => {
-    const ast = parseQuery('tag:');
-    expect(ast.freetext).toEqual({ include: ['tag:'], exclude: [] });
-    expect(ast.filters).toEqual([]);
-  });
-
-  it('treats colon-only token as freetext', () => {
-    const ast = parseQuery(':foo');
-    expect(ast.freetext).toEqual({ include: [':foo'], exclude: [] });
-    expect(ast.filters).toEqual([]);
-  });
-
-  it('a `-key:value` with unknown key degrades into a freetext exclude', () => {
-    // The dash is a meaningful negator (Tier 1.5) when the body is not an
-    // operator — `-foo:bar` excludes the substring `foo:bar`.
-    const ast = parseQuery('-foo:bar');
-    expect(ast.freetext).toEqual({ include: [], exclude: ['foo:bar'] });
-    expect(ast.filters).toEqual([]);
-  });
-});
-
-describe('parseQuery — multiple filters', () => {
-  it('parses a complex query', () => {
+describe('parseQuery — multiple filters (regression)', () => {
+  it('parses a complex Tier 1 query', () => {
     const ast = parseQuery(
       'tag:reading -tag:archived folder:inbox created:>2026-01-01 has:link foo bar'
     );
-    expect(ast.freetext).toEqual({ include: ['foo', 'bar'], exclude: [] });
-    expect(ast.filters).toHaveLength(5);
-    expect(ast.filters[0]).toMatchObject({ kind: 'tag', value: 'reading', negated: false });
-    expect(ast.filters[1]).toMatchObject({ kind: 'tag', value: 'archived', negated: true });
-    expect(ast.filters[2]).toMatchObject({ kind: 'folder', value: 'inbox' });
-    expect(ast.filters[3]).toMatchObject({ kind: 'date', field: 'created' });
-    expect(ast.filters[4]).toMatchObject({ kind: 'has', value: 'link' });
+    expect(ast.root?.kind).toBe('and');
+    if (ast.root?.kind !== 'and') throw new Error('expected and');
+    expect(ast.root.children).toHaveLength(7);
+    expect(ast.root.children[0]).toEqual(tag('reading'));
+    expect(ast.root.children[1]).toEqual(tag('archived', true));
+    expect(ast.root.children[2]).toEqual(folder('inbox'));
+    // [3] is the date filter — checked by kind below.
+    const dateNode = ast.root.children[3];
+    expect(dateNode.kind === 'leaf-filter' && dateNode.filter.kind === 'date').toBe(true);
+    expect(ast.root.children[4]).toEqual(has('link'));
+    expect(ast.root.children[5]).toEqual(text('foo'));
+    expect(ast.root.children[6]).toEqual(text('bar'));
   });
 });

--- a/packages/utils/src/search-query/parser.ts
+++ b/packages/utils/src/search-query/parser.ts
@@ -1,4 +1,4 @@
-import type { DateField, Filter, FreetextSpec, IsFlag, QueryAST } from './ast';
+import type { DateField, Filter, IsFlag, Node, QueryAST } from './ast';
 import { parseDateExpression } from './date-parser';
 
 const IS_FLAGS: ReadonlySet<IsFlag> = new Set([
@@ -20,115 +20,195 @@ const KNOWN_KEYS = new Set([
   'is'
 ]);
 
-interface RawToken {
-  /** Token contents with surrounding quotes stripped, but `-` prefix preserved. */
-  text: string;
-  /** Index inside `text` of the first unquoted `:`, or -1 when none. */
-  unquotedColonIdx: number;
-}
+/**
+ * Token kinds produced by the tokenizer.
+ *
+ * `OR` is a structural token — recognized only when the input substring is
+ * exactly `OR` between whitespace (uppercase, no quotes around it). Any other
+ * casing (`or`, `Or`) becomes a regular WORD, matching Gmail/GitHub/Linear.
+ *
+ * `(` and `)` always terminate the current token outside quotes — `foo(bar)`
+ * tokenizes as WORD `foo`, LPAREN, WORD `bar`, RPAREN. Inside quotes they
+ * are preserved as plain characters.
+ */
+type Token =
+  | { kind: 'WORD'; text: string; unquotedColonIdx: number }
+  | { kind: 'OR' }
+  | { kind: 'LPAREN' }
+  | { kind: 'RPAREN' };
 
 /**
- * Parse a search box input string into a structured AST.
+ * Parse a search box input string into a structured tree AST.
  *
  * Tokenization rules:
- *   - Whitespace separates tokens; quoted segments (`"..."`) preserve internal whitespace.
+ *   - Whitespace separates tokens; quoted segments (`"..."`) preserve internal
+ *     whitespace, parentheses, and the literal token `OR`.
  *   - A `:` that is inside quotes does not split key from value.
- *   - A token starting with `-` is tentatively negated:
- *       - If the rest forms a recognized operator → negated operator filter.
- *       - Otherwise → freetext exclude (Tier 1.5; the leading `-` is stripped).
- *   - Unknown operator keys, malformed dates, or `is:` flags outside the supported
- *     set degrade the entire token to freetext (no errors, no warnings — the user
- *     simply gets a substring search). This matters because users mid-typing should
- *     never see a hard failure.
- *   - Multi-word phrases inside quotes stay as a single freetext item, so
- *     `"meeting prep"` matches the literal substring with whitespace.
+ *   - `(` / `)` outside quotes are structural tokens.
+ *   - A standalone uppercase `OR` between whitespace is the boolean operator.
+ *   - A token starting with `-` is tentatively negated (parser handles it):
+ *       - `-(` opens a negated group.
+ *       - `-key:value` (recognized operator) → negated filter leaf.
+ *       - `-word` / `-"phrase"` → negated text leaf.
+ *
+ * Grammar (recursive descent, AND binds tighter than OR):
+ *
+ *   expr     := or_expr
+ *   or_expr  := and_expr ('OR' and_expr)*
+ *   and_expr := primary primary*
+ *   primary  := '(' expr ')' | '-' '(' expr ')' | '-' atom | atom
+ *   atom     := KEY_VALUE | WORD
+ *
+ * Graceful degradation:
+ *   - Any structural error (unmatched paren, dangling `OR`, empty group in a
+ *     mandatory position) falls back to a flat parse where every token is
+ *     treated as freetext (parens / `OR` become plain words). The user never
+ *     sees a hard error mid-typing.
  */
 export function parseQuery(input: string): QueryAST {
   const tokens = tokenize(input);
-  const filters: Filter[] = [];
-  const include: string[] = [];
-  const exclude: string[] = [];
+  if (tokens.length === 0) return { root: null };
 
-  for (const tok of tokens) {
-    const classified = classify(tok);
-    if (classified.kind === 'filter') {
-      filters.push(classified.filter);
-      continue;
-    }
-    if (classified.kind === 'exclude') {
-      exclude.push(classified.value);
-    } else {
-      include.push(classified.value);
-    }
+  try {
+    const parser = new Parser(tokens);
+    const node = parser.parseExpr();
+    if (!parser.atEnd()) throw new ParseError('trailing tokens');
+    return { root: node };
+  } catch {
+    // Flat fallback: every token (including LPAREN/RPAREN/OR) becomes
+    // freetext, AND-combined. Mid-typing inputs always render something.
+    return flatFallback(tokens);
   }
-
-  const freetext: FreetextSpec = { include, exclude };
-  return { freetext, filters };
 }
 
-function tokenize(input: string): RawToken[] {
-  const tokens: RawToken[] = [];
-  let i = 0;
-  while (i < input.length) {
-    while (i < input.length && isWhitespace(input[i])) i++;
-    if (i >= input.length) break;
+class ParseError extends Error {}
 
-    let text = '';
-    let unquotedColonIdx = -1;
-    let inQuotes = false;
+class Parser {
+  private pos = 0;
+  constructor(private readonly tokens: Token[]) {}
 
-    while (i < input.length && (inQuotes || !isWhitespace(input[i]))) {
-      const ch = input[i];
-      if (ch === '"') {
-        inQuotes = !inQuotes;
-        i++;
-        continue;
-      }
-      if (ch === ':' && !inQuotes && unquotedColonIdx === -1) {
-        unquotedColonIdx = text.length;
-      }
-      text += ch;
-      i++;
-    }
-
-    if (text.length > 0) {
-      tokens.push({ text, unquotedColonIdx });
-    }
+  atEnd(): boolean {
+    return this.pos >= this.tokens.length;
   }
-  return tokens;
+
+  private peek(): Token | null {
+    return this.tokens[this.pos] ?? null;
+  }
+
+  private advance(): Token | null {
+    return this.tokens[this.pos++] ?? null;
+  }
+
+  /** expr := or_expr */
+  parseExpr(): Node {
+    return this.parseOr();
+  }
+
+  /** or_expr := and_expr ('OR' and_expr)* */
+  private parseOr(): Node {
+    const first = this.parseAnd();
+    const operands: Node[] = [first];
+    while (this.peek()?.kind === 'OR') {
+      this.advance();
+      const next = this.parseAnd();
+      operands.push(next);
+    }
+    if (operands.length === 1) return first;
+    return { kind: 'or', children: operands };
+  }
+
+  /**
+   * and_expr := primary primary*
+   *
+   * Rejects empty primary sequences — caller (parseOr) relies on this to
+   * detect dangling `OR` (`cat OR`, `OR cat`) and trigger flat fallback.
+   */
+  private parseAnd(): Node {
+    const first = this.parsePrimary();
+    const operands: Node[] = [first];
+    while (true) {
+      const t = this.peek();
+      if (t === null) break;
+      if (t.kind === 'OR' || t.kind === 'RPAREN') break;
+      operands.push(this.parsePrimary());
+    }
+    if (operands.length === 1) return first;
+    return { kind: 'and', children: operands };
+  }
+
+  /**
+   * primary := '(' expr ')' | '-' '(' expr ')' | '-' atom | atom
+   *
+   * A bare `-` followed by `(` becomes Not(group). A `-` followed by anything
+   * else is part of an atom (negation lives on the leaf), handled by parseAtom.
+   */
+  private parsePrimary(): Node {
+    const t = this.peek();
+    if (t === null) throw new ParseError('expected primary, got end of input');
+
+    if (t.kind === 'LPAREN') {
+      return this.parseGroup(false);
+    }
+    if (t.kind === 'WORD' && t.text === '-' && this.tokens[this.pos + 1]?.kind === 'LPAREN') {
+      this.advance(); // consume the `-`
+      return this.parseGroup(true);
+    }
+    if (t.kind === 'WORD') {
+      this.advance();
+      return parseAtom(t.text, t.unquotedColonIdx);
+    }
+    // OR / RPAREN here are structural errors (dangling OR, unmatched paren).
+    throw new ParseError(`unexpected token kind ${t.kind} in primary`);
+  }
+
+  /** Consume `(` expr `)` (or after `-` already consumed). */
+  private parseGroup(negated: boolean): Node {
+    const open = this.advance();
+    if (open?.kind !== 'LPAREN') throw new ParseError('expected `(`');
+
+    // Empty `()` would make parseAnd() throw; intercept it as a no-op group
+    // that drops out of its parent (handled by simplification at the caller).
+    if (this.peek()?.kind === 'RPAREN') {
+      this.advance();
+      const empty: Node = { kind: 'and', children: [] }; // TRUE sentinel
+      return negated ? { kind: 'not', child: empty } : empty;
+    }
+
+    const inner = this.parseExpr();
+    const close = this.advance();
+    if (close?.kind !== 'RPAREN') throw new ParseError('expected `)`');
+
+    return negated ? { kind: 'not', child: inner } : inner;
+  }
 }
 
-type ClassifyResult =
-  | { kind: 'filter'; filter: Filter }
-  | { kind: 'include'; value: string }
-  | { kind: 'exclude'; value: string };
-
-function classify(token: RawToken): ClassifyResult {
-  const { text, unquotedColonIdx } = token;
-  const negated = text.startsWith('-');
+/**
+ * Convert a WORD token (with optional unquoted-colon index) into a leaf node.
+ *
+ * Order: try operator first, otherwise fall through to leaf-text. A leading
+ * `-` on a non-operator word becomes `leaf-text` with `negated: true`. The
+ * single-character `-` is preserved as a literal `leaf-text` (so `cat - dog`
+ * doesn't lose the dash).
+ */
+function parseAtom(text: string, unquotedColonIdx: number): Node {
+  const negated = text.startsWith('-') && text.length > 1;
   const keyStart = negated ? 1 : 0;
 
-  // Try operator first (with or without `-` prefix). Need a non-empty key
-  // before the colon and a colon past `keyStart`.
   if (unquotedColonIdx > keyStart) {
     const key = text.slice(keyStart, unquotedColonIdx).toLowerCase();
     if (KNOWN_KEYS.has(key)) {
       const value = text.slice(unquotedColonIdx + 1);
       if (value) {
         const filter = parseOperator(key, value, negated);
-        if (filter) return { kind: 'filter', filter };
+        if (filter) return { kind: 'leaf-filter', filter };
       }
     }
   }
 
-  // Not an operator — treat as freetext. A leading `-` on a non-operator token
-  // means "exclude this substring", but only when there's something after it
-  // (a bare `-` stays as include). Lowercase for case-insensitive matching;
-  // empty results are dropped by the caller.
-  if (negated && text.length > 1) {
-    return { kind: 'exclude', value: text.slice(1).toLowerCase() };
+  if (negated) {
+    return { kind: 'leaf-text', value: text.slice(1).toLowerCase(), negated: true };
   }
-  return { kind: 'include', value: text.toLowerCase() };
+  return { kind: 'leaf-text', value: text.toLowerCase(), negated: false };
 }
 
 function parseOperator(key: string, value: string, negated: boolean): Filter | null {
@@ -176,6 +256,91 @@ function normalizeFolderPath(path: string): string {
     .map((s) => s.trim().toLowerCase())
     .filter((s) => s.length > 0)
     .join('/');
+}
+
+/**
+ * Reduce every token to a freetext leaf and AND-combine. Used when the
+ * recursive-descent parser fails on a structurally invalid input — the user
+ * sees a degraded but coherent search instead of an error state.
+ *
+ * Structural tokens (`(`, `)`, `OR`) become literal words so they can match
+ * by substring if the user actually has those characters in their data.
+ */
+function flatFallback(tokens: Token[]): QueryAST {
+  const children: Node[] = [];
+  for (const t of tokens) {
+    if (t.kind === 'WORD') {
+      children.push(parseAtom(t.text, t.unquotedColonIdx));
+    } else if (t.kind === 'OR') {
+      children.push({ kind: 'leaf-text', value: 'or', negated: false });
+    } else if (t.kind === 'LPAREN') {
+      children.push({ kind: 'leaf-text', value: '(', negated: false });
+    } else if (t.kind === 'RPAREN') {
+      children.push({ kind: 'leaf-text', value: ')', negated: false });
+    }
+  }
+  if (children.length === 0) return { root: null };
+  if (children.length === 1) return { root: children[0] };
+  return { root: { kind: 'and', children } };
+}
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < input.length) {
+    while (i < input.length && isWhitespace(input[i])) i++;
+    if (i >= input.length) break;
+
+    const ch = input[i];
+
+    // Structural tokens — only outside quotes, which is the case here because
+    // the inner loop below stops as soon as it sees `(`/`)` outside quotes.
+    if (ch === '(') {
+      tokens.push({ kind: 'LPAREN' });
+      i++;
+      continue;
+    }
+    if (ch === ')') {
+      tokens.push({ kind: 'RPAREN' });
+      i++;
+      continue;
+    }
+
+    // Otherwise consume a WORD (possibly containing quotes / colons).
+    let text = '';
+    let unquotedColonIdx = -1;
+    let inQuotes = false;
+    let sawQuotes = false;
+
+    while (i < input.length) {
+      const c = input[i];
+      if (!inQuotes && (isWhitespace(c) || c === '(' || c === ')')) break;
+      if (c === '"') {
+        inQuotes = !inQuotes;
+        sawQuotes = true;
+        i++;
+        continue;
+      }
+      if (c === ':' && !inQuotes && unquotedColonIdx === -1) {
+        unquotedColonIdx = text.length;
+      }
+      text += c;
+      i++;
+    }
+
+    if (text.length === 0) continue;
+
+    // Standalone `OR` (uppercase) is the boolean operator. Quotation around
+    // `OR` makes it a literal — `"OR"` renders as a phrase WORD with text
+    // `OR` but `sawQuotes === true`, so this branch correctly skips it.
+    if (text === 'OR' && !sawQuotes) {
+      tokens.push({ kind: 'OR' });
+      continue;
+    }
+
+    tokens.push({ kind: 'WORD', text, unquotedColonIdx });
+  }
+  return tokens;
 }
 
 function isWhitespace(ch: string): boolean {

--- a/packages/utils/src/search-query/parser.ts
+++ b/packages/utils/src/search-query/parser.ts
@@ -23,9 +23,16 @@ const KNOWN_KEYS = new Set([
 /**
  * Token kinds produced by the tokenizer.
  *
- * `OR` is a structural token — recognized only when the input substring is
- * exactly `OR` between whitespace (uppercase, no quotes around it). Any other
- * casing (`or`, `Or`) becomes a regular WORD, matching Gmail/GitHub/Linear.
+ * `OR` and `AND` are structural tokens — recognized only when the input
+ * substring is exactly `OR`/`AND` between whitespace (uppercase, no quotes
+ * around it). Any other casing (`or`, `And`) becomes a regular WORD, matching
+ * Gmail/GitHub/Linear.
+ *
+ * `AND` is semantically a no-op: AND is the implicit combinator between
+ * primaries, so `cat AND dog` parses identically to `cat dog`. The token
+ * exists only so that users who reach for explicit boolean syntax (natural
+ * after meeting `OR`) get the result they expect instead of searching for
+ * the literal word "and".
  *
  * `(` and `)` always terminate the current token outside quotes — `foo(bar)`
  * tokenizes as WORD `foo`, LPAREN, WORD `bar`, RPAREN. Inside quotes they
@@ -34,6 +41,7 @@ const KNOWN_KEYS = new Set([
 type Token =
   | { kind: 'WORD'; text: string; unquotedColonIdx: number }
   | { kind: 'OR' }
+  | { kind: 'AND' }
   | { kind: 'LPAREN' }
   | { kind: 'RPAREN' };
 
@@ -42,10 +50,13 @@ type Token =
  *
  * Tokenization rules:
  *   - Whitespace separates tokens; quoted segments (`"..."`) preserve internal
- *     whitespace, parentheses, and the literal token `OR`.
+ *     whitespace, parentheses, and the literal tokens `OR` / `AND`.
  *   - A `:` that is inside quotes does not split key from value.
  *   - `(` / `)` outside quotes are structural tokens.
  *   - A standalone uppercase `OR` between whitespace is the boolean operator.
+ *   - A standalone uppercase `AND` between whitespace is a no-op separator
+ *     (same precedence as the implicit AND between primaries) — it lets users
+ *     write `cat AND dog` symmetrically to `cat OR dog`.
  *   - A token starting with `-` is tentatively negated (parser handles it):
  *       - `-(` opens a negated group.
  *       - `-key:value` (recognized operator) → negated filter leaf.
@@ -55,7 +66,7 @@ type Token =
  *
  *   expr     := or_expr
  *   or_expr  := and_expr ('OR' and_expr)*
- *   and_expr := primary primary*
+ *   and_expr := primary ('AND'? primary)*
  *   primary  := '(' expr ')' | '-' '(' expr ')' | '-' atom | atom
  *   atom     := KEY_VALUE | WORD
  *
@@ -118,10 +129,14 @@ class Parser {
   }
 
   /**
-   * and_expr := primary primary*
+   * and_expr := primary ('AND'? primary)*
    *
-   * Rejects empty primary sequences — caller (parseOr) relies on this to
-   * detect dangling `OR` (`cat OR`, `OR cat`) and trigger flat fallback.
+   * `AND` between primaries is consumed and discarded — it has the same
+   * precedence as the implicit AND, so `cat AND dog` and `cat dog` produce
+   * identical ASTs. A dangling `AND` (no following primary) is a structural
+   * error: parsePrimary throws → flat fallback (mirrors how dangling `OR`
+   * behaves). Leading `AND` likewise throws because parseAnd starts with
+   * parsePrimary, which doesn't accept an AND token.
    */
   private parseAnd(): Node {
     const first = this.parsePrimary();
@@ -130,6 +145,7 @@ class Parser {
       const t = this.peek();
       if (t === null) break;
       if (t.kind === 'OR' || t.kind === 'RPAREN') break;
+      if (t.kind === 'AND') this.advance(); // optional infix AND
       operands.push(this.parsePrimary());
     }
     if (operands.length === 1) return first;
@@ -157,7 +173,8 @@ class Parser {
       this.advance();
       return parseAtom(t.text, t.unquotedColonIdx);
     }
-    // OR / RPAREN here are structural errors (dangling OR, unmatched paren).
+    // OR / AND / RPAREN here are structural errors (dangling boolean,
+    // unmatched paren).
     throw new ParseError(`unexpected token kind ${t.kind} in primary`);
   }
 
@@ -273,6 +290,8 @@ function flatFallback(tokens: Token[]): QueryAST {
       children.push(parseAtom(t.text, t.unquotedColonIdx));
     } else if (t.kind === 'OR') {
       children.push({ kind: 'leaf-text', value: 'or', negated: false });
+    } else if (t.kind === 'AND') {
+      children.push({ kind: 'leaf-text', value: 'and', negated: false });
     } else if (t.kind === 'LPAREN') {
       children.push({ kind: 'leaf-text', value: '(', negated: false });
     } else if (t.kind === 'RPAREN') {
@@ -330,11 +349,18 @@ function tokenize(input: string): Token[] {
 
     if (text.length === 0) continue;
 
-    // Standalone `OR` (uppercase) is the boolean operator. Quotation around
-    // `OR` makes it a literal — `"OR"` renders as a phrase WORD with text
-    // `OR` but `sawQuotes === true`, so this branch correctly skips it.
+    // Standalone `OR`/`AND` (uppercase) are the boolean operators. Quotation
+    // around them makes them literals — `"OR"` renders as a phrase WORD with
+    // text `OR` but `sawQuotes === true`, so these branches correctly skip
+    // it. AND is functionally a no-op (same precedence as implicit AND), the
+    // token exists so the parser can swallow it cleanly instead of treating
+    // it as a freetext word.
     if (text === 'OR' && !sawQuotes) {
       tokens.push({ kind: 'OR' });
+      continue;
+    }
+    if (text === 'AND' && !sawQuotes) {
+      tokens.push({ kind: 'AND' });
       continue;
     }
 


### PR DESCRIPTION
## Summary

- **Boolean operators** — explicit `OR`, parenthesized grouping `(...)`, group negation `-(...)`, and explicit `AND` (no-op redundant synonym for the implicit AND between primaries). Precedence mirrors Gmail/GitHub/Linear: AND binds tighter than OR.
- **Tree AST + recursive-descent parser** replaces the flat AST. Graceful flat fallback on structural errors (unmatched paren, dangling boolean) keeps mid-typing usable.
- **Polarity-aware lite-AST builder** for body-aware pre-filter — over-approximation soundness contract (lite ⊇ full). Polarity tracking under NOT prevents `-(cat) tag:work` collapsing to FALSE.
- **Public docs** in [docs/search-operators.md](docs/search-operators.md) — full operator reference shipped alongside the feature.

## Out of scope (Tier 3)

Field-scoped operators (`title:`, `body:`), search history, regex/wildcards, sort operators. See [docs/search-operators.md](docs/search-operators.md) "Out of scope" notes for the rationale.

## Test plan

Unit tests (already green locally):

- [x] `@reborn/utils`: 143 tests (parser 60 / date-parser 17 / evaluator 45 / lite-AST 21)
- [x] `reborn-notes`: 366 tests
- [x] `reborn-task`: 25 tests
- [x] `pnpm nx run-many -t check build -p reborn-task reborn-notes` green

Browser smoke (re/notes + re/task, both with "search in body/description" off and on):

- [x] `cat OR mouse` — either word matches
- [x] `tag:work OR tag:personal` — either tag matches (notes only)
- [x] `is:completed OR is:overdue` — either flag matches (task only)
- [x] `(cat OR dog) -tag:archived` — grouped OR combined with leaf-negated filter
- [x] `(tag:reading AND has:link) OR is:starred` — explicit AND inside group, mixed with OR (notes)
- [x] `-(tag:archived OR is:trashed)` — group negation
- [x] `cat AND dog` ≡ `cat dog` — explicit AND produces identical results to implicit
- [x] `(ale AND jaki)` matches an item whose description contains "ale jaki olej" (regression for the AND hotfix)
- [x] Quoted booleans literal: `"OR"`, `"AND"`, `"(test)"` — treated as plain phrases
- [x] Graceful fallback: `(cat OR ` (unmatched paren), `cat OR` / `cat AND` (trailing boolean) — degrade to flat plain-text search instead of erroring

Privacy invariants (re-verified — no surface change vs. Tier 1):

- [x] No plaintext titles / descriptions / tag names / metadata in DevTools network tab during search
- [x] Server logs (if checked) show no query strings — search runs entirely client-side

