### PR TITLE
fix(i18n): deep-recursive translation merge so common keys survive app-specific overrides

### DIFF
--- a/packages/i18n/src/__tests__/merge.spec.ts
+++ b/packages/i18n/src/__tests__/merge.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { mergeTranslations } from '../setup';
+
+describe('mergeTranslations', () => {
+  it('overwrites primitive leaves with source values', () => {
+    const target: Record<string, any> = { hello: 'common-hi', count: 1 };
+    mergeTranslations(target, { hello: 'app-hi', count: 2 });
+    expect(target).toEqual({ hello: 'app-hi', count: 2 });
+  });
+
+  it('preserves keys present only in target', () => {
+    const target: Record<string, any> = { onlyTarget: 'keep' };
+    mergeTranslations(target, { onlySource: 'add' });
+    expect(target).toEqual({ onlyTarget: 'keep', onlySource: 'add' });
+  });
+
+  it('merges nested objects deeply instead of replacing them (regression: ReAuthModal TOTP keys)', () => {
+    // Mirrors the Task app load order: common first, then tasks/<loc>/auth.json.
+    // The shallow merge bug used to wipe auth.session.totp_* defined only in common.
+    const target: Record<string, any> = {
+      auth: {
+        session: {
+          reauth_title: 'Session expired',
+          totp_title: 'Two-factor verification',
+          totp_label: '2FA code',
+          use_recovery: 'Use a recovery code'
+        }
+      }
+    };
+    const source = {
+      auth: {
+        session: {
+          reauth_title: 'Session expired (task)',
+          submitting: 'Logging in…'
+        }
+      }
+    };
+
+    mergeTranslations(target, source);
+
+    expect(target.auth.session).toEqual({
+      reauth_title: 'Session expired (task)',
+      totp_title: 'Two-factor verification',
+      totp_label: '2FA code',
+      use_recovery: 'Use a recovery code',
+      submitting: 'Logging in…'
+    });
+  });
+
+  it('replaces arrays entirely instead of element-wise merging', () => {
+    const target: Record<string, any> = { items: ['a', 'b', 'c'] };
+    mergeTranslations(target, { items: ['x'] });
+    expect(target.items).toEqual(['x']);
+  });
+
+  it('overwrites object with primitive and vice versa', () => {
+    const target: Record<string, any> = { mixed: { inner: 1 }, swapped: 'hello' };
+    mergeTranslations(target, { mixed: 'replaced', swapped: { now: 'object' } });
+    expect(target.mixed).toBe('replaced');
+    expect(target.swapped).toEqual({ now: 'object' });
+  });
+
+  it('handles null source values by overwriting target leaf', () => {
+    const target: Record<string, any> = { key: { inner: 'val' } };
+    mergeTranslations(target, { key: null });
+    expect(target.key).toBeNull();
+  });
+});

--- a/packages/i18n/src/__tests__/merge.spec.ts
+++ b/packages/i18n/src/__tests__/merge.spec.ts
@@ -65,4 +65,20 @@ describe('mergeTranslations', () => {
     mergeTranslations(target, { key: null });
     expect(target.key).toBeNull();
   });
+
+  it('skips __proto__, constructor, and prototype to prevent prototype pollution', () => {
+    // Object.keys(JSON.parse('{"__proto__":{"polluted":true}}')) returns
+    // ['__proto__'] as an own property — without the guard this would mutate
+    // Object.prototype globally.
+    const malicious = JSON.parse('{"__proto__":{"polluted":true},"constructor":"x","prototype":"y","safe":"ok"}');
+    const target: Record<string, any> = {};
+    mergeTranslations(target, malicious);
+
+    expect(target.safe).toBe('ok');
+    expect(target.constructor).toBe(Object); // not overwritten
+    expect((target as any).polluted).toBeUndefined();
+    expect(({} as any).polluted).toBeUndefined(); // prototype not polluted
+    expect(Object.prototype.hasOwnProperty.call(target, '__proto__')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(target, 'prototype')).toBe(false);
+  });
 });

--- a/packages/i18n/src/setup.ts
+++ b/packages/i18n/src/setup.ts
@@ -29,6 +29,10 @@ type LocaleDictionary = Record<string, any>;
  */
 export function mergeTranslations(target: LocaleDictionary, source: LocaleDictionary): void {
   for (const key of Object.keys(source)) {
+    // Defense-in-depth against prototype pollution: JSON.parse can produce own
+    // properties named __proto__/constructor/prototype, and assigning them would
+    // mutate Object.prototype or replace the constructor.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
     const sourceValue = source[key];
     const targetValue = target[key];
     if (

--- a/packages/i18n/src/setup.ts
+++ b/packages/i18n/src/setup.ts
@@ -15,22 +15,33 @@ import {
 type LocaleDictionary = Record<string, any>;
 
 /**
- * Shallow-deep merge: for each top-level key, if both sides are objects,
- * merge their properties instead of overwriting. This prevents module
- * collisions (e.g. tasks/common.json overwriting common/en.json → "common").
+ * Recursive deep merge: when both target[key] and source[key] are plain objects,
+ * merge their properties at every depth. Leaves (strings, arrays, primitives)
+ * are overwritten by source. Arrays are NOT merged element-wise.
+ *
+ * Rationale: a shallow (one-level) merge causes app-specific module files (e.g.
+ * tasks/<loc>/auth.json) to silently drop nested keys defined only in the shared
+ * common module — even when the app-specific override only wants to refine a
+ * single leaf. Example: `auth.session.totp_*` defined in common/<loc>.json was
+ * wiped out by tasks/<loc>/auth.json's minimal `session` block, leaving the
+ * re-auth modal showing raw keys in Task. Deep merge lets shared keys flow
+ * through while preserving per-app leaf overrides.
  */
-function mergeTranslations(target: LocaleDictionary, source: LocaleDictionary): void {
+export function mergeTranslations(target: LocaleDictionary, source: LocaleDictionary): void {
   for (const key of Object.keys(source)) {
+    const sourceValue = source[key];
+    const targetValue = target[key];
     if (
-      target[key] &&
-      typeof target[key] === 'object' &&
-      !Array.isArray(target[key]) &&
-      typeof source[key] === 'object' &&
-      !Array.isArray(source[key])
+      targetValue &&
+      typeof targetValue === 'object' &&
+      !Array.isArray(targetValue) &&
+      sourceValue &&
+      typeof sourceValue === 'object' &&
+      !Array.isArray(sourceValue)
     ) {
-      target[key] = { ...target[key], ...source[key] };
+      mergeTranslations(targetValue, sourceValue);
     } else {
-      target[key] = source[key];
+      target[key] = sourceValue;
     }
   }
 }


### PR DESCRIPTION
mergeTranslations was shallow (one level), so any nested object in tasks/<loc>/auth.json silently replaced its counterpart in common/<loc>.json instead of merging at the leaf level. The Task re-auth modal's TOTP step was the visible symptom: tasks/<loc>/auth.json defines a minimal `session` block (11 keys) that wiped out the 12 keys only present in common — totp_*, use_recovery, use_app, recovery_*, error_locked — leaving raw i18n keys on screen. Notes was unaffected only because notes/<loc>.json does not redefine `auth.session`.

Replace with a true recursive deep merge: nested objects are merged at every depth, leaves (strings, primitives, arrays) are overwritten by source. Per-app stylistic refinements (e.g. DE/FR/ES "submitting", "password_placeholder") still win where defined; missing keys flow through from common. Add regression test covering the Task load order.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>