### PR TITLE
chore(ci): group @codemirror/* and @lezer/* in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,12 @@
       "automerge": false
     },
     {
+      "description": "Group CodeMirror + Lezer ecosystem updates — bumping @codemirror/view alone causes transitive duplicate (TS errors on EditorView's private dispatchTransactions). Cohesive bump avoids it.",
+      "matchPackageNames": ["/^@codemirror\\//", "/^@lezer\\//"],
+      "groupName": "codemirror",
+      "automerge": false
+    },
+    {
       "description": "Group Nx monorepo updates",
       "matchPackageNames": ["/^@nx\\//", "/^nx$/"],
       "groupName": "nx",


### PR DESCRIPTION
## Summary
- Add Renovate group for the entire CodeMirror + Lezer ecosystem (`@codemirror/*`, `@lezer/*`).
- Avoids the dedupe trap that hit #161: bumping a single CodeMirror package leaves transitive deps on the older version, creating two `EditorView` types with mismatched private `dispatchTransactions` field → svelte-check fails.

## Test plan
- [x] JSON validates (`node -e \"JSON.parse(...)\"`)
- [ ] Renovate next run (Monday 9:00 Europe/Warsaw) opens grouped \`codemirror\` PR if any CodeMirror update is available