### PR TITLE
fix(auth): cross-app SSO unlock for shared E2E master key

### DIFF
--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -80,6 +80,18 @@ function readFromStorage(): AuthState {
 function createAuthStore() {
   const { subscribe, set } = writable<AuthState>(readFromStorage());
 
+  /**
+   * Mark E2E as unlocked when the master key was loaded by another path —
+   * cross-app SSO (peer Task/Notes already unlocked the shared origin IDB
+   * key) or fast-path on `/auth/unlock`. Re-reads the auth credentials from
+   * localStorage so other fields stay in sync.
+   */
+  function markE2EUnlocked(): void {
+    if (!browser) return;
+    if (!cryptoManager.isInitialized()) return;
+    set({ ...readFromStorage(), hasE2E: true });
+  }
+
   /** Call once from the root layout to hydrate state and watch for cross-tab changes. */
   function initialize(): void {
     if (!browser) return;
@@ -123,6 +135,31 @@ function createAuthStore() {
 
       // Token refresh or other update — update store reactively
       set(newState);
+    });
+
+    // Cross-app E2E unlock — peer app (Task) just unlocked the master key in
+    // the shared origin IDB. Flip hasE2E and, if we're stuck on /auth/unlock,
+    // hard-redirect home so the layout's $effect picks up sync. The matching
+    // `cleared` event is a defense-in-depth backstop for `clearMasterKey()`
+    // being called without touching credentials — the normal logout path
+    // still goes through the storage listener above.
+    cryptoManager.subscribeToKeyEvents((event) => {
+      if (event === 'unlocked') {
+        if (!cryptoManager.isInitialized()) return;
+        markE2EUnlocked();
+        const path = window.location.pathname;
+        if (path.includes('/auth/unlock')) {
+          logger.info('Cross-app E2E unlock detected — redirecting from /auth/unlock to home');
+          window.location.href = `${base}/`;
+        }
+        return;
+      }
+      // event === 'cleared'
+      const stillAuthenticated = !!localStorage.getItem(CREDENTIALS_KEY);
+      if (stillAuthenticated && !cryptoManager.isInitialized()) {
+        logger.info('Cross-app key cleared without logout — flipping hasE2E to false');
+        set({ ...readFromStorage(), hasE2E: false });
+      }
     });
   }
 
@@ -215,7 +252,7 @@ function createAuthStore() {
     window.location.href = `${base}/auth/login`;
   }
 
-  return { subscribe, initialize, unlockE2E, logout };
+  return { subscribe, initialize, unlockE2E, logout, markE2EUnlocked };
 }
 
 export const authStore = createAuthStore();

--- a/apps/reborn-notes/src/routes/auth/unlock/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/unlock/+page.svelte
@@ -3,6 +3,7 @@
   import { onMount } from 'svelte';
   import { goto } from '$lib/utils/navigation';
   import { authStore } from '$lib/stores/auth.store';
+  import { cryptoManager } from '@reborn/crypto';
   import { UnlockPage } from '@reborn/ui';
   import { createLogger } from '@reborn/utils';
 
@@ -14,11 +15,24 @@
   let attemptsRemaining = $state<number | undefined>(undefined);
   let username = $state('');
 
-  onMount(() => {
+  onMount(async () => {
     if (!$authStore.isAuthenticated) {
       goto('/auth/login');
       return;
     }
+
+    // Fast-path: shared origin IDB may already hold the master key (peer app
+    // unlocked it, or cold start landed here before the layout's restore
+    // settled). waitForRestore() resolves with a 5s fail-soft timeout, so the
+    // password form still appears if IDB is genuinely empty/slow.
+    await cryptoManager.waitForRestore();
+    if (cryptoManager.isInitialized()) {
+      logger.info('Master key found in shared IDB — skipping password prompt');
+      authStore.markE2EUnlocked();
+      goto('/');
+      return;
+    }
+
     if ($authStore.hasE2E) {
       goto('/');
       return;

--- a/apps/reborn-task/src/hooks.client.ts
+++ b/apps/reborn-task/src/hooks.client.ts
@@ -99,6 +99,33 @@ window.addEventListener('storage', (e) => {
 });
 
 // ---------------------------------------------------------------------------
+// Cross-app E2E unlock (BroadcastChannel)
+// ---------------------------------------------------------------------------
+// When the peer app (reborn-notes) calls setMasterKey() it broadcasts an
+// `unlocked` event over the `reborn_e2e` channel. The master key already lives
+// in the shared origin IndexedDB, so this tab can flip hasE2E and bounce off
+// /auth/unlock without a second password prompt. The matching `cleared` event
+// is defense-in-depth — the primary logout path is the storage listener above.
+cryptoManager.subscribeToKeyEvents((event) => {
+	if (event === 'unlocked') {
+		if (!cryptoManager.isInitialized()) return;
+		logger.info('Cross-app E2E unlock detected — flipping hasE2E');
+		authOperationsService.getSessionManager().setSession({ hasE2E: true });
+		const path = window.location.pathname;
+		if (path.includes('/auth/unlock')) {
+			window.location.href = `${base}/`;
+		}
+		return;
+	}
+	// event === 'cleared'
+	const stillAuthenticated = !!localStorage.getItem(CREDENTIALS_KEY);
+	if (stillAuthenticated && !cryptoManager.isInitialized()) {
+		logger.info('Cross-app key cleared without logout — flipping hasE2E to false');
+		authOperationsService.getSessionManager().setSession({ hasE2E: false });
+	}
+});
+
+// ---------------------------------------------------------------------------
 // Initialize storage when the app starts
 // ---------------------------------------------------------------------------
 logger.info('Initializing storage on app startup');

--- a/apps/reborn-task/src/routes/auth/unlock/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/unlock/+page.svelte
@@ -6,6 +6,7 @@
 	import { session } from '$lib/stores/auth.store';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
 	import { browser } from '$app/environment';
+	import { cryptoManager } from '@reborn/crypto';
 	import { createLogger } from '@reborn/utils';
 
 	const logger = createLogger('UnlockRoute');
@@ -56,6 +57,21 @@
 				'/auth/login' + (returnTo !== '/' ? `?returnTo=${encodeURIComponent(returnTo)}` : '')
 			);
 			return;
+		}
+
+		// Fast-path for cross-app SSO: shared origin IDB may already hold the
+		// master key (peer Notes unlocked it, or initializeAuth() raced this
+		// $effect). waitForRestore() resolves with a 5s fail-soft timeout, so
+		// the password form still appears if IDB is genuinely empty/slow.
+		if (!currentSession.hasE2E) {
+			await cryptoManager.waitForRestore();
+			if (cryptoManager.isInitialized()) {
+				logger.info('Master key found in shared IDB — skipping password prompt');
+				authOperationsService.getSessionManager().setSession({ hasE2E: true });
+				isRedirecting = true;
+				await goto(returnTo);
+				return;
+			}
 		}
 
 		// If user already has E2E unlocked, redirect to return URL

--- a/packages/crypto/src/__tests__/cryptoManager.spec.ts
+++ b/packages/crypto/src/__tests__/cryptoManager.spec.ts
@@ -460,6 +460,97 @@ describe('CryptoManager', () => {
     }, 10_000);
   });
 
+  describe('cross-app key events (BroadcastChannel)', () => {
+    interface FakeChannel {
+      postMessage: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+      onmessage: ((e: { data: unknown }) => void) | null;
+    }
+    let createdChannels: FakeChannel[];
+    let originalBroadcastChannel: unknown;
+
+    beforeEach(() => {
+      createdChannels = [];
+      originalBroadcastChannel = (globalThis as any).BroadcastChannel;
+      // Use a real class — vi.fn arrow form doesn't work with `new`.
+      class MockBroadcastChannel implements FakeChannel {
+        postMessage = vi.fn();
+        close = vi.fn();
+        onmessage: ((e: { data: unknown }) => void) | null = null;
+        constructor(_name: string) {
+          createdChannels.push(this);
+        }
+      }
+      (globalThis as any).BroadcastChannel = MockBroadcastChannel;
+    });
+
+    afterEach(() => {
+      (globalThis as any).BroadcastChannel = originalBroadcastChannel;
+    });
+
+    it('broadcasts "unlocked" after setMasterKey', async () => {
+      const fresh = new (CryptoManager as any)();
+      const key = await fresh.generateMasterKey();
+      await fresh.setMasterKey(key);
+
+      expect(createdChannels).toHaveLength(1);
+      expect(createdChannels[0].postMessage).toHaveBeenCalledWith({ type: 'unlocked' });
+    });
+
+    it('broadcasts "cleared" after clearMasterKey', async () => {
+      const fresh = new (CryptoManager as any)();
+      const key = await fresh.generateMasterKey();
+      await fresh.setMasterKey(key);
+      const calls = createdChannels[0].postMessage.mock.calls.length;
+
+      fresh.clearMasterKey();
+
+      expect(createdChannels[0].postMessage.mock.calls.length).toBe(calls + 1);
+      expect(createdChannels[0].postMessage).toHaveBeenLastCalledWith({ type: 'cleared' });
+    });
+
+    it('reuses a single BroadcastChannel across multiple subscribers', () => {
+      const fresh = new (CryptoManager as any)();
+      const handlerA = vi.fn();
+      const handlerB = vi.fn();
+
+      const unsubA = fresh.subscribeToKeyEvents(handlerA);
+      const unsubB = fresh.subscribeToKeyEvents(handlerB);
+
+      expect(createdChannels).toHaveLength(1);
+
+      // Simulate a peer broadcast — invoke the channel's onmessage directly.
+      createdChannels[0].onmessage?.({ data: { type: 'unlocked' } });
+
+      expect(handlerA).toHaveBeenCalledWith('unlocked');
+      expect(handlerB).toHaveBeenCalledWith('unlocked');
+
+      unsubA();
+      createdChannels[0].onmessage?.({ data: { type: 'cleared' } });
+
+      expect(handlerA).toHaveBeenCalledTimes(1); // unsubscribed → no new call
+      expect(handlerB).toHaveBeenCalledWith('cleared');
+
+      unsubB();
+    });
+
+    it('degrades silently when BroadcastChannel constructor throws', async () => {
+      class ThrowingChannel {
+        constructor() {
+          throw new Error('sandboxed');
+        }
+      }
+      (globalThis as any).BroadcastChannel = ThrowingChannel;
+
+      const fresh = new (CryptoManager as any)();
+      const key = await fresh.generateMasterKey();
+
+      // Must not throw — degraded mode just skips the broadcast.
+      await expect(fresh.setMasterKey(key)).resolves.toBeUndefined();
+      expect(fresh.isInitialized()).toBe(true);
+    });
+  });
+
   describe('error handling', () => {
     it('should handle encryption errors gracefully', async () => {
       const masterKey = await manager.generateMasterKey();

--- a/packages/crypto/src/cryptoManager.ts
+++ b/packages/crypto/src/cryptoManager.ts
@@ -21,6 +21,24 @@ import { createLogger } from '@reborn/utils';
 
 const logger = createLogger('CryptoManager');
 
+/**
+ * Cross-app key event broadcast.
+ *
+ * Both reborn-task and reborn-notes share origin (and therefore IndexedDB).
+ * After one app calls `setMasterKey()` / `clearMasterKey()`, the other app —
+ * if already open — has no way to discover the change without polling. The
+ * BroadcastChannel `reborn_e2e` lets the crypto layer notify all peers on
+ * the same origin; subscribers (auth stores, layout guards) react by flipping
+ * `hasE2E` and redirecting away from `/auth/unlock` without a second password
+ * prompt. The key itself stays in IndexedDB — we never put plaintext on the
+ * wire and never leak it across origins.
+ */
+const KEY_EVENT_CHANNEL = 'reborn_e2e';
+
+export type CryptoKeyEvent = 'unlocked' | 'cleared';
+
+export type KeyEventHandler = (event: CryptoKeyEvent) => void;
+
 export class CryptoManager {
   private static instance: CryptoManager;
   private masterKey: CryptoKey | null = null;
@@ -32,6 +50,12 @@ export class CryptoManager {
   private readonly IDB_KEY_ID = 'current';
   private restoreKeyAttempted = false;
   private restorePromise: Promise<boolean> | null = null;
+
+  // Cross-app key event channel — single instance with a fanout list of
+  // subscribers so HMR re-subscribing doesn't allocate extra channels.
+  private channel: BroadcastChannel | null = null;
+  private channelInitialized = false;
+  private keyEventHandlers: Set<KeyEventHandler> = new Set();
 
   // Private constructor for singleton pattern
   private constructor() {
@@ -241,6 +265,72 @@ export class CryptoManager {
     }
   }
 
+  // ── Cross-app key events (BroadcastChannel) ──────────────────
+
+  /**
+   * Lazily create the BroadcastChannel and wire its listener. Called once on
+   * first emit/subscribe. Some sandboxed environments (older iOS PWA, hardened
+   * browser modes) throw when constructing BroadcastChannel — we degrade
+   * silently so the rest of crypto keeps working (fast-path on /auth/unlock
+   * still covers cold-start scenarios; only S3 — warm cross-app unlock —
+   * regresses to the previous behaviour).
+   */
+  private ensureChannel(): void {
+    if (this.channelInitialized) return;
+    this.channelInitialized = true;
+    if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') return;
+    try {
+      this.channel = new BroadcastChannel(KEY_EVENT_CHANNEL);
+      this.channel.onmessage = (e: MessageEvent) => {
+        const data = e.data as { type?: CryptoKeyEvent } | null;
+        if (!data || (data.type !== 'unlocked' && data.type !== 'cleared')) return;
+        for (const handler of this.keyEventHandlers) {
+          try {
+            handler(data.type);
+          } catch (err) {
+            logger.error('Key event handler threw:', err);
+          }
+        }
+      };
+    } catch (error) {
+      logger.warn('BroadcastChannel unavailable — cross-app key events disabled:', error);
+      this.channel = null;
+    }
+  }
+
+  /**
+   * Emit a key event to peer apps on the same origin. Fire-and-forget —
+   * failure to broadcast must not break the local set/clear operation.
+   */
+  private postKeyEvent(type: CryptoKeyEvent): void {
+    this.ensureChannel();
+    if (!this.channel) return;
+    try {
+      this.channel.postMessage({ type });
+    } catch (error) {
+      logger.warn(`Failed to broadcast key event "${type}":`, error);
+    }
+  }
+
+  /**
+   * Subscribe to cross-app key events. Returns an unsubscriber.
+   *
+   * Usage: the peer app's auth store calls this once during initialization
+   * and reacts to `unlocked` (flip hasE2E, redirect away from /auth/unlock)
+   * and `cleared` (defense-in-depth — main logout path is the storage event
+   * on `reborn_auth_credentials`).
+   *
+   * BroadcastChannel only delivers messages to *other* contexts on the same
+   * origin, so the emitting tab does not receive its own events.
+   */
+  public subscribeToKeyEvents(handler: KeyEventHandler): () => void {
+    this.ensureChannel();
+    this.keyEventHandlers.add(handler);
+    return () => {
+      this.keyEventHandlers.delete(handler);
+    };
+  }
+
   /**
    * Get the singleton instance of CryptoManager
    */
@@ -357,6 +447,11 @@ export class CryptoManager {
     // Persist to IndexedDB (survives tab close / PWA restart)
     await this.persistKeyToIDB();
 
+    // Notify peer apps (Notes ↔ Task on same origin) so they can flip
+    // hasE2E and skip the password prompt — IDB has the key and they
+    // can read it directly.
+    this.postKeyEvent('unlocked');
+
     // Zapisz tymczasową wersję klucza w sessionStorage, aby przetrwał nawigację
     if (typeof window !== 'undefined' && window.sessionStorage) {
       try {
@@ -395,6 +490,12 @@ export class CryptoManager {
       window.sessionStorage.removeItem(this.CRYPTO_VERIFIED_KEY);
       logger.debug('Temporary master key removed from session storage');
     }
+
+    // Defense-in-depth — the primary logout path is the storage event on
+    // `reborn_auth_credentials`. Peer apps that already handle that event
+    // will treat this as a no-op; the broadcast only matters when someone
+    // calls clearMasterKey() without touching credentials (rare/buggy).
+    this.postKeyEvent('cleared');
 
     logger.debug('Master key cleared');
   }

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -7,6 +7,7 @@
 
 // CryptoManager - main crypto operations class
 export { CryptoManager, cryptoManager } from './cryptoManager';
+export type { CryptoKeyEvent, KeyEventHandler } from './cryptoManager';
 
 // Encryption utilities
 export {


### PR DESCRIPTION
Both apps already share the master key through origin-scoped IndexedDB (`reborn_crypto_keys`), but the second app still showed an unlock prompt because nothing flipped `hasE2E` after the peer unlocked. Now:

- `@reborn/crypto` exposes `subscribeToKeyEvents()` and broadcasts `unlocked` / `cleared` over `BroadcastChannel('reborn_e2e')` from `setMasterKey()` / `clearMasterKey()`. Try/catch around the constructor keeps sandboxed environments (older iOS PWA) on the previous behaviour rather than throwing.
- Both `/auth/unlock` pages run a fast-path: `await waitForRestore()` → if the key is already in shared IDB, flip `hasE2E` and redirect home without a password prompt. Covers cold-start (S1) and the cross-app hard-redirect path (S2).
- Notes `auth.store` and Task `hooks.client` subscribe to the channel and react to live unlocks while both apps are open (S3 — the scenario observed on mobile after a session expiry + relog).

Zero Knowledge is unaffected: the channel is origin-scoped, the payload is just the literal `unlocked` / `cleared`, and the key itself never leaves the browser.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>