### PR TITLE
fix(task): preserve shadow indexes when metadata decrypt fails after session unlock

### DIFF
--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -483,6 +483,20 @@ export class AuthOperationsService {
 					await syncService.initialSync();
 				}
 
+				// Reconcile any IDB shadow indexes that drifted from the
+				// metadata bundle (recovery for the 2026-05-10 incident — see
+				// shadow-index-reconciler.service.ts). Cheap no-op when IDB
+				// is consistent. Run before loadLists so any UI that reads
+				// task counts immediately afterwards sees corrected state.
+				try {
+					const { verifyAndRebuildLocalShadowIndexes } = await import(
+						'./shadow-index-reconciler.service'
+					);
+					await verifyAndRebuildLocalShadowIndexes();
+				} catch (err) {
+					logger.warn('Shadow index reconciliation failed (non-fatal):', err);
+				}
+
 				// Reload lists after sync completes
 				await taskListStore.loadLists();
 
@@ -786,6 +800,18 @@ export class AuthOperationsService {
 
 		try {
 			await syncService.initialSync();
+
+			// Repair any drifted shadow indexes (post-incident recovery —
+			// see shadow-index-reconciler.service.ts). Must run before
+			// taskTitleIndex.rebuild() so the index reads corrected values.
+			try {
+				const { verifyAndRebuildLocalShadowIndexes } = await import(
+					'./shadow-index-reconciler.service'
+				);
+				await verifyAndRebuildLocalShadowIndexes();
+			} catch (err) {
+				logger.warn('Shadow index reconciliation failed (non-fatal):', err);
+			}
 
 			const { refreshDecryptedLists } = await import('$lib/stores/decrypted-lists.store');
 			const { refreshDecryptedSubtasks } = await import(

--- a/apps/reborn-task/src/lib/services/shadow-index-reconciler.service.spec.ts
+++ b/apps/reborn-task/src/lib/services/shadow-index-reconciler.service.spec.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { TaskEncryptedBooleans, TaskSensitiveMetadata } from '@reborn/types';
+
+/**
+ * Recovery half of the 2026-05-10 fix: the reconciler walks IDB after each
+ * unlock and overwrites shadow indexes that drifted from the metadata
+ * bundle's truth. These tests pin down its key invariants:
+ *
+ *   - decrypt-failure NEVER overwrites IDB (overwriting was the bug we fixed)
+ *   - drift triggers a save, equality skips the save
+ *   - tasks without `metadata_encrypted` are left alone
+ *   - reconciler is a no-op when crypto is not initialized
+ */
+
+vi.mock('@reborn/crypto', () => ({
+	cryptoManager: {
+		isInitialized: vi.fn(),
+		decryptObject: vi.fn()
+	}
+}));
+
+vi.mock('@reborn/storage', () => ({
+	taskStore: {
+		getAll: vi.fn(),
+		save: vi.fn()
+	}
+}));
+
+vi.mock('@reborn/utils', () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	})
+}));
+
+import { cryptoManager } from '@reborn/crypto';
+import { taskStore } from '@reborn/storage';
+import { verifyAndRebuildLocalShadowIndexes } from './shadow-index-reconciler.service';
+
+function makeTask(overrides: Partial<TaskEncryptedBooleans> = {}): TaskEncryptedBooleans {
+	return {
+		id: 'task-1',
+		user_id: 'user-1',
+		task_list_id: 'list-1',
+		title_encrypted: 'iv:cipher',
+		metadata_encrypted: 'iv:meta',
+		is_template: false,
+		is_completed: false,
+		is_starred: false,
+		due_date: null,
+		position: 0,
+		sync_version: 1,
+		created_at: '2026-05-10T00:00:00.000Z',
+		updated_at: '2026-05-10T00:00:00.000Z',
+		deleted_at: null,
+		...overrides
+	} as unknown as TaskEncryptedBooleans;
+}
+
+describe('verifyAndRebuildLocalShadowIndexes', () => {
+	const isInitializedMock = vi.mocked(cryptoManager.isInitialized);
+	const decryptObjectMock = vi.mocked(cryptoManager.decryptObject);
+	const getAllMock = vi.mocked(taskStore.getAll);
+	const saveMock = vi.mocked(taskStore.save);
+
+	beforeEach(() => {
+		isInitializedMock.mockReset();
+		decryptObjectMock.mockReset();
+		getAllMock.mockReset();
+		saveMock.mockReset();
+	});
+
+	it('is a no-op and reports zero scanned when crypto is not initialized', async () => {
+		isInitializedMock.mockReturnValue(false);
+		const result = await verifyAndRebuildLocalShadowIndexes();
+		expect(result.scanned).toBe(0);
+		expect(result.repaired).toBe(0);
+		expect(getAllMock).not.toHaveBeenCalled();
+		expect(saveMock).not.toHaveBeenCalled();
+	});
+
+	it('repairs a drifted task when decrypted metadata disagrees with IDB shadow indexes', async () => {
+		isInitializedMock.mockReturnValue(true);
+		const corruptedTask = makeTask({
+			id: 'corrupt-1',
+			is_completed: false,
+			is_starred: false,
+			due_date: null
+		});
+		getAllMock.mockResolvedValue([corruptedTask]);
+		const truth: TaskSensitiveMetadata = {
+			is_completed: true,
+			is_starred: true,
+			is_recurring: false,
+			due_date: '2026-05-15T00:00:00.000Z'
+		};
+		decryptObjectMock.mockResolvedValue(truth);
+
+		const result = await verifyAndRebuildLocalShadowIndexes();
+
+		expect(result.scanned).toBe(1);
+		expect(result.repaired).toBe(1);
+		expect(saveMock).toHaveBeenCalledTimes(1);
+		const saved = saveMock.mock.calls[0][0] as TaskEncryptedBooleans;
+		expect(saved.is_completed).toBe(true);
+		expect(saved.is_starred).toBe(true);
+		expect(saved.due_date).toBe('2026-05-15T00:00:00.000Z');
+	});
+
+	it('skips save when shadow indexes already match the metadata bundle', async () => {
+		isInitializedMock.mockReturnValue(true);
+		const consistentTask = makeTask({
+			is_completed: true,
+			is_starred: false,
+			due_date: '2026-06-01T00:00:00.000Z'
+		});
+		getAllMock.mockResolvedValue([consistentTask]);
+		decryptObjectMock.mockResolvedValue({
+			is_completed: true,
+			is_starred: false,
+			due_date: '2026-06-01T00:00:00.000Z'
+		} as TaskSensitiveMetadata);
+
+		const result = await verifyAndRebuildLocalShadowIndexes();
+
+		expect(result.scanned).toBe(1);
+		expect(result.repaired).toBe(0);
+		expect(saveMock).not.toHaveBeenCalled();
+	});
+
+	it('does NOT overwrite IDB when decryption fails (key mismatch)', async () => {
+		isInitializedMock.mockReturnValue(true);
+		const task = makeTask({ is_completed: true, is_starred: true });
+		getAllMock.mockResolvedValue([task]);
+		decryptObjectMock.mockRejectedValue(new Error('OperationError'));
+
+		const result = await verifyAndRebuildLocalShadowIndexes();
+
+		expect(result.scanned).toBe(1);
+		expect(result.repaired).toBe(0);
+		expect(result.skipped).toBe(1);
+		expect(saveMock).not.toHaveBeenCalled();
+	});
+
+	it('counts tasks without metadata_encrypted separately and leaves them alone', async () => {
+		isInitializedMock.mockReturnValue(true);
+		const legacyTask = makeTask({ id: 'legacy-1', metadata_encrypted: '' as string });
+		getAllMock.mockResolvedValue([legacyTask]);
+
+		const result = await verifyAndRebuildLocalShadowIndexes();
+
+		expect(result.scanned).toBe(1);
+		expect(result.skippedNoMetadata).toBe(1);
+		expect(result.repaired).toBe(0);
+		expect(decryptObjectMock).not.toHaveBeenCalled();
+		expect(saveMock).not.toHaveBeenCalled();
+	});
+});

--- a/apps/reborn-task/src/lib/services/shadow-index-reconciler.service.ts
+++ b/apps/reborn-task/src/lib/services/shadow-index-reconciler.service.ts
@@ -1,0 +1,129 @@
+import { taskStore } from '@reborn/storage';
+import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
+import type { TaskEncryptedBooleans, TaskSensitiveMetadata } from '@reborn/types';
+
+const logger = createLogger('ShadowIndexReconciler');
+
+/**
+ * Result of a reconciliation pass — exposed for telemetry / tests.
+ */
+export interface ReconcileResult {
+	/** Tasks scanned in IDB. */
+	scanned: number;
+	/** Tasks whose shadow indexes were corrected (had drifted from metadata bundle). */
+	repaired: number;
+	/** Tasks whose `metadata_encrypted` could not be decrypted — left unchanged. */
+	skipped: number;
+	/** Tasks with no `metadata_encrypted` payload (legacy backward-compat). */
+	skippedNoMetadata: number;
+}
+
+/**
+ * Compare two shadow-index field sets — true if they differ enough to need a save.
+ * Compares `is_completed`, `is_starred`, `is_recurring`, `due_date` — the four
+ * fields the UI reads directly from IDB without re-deriving from metadata.
+ */
+function shadowIndexesDiffer(
+	current: TaskEncryptedBooleans,
+	rebuilt: TaskEncryptedBooleans
+): boolean {
+	return (
+		current.is_completed !== rebuilt.is_completed ||
+		current.is_starred !== rebuilt.is_starred ||
+		(current.is_recurring ?? false) !== (rebuilt.is_recurring ?? false) ||
+		(current.due_date ?? null) !== (rebuilt.due_date ?? null)
+	);
+}
+
+/**
+ * Iterate all tasks in IDB, decrypt each `metadata_encrypted` bundle, and
+ * overwrite local shadow indexes when they drift from the bundle's truth.
+ *
+ * This is the recovery half of the 2026-05-10 fix. Phase 1 hardens the
+ * write path so new corruptions cannot happen; this reconciler heals
+ * already-corrupted IDB rows that no future server pull will fix on its
+ * own (server `sync_version` ≤ local → pull is a no-op).
+ *
+ * Tasks whose metadata cannot be decrypted (wrong key, corrupted ciphertext)
+ * are deliberately left unchanged — overwriting them with defaults would be
+ * exactly the bug we are fixing.
+ *
+ * Caller MUST ensure `cryptoManager.isInitialized() === true` before invoking,
+ * otherwise this is a no-op (every decrypt would fail).
+ */
+export async function verifyAndRebuildLocalShadowIndexes(): Promise<ReconcileResult> {
+	const result: ReconcileResult = {
+		scanned: 0,
+		repaired: 0,
+		skipped: 0,
+		skippedNoMetadata: 0
+	};
+
+	if (!cryptoManager.isInitialized()) {
+		logger.debug('Reconciler skipped — crypto not initialized');
+		return result;
+	}
+
+	let tasks: TaskEncryptedBooleans[];
+	try {
+		tasks = await taskStore.getAll();
+	} catch (error: unknown) {
+		logger.error('Reconciler failed to read tasks from IDB:', error);
+		return result;
+	}
+
+	for (const task of tasks) {
+		result.scanned++;
+
+		if (!task.metadata_encrypted) {
+			result.skippedNoMetadata++;
+			continue;
+		}
+
+		let meta: TaskSensitiveMetadata;
+		try {
+			meta = await cryptoManager.decryptObject<TaskSensitiveMetadata>(task.metadata_encrypted);
+		} catch (error: unknown) {
+			result.skipped++;
+			logger.debug(
+				`Reconciler skipped task ${task.id} — metadata decrypt failed (likely key mismatch)`,
+				error
+			);
+			continue;
+		}
+
+		const rebuilt: TaskEncryptedBooleans = {
+			...task,
+			is_completed: meta.is_completed ?? false,
+			is_starred: meta.is_starred ?? false,
+			is_recurring: meta.is_recurring,
+			due_date: meta.due_date ?? null
+		};
+
+		if (!shadowIndexesDiffer(task, rebuilt)) continue;
+
+		try {
+			await taskStore.save(rebuilt);
+			result.repaired++;
+		} catch (error: unknown) {
+			logger.warn(`Reconciler failed to save repaired task ${task.id}:`, error);
+		}
+	}
+
+	if (result.repaired > 0 || result.skipped > 0) {
+		logger.info(
+			`Reconciled shadow indexes: scanned=${result.scanned} repaired=${result.repaired} ` +
+				`skipped(decrypt-failed)=${result.skipped} skipped(no-metadata)=${result.skippedNoMetadata}`
+		);
+	} else {
+		logger.debug(
+			`Reconciler no-op: scanned=${result.scanned} skipped(no-metadata)=${result.skippedNoMetadata}`
+		);
+	}
+
+	return result;
+}
+
+// Exported for tests
+export const __testing = { shadowIndexesDiffer };

--- a/apps/reborn-task/src/lib/services/sync/shadow-indexes.spec.ts
+++ b/apps/reborn-task/src/lib/services/sync/shadow-indexes.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { TaskEncrypted, TaskSensitiveMetadata } from '@reborn/types';
+import { defaultShadowIndexes, rebuildShadowIndexes } from './shadow-indexes';
+
+/**
+ * Regression tests for the 2026-05-10 incident where the PWA Task UI showed
+ * every task with `is_completed=false / due_date=null` after a session-expiry
+ * unlock. Root cause: `rebuildShadowIndexes()` silently fell back to default
+ * shadow indexes whenever crypto was not ready or `decryptObject` threw,
+ * corrupting IDB. This suite locks in the new contract:
+ *
+ *   - missing `metadata_encrypted` → defaults (legitimate backward-compat)
+ *   - crypto not initialized → throw
+ *   - decrypt fails → throw
+ *   - decrypt ok → values from metadata bundle
+ */
+
+vi.mock('@reborn/crypto', () => ({
+	cryptoManager: {
+		isInitialized: vi.fn(),
+		decryptObject: vi.fn()
+	}
+}));
+
+import { cryptoManager } from '@reborn/crypto';
+
+const baseEncryptedTask: TaskEncrypted = {
+	id: 'task-1',
+	user_id: 'user-1',
+	task_list_id: 'list-1',
+	title_encrypted: 'iv:cipher',
+	metadata_encrypted: 'iv:meta-cipher',
+	is_template: 0,
+	position: 0,
+	sync_version: 1,
+	created_at: '2026-05-10T00:00:00.000Z',
+	updated_at: '2026-05-10T00:00:00.000Z',
+	deleted_at: null
+} as unknown as TaskEncrypted;
+
+const richMetadata: TaskSensitiveMetadata = {
+	is_completed: true,
+	is_starred: true,
+	is_recurring: true,
+	due_date: '2026-05-15T00:00:00.000Z',
+	has_time: false,
+	completed_at: '2026-05-12T10:00:00.000Z',
+	completed_occurrences_count: 3
+};
+
+describe('defaultShadowIndexes', () => {
+	it('returns false/null defaults and converts is_template to boolean', () => {
+		const result = defaultShadowIndexes({ ...baseEncryptedTask, is_template: 1 });
+		expect(result.is_completed).toBe(false);
+		expect(result.is_starred).toBe(false);
+		expect(result.is_template).toBe(true);
+		expect(result.due_date).toBeNull();
+	});
+
+	it('preserves passthrough fields (id, ciphertext, position, sync_version)', () => {
+		const result = defaultShadowIndexes(baseEncryptedTask);
+		expect(result.id).toBe('task-1');
+		expect(result.title_encrypted).toBe('iv:cipher');
+		expect(result.metadata_encrypted).toBe('iv:meta-cipher');
+		expect(result.position).toBe(0);
+		expect(result.sync_version).toBe(1);
+	});
+});
+
+describe('rebuildShadowIndexes', () => {
+	const isInitializedMock = vi.mocked(cryptoManager.isInitialized);
+	const decryptObjectMock = vi.mocked(cryptoManager.decryptObject);
+
+	beforeEach(() => {
+		isInitializedMock.mockReset();
+		decryptObjectMock.mockReset();
+	});
+
+	it('falls back to defaults when metadata_encrypted is missing (backward compat)', async () => {
+		const task = { ...baseEncryptedTask, metadata_encrypted: '' as string };
+		const result = await rebuildShadowIndexes(task);
+		expect(result.is_completed).toBe(false);
+		expect(result.is_starred).toBe(false);
+		expect(result.due_date).toBeNull();
+		expect(isInitializedMock).not.toHaveBeenCalled();
+		expect(decryptObjectMock).not.toHaveBeenCalled();
+	});
+
+	it('throws when cryptoManager is not initialized (no silent default fallback)', async () => {
+		isInitializedMock.mockReturnValue(false);
+		await expect(rebuildShadowIndexes(baseEncryptedTask)).rejects.toThrow(
+			/crypto-not-ready/
+		);
+		expect(decryptObjectMock).not.toHaveBeenCalled();
+	});
+
+	it('throws when decryptObject rejects (no silent default fallback)', async () => {
+		isInitializedMock.mockReturnValue(true);
+		decryptObjectMock.mockRejectedValue(new Error('OperationError'));
+		await expect(rebuildShadowIndexes(baseEncryptedTask)).rejects.toThrow(
+			/decrypt-failed/
+		);
+	});
+
+	it('returns metadata-derived shadow indexes on success', async () => {
+		isInitializedMock.mockReturnValue(true);
+		decryptObjectMock.mockResolvedValue(richMetadata);
+		const result = await rebuildShadowIndexes(baseEncryptedTask);
+		expect(result.is_completed).toBe(true);
+		expect(result.is_starred).toBe(true);
+		expect(result.is_recurring).toBe(true);
+		expect(result.due_date).toBe('2026-05-15T00:00:00.000Z');
+	});
+
+	it('coerces is_template BooleanInt → boolean even on success path', async () => {
+		isInitializedMock.mockReturnValue(true);
+		decryptObjectMock.mockResolvedValue(richMetadata);
+		const templateTask = { ...baseEncryptedTask, is_template: 1 } as TaskEncrypted;
+		const result = await rebuildShadowIndexes(templateTask);
+		expect(result.is_template).toBe(true);
+	});
+});

--- a/apps/reborn-task/src/lib/services/sync/shadow-indexes.ts
+++ b/apps/reborn-task/src/lib/services/sync/shadow-indexes.ts
@@ -1,0 +1,69 @@
+import { cryptoManager } from '@reborn/crypto';
+import type {
+	TaskEncrypted,
+	TaskEncryptedBooleans,
+	TaskSensitiveMetadata
+} from '@reborn/types';
+
+/**
+ * Backward-compat shadow indexes for tasks that legitimately have no
+ * `metadata_encrypted` bundle (created before the bundle was introduced).
+ * Used only as a deliberate fallback — never as a silent rescue from a
+ * failed decrypt, which is what corrupted IDB on 2026-05-10.
+ */
+export function defaultShadowIndexes(task: TaskEncrypted): TaskEncryptedBooleans {
+	return {
+		...task,
+		is_completed: false,
+		is_starred: false,
+		is_template: task.is_template === 1,
+		due_date: null
+	} as TaskEncryptedBooleans;
+}
+
+/**
+ * Rebuild local shadow indexes from encrypted metadata.
+ * Decrypts metadata_encrypted → TaskSensitiveMetadata → shadow fields.
+ *
+ * Throws when crypto is not ready or decryption fails — caller MUST skip
+ * the IDB save in that case. Silently writing default shadow indexes here
+ * caused the 2026-05-10 incident where unlock'd PWA Task showed every task
+ * with `is_completed=false / due_date=null` until a full logout+login.
+ *
+ * The only branch that legitimately falls back to defaults is a task
+ * without any `metadata_encrypted` payload — backward compat for tasks
+ * created before the metadata bundle existed.
+ */
+export async function rebuildShadowIndexes(
+	task: TaskEncrypted
+): Promise<TaskEncryptedBooleans> {
+	if (!task.metadata_encrypted) {
+		return defaultShadowIndexes(task);
+	}
+
+	if (!cryptoManager.isInitialized()) {
+		throw new Error(
+			`crypto-not-ready: master key unavailable while rebuilding shadow indexes for task ${task.id}`
+		);
+	}
+
+	try {
+		const meta = await cryptoManager.decryptObject<TaskSensitiveMetadata>(
+			task.metadata_encrypted
+		);
+		return {
+			...task,
+			is_completed: meta.is_completed ?? false,
+			is_starred: meta.is_starred ?? false,
+			is_recurring: meta.is_recurring,
+			is_template: task.is_template === 1,
+			due_date: meta.due_date ?? null
+		} as TaskEncryptedBooleans;
+	} catch (error: unknown) {
+		const cause = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`decrypt-failed: metadata decryption failed for task ${task.id} (${cause})`,
+			{ cause: error }
+		);
+	}
+}

--- a/apps/reborn-task/src/lib/services/sync/sync-tasks.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-tasks.service.ts
@@ -1,10 +1,9 @@
 import { SyncBaseService } from './sync-base.service';
+import { rebuildShadowIndexes } from './shadow-indexes';
 import { taskStore } from '@reborn/storage';
-import { cryptoManager } from '@reborn/crypto';
 import type {
 	TaskEncrypted,
 	TaskEncryptedBooleans,
-	TaskSensitiveMetadata,
 	StorageOfflineOperation
 } from '@reborn/types';
 
@@ -189,7 +188,7 @@ export class SyncTasksService extends SyncBaseService {
 						if (localTask && task.sync_version > (localTask.sync_version || 0)) {
 							serverUpdates++;
 						}
-						await taskStore.save(await this.rebuildShadowIndexes(task));
+						await this.saveWithShadowIndexes(task);
 					}
 				} catch (error: unknown) {
 					this.logger.error(`Failed to save task ${task.id}:`, error);
@@ -410,7 +409,7 @@ export class SyncTasksService extends SyncBaseService {
 							continue;
 						}
 
-						await taskStore.save(await this.rebuildShadowIndexes(task));
+						await this.saveWithShadowIndexes(task);
 					}
 				} catch (error: unknown) {
 					this.logger.error(`Failed to save deleted task ${task.id}:`, error);
@@ -446,41 +445,23 @@ export class SyncTasksService extends SyncBaseService {
 	}
 
 	/**
-	 * Rebuild local shadow indexes from encrypted metadata.
-	 * Decrypts metadata_encrypted → TaskSensitiveMetadata → shadow fields.
+	 * Wrap {@link rebuildShadowIndexes} and persist to IDB. If the rebuild throws
+	 * (crypto not ready or decrypt failed), log a warn and skip the save —
+	 * server ciphertext is unchanged so the next successful sync will retry.
 	 */
-	private async rebuildShadowIndexes(task: TaskEncrypted): Promise<TaskEncryptedBooleans> {
+	private async saveWithShadowIndexes(task: TaskEncrypted): Promise<void> {
+		let prepared: TaskEncryptedBooleans;
 		try {
-			if (task.metadata_encrypted && cryptoManager.isInitialized()) {
-				const meta = await cryptoManager.decryptObject<TaskSensitiveMetadata>(
-					task.metadata_encrypted
-				);
-				return {
-					...task,
-					is_completed: meta.is_completed ?? false,
-					is_starred: meta.is_starred ?? false,
-					is_recurring: meta.is_recurring,
-					is_template: task.is_template === 1,
-					due_date: meta.due_date ?? null
-				} as TaskEncryptedBooleans;
-			}
+			prepared = await rebuildShadowIndexes(task);
 		} catch (error: unknown) {
-			// ERROR: metadata decryption failed — shadow indexes (is_completed, is_starred, etc.)
-			// will use defaults (false/null). The task's metadata_encrypted is preserved for
-			// future retry on next pull. This may cause incorrect UI state until next successful decrypt.
-			this.logger.error(
-				`METADATA_DECRYPT_FAILED for task ${task.id} — shadow indexes may be incorrect`,
+			this.logger.warn(
+				`Skipping save of task ${task.id} — shadow indexes could not be derived. ` +
+					`Will retry on next successful sync.`,
 				error
 			);
+			return;
 		}
-
-		return {
-			...task,
-			is_completed: false,
-			is_starred: false,
-			is_template: task.is_template === 1,
-			due_date: null
-		} as TaskEncryptedBooleans;
+		await taskStore.save(prepared);
 	}
 
 	/**
@@ -500,7 +481,7 @@ export class SyncTasksService extends SyncBaseService {
 
 				// Update local task with server response
 				if (createResponse.data) {
-					await taskStore.save(await this.rebuildShadowIndexes(createResponse.data));
+					await this.saveWithShadowIndexes(createResponse.data);
 					// Return the response so it can be processed further if needed
 					return createResponse.data;
 				}
@@ -519,7 +500,7 @@ export class SyncTasksService extends SyncBaseService {
 
 				// Save server response to IndexedDB (resets sync_status, updates sync_version)
 				if (updateResponse.data) {
-					await taskStore.save(await this.rebuildShadowIndexes(updateResponse.data));
+					await this.saveWithShadowIndexes(updateResponse.data);
 				}
 				break;
 			}


### PR DESCRIPTION
Sync write-path no longer silently writes default shadow indexes (is_completed=false, due_date=null, …) to IndexedDB when crypto is not ready or metadata_encrypted decryption fails — the write is skipped and the next successful sync retries. Adds a post-unlock reconciler that walks taskStore and repairs already-corrupted rows from earlier incidents (the server-side ciphertext is intact, but lower sync_version on the server means a normal pull would never overwrite local drift).

Reported by Michał on a mobile PWA after a session-expiry unlock: every task — including completed recurring instances — rendered with no due date, no star, no completion status; only titles. A full logout+login fixed it. Root cause was a silent fallback branch in SyncTasksService.rebuildShadowIndexes() and the absence of any reconciliation analogous to reborn-notes' rule 10 in guideline 36-sync-architecture.md.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>