### PR TITLE
chore(release): disable nx workspaceChangelog `authors` renderer,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,11 @@
 
 - **notes:** match periodic notes by encrypted anchor, not by title ([#185](https://github.com/fundacja-reborn/reapps/pull/185))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.22.0 (2026-05-12)
 
 ### 🚀 Features
 
 - **notes:** multi select ([#183](https://github.com/fundacja-reborn/reapps/pull/183))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.21.0 (2026-05-11)
 
@@ -31,12 +21,6 @@
 - **api-client:** three-state onUnauthorized contract with onSessionExpired callback ([#181](https://github.com/fundacja-reborn/reapps/pull/181))
 - **deps:** rollback cookie to 0.7.2 and @hono/node-server to 1.19.14 ([#179](https://github.com/fundacja-reborn/reapps/pull/179))
 - **i18n:** deep-recursive translation merge so common keys survive app-specific overrides ([#182](https://github.com/fundacja-reborn/reapps/pull/182))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
 
 ## 0.20.1 (2026-05-11)
 
@@ -54,11 +38,6 @@
 
 - **task:** preserve shadow indexes when metadata decrypt fails after session unlock ([#172](https://github.com/fundacja-reborn/reapps/pull/172))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.19.1 (2026-05-10)
 
 ### 🩹 Fixes
@@ -66,22 +45,11 @@
 - **deps:** update patch-updates ([#159](https://github.com/fundacja-reborn/reapps/pull/159))
 - **deps:** update minor-updates ([#161](https://github.com/fundacja-reborn/reapps/pull/161))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.19.0 (2026-05-09)
 
 ### 🚀 Features
 
 - **notes:** task lists ([#158](https://github.com/fundacja-reborn/reapps/pull/158), [#147](https://github.com/fundacja-reborn/reapps/issues/147))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
 
 ## 0.18.1 (2026-05-09)
 
@@ -93,24 +61,12 @@
 - **notes:** toolbar empty sub-bullet renders as BulletList ([#156](https://github.com/fundacja-reborn/reapps/pull/156))
 - **notes:** render PDF export list markers via CSS counters ([#157](https://github.com/fundacja-reborn/reapps/pull/157))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.18.0 (2026-05-09)
 
 ### 🚀 Features
 
 - **notes:** periodic notes ([#150](https://github.com/fundacja-reborn/reapps/pull/150))
 - **storage:** e2e settings sync ([#151](https://github.com/fundacja-reborn/reapps/pull/151))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
 
 ## 0.17.0 (2026-05-08)
 
@@ -127,22 +83,11 @@
 - **task:** auto-expand completed accordion when active results are empty ([#144](https://github.com/fundacja-reborn/reapps/pull/144))
 - **utils:** avoid polynomial ReDoS in has:link evaluator ([#140](https://github.com/fundacja-reborn/reapps/pull/140), [#7](https://github.com/fundacja-reborn/reapps/issues/7))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.16.0 (2026-05-05)
 
 ### 🚀 Features
 
 - **notes:** tasks show time in list ([#136](https://github.com/fundacja-reborn/reapps/pull/136), [#135](https://github.com/fundacja-reborn/reapps/issues/135))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.15.2 (2026-05-04)
 
@@ -152,20 +97,11 @@
 - **deps:** update minor-updates ([#130](https://github.com/fundacja-reborn/reapps/pull/130))
 - **deps:** update patch-updates ([#128](https://github.com/fundacja-reborn/reapps/pull/128))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.15.1 (2026-05-02)
 
 ### 🩹 Fixes
 
 - **auth:** treat transient refresh failures as retryable, not session expiry ([#126](https://github.com/fundacja-reborn/reapps/pull/126))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
 
 ## 0.15.0 (2026-05-02)
 
@@ -173,21 +109,11 @@
 
 - **task:** configurable notification lead time and date-only reminder hour ([#125](https://github.com/fundacja-reborn/reapps/pull/125))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.14.6 (2026-05-01)
 
 ### 🩹 Fixes
 
 - **notes:** make folder and tag DELETE endpoints idempotent ([#123](https://github.com/fundacja-reborn/reapps/pull/123))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.14.5 (2026-05-01)
 
@@ -195,21 +121,11 @@
 
 - **notes:** defer all imports to pushPendingItems to satisfy folder FK ([#122](https://github.com/fundacja-reborn/reapps/pull/122))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.14.4 (2026-05-01)
 
 ### 🩹 Fixes
 
 - **notes:** make backup import resilient to legacy/null user_id ([#121](https://github.com/fundacja-reborn/reapps/pull/121), [#120](https://github.com/fundacja-reborn/reapps/issues/120))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
 
 ## 0.14.3 (2026-05-01)
 
@@ -217,22 +133,11 @@
 
 - **notes:** accept null in folder_id/parent_id when importing JSON backup ([#120](https://github.com/fundacja-reborn/reapps/pull/120))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.14.2 (2026-04-30)
 
 ### 🩹 Fixes
 
 - **notes:** prevent wide code blocks/tables from stretching live preview on mobile ([#117](https://github.com/fundacja-reborn/reapps/pull/117))
-
-### ❤️ Thank You
-
-- Claude Sonnet 4.5
-- rerefu @rerefu
 
 ## 0.14.1 (2026-04-30)
 
@@ -240,21 +145,11 @@
 
 - **notes:** editor mode dialog icon, dark popover contrast, missing register title ([#115](https://github.com/fundacja-reborn/reapps/pull/115))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.14.0 (2026-04-30)
 
 ### 🚀 Features
 
 - **notes:** render inline images in Live Preview with click-to-load ([#114](https://github.com/fundacja-reborn/reapps/pull/114))
-
-### ❤️ Thank You
-
-- Claude Opus 4.6
-- rerefu @rerefu
 
 ## 0.13.0 (2026-04-29)
 
@@ -262,21 +157,11 @@
 
 - **notes:** make Live Preview the default editor mode with first-run intro ([#113](https://github.com/fundacja-reborn/reapps/pull/113))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.12.3 (2026-04-29)
 
 ### 🩹 Fixes
 
 - **notes:** position dialogs in visual viewport so iPad keyboard does not cover them ([#112](https://github.com/fundacja-reborn/reapps/pull/112))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.12.2 (2026-04-29)
 
@@ -284,21 +169,11 @@
 
 - **notes:** also size desktop layout to visual viewport for iPad keyboard ([#111](https://github.com/fundacja-reborn/reapps/pull/111))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.12.1 (2026-04-29)
 
 ### 🩹 Fixes
 
 - **notes:** keep editor panel sized to visual viewport on mobile keyboard ([#110](https://github.com/fundacja-reborn/reapps/pull/110))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
 
 ## 0.12.0 (2026-04-29)
 
@@ -306,22 +181,11 @@
 
 - **notes:** editable tables in live preview (Obsidian-style) ([#109](https://github.com/fundacja-reborn/reapps/pull/109))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.11.0 (2026-04-29)
 
 ### 🚀 Features
 
 - **live:** preview code blocks ([#108](https://github.com/fundacja-reborn/reapps/pull/108))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.10.6 (2026-04-28)
 
@@ -329,21 +193,11 @@
 
 - **notes:** editor placeholder and caret ([#107](https://github.com/fundacja-reborn/reapps/pull/107))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.10.5 (2026-04-28)
 
 ### 🩹 Fixes
 
 - **notes:** restore scrolling in preview, settings, auth, and error pages ([#106](https://github.com/fundacja-reborn/reapps/pull/106), [#105](https://github.com/fundacja-reborn/reapps/issues/105))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.10.4 (2026-04-28)
 
@@ -351,21 +205,11 @@
 
 - **notes:** stabilize editor header, split view, and toolbar on iPadOS Safari ([#105](https://github.com/fundacja-reborn/reapps/pull/105))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.10.3 (2026-04-28)
 
 ### 🩹 Fixes
 
 - **notes:** force raw markdown in split view editor pane ([#104](https://github.com/fundacja-reborn/reapps/pull/104))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.10.2 (2026-04-28)
 
@@ -373,32 +217,17 @@
 
 - **notes:** make Live Preview italic visible, enable strikethrough, match Preview styling ([#103](https://github.com/fundacja-reborn/reapps/pull/103))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.10.1 (2026-04-28)
 
 ### 🩹 Fixes
 
 - **notes:** activate edit view when picking editor mode from toolbar ([#102](https://github.com/fundacja-reborn/reapps/pull/102))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
-
 ## 0.10.0 (2026-04-28)
 
 ### 🚀 Features
 
 - **notes:** add Live Preview editor mode with toolbar toggle ([#101](https://github.com/fundacja-reborn/reapps/pull/101))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.9.6 (2026-04-28)
 
@@ -412,21 +241,11 @@
 
 - **crypto:** clear waitForRestore timer when restore wins the race ([#98](https://github.com/fundacja-reborn/reapps/pull/98))
 
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
-
 ## 0.9.4 (2026-04-27)
 
 ### 🩹 Fixes
 
 - **auth:** single-flight 401 refresh and retry across sync paths ([#97](https://github.com/fundacja-reborn/reapps/pull/97))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7 (1M context)
-- rerefu @rerefu
 
 ## 0.9.3 (2026-04-27)
 
@@ -440,11 +259,6 @@
 - **deps:** update minor-updates ([#67](https://github.com/fundacja-reborn/reapps/pull/67))
 - **types:** use ZodError.issues instead of deprecated .errors ([#95](https://github.com/fundacja-reborn/reapps/pull/95), [#93](https://github.com/fundacja-reborn/reapps/issues/93))
 - **types:** pass explicit key schema to z.record() ([#96](https://github.com/fundacja-reborn/reapps/pull/96), [#93](https://github.com/fundacja-reborn/reapps/issues/93))
-
-### ❤️ Thank You
-
-- Claude Opus 4.7
-- rerefu @rerefu
 
 ## 0.9.2 (2026-04-27)
 
@@ -465,19 +279,11 @@
 
 - **notes:** include subfolders in folder-view search ([#62](https://github.com/fundacja-reborn/reapps/pull/62))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.8.4 (2026-04-26)
 
 ### 🩹 Fixes
 
 - **notes:** drill-up folder navigation on mobile back gesture ([#61](https://github.com/fundacja-reborn/reapps/pull/61))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.8.3 (2026-04-26)
 
@@ -489,19 +295,11 @@ This was a version bump only, there were no code changes.
 
 - **notes:** add progress feedback and content sanitization to imports ([#58](https://github.com/fundacja-reborn/reapps/pull/58))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.8.1 (2026-04-26)
 
 ### 🩹 Fixes
 
 - **task,notes:** cache-bust app icons via ?v query string ([#57](https://github.com/fundacja-reborn/reapps/pull/57))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.8.0 (2026-04-26)
 
@@ -509,29 +307,17 @@ This was a version bump only, there were no code changes.
 
 - **task:** show initial-sync state in main view on fresh login ([#55](https://github.com/fundacja-reborn/reapps/pull/55))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.7.0 (2026-04-26)
 
 ### 🚀 Features
 
 - **notes:** show initial-sync state in main view on fresh login ([#53](https://github.com/fundacja-reborn/reapps/pull/53))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.6.5 (2026-04-26)
 
 ### 🩹 Fixes
 
 - **notes:** heading wraps correctly in PDF export ([#52](https://github.com/fundacja-reborn/reapps/pull/52), [#2696](https://github.com/fundacja-reborn/reapps/issues/2696), [#3205](https://github.com/fundacja-reborn/reapps/issues/3205), [#1497](https://github.com/fundacja-reborn/reapps/issues/1497), [#51](https://github.com/fundacja-reborn/reapps/issues/51))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.6.4 (2026-04-26)
 
@@ -551,19 +337,11 @@ This was a version bump only, there were no code changes.
 
 - **notes:** repair PDF export on iOS Safari and Android PWA ([#48](https://github.com/fundacja-reborn/reapps/pull/48))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.6.1 (2026-04-25)
 
 ### 🩹 Fixes
 
 - **notes:** render PDF export in isolated iframe for PWA + filename ([#47](https://github.com/fundacja-reborn/reapps/pull/47))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.6.0 (2026-04-25)
 
@@ -571,19 +349,11 @@ This was a version bump only, there were no code changes.
 
 - **notes:** add PDF export via native print dialog ([#46](https://github.com/fundacja-reborn/reapps/pull/46))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.5.0 (2026-04-25)
 
 ### 🚀 Features
 
 - **notes:** show subfolders in folder view ([#45](https://github.com/fundacja-reborn/reapps/pull/45))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.4.1 (2026-04-25)
 
@@ -592,19 +362,11 @@ This was a version bump only, there were no code changes.
 - **notes:** switch to all-notes view when creating from trash + use existing delete_permanently i18n key ([#43](https://github.com/fundacja-reborn/reapps/pull/43))
 - **notes:** order folder/tag pushes before notes during folder import ([#44](https://github.com/fundacja-reborn/reapps/pull/44), [#1](https://github.com/fundacja-reborn/reapps/issues/1))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.4.0 (2026-04-25)
 
 ### 🚀 Features
 
 - **notes:** add per-folder markdown import + clarify root prompt ([#42](https://github.com/fundacja-reborn/reapps/pull/42))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.3.0 (2026-04-25)
 
@@ -615,10 +377,6 @@ This was a version bump only, there were no code changes.
 ### 🩹 Fixes
 
 - **deps:** update dependency uuid to v14 ([#35](https://github.com/fundacja-reborn/reapps/pull/35))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.2.0 (2026-04-23)
 
@@ -631,20 +389,12 @@ This was a version bump only, there were no code changes.
 - back sync indicator with real connectivity probe ([#31](https://github.com/fundacja-reborn/reapps/pull/31))
 - **task:** restore offline session regardless of navigator.onLine ([#30](https://github.com/fundacja-reborn/reapps/pull/30))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.1.4 (2026-04-22)
 
 ### 🩹 Fixes
 
 - **notes:** render single newlines as line breaks in markdown preview ([a9efa3d](https://github.com/fundacja-reborn/reapps/commit/a9efa3d))
 - **security:** address CodeQL findings ([#26](https://github.com/fundacja-reborn/reapps/pull/26))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.1.3 (2026-04-22)
 
@@ -656,10 +406,6 @@ This was a version bump only, there were no code changes.
 - **notes:** serialize per-entity push ops and intent-check delete/restore ([2aa7bac](https://github.com/fundacja-reborn/reapps/commit/2aa7bac))
 - **notes:** propagate soft-delete and restore across devices ([5e01b7c](https://github.com/fundacja-reborn/reapps/commit/5e01b7c))
 
-### ❤️ Thank You
-
-- rerefu @rerefu
-
 ## 0.1.2 (2026-04-21)
 
 ### 🩹 Fixes
@@ -669,10 +415,6 @@ This was a version bump only, there were no code changes.
 - **release:** add --specifier flag and release:patch/minor scripts ([a7ba4b8](https://github.com/fundacja-reborn/reapps/commit/a7ba4b8))
 - **release:** detect conventional-commits bump across whole workspace ([3280f6e](https://github.com/fundacja-reborn/reapps/commit/3280f6e))
 - **release:** decode spaces in repo path when resolving workspace root ([a2a7751](https://github.com/fundacja-reborn/reapps/commit/a2a7751))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.1.1 (2026-04-21)
 
@@ -694,10 +436,6 @@ This was a version bump only, there were no code changes.
 - **task:** eliminate offline cold-start race that redirected to login ([8eb8e40](https://github.com/fundacja-reborn/reapps/commit/8eb8e40))
 - **task:** remove redundant onStorageInit from E2E restore path ([5107ddd](https://github.com/fundacja-reborn/reapps/commit/5107ddd))
 - **task:** sync pending offline ops on PWA cold start ([161aa21](https://github.com/fundacja-reborn/reapps/commit/161aa21))
-
-### ❤️ Thank You
-
-- rerefu @rerefu
 
 ## 0.1.0 (2026-04-20)
 

--- a/nx.json
+++ b/nx.json
@@ -54,7 +54,10 @@
     "changelog": {
       "workspaceChangelog": {
         "file": "CHANGELOG.md",
-        "createRelease": "github"
+        "createRelease": "github",
+        "renderOptions": {
+          "authors": false
+        }
       },
       "projectChangelogs": false
     },


### PR DESCRIPTION
(credits were just noise outweighing the actual log entries).

