### PR TITLE
fix(notes): preserve folder id when navigating from note metadata

### DIFF
--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -889,15 +889,28 @@
   }
 
   // ── Folder breadcrumb navigation ──────────────────────────────────
-  function navigateToNoteFolder() {
+  // The section-change $effect above clears `activeFolderId` for any non-periodic
+  // transition. So we set the target id AFTER tick() - once that clearing pass
+  // has run - instead of in the same synchronous batch, where it would be wiped.
+  async function navigateToNoteFolder() {
+    const targetFolderId = noteDetailService.folderId as string | null | undefined;
+    await noteDetailService.flushAndSnapshot();
     activeSection = 'folders';
-    activeFolderId = noteDetailService.folderId as string | null | undefined;
-    if (noteDetailService.folderId) {
-      getAncestorIds(noteDetailService.folderId, $foldersStore).forEach((id) =>
-        expandedIds.add(id)
-      );
+    await tick();
+    activeFolderId = targetFolderId;
+    if (targetFolderId) {
+      getAncestorIds(targetFolderId, $foldersStore).forEach((id) => expandedIds.add(id));
+      expandedIds.add(targetFolderId);
+      lastVisitedFolderId = targetFolderId;
     }
     activeNoteId.set(null);
+    // Mobile: drill into the folder's note list (mirrors handleFolderSelect).
+    // Without this we'd land on the folder tree with the target highlighted but
+    // the user still has to tap it to see the notes - extra step.
+    if (isMobile && targetFolderId) {
+      mobileView = 'list';
+      pushMobileHistory();
+    }
   }
 
   // ── beforeNavigate — flush before SvelteKit navigation ─────────


### PR DESCRIPTION
Clicking the folder name in NoteMetadataBar from a non-Foldery section opened the Foldery view but did not select the target folder. The section-change effect cleared activeFolderId in a microtask after the synchronous batch that set it, so the folder selection was wiped before FolderTree rendered.

Defer the activeFolderId assignment past tick() so it lands after the clearing pass. Also align semantics with applyFolderSelection (flush pending edits, expand the folder itself, set lastVisitedFolderId), and on mobile drill into the folder note list so the user does not have to tap the folder again after landing on the tree.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>