### PR TITLE
fix(notes): toolbar empty sub-bullet renders as BulletList

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -13,6 +13,11 @@
   import { noteLinkDecoration } from '$lib/editor/note-link-decoration';
   import { listIndent, listOutdent } from '$lib/editor/list-keymap';
   import {
+    BULLET_ANCHOR,
+    shouldInsertBulletAnchor,
+    stripBulletAnchorListener
+  } from '$lib/editor/bullet-anchor';
+  import {
     createLivePreviewExtension,
     getMarkdownExtension,
     rebuildLivePreview,
@@ -199,8 +204,11 @@
       });
     } else {
       const stripped = afterWs.replace(/^(#{1,6} |> |[-+*] |\d+[.)] )/, '');
+      const trailing = shouldInsertBulletAnchor(prefix, indent, stripped)
+        ? BULLET_ANCHOR
+        : stripped;
       view.dispatch({
-        changes: { from: line.from, to: line.to, insert: `${indent}${prefix}${stripped}` },
+        changes: { from: line.from, to: line.to, insert: `${indent}${prefix}${trailing}` },
         selection: { anchor: line.from + indent.length + prefix.length }
       });
     }
@@ -385,6 +393,7 @@
             : []
         ),
         noteLinkDecoration,
+        stripBulletAnchorListener,
         EditorView.domEventHandlers({
           click(e) {
             const target = e.target as HTMLElement | null;

--- a/apps/reborn-notes/src/lib/editor/bullet-anchor.test.ts
+++ b/apps/reborn-notes/src/lib/editor/bullet-anchor.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BULLET_ANCHOR,
+  shouldInsertBulletAnchor,
+  shouldStripAnchor
+} from './bullet-anchor';
+
+describe('shouldInsertBulletAnchor', () => {
+  it('returns true for empty sub-bullet conversion (`* ` prefix, indent, no content)', () => {
+    expect(shouldInsertBulletAnchor('* ', '   ', '')).toBe(true);
+    expect(shouldInsertBulletAnchor('- ', '  ', '')).toBe(true);
+    expect(shouldInsertBulletAnchor('+ ', '  ', '')).toBe(true);
+  });
+
+  it('returns false for top-level empty bullet — already parses as BulletList', () => {
+    expect(shouldInsertBulletAnchor('* ', '', '')).toBe(false);
+  });
+
+  it('returns false when content remains after marker', () => {
+    expect(shouldInsertBulletAnchor('* ', '   ', 'text')).toBe(false);
+  });
+
+  it('returns false for ordered prefix — empty sub-OrderedList parses fine', () => {
+    expect(shouldInsertBulletAnchor('1. ', '   ', '')).toBe(false);
+    expect(shouldInsertBulletAnchor('1) ', '   ', '')).toBe(false);
+  });
+
+  it('returns false for non-list prefixes (heading, blockquote)', () => {
+    expect(shouldInsertBulletAnchor('# ', '   ', '')).toBe(false);
+    expect(shouldInsertBulletAnchor('> ', '   ', '')).toBe(false);
+  });
+});
+
+describe('shouldStripAnchor', () => {
+  it('returns false when line has no anchor', () => {
+    expect(shouldStripAnchor('  * hello')).toBe(false);
+    expect(shouldStripAnchor('   1. text')).toBe(false);
+  });
+
+  it('returns false for the sentinel state — anchor present but no real content', () => {
+    expect(shouldStripAnchor(`   * ${BULLET_ANCHOR}`)).toBe(false);
+    expect(shouldStripAnchor(`  - ${BULLET_ANCHOR}`)).toBe(false);
+  });
+
+  it('returns true once the user has typed content', () => {
+    expect(shouldStripAnchor(`   * h${BULLET_ANCHOR}`)).toBe(true);
+    expect(shouldStripAnchor(`   * hello${BULLET_ANCHOR}`)).toBe(true);
+    expect(shouldStripAnchor(`   * ${BULLET_ANCHOR}hello`)).toBe(true);
+  });
+
+  it('returns true even after the line was re-toggled to ordered', () => {
+    expect(shouldStripAnchor(`   1. hello${BULLET_ANCHOR}`)).toBe(true);
+  });
+
+  it('returns false on non-list lines that happen to contain the anchor', () => {
+    expect(shouldStripAnchor(`some text ${BULLET_ANCHOR}`)).toBe(false);
+  });
+});

--- a/apps/reborn-notes/src/lib/editor/bullet-anchor.ts
+++ b/apps/reborn-notes/src/lib/editor/bullet-anchor.ts
@@ -1,0 +1,106 @@
+/**
+ * Zero-width sentinel for empty sub-list bullets created via the toolbar.
+ *
+ * `@lezer/markdown` exhibits a CommonMark-adjacent asymmetry: an empty sub
+ * `OrderedList` line (`   1. `) parses as a sub-list, but an empty sub
+ * `BulletList` line (`   * ` / `   - `) is treated as paragraph continuation
+ * of the outer ListItem. Live Preview then can't apply `cm-lp-bullet-d{N}`
+ * decoration and the bullet visually drops to column 0 until the user types
+ * real content.
+ *
+ * Workaround: when the toolbar produces an empty sub-bullet, append a
+ * zero-width space after the marker so the parser sees content and emits a
+ * BulletList. `stripBulletAnchorListener` removes the sentinel on the next
+ * doc change that adds substantive content, so the saved markdown stays
+ * clean. The anchor is therefore only ever present for the brief window
+ * between toolbar click and first keystroke.
+ *
+ * Scope: toolbar conversions only. Direct typing of `   * ` reproduces the
+ * same parse asymmetry but rewriting user keystrokes is out of scope here.
+ */
+import type { Extension } from '@codemirror/state';
+import { Transaction } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+export const BULLET_ANCHOR = '​';
+
+const BULLET_PREFIX_RE = /^[-+*] $/;
+const LIST_LINE_WITH_CONTENT_RE = /^(\s*)(?:[-+*]|\d+[.)])\s+(.*[^\s​].*)$/;
+
+/**
+ * Decides whether `prefixLine` should append `BULLET_ANCHOR` after the
+ * marker. True only for the bug-triggering shape:
+ *   - prefix is a bullet marker (`* ` / `- ` / `+ `)
+ *   - resulting content after marker is empty
+ *   - line has leading indentation (i.e., a sub-list)
+ *
+ * Top-level empty bullets parse fine, so we skip the anchor there to avoid
+ * pointless cleanup churn.
+ */
+export function shouldInsertBulletAnchor(
+  prefix: string,
+  indent: string,
+  stripped: string
+): boolean {
+  if (stripped.length > 0) return false;
+  if (indent.length === 0) return false;
+  return BULLET_PREFIX_RE.test(prefix);
+}
+
+/**
+ * True when a list-item line still carries `BULLET_ANCHOR` AND has at least
+ * one non-whitespace, non-anchor character after the marker — i.e., the user
+ * has typed real content and the sentinel has done its job.
+ */
+export function shouldStripAnchor(lineText: string): boolean {
+  if (!lineText.includes(BULLET_ANCHOR)) return false;
+  return LIST_LINE_WITH_CONTENT_RE.test(lineText);
+}
+
+/**
+ * Removes `BULLET_ANCHOR` from list-item lines once the user has typed real
+ * content there. Dispatched as a separate, history-excluded transaction so
+ * undo only steps through user-visible edits.
+ *
+ * The async `Promise.resolve().then(...)` queue mirrors
+ * `livePreviewSyncListener` — dispatching synchronously inside an
+ * updateListener triggers a CM6 reentrancy assertion.
+ *
+ * Scan is bounded to lines touched by the current update, so cost is O(edit
+ * size) regardless of document length.
+ */
+export const stripBulletAnchorListener: Extension = EditorView.updateListener.of(
+  (update) => {
+    if (!update.docChanged) return;
+    const doc = update.state.doc;
+    const visited = new Set<number>();
+
+    update.changes.iterChangedRanges((_fromA, _toA, fromB, toB) => {
+      const fromLine = doc.lineAt(fromB).number;
+      const toLine = doc.lineAt(toB).number;
+      for (let n = fromLine; n <= toLine; n++) visited.add(n);
+    });
+
+    const changes: Array<{ from: number; to: number; insert: string }> = [];
+    for (const n of visited) {
+      if (n < 1 || n > doc.lines) continue;
+      const line = doc.line(n);
+      if (!shouldStripAnchor(line.text)) continue;
+
+      let i = -1;
+      while ((i = line.text.indexOf(BULLET_ANCHOR, i + 1)) >= 0) {
+        changes.push({ from: line.from + i, to: line.from + i + 1, insert: '' });
+      }
+    }
+
+    if (changes.length === 0) return;
+
+    const view = update.view;
+    Promise.resolve().then(() => {
+      view.dispatch({
+        changes,
+        annotations: Transaction.addToHistory.of(false)
+      });
+    });
+  }
+);


### PR DESCRIPTION
Converting an empty sub OrderedList line (e.g. `   1. `) to a bullet via the toolbar produced `   * `, which @lezer/markdown does not recognize as a sub-BulletList — only digit+`.` is a strong enough list-start signal in nested context. Live Preview therefore failed to apply `cm-lp-bullet-d{N}` decoration and the bullet visually dropped to column 0 until the user typed real content.

Workaround: append a zero-width sentinel after the marker when the toolbar would otherwise produce an empty sub-bullet. An updateListener strips the sentinel from list-item lines once substantive content is typed, so the saved markdown stays clean — the anchor is only present between the toolbar click and the first keystroke. The strip transaction is excluded from history so undo only steps through user-visible edits.

Limited to bullet+sub-list — top-level empty bullets parse fine without the anchor. Direct typing of `   * ` (without toolbar) reproduces the same parse asymmetry but rewriting user keystrokes is out of scope.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>