### PR TITLE
chore(deps): drop legacy onlyBuiltDependencies after pnpm 11 bump

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,6 @@
 packages:
   - apps/*
   - packages/*
-# Legacy key, used by pnpm <= 10. Drop together with the pnpm 10 packageManager pin.
-onlyBuiltDependencies:
-  - '@prisma/client'
-  - '@prisma/engines'
-  - '@swc/core'
-  - esbuild
-  - nx
-  - prisma
-  - sharp
-  - svelte-preprocess
-# Replacement of `onlyBuiltDependencies` in pnpm 11 (strictDepBuilds=true by default).
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true


### PR DESCRIPTION
`onlyBuiltDependencies` is removed in pnpm 11 — it was kept side-by-side with `allowBuilds` only as a transitional safety net while the packageManager pin still resolved to pnpm 10. With #165 merged, packageManager is pnpm 11 and the legacy block is dead code.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>