### PR TITLE
chore(deps): migrate pnpm-workspace to allowBuilds for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - apps/*
   - packages/*
+# Legacy key, used by pnpm <= 10. Drop together with the pnpm 10 packageManager pin.
 onlyBuiltDependencies:
   - '@prisma/client'
   - '@prisma/engines'
@@ -8,4 +9,17 @@ onlyBuiltDependencies:
   - esbuild
   - nx
   - prisma
+  - sharp
   - svelte-preprocess
+# Replacement of `onlyBuiltDependencies` in pnpm 11 (strictDepBuilds=true by default).
+allowBuilds:
+  '@prisma/client': true
+  '@prisma/engines': true
+  '@swc/core': true
+  esbuild: true
+  nx: true
+  prisma: true
+  sharp: true
+  svelte-preprocess: true
+  core-js: false
+  es5-ext: false


### PR DESCRIPTION
pnpm 11 removes `onlyBuiltDependencies` (along with `neverBuiltDependencies`, `ignoredBuiltDependencies`, `onlyBuiltDependenciesFile`, `ignoreDepScripts`) and replaces them with the `allowBuilds` map. Combined with `strictDepBuilds=true` default, any unlisted postinstall script makes `pnpm install --frozen-lockfile` fail with ERR_PNPM_IGNORED_BUILDS — which is what currently breaks CI on #165 (pnpm 10.33.4 → 11.0.9).

Both keys are kept side by side during the transition: pnpm 10 reads the legacy `onlyBuiltDependencies` and ignores `allowBuilds`; pnpm 11 ignores the legacy key and reads `allowBuilds`. Drop the legacy block once #165 lands and the packageManager pin moves to pnpm 11.

Also adds `sharp` (native binaries needed for image processing) which was missing from the previous allowlist; `core-js` and `es5-ext` are explicitly opted out — their postinstalls are donation/sponsor messages, not actual builds.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>