### PR TITLE
fix(i18n): localize service worker update toast across 5 locales

### DIFF
--- a/apps/reborn-notes/src/lib/services/sw-update.service.ts
+++ b/apps/reborn-notes/src/lib/services/sw-update.service.ts
@@ -24,8 +24,10 @@
  */
 
 import { browser } from '$app/environment';
+import { get } from 'svelte/store';
 import { toastStore } from '@reborn/ui';
 import { createLogger } from '@reborn/utils';
+import { t } from '$lib/stores/i18n.store';
 
 const logger = createLogger('SwUpdateService');
 
@@ -118,11 +120,13 @@ function promptReload(): void {
 
   logger.info('New service worker version available — prompting user to reload');
 
-  toastStore.info('Nowa wersja aplikacji jest dostępna', {
-    description: 'Odśwież stronę, aby załadować najnowszą wersję.',
+  const $t = get(t);
+
+  toastStore.info($t('app.sw_update.title'), {
+    description: $t('app.sw_update.description'),
     duration: Number.POSITIVE_INFINITY,
     action: {
-      label: 'Odśwież',
+      label: $t('app.sw_update.button'),
       onClick: () => window.location.reload()
     }
   });

--- a/apps/reborn-task/src/lib/services/sw-update.service.ts
+++ b/apps/reborn-task/src/lib/services/sw-update.service.ts
@@ -24,8 +24,10 @@
  */
 
 import { browser } from '$app/environment';
+import { get } from 'svelte/store';
 import { toastStore } from '@reborn/ui';
 import { createLogger } from '@reborn/utils';
+import { t } from '$lib/stores/i18n.store';
 
 const logger = createLogger('SwUpdateService');
 
@@ -118,11 +120,13 @@ function promptReload(): void {
 
 	logger.info('New service worker version available — prompting user to reload');
 
-	toastStore.info('Nowa wersja aplikacji jest dostępna', {
-		description: 'Odśwież stronę, aby załadować najnowszą wersję.',
+	const $t = get(t);
+
+	toastStore.info($t('app.sw_update.title'), {
+		description: $t('app.sw_update.description'),
 		duration: Number.POSITIVE_INFINITY,
 		action: {
-			label: 'Odśwież',
+			label: $t('app.sw_update.button'),
 			onClick: () => window.location.reload()
 		}
 	});

--- a/packages/i18n/src/translations/common/de.json
+++ b/packages/i18n/src/translations/common/de.json
@@ -1,7 +1,12 @@
 {
   "app": {
     "name": "Reborn",
-    "loading": "Anwendung wird geladen..."
+    "loading": "Anwendung wird geladen...",
+    "sw_update": {
+      "title": "Eine neue Version der App ist verfügbar",
+      "description": "Laden Sie die Seite neu, um die neueste Version zu laden.",
+      "button": "Neu laden"
+    }
   },
   "dates": {
     "today": "heute",

--- a/packages/i18n/src/translations/common/en.json
+++ b/packages/i18n/src/translations/common/en.json
@@ -1,7 +1,12 @@
 {
   "app": {
     "name": "Reborn",
-    "loading": "Loading application..."
+    "loading": "Loading application...",
+    "sw_update": {
+      "title": "A new version of the app is available",
+      "description": "Reload the page to load the latest version.",
+      "button": "Reload"
+    }
   },
   "dates": {
     "today": "today",

--- a/packages/i18n/src/translations/common/es.json
+++ b/packages/i18n/src/translations/common/es.json
@@ -1,7 +1,12 @@
 {
   "app": {
     "name": "Reborn",
-    "loading": "Cargando aplicación..."
+    "loading": "Cargando aplicación...",
+    "sw_update": {
+      "title": "Hay una nueva versión de la aplicación disponible",
+      "description": "Recarga la página para cargar la última versión.",
+      "button": "Recargar"
+    }
   },
   "dates": {
     "today": "hoy",

--- a/packages/i18n/src/translations/common/fr.json
+++ b/packages/i18n/src/translations/common/fr.json
@@ -1,7 +1,12 @@
 {
   "app": {
     "name": "Reborn",
-    "loading": "Chargement de l'application..."
+    "loading": "Chargement de l'application...",
+    "sw_update": {
+      "title": "Une nouvelle version de l'application est disponible",
+      "description": "Rechargez la page pour charger la dernière version.",
+      "button": "Recharger"
+    }
   },
   "dates": {
     "today": "aujourd'hui",

--- a/packages/i18n/src/translations/common/pl.json
+++ b/packages/i18n/src/translations/common/pl.json
@@ -1,7 +1,12 @@
 {
   "app": {
     "name": "Reborn",
-    "loading": "Ładowanie aplikacji..."
+    "loading": "Ładowanie aplikacji...",
+    "sw_update": {
+      "title": "Nowa wersja aplikacji jest dostępna",
+      "description": "Odśwież stronę, aby załadować najnowszą wersję.",
+      "button": "Odśwież"
+    }
   },
   "dates": {
     "today": "dzisiaj",


### PR DESCRIPTION
The SW update toast in both reborn-notes and reborn-task previously hardcoded Polish strings in promptReload(), so non-PL users saw a Polish "Nowa wersja aplikacji jest dostępna" prompt regardless of their UI locale — the very prompt that tells users to reload after a new build deploys was itself untranslated.

Replace the hardcoded strings with $t() reading new keys app.sw_update.{title,description,button} added to common/{en,pl,de,fr,es}.json.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>