### PR TITLE
fix(notes): render nested list indentation in live preview

### DIFF
--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
@@ -230,7 +230,9 @@ describe('buildDecorations — blockquote and lists', () => {
     const state = makeState(doc, doc.length - 1);
     const ranges = asRanges(buildDecorations(state));
 
-    expect(classAt(ranges, 0, 0)).toBe('cm-lp-bullet-line');
+    const cls = classAt(ranges, 0, 0);
+    expect(cls).toContain('cm-lp-bullet-line');
+    expect(cls).toContain('cm-lp-bullet-d1');
     expect(hasHiddenRange(ranges, 0, 2)).toBe(true);
   });
 
@@ -239,10 +241,104 @@ describe('buildDecorations — blockquote and lists', () => {
     const state = makeState(doc, doc.length - 1);
     const ranges = asRanges(buildDecorations(state));
 
-    expect(classAt(ranges, 0, 0)).toBe('cm-lp-ordered-line');
+    const cls = classAt(ranges, 0, 0);
+    expect(cls).toContain('cm-lp-ordered-line');
+    expect(cls).toContain('cm-lp-ordered-d1');
     // No hidden range over the "1. " marker
     const hiddenAtMark = ranges.find((r) => r.from === 0 && r.isHidden);
     expect(hiddenAtMark).toBeUndefined();
+  });
+});
+
+describe('buildDecorations — nested list depth', () => {
+  it('applies cm-lp-bullet-d1 to top-level bullets', () => {
+    const doc = '- one\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+    expect(classAt(ranges, 0, 0)).toContain('cm-lp-bullet-d1');
+  });
+
+  it('applies cm-lp-bullet-d2 to nested bullets and hides leading whitespace', () => {
+    const doc = '- one\n- two\n    - 2.1\n\nbody';
+    const cursor = doc.length - 1; // cursor in "body"
+    const state = makeState(doc, cursor);
+    const ranges = asRanges(buildDecorations(state));
+
+    const nestedLineFrom = doc.indexOf('    - 2.1');
+    expect(classAt(ranges, nestedLineFrom, nestedLineFrom)).toContain('cm-lp-bullet-d2');
+
+    // Leading "    " (4 spaces) hidden when cursor outside the line
+    const listMarkPos = doc.indexOf('- 2.1');
+    expect(hasHiddenRange(ranges, nestedLineFrom, listMarkPos)).toBe(true);
+  });
+
+  it('applies cm-lp-bullet-d3 at depth 3', () => {
+    const doc = '- a\n  - b\n    - c\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+
+    const lineCFrom = doc.indexOf('    - c');
+    expect(classAt(ranges, lineCFrom, lineCFrom)).toContain('cm-lp-bullet-d3');
+  });
+
+  it('clamps deeper-than-MAX nesting to cm-lp-bullet-d6', () => {
+    // 7 levels deep — should still render with d6 (visual cap).
+    const doc =
+      [
+        '- 1',
+        '  - 2',
+        '    - 3',
+        '      - 4',
+        '        - 5',
+        '          - 6',
+        '            - 7'
+      ].join('\n') + '\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+
+    const line7From = doc.indexOf('            - 7');
+    expect(classAt(ranges, line7From, line7From)).toContain('cm-lp-bullet-d6');
+  });
+
+  it('keeps leading whitespace HIDDEN even when cursor is on the nested line (deterministic geometry)', () => {
+    // Showing the indent spaces on cursor-enter would shift the visible
+    // content rightward by ~1em per 4 spaces in proportional Roboto, making
+    // the user think they're editing at a deeper indent than they actually
+    // are. The depth-class padding already communicates nesting visually.
+    const doc = '- one\n  - two\n\nbody';
+    const cursor = doc.indexOf('two'); // cursor on the nested line
+    const state = makeState(doc, cursor);
+    const ranges = asRanges(buildDecorations(state));
+
+    const nestedLineFrom = doc.indexOf('  - two');
+    const listMarkPos = doc.indexOf('- two');
+    // Whitespace stays hidden
+    expect(hasHiddenRange(ranges, nestedLineFrom, listMarkPos)).toBe(true);
+    // But the marker `- ` IS revealed (cursor on line) — user can edit/delete it
+    expect(hasHiddenRange(ranges, listMarkPos, listMarkPos + 2)).toBe(false);
+  });
+
+  it('handles ordered lists with depth-aware padding', () => {
+    const doc = '1. a\n   1. b\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+
+    const nestedLineFrom = doc.indexOf('   1. b');
+    expect(classAt(ranges, nestedLineFrom, nestedLineFrom)).toContain('cm-lp-ordered-d2');
+
+    // Ordered marker stays visible (number is meaningful content)
+    const numberPos = doc.indexOf('1. b');
+    const hasMarkerHidden = ranges.some((r) => r.from === numberPos && r.isHidden);
+    expect(hasMarkerHidden).toBe(false);
+  });
+
+  it('handles mixed ordered → bullet nesting (depth counts both)', () => {
+    const doc = '1. a\n   - b\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+
+    const nestedLineFrom = doc.indexOf('   - b');
+    expect(classAt(ranges, nestedLineFrom, nestedLineFrom)).toContain('cm-lp-bullet-d2');
   });
 });
 

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
@@ -63,14 +63,46 @@ const EM_MARK = Decoration.mark({ class: 'cm-lp-em' });
 const STRIKE_MARK = Decoration.mark({ class: 'cm-lp-strike' });
 const INLINE_CODE_MARK = Decoration.mark({ class: 'cm-lp-code' });
 const BLOCKQUOTE_LINE = Decoration.line({ class: 'cm-lp-blockquote-line' });
-const BULLET_LINE = Decoration.line({ class: 'cm-lp-bullet-line' });
-const ORDERED_LINE = Decoration.line({ class: 'cm-lp-ordered-line' });
+
+// Visual cap on list nesting. Past 6 levels the indent eats the viewport on
+// mobile and CommonMark realistically never goes deeper. Bumping this requires
+// matching `.cm-lp-bullet-d{N}` / `.cm-lp-ordered-d{N}` rules in theme.ts.
+const MAX_LIST_DEPTH = 6;
+
+const BULLET_LINE: Decoration[] = Array.from({ length: MAX_LIST_DEPTH }, (_, i) =>
+  Decoration.line({ class: `cm-lp-bullet-line cm-lp-bullet-d${i + 1}` })
+);
+const ORDERED_LINE: Decoration[] = Array.from({ length: MAX_LIST_DEPTH }, (_, i) =>
+  Decoration.line({ class: `cm-lp-ordered-line cm-lp-ordered-d${i + 1}` })
+);
 
 export function isAnySelectionInRange(state: EditorState, from: number, to: number): boolean {
   for (const r of state.selection.ranges) {
     if (r.from <= to && r.to >= from) return true;
   }
   return false;
+}
+
+/**
+ * Counts BulletList/OrderedList ancestors of a ListItem node — the ListItem's
+ * own list parent is depth 1, a list inside another list is depth 2, etc.
+ *
+ * Walking the parent chain is robust to mid-edit malformed trees (the
+ * incremental parser sometimes returns nodes with incomplete children, but
+ * parent linkage stays stable) and cheap (≤ MAX_LIST_DEPTH hops).
+ *
+ * Mixed bullet/ordered nesting counts both — depth follows the visual nesting
+ * the user sees in Preview's `<ul>`/`<ol>` tree.
+ */
+function getListDepth(node: SyntaxNode): number {
+  let depth = 0;
+  let p = node.parent;
+  while (p) {
+    const n = p.type.name;
+    if (n === 'BulletList' || n === 'OrderedList') depth++;
+    p = p.parent;
+  }
+  return Math.min(Math.max(depth, 1), MAX_LIST_DEPTH);
 }
 
 function findFirstChild(node: SyntaxNode, name: string): SyntaxNode | null {
@@ -402,14 +434,29 @@ export function buildDecorations(
         const listMark = findFirstChild(nodeRef.node, 'ListMark');
         const markText = listMark ? doc.sliceString(listMark.from, listMark.to) : '';
         const isOrdered = /^\d/.test(markText);
-        ranges.push((isOrdered ? ORDERED_LINE : BULLET_LINE).range(itemLine.from));
+        const depth = getListDepth(nodeRef.node);
+        const lineDecoSet = isOrdered ? ORDERED_LINE : BULLET_LINE;
+        ranges.push(lineDecoSet[depth - 1].range(itemLine.from));
 
-        // Bullets: hide "- " / "* " when cursor outside this line.
-        // Ordered: keep marker visible — the number is meaningful and recognizable.
-        if (!isOrdered && listMark && !isAnySelectionInRange(state, itemLine.from, itemLine.to)) {
-          const next = doc.sliceString(listMark.to, listMark.to + 1);
-          const hideTo = next === ' ' ? listMark.to + 1 : listMark.to;
-          ranges.push(HIDDEN.range(listMark.from, hideTo));
+        if (listMark) {
+          // Hide leading indentation whitespace ALWAYS (regardless of cursor
+          // position). Showing it on cursor-enter would shift the visible
+          // content rightward by the width of the source spaces, making the
+          // user think their edit is happening at a deeper indent than it
+          // actually is. The depth-class padding on the line already
+          // communicates nesting visually — the literal spaces are noise.
+          if (listMark.from > itemLine.from) {
+            ranges.push(HIDDEN.range(itemLine.from, listMark.from));
+          }
+
+          // Bullets: hide "- " / "* " when cursor outside this line.
+          // Ordered: keep marker visible — the number is meaningful content.
+          const cursorOnLine = isAnySelectionInRange(state, itemLine.from, itemLine.to);
+          if (!isOrdered && !cursorOnLine) {
+            const next = doc.sliceString(listMark.to, listMark.to + 1);
+            const hideTo = next === ' ' ? listMark.to + 1 : listMark.to;
+            ranges.push(HIDDEN.range(listMark.from, hideTo));
+          }
         }
         return; // descend so inline content inside item gets decorated
       }
@@ -492,25 +539,89 @@ export const livePreviewSyncListener = EditorView.updateListener.of((update) => 
 });
 
 /**
- * Treat each `Table` block as a single atomic range so CM6 selection cannot
- * land mid-table in the markdown source. Without this, pressing arrow keys
- * or End/PageDown could place the caret between `|` characters, causing the
- * decorated widget to flicker and stealing focus from contenteditable cells.
+ * Atomic ranges for two distinct cases:
  *
- * Tables are the only Live Preview construct that need this treatment —
- * other widgets (links, code blocks) toggle to raw markdown when the cursor
- * enters them, but tables stay rendered always.
+ *  1. **Whole `Table` blocks** — selection cannot land mid-table in the
+ *     markdown source. Without this, arrow keys / End / PageDown could place
+ *     the caret between `|` characters, causing the decorated widget to
+ *     flicker and stealing focus from contenteditable cells.
+ *
+ *  2. **Leading whitespace of nested `ListItem`s** (`[itemLine.from,
+ *     listMark.from]`). Pairs with the always-hidden HIDDEN replace
+ *     decoration on the same range emitted in `buildDecorations`. Without
+ *     this, Home / arrow-Left / posAtCoords could put the cursor in the
+ *     middle of zero-width replaced whitespace — invisible cursor, drag
+ *     selection of "padding", off-by-N edits.
+ *
+ *  Tables short-circuit (`return false`) so we don't emit list atomics for
+ *  list items that live inside a table cell — tables own their own editing.
  */
 export const livePreviewAtomicRanges = EditorView.atomicRanges.of((view) => {
   const builder = new RangeSetBuilder<Decoration>();
   const tree = syntaxTree(view.state);
+  const doc = view.state.doc;
   tree.iterate({
     enter(nodeRef) {
-      if (nodeRef.type.name === 'Table') {
+      const name = nodeRef.type.name;
+      if (name === 'Table') {
         builder.add(nodeRef.from, nodeRef.to, Decoration.mark({}));
         return false;
+      }
+      if (name === 'ListItem') {
+        const itemLine = doc.lineAt(nodeRef.from);
+        const listMark = findFirstChild(nodeRef.node, 'ListMark');
+        if (listMark && listMark.from > itemLine.from) {
+          builder.add(itemLine.from, listMark.from, Decoration.mark({}));
+        }
       }
     }
   });
   return builder.finish();
+});
+
+/**
+ * Forwards a click in the "padding zone" of a list-item line (the area left
+ * of the marker and over the rendered `::before` bullet) to the content start
+ * (position right after `- ` / `1. `). Without this, CM6's `posAtCoords` maps
+ * such clicks to `itemLine.from`, which then bumps to `listMark.from` via
+ * the atomic prefix — leaving the cursor BEFORE the marker, where the user
+ * has to manually arrow-right twice to start typing.
+ *
+ * Trigger condition: `event.target` is the `.cm-line` element itself (i.e.
+ * the click did NOT land on any text node / span inside the line). When the
+ * user clicks an actual character — including the marker once it's revealed
+ * (cursor on line) — `target` is a child span and we let CM6's default
+ * selection handling run, so the caret lands exactly where clicked.
+ */
+export const livePreviewListClickForward = EditorView.domEventHandlers({
+  mousedown(event, view) {
+    const target = event.target as HTMLElement | null;
+    if (!target || !target.classList) return false;
+    if (!target.classList.contains('cm-line')) return false;
+    if (
+      !target.classList.contains('cm-lp-bullet-line') &&
+      !target.classList.contains('cm-lp-ordered-line')
+    ) {
+      return false;
+    }
+
+    const pos = view.posAtCoords({ x: event.clientX, y: event.clientY }, false);
+    if (pos === null) return false;
+
+    const tree = syntaxTree(view.state);
+    let n: SyntaxNode | null = tree.resolveInner(pos, -1);
+    while (n && n.type.name !== 'ListItem') n = n.parent;
+    if (!n) return false;
+
+    const listMark = findFirstChild(n, 'ListMark');
+    if (!listMark) return false;
+
+    const next = view.state.doc.sliceString(listMark.to, listMark.to + 1);
+    const contentStart = next === ' ' ? listMark.to + 1 : listMark.to;
+
+    event.preventDefault();
+    view.dispatch({ selection: { anchor: contentStart } });
+    view.focus();
+    return true;
+  }
 });

--- a/apps/reborn-notes/src/lib/editor/live-preview/index.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/index.ts
@@ -18,7 +18,8 @@ import type { ImageLoadMode } from '@reborn/storage';
 import {
   createLivePreviewField,
   livePreviewSyncListener,
-  livePreviewAtomicRanges
+  livePreviewAtomicRanges,
+  livePreviewListClickForward
 } from './decorations';
 import { livePreviewTheme } from './theme';
 import { codeLanguages } from './code-languages';
@@ -45,7 +46,14 @@ export function createLivePreviewExtension(options: LivePreviewOptions = {}): Ex
     imageLoadMode: options.imageLoadMode ?? 'ask',
     imageLabels: options.imageLabels ?? DEFAULT_LABELS
   });
-  return [field, loadedImagesField, livePreviewSyncListener, livePreviewAtomicRanges, livePreviewTheme];
+  return [
+    field,
+    loadedImagesField,
+    livePreviewSyncListener,
+    livePreviewAtomicRanges,
+    livePreviewListClickForward,
+    livePreviewTheme
+  ];
 }
 
 /**
@@ -64,6 +72,7 @@ export {
   livePreviewField,
   livePreviewSyncListener,
   livePreviewAtomicRanges,
+  livePreviewListClickForward,
   rebuildLivePreview,
   type BuildDecorationsOptions
 } from './decorations';

--- a/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
@@ -117,22 +117,40 @@ export const livePreviewTheme = EditorView.theme({
     fontStyle: 'italic'
   },
 
-  // Bullet list line — render a bullet via ::before
+  // Bullet list — depth-aware padding + ::before bullet.
+  // Padding/left scale linearly with depth (1.5em per level). Each ListItem
+  // gets `cm-lp-bullet-line cm-lp-bullet-d{N}` from `decorations.ts`, where N
+  // counts BulletList/OrderedList ancestors (clamped to MAX_LIST_DEPTH = 6).
+  // Mirrors MarkdownPreview's `<ul><ul>` nesting (1.5em per level).
   '.cm-lp-bullet-line': {
-    position: 'relative',
-    paddingLeft: '1.5em'
+    position: 'relative'
   },
   '.cm-lp-bullet-line::before': {
     content: '"•"',
     position: 'absolute',
-    left: '0.5em',
     color: 'var(--muted-foreground)'
   },
+  '.cm-lp-bullet-d1': { paddingLeft: '1.5em' },
+  '.cm-lp-bullet-d1::before': { left: '0.5em' },
+  '.cm-lp-bullet-d2': { paddingLeft: '3em' },
+  '.cm-lp-bullet-d2::before': { left: '2em' },
+  '.cm-lp-bullet-d3': { paddingLeft: '4.5em' },
+  '.cm-lp-bullet-d3::before': { left: '3.5em' },
+  '.cm-lp-bullet-d4': { paddingLeft: '6em' },
+  '.cm-lp-bullet-d4::before': { left: '5em' },
+  '.cm-lp-bullet-d5': { paddingLeft: '7.5em' },
+  '.cm-lp-bullet-d5::before': { left: '6.5em' },
+  '.cm-lp-bullet-d6': { paddingLeft: '9em' },
+  '.cm-lp-bullet-d6::before': { left: '8em' },
 
-  // Ordered list line — keep marker visible, just indent slightly
-  '.cm-lp-ordered-line': {
-    paddingLeft: '0.5em'
-  },
+  // Ordered list — same indent rhythm but no ::before (number stays in source).
+  '.cm-lp-ordered-line': {},
+  '.cm-lp-ordered-d1': { paddingLeft: '1.5em' },
+  '.cm-lp-ordered-d2': { paddingLeft: '3em' },
+  '.cm-lp-ordered-d3': { paddingLeft: '4.5em' },
+  '.cm-lp-ordered-d4': { paddingLeft: '6em' },
+  '.cm-lp-ordered-d5': { paddingLeft: '7.5em' },
+  '.cm-lp-ordered-d6': { paddingLeft: '9em' },
 
   // ─── Fenced code blocks ──────────────────────────────────────
   // Cursor outside: replaced with <div class="cm-lp-codeblock-wrap"><pre>.


### PR DESCRIPTION
Live Preview rendered all bullets at the same X position regardless of nesting depth, because the line decoration applied a fixed padding-left and the ::before bullet was absolutely positioned at a fixed offset. Leading source whitespace was visible but inconsistent in the proportional Roboto font, so depth >= 2 collapsed visually to depth 1.

Walks the syntax tree's parent chain to count BulletList/OrderedList ancestors (capped at 6) and emits per-depth classes (cm-lp-bullet-d1..d6, cm-lp-ordered-d1..d6) with linearly-scaling padding and bullet position. Hides leading indentation whitespace unconditionally so the visual geometry is deterministic regardless of font and stays stable when the cursor enters or leaves the line.

Adds an atomic range over the leading whitespace so CM6 selection cannot land in the (zero-width) HIDDEN region, and a mousedown handler that forwards clicks landing in the padding/bullet zone to the start of the item's content (after \`- \` / \`1. \`) -- without it CM6 placed the caret before the marker, where the user had to arrow-right twice to type.

Fixes #146.

Reported-by: Travis Solin <@computrav> (#146) Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>