### PR TITLE
chore(docker): bump Dockerfile pnpm from 10 to 11.0.9 to match CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # ─── Base: shared Node + pnpm layer ────────────────────────────
 FROM node:24.15.0-alpine AS base
 WORKDIR /app
-RUN npm install -g pnpm@10 --quiet
+RUN npm install -g pnpm@11.0.9 --quiet
 
 # ─── Deps: install workspace + build shared packages ───────────
 # Kept separate from app builds so its cache is reused between task/notes.


### PR DESCRIPTION
CI workflow pins pnpm 11.0.9 (since #165) and pnpm-workspace.yaml uses pnpm 11 syntax (allowBuilds, no onlyBuiltDependencies after #167), but the Dockerfile still installed pnpm@10 inside the build image. Two consequences:

1. `allowBuilds` was silently ignored in container — pnpm 10 in the image doesn't read it, and the legacy `onlyBuiltDependencies` is gone, so sharp/es5-ext postinstalls were skipped with an "Ignored build scripts" warning. Sharp 0.34 ships prebuilt libvips so runtime works, but the warning was a real signal of config drift.
2. pnpm.overrides in pnpm-workspace.yaml (cookie/esbuild/@hono/node-server from #170) were applying through pnpm 9.x compatibility layer in pnpm 10 — works today but not contractually guaranteed.

Pin to exact 11.0.9 (not the `pnpm@11` tag) for build determinism and so Renovate keeps it in lockstep with the CI pin.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>