### PR TITLE
fix(notes): create unfoldered note from periodic view

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -67,6 +67,7 @@
     activeSection = 'all',
     activeFolderId = null,
     isTrash = false,
+    isPeriodic = false,
     showSidebarTrigger = false,
     prominentHeader = false,
     autoFocusSearch = false,
@@ -81,6 +82,7 @@
     /** Current folder ID — used to render a breadcrumb under search results from subfolders. */
     activeFolderId?: string | null;
     isTrash?: boolean;
+    isPeriodic?: boolean;
     showSidebarTrigger?: boolean;
     prominentHeader?: boolean;
     autoFocusSearch?: boolean;
@@ -329,7 +331,7 @@
         <NoteListSortMenu bind:sortSheetOpen />
       {/if}
 
-      {#if !isTrash}
+      {#if !isTrash && !isPeriodic}
         <button
           type="button"
           onclick={handleCreate}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -562,7 +562,12 @@
     // tag yet), so the user would create a note and see nothing. Switch to "All
     // notes" first and await tick so the section $effect drives the store filter
     // before we call create() + refresh().
-    if (activeSection === 'trash' || activeSection === 'starred' || activeSection === 'tags') {
+    if (
+      activeSection === 'trash' ||
+      activeSection === 'starred' ||
+      activeSection === 'tags' ||
+      isPeriodicSection(activeSection)
+    ) {
       activeSection = 'all';
       activeFolderId = undefined;
       activeTagId = null;
@@ -1169,6 +1174,7 @@
                 {activeSection}
                 activeFolderId={activeFolderId ?? null}
                 isTrash={activeTrash}
+                isPeriodic={isPeriodicSection(activeSection)}
                 subfolders={activeFolderSubfolders}
                 onSubfolderSelect={handleFolderSelect}
                 autoFocusSearch={activeSection === 'search'}
@@ -1433,6 +1439,7 @@
               {activeFolderName}
               {activeSection}
               isTrash={false}
+              isPeriodic={false}
               autoFocusSearch
               searchOnly
               oncreate={handleNewNote}
@@ -1442,6 +1449,7 @@
               {activeFolderName}
               {activeSection}
               isTrash={activeTrash}
+              isPeriodic={isPeriodicSection(activeSection)}
               oncreate={handleNewNote}
             />
           {/if}
@@ -1581,6 +1589,7 @@
             {activeSection}
             activeFolderId={activeFolderId ?? null}
             isTrash={false}
+            isPeriodic={isPeriodicSection(activeSection)}
             showSidebarTrigger
             subfolders={activeFolderSubfolders}
             onSubfolderSelect={handleFolderSelect}


### PR DESCRIPTION
Clicking FilePlus in IconNav while in a periodic notes view (Daily/ Weekly/Monthly) was creating the new note inside the periodic folder because notesStore.create() falls back to currentFolderId. Extend the existing pre-flight reset (which already handles trash/starred/tags) to also reset periodic sections to "All notes" before creating.

Also remove the FilePlus button from the NoteList sidebar header in periodic views — that button always created the note inside the periodic folder, which contradicts the "container for periodic notes only" UX of those views.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>