### PR TITLE
fix(api-client): three-state onUnauthorized contract with onSessionExpired callback

### DIFF
--- a/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-base.service.ts
@@ -1,8 +1,11 @@
 import { ApiClient } from '@reborn/api-client';
+import type { UnauthorizedResult } from '@reborn/api-client';
+import { TransientRefreshError } from '@reborn/auth';
 import { PUBLIC_BASE_PATH } from '$env/static/public';
 import { createLogger } from '@reborn/utils';
 import type { Logger } from '@reborn/utils';
 import { authFetch } from '$lib/utils/auth-fetch';
+import { sessionExpired } from '$lib/stores/session-expired.store';
 
 /**
  * Base class for sync services with common functionality
@@ -25,22 +28,34 @@ export abstract class SyncBaseService {
 		// black hole (navigator.onLine=true but no upstream) doesn't hang a
 		// sync for the default 30 s.
 		//
-		// `authFetch.refresh()` throws `TransientRefreshError` when the server
-		// is briefly unreachable (e.g. 5xx from nginx during a Docker rebuild
-		// on the production VPS). Swallow it and return `false` so the caller
-		// gets the original 401 — sync will treat it as a transient sync error
-		// and retry on the next tick instead of falsely flagging the session
-		// as expired.
+		// Three-state contract (`UnauthorizedResult`):
+		// - `'refreshed'` — new access token → ApiClient retries once,
+		// - `'session-expired'` — `/auth/refresh` returned definitive 401/403
+		//   → ApiClient surfaces the 401 AND fires `onSessionExpired`, which
+		//   flips the `sessionExpired` store so the banner appears. Without
+		//   wiring this here, a sync 401 would never trigger the banner — only
+		//   direct `authFetch(...)` calls would, leaving sync silently broken
+		//   (the bug that motivated this change, observed 2026-05-11).
+		// - `'transient'` — `TransientRefreshError` (5xx from nginx during a
+		//   Docker rebuild, network error, timeout) → ApiClient surfaces the
+		//   401 without flipping the banner; sync retries on the next tick.
 		this.apiClient = new ApiClient({
 			baseUrl,
 			timeout: 15_000,
-			onUnauthorized: async () => {
+			onUnauthorized: async (): Promise<UnauthorizedResult> => {
 				try {
-					return (await authFetch.refresh()) !== null;
-				} catch {
-					return false;
+					const newToken = await authFetch.refresh();
+					return newToken !== null ? 'refreshed' : 'session-expired';
+				} catch (err) {
+					if (err instanceof TransientRefreshError) return 'transient';
+					// Unknown error from the refresh path is safer to treat as
+					// transient than as expiry (don't log the user out on a
+					// programming bug); rethrowing would also leak from request().
+					this.logger.warn('Unexpected refresh error, treating as transient:', err);
+					return 'transient';
 				}
-			}
+			},
+			onSessionExpired: () => sessionExpired.set(true)
 		});
 	}
 
@@ -101,10 +116,11 @@ export abstract class SyncBaseService {
 		if (!response.success) {
 			const errorMessage = response.error || response.message;
 			if (this.isAuthError(errorMessage) || response.status === 401 || response.status === 403) {
-				// ApiClient already attempted a refresh + retry via `onUnauthorized`,
-				// and `authFetch` flipped `sessionExpired` on failure. If we still see
-				// a 401/403 here, the user must re-authenticate — give up the entity
-				// pull silently so the SessionExpiredBanner is the only signal.
+				// ApiClient already attempted a refresh + retry via `onUnauthorized`.
+				// On 'session-expired' it also fired `onSessionExpired` → the banner
+				// is already up. On 'transient' it left the banner alone — sync will
+				// retry on the next tick. Either way, give up this entity pull
+				// silently here so we don't double-signal the user.
 				this.logger.info(
 					`${entityType} sync skipped — session refresh failed, awaiting re-authentication.`
 				);

--- a/packages/api-client/src/__tests__/client-401-refresh.spec.ts
+++ b/packages/api-client/src/__tests__/client-401-refresh.spec.ts
@@ -51,7 +51,7 @@ describe('ApiClient — 401 refresh + retry', () => {
     vi.restoreAllMocks();
   });
 
-  it('retries the original request once after onUnauthorized returns true', async () => {
+  it('retries the original request once after onUnauthorized returns "refreshed"', async () => {
     localStorage.setItem('access_token', 'expired');
 
     const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
@@ -74,14 +74,16 @@ describe('ApiClient — 401 refresh + retry', () => {
 
     const onUnauthorized = vi.fn().mockImplementation(async () => {
       localStorage.setItem('access_token', 'fresh');
-      return true;
+      return 'refreshed' as const;
     });
+    const onSessionExpired = vi.fn();
 
-    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized, onSessionExpired });
     const res = await client.get<{ ok: boolean }>('/things');
 
     expect(res.success).toBe(true);
     expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(onSessionExpired).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     // Initial used expired, retry used fresh
     expect(
@@ -92,7 +94,7 @@ describe('ApiClient — 401 refresh + retry', () => {
     ).toBe('Bearer fresh');
   });
 
-  it('returns the original 401 when onUnauthorized returns false (no retry)', async () => {
+  it('surfaces 401 AND fires onSessionExpired when onUnauthorized returns "session-expired"', async () => {
     localStorage.setItem('access_token', 'expired');
 
     const fetchMock = vi
@@ -103,14 +105,65 @@ describe('ApiClient — 401 refresh + retry', () => {
       }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const onUnauthorized = vi.fn().mockResolvedValue(false);
+    const onUnauthorized = vi.fn().mockResolvedValue('session-expired' as const);
+    const onSessionExpired = vi.fn();
 
-    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized, onSessionExpired });
     const res = await client.get('/things');
 
     expect(res.success).toBe(false);
     expect(res.status).toBe(401);
     expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(onSessionExpired).toHaveBeenCalledOnce();
+    // No retry — the 401 was definitive.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces 401 WITHOUT firing onSessionExpired when onUnauthorized returns "transient"', async () => {
+    localStorage.setItem('access_token', 'expired');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn().mockResolvedValue('transient' as const);
+    const onSessionExpired = vi.fn();
+
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized, onSessionExpired });
+    const res = await client.get('/things');
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(401);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+    // Crucial: transient failures must NOT flip the session-expired banner.
+    expect(onSessionExpired).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a thrown onUnauthorized as "transient" (no banner, no retry)', async () => {
+    localStorage.setItem('access_token', 'expired');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ success: false }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn().mockRejectedValue(new Error('boom'));
+    const onSessionExpired = vi.fn();
+
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized, onSessionExpired });
+    const res = await client.get('/things');
+
+    expect(res.status).toBe(401);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(onSessionExpired).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -125,12 +178,14 @@ describe('ApiClient — 401 refresh + retry', () => {
       );
     vi.stubGlobal('fetch', fetchMock);
 
-    const onUnauthorized = vi.fn();
+    const onUnauthorized = vi.fn().mockResolvedValue('session-expired' as const);
+    const onSessionExpired = vi.fn();
 
-    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized, onSessionExpired });
     await client.post('/auth/refresh', {});
 
     expect(onUnauthorized).not.toHaveBeenCalled();
+    expect(onSessionExpired).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -145,11 +200,13 @@ describe('ApiClient — 401 refresh + retry', () => {
       );
     vi.stubGlobal('fetch', fetchMock);
 
-    const onUnauthorized = vi.fn();
-    const client = new ApiClient({ baseUrl: '/api', onUnauthorized });
+    const onUnauthorized = vi.fn().mockResolvedValue('session-expired' as const);
+    const onSessionExpired = vi.fn();
+    const client = new ApiClient({ baseUrl: '/api', onUnauthorized, onSessionExpired });
     await client.get('/things', { skipAuth: true });
 
     expect(onUnauthorized).not.toHaveBeenCalled();
+    expect(onSessionExpired).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api-client/src/core/client.ts
+++ b/packages/api-client/src/core/client.ts
@@ -10,7 +10,8 @@ import type {
   SyncStatus,
   IdMapping,
   EntityType,
-  OperationType
+  OperationType,
+  UnauthorizedResult
 } from '../types';
 import { AuthInterceptor } from '../interceptors/auth';
 import { EncryptionInterceptor } from '../interceptors/encryption';
@@ -45,7 +46,11 @@ export class ApiClient {
       onRequest: config.onRequest || ((c) => c),
       onResponse: config.onResponse || ((r) => r),
       onError: config.onError || (() => {}),
-      onUnauthorized: config.onUnauthorized || (async () => false)
+      // Default: no refresh handler installed → treat 401s as transient (no
+      // retry, no session-expired UI). Apps wire `authFetch.refresh()` in
+      // through the public constructor.
+      onUnauthorized: config.onUnauthorized || (async () => 'transient'),
+      onSessionExpired: config.onSessionExpired || (() => {})
     };
 
     // Initialize utilities
@@ -162,20 +167,38 @@ export class ApiClient {
       // the new token. The retry rebuilds the request config so AuthInterceptor
       // re-reads the rotated token. Auth endpoints are skipped to avoid
       // infinite recursion (the refresh endpoint itself can return 401).
+      //
+      // `onUnauthorized` returns a discriminated union — `'session-expired'`
+      // additionally triggers `onSessionExpired` so the app's re-auth UI fires
+      // here (sync path) just as it does in the direct `authFetch(...)` wrapper.
+      // Without this, a 401 on a sync request (which goes through ApiClient,
+      // not the wrapper) would silently retry-and-fail without ever surfacing
+      // the session-expired banner.
       if (
         response.status === 401 &&
         !this.isAuthEndpoint(fullUrl) &&
         !requestConfig.skipAuth
       ) {
-        const refreshed = await this.config.onUnauthorized();
-        if (refreshed) {
+        let unauthorizedResult: UnauthorizedResult;
+        try {
+          unauthorizedResult = await this.config.onUnauthorized();
+        } catch (err) {
+          logger.warn('onUnauthorized threw — treating as transient:', err);
+          unauthorizedResult = 'transient';
+        }
+
+        if (unauthorizedResult === 'refreshed') {
           requestConfig = await buildRequestConfig();
           response = await fetch(fullUrl, {
             ...requestConfig,
             signal: controller.signal,
             credentials: 'include'
           });
+        } else if (unauthorizedResult === 'session-expired') {
+          this.config.onSessionExpired();
         }
+        // 'transient' → fall through, surface the original 401 to the caller
+        // (e.g. sync treats it as a regular error and retries on the next tick).
       }
 
       clearTimeout(timeoutId);

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -55,6 +55,23 @@ export interface QueuedRequest {
 }
 
 /**
+ * Outcome of an `onUnauthorized` refresh attempt. Discriminates three
+ * semantically distinct cases that the legacy `boolean` return type collapsed:
+ *
+ * - `'refreshed'` — access token was rotated; ApiClient retries the original
+ *   request once with the new Bearer header.
+ * - `'session-expired'` — `/auth/refresh` returned a definitive 401/403 (or
+ *   `success:false`). The refresh token is gone; the user must re-authenticate.
+ *   ApiClient surfaces the original 401 AND invokes `onSessionExpired` so the
+ *   app can show its re-auth UI (e.g. the session-expired banner).
+ * - `'transient'` — refresh failed for a non-definitive reason (5xx from nginx
+ *   during a deploy, network error, timeout). The session is probably still
+ *   valid; ApiClient surfaces the original 401 as a regular sync error and
+ *   does NOT invoke `onSessionExpired`. Callers should retry later.
+ */
+export type UnauthorizedResult = 'refreshed' | 'session-expired' | 'transient';
+
+/**
  * API client configuration
  */
 export interface ApiClientConfig {
@@ -69,11 +86,24 @@ export interface ApiClientConfig {
   /**
    * Called when a non-auth endpoint returns 401. Implementations should
    * single-flight refresh the access token (typically `authFetch.refresh()`)
-   * and return `true` if a new token is now available — the client will
-   * re-run request interceptors and retry the original request once. Return
-   * `false` (or throw) to surface the original 401 to the caller.
+   * and return:
+   * - `'refreshed'` when a new token is available → client retries once,
+   * - `'session-expired'` when refresh failed definitively → client surfaces
+   *   the 401 AND invokes `onSessionExpired` (so the app can prompt re-auth),
+   * - `'transient'` when refresh failed transiently → client surfaces the 401
+   *   without flagging the session as expired.
+   *
+   * Throwing from this callback is treated as `'transient'` (defensive default).
    */
-  onUnauthorized?: () => Promise<boolean>;
+  onUnauthorized?: () => Promise<UnauthorizedResult>;
+  /**
+   * Called when `onUnauthorized` resolves to `'session-expired'`. Use to
+   * surface the re-auth UI (e.g. flip a `sessionExpired` store that drives the
+   * session-expired banner). Symmetric to `createAuthFetch`'s
+   * `onSessionExpired` so both refresh paths (direct `authFetch(...)` wrapper
+   * and `ApiClient` on 401) share the same UX trigger.
+   */
+  onSessionExpired?: () => void;
 }
 
 /**


### PR DESCRIPTION
The previous `() => Promise<boolean>` conflated 'session-expired' and 'transient' refresh outcomes, leaving ApiClient unable to signal the session-expired banner from the sync path. Task sync 401s never surfaced the banner — only direct authFetch wrapper calls did. Notes was unaffected because notes-sync uses the authFetch wrapper directly (with its own onSessionExpired) plus a defensive pullFromServer workaround.

Replace with `UnauthorizedResult = 'refreshed' | 'session-expired' | 'transient'` plus an `onSessionExpired` callback symmetric to createAuthFetch. Task sync-base now maps authFetch.refresh() to the union explicitly and wires sessionExpired.set(true) through onSessionExpired. New test cases cover session-expired, transient, and thrown-handler outcomes; existing tests updated to the union return type.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>