### PR TITLE
refactor(search): drop is:trashed operator

### DIFF
--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -336,11 +336,13 @@ class NoteIndex {
    * the body-aware path in `notes.store.ts → triggerContentSearch`.
    *
    * Operator → entity mapping for notes:
-   *   - `is:trashed`  → `entity.flags.trashed = entry.isArchived`
    *   - `is:starred`  → `entity.flags.starred = entry.isStarred`
    *   - `is:pinned`   → `entity.flags.pinned  = entry.isPinned`
    *   - `is:completed`/`is:overdue`/`due:`     → always false (notes have no completion/due semantics)
    *   - `list:`       → always false (notes have no lists)
+   *
+   * The active/trash split is handled by the `archived` pre-filter above —
+   * there is no public `is:trashed` operator.
    */
   getFilteredByAst(
     ast: QueryAST,

--- a/apps/reborn-task/src/lib/services/task-title-index.svelte.ts
+++ b/apps/reborn-task/src/lib/services/task-title-index.svelte.ts
@@ -443,7 +443,6 @@ class TaskIndex {
 	 * to false and the caller is expected to be on the title-only path.
 	 *
 	 * Operator → entity mapping for tasks:
-	 *   - `is:trashed`   → `entity.flags.trashed   = entry.isDeleted` (NOT `deleted_at`)
 	 *   - `is:starred`   → `entity.flags.starred   = entry.isStarred`
 	 *   - `is:completed` → `entity.flags.completed = entry.isCompleted`
 	 *   - `is:overdue`   → evaluator derives from `entity.dueAt < now && !completed && !trashed`
@@ -451,6 +450,10 @@ class TaskIndex {
 	 *   - `tag:` / `folder:` → resolvers are empty → match nothing (graceful degradation)
 	 *   - `list:`        → `entity.listId === ctx.listIdByName.get(value)`
 	 *   - `due:`         → `entity.dueAt = entry.dueDate`
+	 *
+	 * `entity.flags.trashed = entry.isDeleted` is plumbed for the `is:overdue`
+	 * derivation only — there is no public `is:trashed` operator (the active/trash
+	 * split is handled by the pre-filter above).
 	 */
 	getFilteredByAst(
 		ast: QueryAST,

--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -20,7 +20,6 @@ All search runs **client-side** over already-decrypted data — the server never
 | `is:pinned` | re/notes | `is:pinned` |
 | `is:completed` | re/task | `is:completed` |
 | `is:overdue` | re/task | `is:overdue` |
-| `is:trashed` | both | `is:trashed` (see [trash note](#searching-in-trash) below) |
 | `has:link` | both | `has:link` (matches notes/descriptions containing URLs or Markdown links) |
 
 **Modifiers**
@@ -94,7 +93,7 @@ Empty groups `()` are ignored. Redundant nesting like `((cat))` collapses natura
 A leading `-` before a group negates the entire group:
 
 ```
--(tag:archived OR is:trashed)   # neither archived nor trashed
+-(tag:archived OR tag:draft)    # neither archived nor draft
 tag:work -(is:completed AND -has:link)  # active work tasks that have either an
                                         # incomplete state or a linked reference
 ```
@@ -180,11 +179,9 @@ Quoting also works inside operator values: `tag:"side projects"`, `list:"Q2 plan
 
 ## Searching in trash
 
-In re/notes the trash has its own view; switching to it makes `is:trashed` redundant but useful to combine with other operators (e.g. `is:trashed tag:work`).
+Both apps have a dedicated trash view, and the search box always scans the current bucket only — active items in normal views, trashed items in the trash view. There is no operator to mix the two; to browse deleted items, switch to the trash view directly. Search there works with all the operators above (tag, folder, list, dates, …) over the trashed set.
 
-In re/task the search box only scans active tasks — `is:trashed` will return zero results from the global search. To browse deleted tasks, use the trash view directly.
-
-This is by design: searching across active and trashed items at the same time is rarely useful and would surface stale matches in everyday queries. Future versions may add an explicit "search in trash" mode.
+This is by design: cross-bucket search is rarely useful and would surface stale matches in everyday queries. A future version may introduce an explicit unified search mode.
 
 ---
 

--- a/packages/utils/src/search-query/ast.ts
+++ b/packages/utils/src/search-query/ast.ts
@@ -8,7 +8,7 @@
  *   modified:<14d
  *   due:<7d              (task only)
  *   has:link             (forces content-search path)
- *   is:starred | pinned | completed | overdue | trashed
+ *   is:starred | pinned | completed | overdue
  *   -OPERATOR            negation prefix on operators (-tag:archived, -is:completed)
  *   "quoted value"       allows whitespace and colons in operator values
  *
@@ -16,7 +16,7 @@
  *   foo bar              — implicit AND between consecutive primaries
  *   foo OR bar           — explicit OR (uppercase only — lowercase `or` is plain text)
  *   (foo bar) OR baz     — grouping; precedence is AND > OR
- *   -(tag:work OR is:trashed) — negate a group
+ *   -(tag:work OR is:starred) — negate a group
  *
  * Freetext (Tier 1.5):
  *   foo                  — substring match against title (and body when populated)
@@ -53,7 +53,7 @@ export type DateExpression =
   | { op: 'on'; date: DateRef } // entity.date falls on the same calendar day
   | { op: 'between'; from: DateRef; to: DateRef }; // entity.date >= from-start-of-day && entity.date <= to-end-of-day
 
-export type IsFlag = 'starred' | 'pinned' | 'completed' | 'overdue' | 'trashed';
+export type IsFlag = 'starred' | 'pinned' | 'completed' | 'overdue';
 
 export type HasFlag = 'link';
 

--- a/packages/utils/src/search-query/evaluator.test.ts
+++ b/packages/utils/src/search-query/evaluator.test.ts
@@ -488,8 +488,8 @@ describe('evaluate — Tier 2 grouping', () => {
     const ctx = makeCtx({
       tagIdByName: new Map([['archived', 'tag-a']])
     });
-    const ast = parseQuery('-(tag:archived OR is:trashed)');
-    // Matches entities that are neither tagged archived nor trashed.
+    const ast = parseQuery('-(tag:archived OR is:starred)');
+    // Matches entities that are neither tagged archived nor starred.
     expect(
       evaluate(ast, makeEntity({ tagIds: [], flags: {} }), ctx)
     ).toBe(true);
@@ -497,7 +497,7 @@ describe('evaluate — Tier 2 grouping', () => {
       evaluate(ast, makeEntity({ tagIds: ['tag-a'], flags: {} }), ctx)
     ).toBe(false);
     expect(
-      evaluate(ast, makeEntity({ tagIds: [], flags: { trashed: true } }), ctx)
+      evaluate(ast, makeEntity({ tagIds: [], flags: { starred: true } }), ctx)
     ).toBe(false);
   });
 

--- a/packages/utils/src/search-query/evaluator.ts
+++ b/packages/utils/src/search-query/evaluator.ts
@@ -157,8 +157,6 @@ function matchFilterPositive(
           return !!entity.flags.pinned;
         case 'completed':
           return !!entity.flags.completed;
-        case 'trashed':
-          return !!entity.flags.trashed;
         case 'overdue':
           return (
             entity.dueAt !== null &&

--- a/packages/utils/src/search-query/lite-ast.test.ts
+++ b/packages/utils/src/search-query/lite-ast.test.ts
@@ -10,7 +10,7 @@ const tag = (value: string, negated = false): Node => ({
   filter: { kind: 'tag', value, negated }
 });
 const is = (
-  value: 'starred' | 'pinned' | 'completed' | 'overdue' | 'trashed',
+  value: 'starred' | 'pinned' | 'completed' | 'overdue',
   negated = false
 ): Node => ({ kind: 'leaf-filter', filter: { kind: 'is', value, negated } });
 const and = (...children: Node[]): Node => ({ kind: 'and', children });

--- a/packages/utils/src/search-query/parser.test.ts
+++ b/packages/utils/src/search-query/parser.test.ts
@@ -22,7 +22,7 @@ const has = (value: 'link', negated = false): Node => ({
   filter: { kind: 'has', value, negated }
 });
 const is = (
-  value: 'starred' | 'pinned' | 'completed' | 'overdue' | 'trashed',
+  value: 'starred' | 'pinned' | 'completed' | 'overdue',
   negated = false
 ): Node => ({ kind: 'leaf-filter', filter: { kind: 'is', value, negated } });
 const and = (...children: Node[]): Node => ({ kind: 'and', children });
@@ -97,15 +97,24 @@ describe('parseQuery — operators', () => {
   });
 
   it('parses is: flags', () => {
-    const ast = parseQuery('is:starred is:pinned is:completed is:overdue is:trashed');
+    const ast = parseQuery('is:starred is:pinned is:completed is:overdue');
     expect(ast).toEqual({
-      root: and(is('starred'), is('pinned'), is('completed'), is('overdue'), is('trashed'))
+      root: and(is('starred'), is('pinned'), is('completed'), is('overdue'))
     });
   });
 
   it('combines operators with freetext (implicit AND)', () => {
-    expect(parseQuery('tag:work meeting notes -is:trashed')).toEqual({
-      root: and(tag('work'), text('meeting'), text('notes'), is('trashed', true))
+    expect(parseQuery('tag:work meeting notes -is:starred')).toEqual({
+      root: and(tag('work'), text('meeting'), text('notes'), is('starred', true))
+    });
+  });
+
+  it('unknown is: flag falls back to plain text (graceful degradation)', () => {
+    // is:trashed was retired — confirm the parser hands it back as a literal
+    // substring instead of crashing or silently matching nothing.
+    expect(parseQuery('is:trashed')).toEqual({ root: text('is:trashed') });
+    expect(parseQuery('-is:trashed')).toEqual({
+      root: text('is:trashed', true)
     });
   });
 });
@@ -331,8 +340,8 @@ describe('parseQuery — Tier 2 grouping', () => {
   });
 
   it('parses negated group', () => {
-    expect(parseQuery('-(tag:archived OR is:trashed)')).toEqual({
-      root: not(or(tag('archived'), is('trashed')))
+    expect(parseQuery('-(tag:archived OR is:starred)')).toEqual({
+      root: not(or(tag('archived'), is('starred')))
     });
   });
 

--- a/packages/utils/src/search-query/parser.ts
+++ b/packages/utils/src/search-query/parser.ts
@@ -5,8 +5,7 @@ const IS_FLAGS: ReadonlySet<IsFlag> = new Set([
   'starred',
   'pinned',
   'completed',
-  'overdue',
-  'trashed'
+  'overdue'
 ]);
 
 const KNOWN_KEYS = new Set([


### PR DESCRIPTION
The operator was a no-op in practice — both apps pre-filter the index by trashed/archived state before AST evaluation, so is:trashed always matched everything in the trash view and nothing elsewhere. With it removed from IS_FLAGS, the token now falls through the existing graceful-fallback path and is treated as a literal substring, matching the doc's contract for unknown operators.

The flags.trashed field stays plumbed for the is:overdue derivation.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>