### PR TITLE
fix(notes): dim markdown markers on the active line in Live Preview

### DIFF
--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
@@ -46,6 +46,10 @@ const DEFAULT_OPTIONS: BuildDecorationsOptions = {
 export const rebuildLivePreview = StateEffect.define<null>();
 
 const HIDDEN = Decoration.replace({});
+// Visible markdown markers on the actively-edited line (cursor in range). The
+// CSS rule in `theme.ts` dims them to `--muted-foreground` so the eye lands
+// on content first instead of competing with `#`, `**`, `> `, etc.
+const VISIBLE_MARK = Decoration.mark({ class: 'cm-lp-mark' });
 const CODE_LINE = Decoration.line({ class: 'cm-lp-code-line' });
 const CODE_LINE_FIRST = Decoration.line({ class: 'cm-lp-code-line cm-lp-code-line-first' });
 const CODE_LINE_LAST = Decoration.line({ class: 'cm-lp-code-line cm-lp-code-line-last' });
@@ -311,13 +315,16 @@ export function buildDecorations(
         const line = doc.lineAt(from);
         ranges.push(lineDeco.range(line.from));
 
-        if (!isAnySelectionInRange(state, from, to)) {
-          const headerMark = findFirstChild(nodeRef.node, 'HeaderMark');
-          if (headerMark) {
+        const cursorInside = isAnySelectionInRange(state, from, to);
+        const headerMark = findFirstChild(nodeRef.node, 'HeaderMark');
+        if (headerMark) {
+          if (!cursorInside) {
             // Hide "#... " — including the trailing space if present
             const next = doc.sliceString(headerMark.to, headerMark.to + 1);
             const hideTo = next === ' ' ? headerMark.to + 1 : headerMark.to;
             ranges.push(HIDDEN.range(headerMark.from, hideTo));
+          } else if (headerMark.to > headerMark.from) {
+            ranges.push(VISIBLE_MARK.range(headerMark.from, headerMark.to));
           }
         }
         return; // descend so inline children inside heading text get decorated
@@ -326,44 +333,44 @@ export function buildDecorations(
       // ─── Strong (**bold** / __bold__) ────────────────────────────
       if (name === 'StrongEmphasis') {
         ranges.push(STRONG_MARK.range(from, to));
-        if (!isAnySelectionInRange(state, from, to)) {
-          forEachChild(nodeRef.node, 'EmphasisMark', (mark) => {
-            ranges.push(HIDDEN.range(mark.from, mark.to));
-          });
-        }
+        const cursorInside = isAnySelectionInRange(state, from, to);
+        forEachChild(nodeRef.node, 'EmphasisMark', (mark) => {
+          if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
+          else ranges.push(HIDDEN.range(mark.from, mark.to));
+        });
         return; // descend for nested emphasis/code
       }
 
       // ─── Emphasis (*italic* / _italic_) ──────────────────────────
       if (name === 'Emphasis') {
         ranges.push(EM_MARK.range(from, to));
-        if (!isAnySelectionInRange(state, from, to)) {
-          forEachChild(nodeRef.node, 'EmphasisMark', (mark) => {
-            ranges.push(HIDDEN.range(mark.from, mark.to));
-          });
-        }
+        const cursorInside = isAnySelectionInRange(state, from, to);
+        forEachChild(nodeRef.node, 'EmphasisMark', (mark) => {
+          if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
+          else ranges.push(HIDDEN.range(mark.from, mark.to));
+        });
         return;
       }
 
       // ─── Strikethrough (~~text~~) — GFM ──────────────────────────
       if (name === 'Strikethrough') {
         ranges.push(STRIKE_MARK.range(from, to));
-        if (!isAnySelectionInRange(state, from, to)) {
-          forEachChild(nodeRef.node, 'StrikethroughMark', (mark) => {
-            ranges.push(HIDDEN.range(mark.from, mark.to));
-          });
-        }
+        const cursorInside = isAnySelectionInRange(state, from, to);
+        forEachChild(nodeRef.node, 'StrikethroughMark', (mark) => {
+          if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
+          else ranges.push(HIDDEN.range(mark.from, mark.to));
+        });
         return;
       }
 
       // ─── Inline code (`code`) ────────────────────────────────────
       if (name === 'InlineCode') {
         ranges.push(INLINE_CODE_MARK.range(from, to));
-        if (!isAnySelectionInRange(state, from, to)) {
-          forEachChild(nodeRef.node, 'CodeMark', (mark) => {
-            ranges.push(HIDDEN.range(mark.from, mark.to));
-          });
-        }
+        const cursorInside = isAnySelectionInRange(state, from, to);
+        forEachChild(nodeRef.node, 'CodeMark', (mark) => {
+          if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
+          else ranges.push(HIDDEN.range(mark.from, mark.to));
+        });
         return false;
       }
 
@@ -426,10 +433,14 @@ export function buildDecorations(
         for (let lineNo = startLine.number; lineNo <= endLine.number; lineNo++) {
           const line = doc.line(lineNo);
           ranges.push(BLOCKQUOTE_LINE.range(line.from));
-          if (!isAnySelectionInRange(state, line.from, line.to)) {
-            const m = /^(\s*>\s?)/.exec(line.text);
-            if (m) {
-              ranges.push(HIDDEN.range(line.from, line.from + m[1].length));
+          const m = /^(\s*>\s?)/.exec(line.text);
+          if (m) {
+            const markFrom = line.from;
+            const markTo = line.from + m[1].length;
+            if (!isAnySelectionInRange(state, line.from, line.to)) {
+              ranges.push(HIDDEN.range(markFrom, markTo));
+            } else if (markTo > markFrom) {
+              ranges.push(VISIBLE_MARK.range(markFrom, markTo));
             }
           }
         }
@@ -480,26 +491,37 @@ export function buildDecorations(
 
           const cursorOnLine = isAnySelectionInRange(state, itemLine.from, itemLine.to);
 
-          if (isTask && !cursorOnLine && taskMarker) {
-            // Replace `- [ ] ` (ListMark + space + TaskMarker + space) with
-            // the interactive checkbox widget. Toggle handler: `livePreviewTaskCheckboxToggle`.
-            const checked = /\[[xX]\]/.test(
-              doc.sliceString(taskMarker.from, taskMarker.to)
-            );
+          if (isTask && taskMarker) {
             const next = doc.sliceString(taskMarker.to, taskMarker.to + 1);
             const replaceTo = next === ' ' ? taskMarker.to + 1 : taskMarker.to;
-            ranges.push(
-              Decoration.replace({
-                widget: new TaskCheckboxWidget(checked)
-              }).range(listMark.from, replaceTo)
-            );
-          } else if (!isTask && !isOrdered && !cursorOnLine) {
+            if (!cursorOnLine) {
+              // Replace `- [ ] ` (ListMark + space + TaskMarker + space) with
+              // the interactive checkbox widget. Toggle handler: `livePreviewTaskCheckboxToggle`.
+              const checked = /\[[xX]\]/.test(
+                doc.sliceString(taskMarker.from, taskMarker.to)
+              );
+              ranges.push(
+                Decoration.replace({
+                  widget: new TaskCheckboxWidget(checked)
+                }).range(listMark.from, replaceTo)
+              );
+            } else {
+              // Cursor on line — raw `- [ ] ` visible; dim the marker so the
+              // checkbox/structural punctuation doesn't compete with content.
+              ranges.push(VISIBLE_MARK.range(listMark.from, replaceTo));
+            }
+          } else if (!isTask && !isOrdered) {
             // Plain bullet — hide "- " / "* " when cursor is off the line so
             // the rendered ::before bullet takes over. Ordered lists keep
-            // their numeric marker (the number is meaningful content).
+            // their numeric marker (the number is meaningful content, not a
+            // marker — don't dim it).
             const next = doc.sliceString(listMark.to, listMark.to + 1);
             const hideTo = next === ' ' ? listMark.to + 1 : listMark.to;
-            ranges.push(HIDDEN.range(listMark.from, hideTo));
+            if (!cursorOnLine) {
+              ranges.push(HIDDEN.range(listMark.from, hideTo));
+            } else {
+              ranges.push(VISIBLE_MARK.range(listMark.from, hideTo));
+            }
           }
         }
         return; // descend so inline content inside item gets decorated

--- a/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
@@ -79,6 +79,27 @@ export const livePreviewTheme = EditorView.theme({
     '.cm-lp-h6-line': { fontSize: '0.875rem' }
   },
 
+  // Visible markdown markers on the actively-edited line. Emitted by
+  // `buildDecorations` as `Decoration.mark({ class: 'cm-lp-mark' })` on the
+  // ranges that would otherwise be hidden (`#`, `**`, `_`, `~~`, `` ` ``,
+  // `> `, `- `, `- [ ] ` / `- [x] `).
+  //
+  // Color goal: clearly subordinate to body text (Obsidian-style), so the eye
+  // lands on content. `--muted-foreground` alone (oklch ~0.556 light / ~0.65
+  // dark) is "medium gray" - too close in weight to the body. We layer
+  // `opacity: 0.5` on top so the marker reads as light gray in light mode and
+  // dim gray in dark mode, scaling against `--background` rather than being
+  // pinned to one literal lightness value.
+  //
+  // The `, .cm-lp-mark *` half of the selector handles CM6's habit of wrapping
+  // the highlight tokens (heading/processingInstruction tag spans from
+  // `defaultHighlightStyle`) inside our `Decoration.mark` span. If we only
+  // styled `.cm-lp-mark`, the inner highlight span's own color rule could
+  // shadow inheritance from the outer wrapper. `opacity` stays on the outer
+  // only - applying it to descendants too would double-multiply.
+  '.cm-lp-mark, .cm-lp-mark *': { color: 'var(--muted-foreground)' },
+  '.cm-lp-mark': { opacity: '0.5' },
+
   // Inline marks
   '.cm-lp-strong': { fontWeight: '700' },
   '.cm-lp-em': { fontStyle: 'italic' },


### PR DESCRIPTION
When the cursor enters a Live Preview block, markdown markers (#, **, _, ~~, `, > , - , - [ ] / - [x]) become visible for editing instead of being hidden. Previously they rendered in body foreground color and competed with content. Emit a Decoration.mark with class `cm-lp-mark` on those ranges and style it as muted-foreground at opacity 0.5, mirroring the Obsidian Live Preview convention so the eye lands on content first.

The selector `, .cm-lp-mark *` is required because CM6 wraps the HighlightStyle token spans inside our decoration mark; styling only the outer would let the inner span's color win the cascade. Opacity stays on the outer wrapper alone so it does not compound on nested elements.

Ordered list markers (1. , 2.) are intentionally left undimmed because the number is meaningful content (position in the list), not punctuation.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>