### PR TITLE
fix(notes): preserve shadow indexes when metadata decrypt fails after login

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -3,7 +3,7 @@
  *
  * Calls the local /api/auth/login endpoint, saves credentials to localStorage
  * in the same format as reborn-task, then unlocks E2E via cryptoManager.
- * This allows Notes to authenticate users independently — without reborn-task.
+ * This allows Notes to authenticate users independently - without reborn-task.
  */
 import { PUBLIC_BASE_PATH } from '$env/static/public';
 import { authStore, CREDENTIALS_KEY, ACCESS_TOKEN_KEY } from '$lib/stores/auth.store';
@@ -44,7 +44,7 @@ export async function loginInNotes(username: string, password: string): Promise<
 
     const { data } = body;
 
-    // 2FA required — return redirect info (password saved by caller via sessionStorage)
+    // 2FA required - return redirect info (password saved by caller via sessionStorage)
     if (data?.twoFactorRequired) {
       return {
         success: false,
@@ -85,10 +85,10 @@ export async function loginInNotes(username: string, password: string): Promise<
     // Clear stale session-expired banner from a previous session
     sessionExpired.set(false);
 
-    // Unlock E2E using the same password — avoids a second prompt
+    // Unlock E2E using the same password - avoids a second prompt
     const unlocked = await authStore.unlockE2E(password);
     if (!unlocked) {
-      // Credentials saved, but E2E failed — redirect to unlock page
+      // Credentials saved, but E2E failed - redirect to unlock page
       authStore.initialize();
       return { success: true };
     }
@@ -110,22 +110,32 @@ async function refreshAfterReauth(): Promise<void> {
     const { pullFromServer, refreshStoresAfterPull } = await import(
       '$lib/services/notes-sync.service'
     );
+    const { verifyAndRebuildLocalShadowIndexes } = await import(
+      '$lib/services/shadow-index-reconciler.service'
+    );
     const synced = await pullFromServer();
-    if (synced) await refreshStoresAfterPull();
+    if (synced) {
+      // Re-auth keeps IDB intact (offline-first), so any shadow-index drift
+      // from the previous unlock-race window sits across the reauth boundary.
+      // Run the reconciler before refreshing in-memory stores so the
+      // post-pull noteIndex rebuild sees corrected pinned/starred flags.
+      await verifyAndRebuildLocalShadowIndexes().catch(() => {});
+      await refreshStoresAfterPull();
+    }
   } catch {
-    // Non-blocking — re-auth succeeded even if sync fails.
+    // Non-blocking - re-auth succeeded even if sync fails.
     // User can trigger manual sync via SyncStatusFooter.
   }
 }
 
 /**
- * Re-authenticate after session expiry — password step.
+ * Re-authenticate after session expiry - password step.
  *
  * Calls /api/auth/login to obtain new tokens. Master key in CryptoManager is
  * preserved (E2E access kept across session-expiry events).
  *
  * If the account has 2FA enabled the endpoint returns `twoFactorRequired: true`
- * without an access token — we propagate that to the caller so the UI can
+ * without an access token - we propagate that to the caller so the UI can
  * collect a TOTP/recovery code and call {@link verifyTotpForReauth}.
  */
 export async function reAuthenticate(password: string): Promise<ReAuthResult> {
@@ -182,7 +192,7 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
 
   localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
 
-  // Credentials remain the same — touch to ensure they're still parseable
+  // Credentials remain the same - touch to ensure they're still parseable
   try {
     localStorage.setItem(CREDENTIALS_KEY, credentialsRaw);
   } catch {
@@ -195,7 +205,7 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
 }
 
 /**
- * Re-authenticate after session expiry — TOTP step (invoked from ReAuthModal
+ * Re-authenticate after session expiry - TOTP step (invoked from ReAuthModal
  * after {@link reAuthenticate} returned `two_factor_required`).
  */
 export async function verifyTotpForReauth(userId: string, code: string): Promise<ReAuthResult> {
@@ -224,7 +234,7 @@ export async function verifyTotpForReauth(userId: string, code: string): Promise
   }
 
   if (!res.ok || !body?.success) {
-    // The server returns 400 for invalid codes — treat as invalid_totp so the
+    // The server returns 400 for invalid codes - treat as invalid_totp so the
     // UI can show a code-specific error instead of the generic password one.
     if (res.status === 400) return { kind: 'invalid_totp' };
     return { kind: 'error', message: body?.error };

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -16,7 +16,7 @@ function readSource(relative: string): string {
   return readFileSync(resolve(__dirname, relative), 'utf-8');
 }
 
-describe('notes-sync — regression (offline data loss)', () => {
+describe('notes-sync - regression (offline data loss)', () => {
   it('pullFromServer does NOT clear local stores before fetching (BUG-2)', () => {
     const src = readSource('./notes-sync.service.ts');
     const pullFn = src.slice(
@@ -91,7 +91,7 @@ describe('notes-sync — regression (offline data loss)', () => {
       const match = signature.exec(src);
       expect(match, `signature not found: ${signature}`).not.toBeNull();
       const start = match!.index;
-      // Scan only the next ~600 chars — long enough for the wrapper, short
+      // Scan only the next ~600 chars - long enough for the wrapper, short
       // enough to avoid crossing into the next function.
       const body = src.slice(start, start + 600);
       expect(body, `${signature} must call serializePerEntity('${type}', …)`).toMatch(
@@ -243,7 +243,7 @@ describe('notes-sync — regression (offline data loss)', () => {
   it('pushPendingItems pushes folders BFS-by-layer (parent before child)', () => {
     // Server's POST /api/folders FK-checks parent_id and 404s if the parent
     // isn't on the server yet. Flat Promise.allSettled would 404-spam mid-batch
-    // on nested vault imports — pushPendingItems must use buildFolderLayers
+    // on nested vault imports - pushPendingItems must use buildFolderLayers
     // and await each layer before starting the next.
     const src = readSource('./notes-sync.service.ts');
     const fn = src.slice(
@@ -279,7 +279,7 @@ describe('notes-sync — regression (offline data loss)', () => {
   it('importJsonBackup defers all pushes to pushPendingItems (ordering)', () => {
     // Production reproduction: backup with 7 folders + 85 notes triggered ~25
     // simultaneous "POST /api/notes 404 Folder not found" errors during import
-    // because per-loop fire-and-forget pushFolder/pushNote raced — notes POST
+    // because per-loop fire-and-forget pushFolder/pushNote raced - notes POST
     // reached the server before their parent folder POST completed, the
     // server's FK check missed the folder, and 404 came back. pushPendingItems
     // already runs `Promise.allSettled([folders + tags]) → Promise.allSettled
@@ -293,7 +293,7 @@ describe('notes-sync — regression (offline data loss)', () => {
     expect(importEnd).toBeGreaterThan(importStart);
     const importBody = src.slice(importStart, importEnd);
 
-    // No per-element pushFolder/pushTag/pushNote in importJsonBackup — all
+    // No per-element pushFolder/pushTag/pushNote in importJsonBackup - all
     // imports save with sync_status='pending' and rely on pushPendingItems.
     expect(importBody).not.toMatch(/\bpushFolder\s*\(/);
     expect(importBody).not.toMatch(/\bpushTag\s*\(/);
@@ -324,7 +324,7 @@ describe('notes-sync — regression (offline data loss)', () => {
       /TagService\.createTag\([^)]*\{\s*skipSync:\s*true\s*\}\s*\)/
     );
 
-    // No direct pushNote/pushFolder/pushTag calls inside importFolder —
+    // No direct pushNote/pushFolder/pushTag calls inside importFolder -
     // pushPendingItems() is the single push path so order is enforced.
     const importFolder = src.slice(importFolderStart);
     expect(importFolder).not.toMatch(/\bpushNote\s*\(/);
@@ -339,7 +339,7 @@ describe('notes-sync — regression (offline data loss)', () => {
     // The schema requires user_id to be a UUID; the importer always
     // overwrites it with the current account's userId on save. Setting it
     // before validation (instead of after) makes legacy backups with
-    // null/missing/invalid user_id pass — the value from the file is dead
+    // null/missing/invalid user_id pass - the value from the file is dead
     // weight we don't use. See guideline 44.
     const src = readSource('./export-import.service.ts');
 
@@ -372,7 +372,7 @@ describe('notes-sync — regression (offline data loss)', () => {
     for (const fnName of ['pullFolders', 'pullTags', 'pullNotes']) {
       const start = src.indexOf(`async function ${fnName}`);
       expect(start, `${fnName} not found`).toBeGreaterThan(-1);
-      // Bound the function body — stop at the next top-level `async function`
+      // Bound the function body - stop at the next top-level `async function`
       // or the push-helpers section header.
       const after = src.slice(start);
       const nextFnIdx = after.indexOf('\nasync function ', 1);
@@ -454,5 +454,51 @@ describe('notes-sync — regression (offline data loss)', () => {
         /userId/
       );
     }
+  });
+
+  it('pullNotes routes shadow-index decoding through extractShadowIndexes and skips save on throw', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const pullNotes = src.slice(
+      src.indexOf('async function pullNotes'),
+      src.indexOf('// ── Push helpers')
+    );
+    // Must call the typed helper, not an inline cryptoManager.decryptObject. The
+    // inline pattern was the original silent-default trap that wrote is_pinned:
+    // false / is_starred: false on transient crypto-not-ready.
+    expect(pullNotes).toMatch(/extractShadowIndexes\s*\(/);
+    expect(pullNotes).not.toMatch(/cryptoManager\.decryptObject<NoteSensitiveMetadata>/);
+
+    // The catch block following extractShadowIndexes must skip the noteStore.save
+    // for this iteration (return from the map callback). Anchor on the actual
+    // call expression (not a comment mention) and look for try/catch/return.
+    const callMatch = /await\s+extractShadowIndexes\s*\(/.exec(pullNotes);
+    expect(callMatch).not.toBeNull();
+    const window = pullNotes.slice(callMatch!.index, callMatch!.index + 600);
+    expect(window).toMatch(/catch\s*\(/);
+    expect(window).toMatch(/return;/);
+  });
+
+  it('post-pull reconciler runs in +layout.svelte runSync and onMount paths', () => {
+    const layout = readSource('../../routes/+layout.svelte');
+    expect(layout).toMatch(/from '\$lib\/services\/shadow-index-reconciler\.service'/);
+    // Both sync paths (the $effect runSync and the onMount fallback) must call
+    // the reconciler when pullFromServer returned synced=true. We check that the
+    // reconciler symbol appears at least twice after the pullFromServer wiring.
+    const calls = [...layout.matchAll(/verifyAndRebuildLocalShadowIndexes\s*\(/g)];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('post-reauth path runs the reconciler before refreshing in-memory stores', () => {
+    const src = readSource('./notes-auth.service.ts');
+    const refresh = src.slice(
+      src.indexOf('async function refreshAfterReauth'),
+      src.indexOf('export async function reAuthenticate')
+    );
+    expect(refresh).toMatch(/verifyAndRebuildLocalShadowIndexes/);
+    const reconcileIdx = refresh.search(/verifyAndRebuildLocalShadowIndexes\s*\(/);
+    const refreshIdx = refresh.search(/refreshStoresAfterPull\s*\(/);
+    expect(reconcileIdx).toBeGreaterThan(-1);
+    expect(refreshIdx).toBeGreaterThan(-1);
+    expect(reconcileIdx).toBeLessThan(refreshIdx);
   });
 });

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -8,7 +8,7 @@
  *          If the call fails (offline / error), the item keeps sync_status='pending'
  *          in IndexedDB and will be retried on the next pull sync.
  *
- * The service is intentionally simple — no dedicated queue store, no complex
+ * The service is intentionally simple - no dedicated queue store, no complex
  * retry logic. Multi-device sync works by pulling from server on next app load.
  */
 import {
@@ -24,12 +24,12 @@ import {
 import type {
   NoteEncrypted,
   NoteStoredLocal,
-  NoteSensitiveMetadata,
   NoteHistoryEntry,
   FolderEncrypted,
   TagEncrypted
 } from '@reborn/types';
 import { cryptoManager } from '@reborn/crypto';
+import { extractShadowIndexes } from './shadow-index-extractor';
 import { get } from 'svelte/store';
 import { PUBLIC_BASE_PATH } from '$env/static/public';
 import { authStore } from '$lib/stores/auth.store';
@@ -69,7 +69,7 @@ function isNetworkError(e: unknown): boolean {
 
 /**
  * Central hook for any caught sync error. Hints the connectivity store whenever
- * the failure smells like a dead network — which `navigator.onLine` would
+ * the failure smells like a dead network - which `navigator.onLine` would
  * otherwise miss under an active VPN tunnel.
  */
 function reportSyncError(e: unknown): void {
@@ -86,7 +86,7 @@ function isAuthenticated(): boolean {
 /**
  * Rebuild in-memory indexes and refresh Svelte stores after a successful pull.
  *
- * `pullFromServer()` only writes to IndexedDB — the in-memory `noteIndex`,
+ * `pullFromServer()` only writes to IndexedDB - the in-memory `noteIndex`,
  * `foldersStore`, `tagsStore`, and `notesStore` remain stale until explicitly
  * refreshed. Call this after every successful pull to propagate changes to UI.
  */
@@ -100,7 +100,7 @@ export async function refreshStoresAfterPull(): Promise<void> {
   notesStore.refresh();
 }
 
-// ── Pull sync — server → IndexedDB ───────────────────────────────
+// ── Pull sync - server → IndexedDB ───────────────────────────────
 
 /**
  * Full pull sync: fetch all notes, folders, tags from server and upsert locally.
@@ -131,7 +131,7 @@ export async function pullFromServer(): Promise<boolean> {
   try {
     // NOTE: We intentionally do NOT clear local stores before pulling.
     // Each pull* helper merges by sync_version and skips items with
-    // sync_status='pending' — clearing would wipe offline edits that haven't
+    // sync_status='pending' - clearing would wipe offline edits that haven't
     // been pushed yet (observed data loss in offline → online transitions).
     // Cross-user cleanup is handled by clearAllUserData() during login/logout.
     await Promise.all([
@@ -164,7 +164,7 @@ export async function pullFromServer(): Promise<boolean> {
         await pullNoteVersions(noteIds).catch((e) => {
           reportSyncError(e);
           logger.error('Pull note versions failed:', e);
-          // Non-critical — don't set success=false
+          // Non-critical - don't set success=false
         });
       }
     }
@@ -193,7 +193,7 @@ export async function pullFromServer(): Promise<boolean> {
 async function pullFolders(): Promise<void> {
   // Capture userId once at the top. Without this guard, a logout (or auth
   // store hydration race) mid-pull would let a non-null assertion on the
-  // store's userId evaluate to undefined further down — silently writing
+  // store's userId evaluate to undefined further down - silently writing
   // user_id=undefined to IDB, which then propagates to every fresh export
   // and trips the import validator for that account. See guideline 44 +
   // `idb-cleanup.service.ts`.
@@ -215,10 +215,10 @@ async function pullFolders(): Promise<void> {
         sync_version?: number;
       }>
     ).map(async (f) => {
-      // Skip if local folder has pending changes — don't overwrite offline edits
+      // Skip if local folder has pending changes - don't overwrite offline edits
       const localFolder = await folderStore.get(f.id);
       if (localFolder && localFolder.sync_status === 'pending') {
-        logger.debug(`Skipping pull for folder ${f.id} — has pending local changes`);
+        logger.debug(`Skipping pull for folder ${f.id} - has pending local changes`);
         return;
       }
 
@@ -234,7 +234,7 @@ async function pullFolders(): Promise<void> {
             (localFolder.parent_id ?? null) !== (f.parent_id ?? null) ||
             localFolder.order_index !== f.order_index)
         ) {
-          logger.warn(`Reconciling orphaned folder edit ${f.id} — marking pending`);
+          logger.warn(`Reconciling orphaned folder edit ${f.id} - marking pending`);
           await folderStore.save({ ...localFolder, sync_status: 'pending' });
         }
         return;
@@ -257,7 +257,7 @@ async function pullFolders(): Promise<void> {
   );
 
   // Remove local folders that no longer exist on the server (deleted on another device).
-  // Only remove 'synced' items — 'pending' items were created/edited locally and not yet pushed.
+  // Only remove 'synced' items - 'pending' items were created/edited locally and not yet pushed.
   const serverFolderIds = new Set((data as Array<{ id: string }>).map((f) => f.id));
   const allLocalFolders = (await folderStore.getAll()) as FolderEncrypted[];
   const orphanIds = allLocalFolders
@@ -288,14 +288,14 @@ async function pullTags(): Promise<void> {
         sync_version?: number;
       }>
     ).map(async (t) => {
-      // Skip if local tag has pending changes — don't overwrite offline edits
+      // Skip if local tag has pending changes - don't overwrite offline edits
       const localTag = await tagStore.get(t.id);
       if (localTag && localTag.sync_status === 'pending') {
-        logger.debug(`Skipping pull for tag ${t.id} — has pending local changes`);
+        logger.debug(`Skipping pull for tag ${t.id} - has pending local changes`);
         return;
       }
 
-      // Compare sync_version — skip if server is not newer
+      // Compare sync_version - skip if server is not newer
       const serverVersion = t.sync_version ?? 1;
       if (localTag && serverVersion <= (localTag.sync_version ?? 0)) {
         // Reconciliation: see pullFolders() for rationale.
@@ -304,7 +304,7 @@ async function pullTags(): Promise<void> {
           (localTag.name_encrypted !== t.name_encrypted ||
             (localTag.color_encrypted ?? null) !== (t.color_encrypted ?? null))
         ) {
-          logger.warn(`Reconciling orphaned tag edit ${t.id} — marking pending`);
+          logger.warn(`Reconciling orphaned tag edit ${t.id} - marking pending`);
           await tagStore.save({ ...localTag, sync_status: 'pending' });
         }
         return;
@@ -359,10 +359,10 @@ async function pullNotes(): Promise<void> {
         sync_version?: number;
       }>
     ).map(async (n) => {
-      // Skip if local note has pending changes — don't overwrite offline edits
+      // Skip if local note has pending changes - don't overwrite offline edits
       const localNote = (await noteStore.get(n.id)) as NoteStoredLocal | undefined;
       if (localNote && localNote.sync_status === 'pending') {
-        logger.debug(`Skipping pull for note ${n.id} — has pending local changes`);
+        logger.debug(`Skipping pull for note ${n.id} - has pending local changes`);
         return;
       }
 
@@ -376,7 +376,7 @@ async function pullNotes(): Promise<void> {
         //   1. Old server deploys that didn't bump sync_version on soft-delete/restore.
         //   2. Rows where the server bumped but the client's pushNoteDelete/Restore
         //      response was dropped before we could mirror the new version locally.
-        // We only adjust is_archived here — content fields stay as they are so
+        // We only adjust is_archived here - content fields stay as they are so
         // local edits aren't clobbered.
         if (
           localNote.sync_status === 'synced' &&
@@ -398,33 +398,32 @@ async function pullNotes(): Promise<void> {
             (localNote.metadata_encrypted ?? null) !== (n.metadata_encrypted ?? null) ||
             (localNote.folder_id ?? null) !== (n.folder_id ?? null))
         ) {
-          logger.warn(`Reconciling orphaned note edit ${n.id} — marking pending`);
+          logger.warn(`Reconciling orphaned note edit ${n.id} - marking pending`);
           await noteStore.save({ ...localNote, sync_status: 'pending' });
         }
         return;
       }
 
-      // Rebuild shadow indexes from metadata_encrypted
-      let is_pinned = false;
-      let is_starred = false;
-      let metaTagIds: string[] = [];
+      // Rebuild shadow indexes from metadata_encrypted. extractShadowIndexes throws when
+      // cryptoManager isn't ready or AES-GCM rejects the ciphertext - in both cases we
+      // skip the save entirely instead of writing default `false/false` shadow indexes
+      // with a preserved ciphertext, which would be locked-in corruption (pull-side
+      // sync_version guard above would skip re-decrypt on every subsequent sync until
+      // the next logout+login wipes IDB). The next successful pull will retry.
+      let is_pinned: boolean;
+      let is_starred: boolean;
+      let metaTagIds: string[];
       try {
-        if (n.metadata_encrypted && cryptoManager.isInitialized()) {
-          const meta = await cryptoManager.decryptObject<NoteSensitiveMetadata>(
-            n.metadata_encrypted
-          );
-          is_pinned = meta.is_pinned ?? false;
-          is_starred = meta.is_starred ?? false;
-          metaTagIds = meta.tags ?? [];
-        }
-      } catch (decryptErr) {
-        // ERROR: metadata decryption failed — shadow indexes (is_pinned, is_starred, tags)
-        // will use defaults (false/empty). The note's metadata_encrypted is preserved for
-        // future retry on next pull. This may cause incorrect UI state until next successful decrypt.
-        logger.error(
-          `METADATA_DECRYPT_FAILED for note ${n.id} — shadow indexes may be incorrect`,
-          decryptErr
+        const shadow = await extractShadowIndexes(n.metadata_encrypted, cryptoManager);
+        is_pinned = shadow.is_pinned;
+        is_starred = shadow.is_starred;
+        metaTagIds = shadow.tagIds;
+      } catch (err) {
+        logger.warn(
+          `Skipping save of note ${n.id} - shadow indexes could not be derived. Will retry on next successful sync.`,
+          err
         );
+        return;
       }
 
       const note: NoteStoredLocal = {
@@ -481,7 +480,7 @@ async function pullNotes(): Promise<void> {
   }
 }
 
-// ── Push helpers — IndexedDB → server ────────────────────────────
+// ── Push helpers - IndexedDB → server ────────────────────────────
 
 /**
  * Push all locally-pending items (folders, tags, notes) to the server.
@@ -525,7 +524,7 @@ export async function pushPendingItems(): Promise<void> {
 
   // Push folders BFS-by-layer so parents land before children. Server's
   // POST /api/folders rejects with 404 "Parent folder not found" when
-  // parent_id references a folder not yet on the server — flat
+  // parent_id references a folder not yet on the server - flat
   // Promise.allSettled would 404-spam mid-batch on vault imports with
   // nested hierarchies. Siblings within a layer push in parallel.
   for (const layer of buildFolderLayers(pendingFolders)) {
@@ -562,7 +561,7 @@ export async function pushPendingItems(): Promise<void> {
     );
   }
 
-  // Tags don't reference folders — push in parallel after folders are
+  // Tags don't reference folders - push in parallel after folders are
   // settled. Notes' metadata_encrypted may embed tag ids, so tags must
   // land before the notes layer below.
   await Promise.allSettled(
@@ -691,7 +690,7 @@ async function pushSilently(fn: (idempotencyKey: string) => Promise<void>): Prom
  *
  * Without this, the browser can dispatch a POST /folders and a DELETE
  * /folders/{id} concurrently; if the network delivers DELETE first the folder
- * stays on the server after the POST — divergent from the empty local state.
+ * stays on the server after the POST - divergent from the empty local state.
  * The delete↔restore race for notes has the same shape.
  *
  * Different entities keep running in parallel. A chain entry clears itself
@@ -763,7 +762,7 @@ export function pushNote(note: NoteEncrypted | NoteStoredLocal): void {
       if (current) {
         const stillDirty = pushedFieldsDiffer(current, pushedFields);
         if (stillDirty) {
-          logger.debug(`Note ${note.id} changed during push — keeping sync_status=pending`);
+          logger.debug(`Note ${note.id} changed during push - keeping sync_status=pending`);
         }
         await noteStore.save({
           ...current,
@@ -801,7 +800,7 @@ export function pushNoteUpdate(
       if (current) {
         const stillDirty = pushedFieldsDiffer(current, fields);
         if (stillDirty) {
-          logger.debug(`Note ${id} changed during push — keeping sync_status=pending`);
+          logger.debug(`Note ${id} changed during push - keeping sync_status=pending`);
         }
         await noteStore.save({
           ...current,
@@ -827,19 +826,19 @@ export function pushNoteDelete(id: string, permanent = false): void {
       // Server bumps sync_version on soft-delete (since rule 11.e) and returns
       // the new value. We MUST mirror it locally, otherwise the next pull sees
       // server=N+1 vs local=N and re-applies the archive state we already have
-      // — harmless but churn. More importantly, future pushes would operate on
+      // - harmless but churn. More importantly, future pushes would operate on
       // stale sync_version and look like conflicts.
       let serverSyncVersion: number | undefined;
       try {
         const body = await res.json();
         serverSyncVersion = body?.data?.sync_version;
       } catch {
-        // Old server deploy — no body. Leave sync_version untouched.
+        // Old server deploy - no body. Leave sync_version untouched.
       }
 
       // Intent-check: if the user restored the note while DELETE was in flight,
       // `current.is_archived` will be false. Marking 'synced' would strand the
-      // local restore — chain a pushNoteRestore instead. See guideline 36 rule 11.b.
+      // local restore - chain a pushNoteRestore instead. See guideline 36 rule 11.b.
       const current = await noteStore.get(id);
       if (!current) return;
       if (current.is_archived) {
@@ -849,7 +848,7 @@ export function pushNoteDelete(id: string, permanent = false): void {
           sync_version: serverSyncVersion ?? current.sync_version
         });
       } else {
-        logger.debug(`Note ${id} restored during delete push — chaining restore`);
+        logger.debug(`Note ${id} restored during delete push - chaining restore`);
         await noteStore.save({
           ...current,
           sync_status: 'pending',
@@ -877,7 +876,7 @@ export function pushNoteRestore(id: string): void {
         const body = await res.json();
         serverSyncVersion = body?.data?.sync_version;
       } catch {
-        // Old server deploy — no body.
+        // Old server deploy - no body.
       }
 
       // Intent-check: if the user re-archived the note while /restore was in
@@ -891,7 +890,7 @@ export function pushNoteRestore(id: string): void {
           sync_version: serverSyncVersion ?? current.sync_version
         });
       } else {
-        logger.debug(`Note ${id} re-archived during restore push — chaining delete`);
+        logger.debug(`Note ${id} re-archived during restore push - chaining delete`);
         await noteStore.save({
           ...current,
           sync_status: 'pending',
@@ -933,7 +932,7 @@ export function pushFolder(
       if (current) {
         const stillDirty = pushedFieldsDiffer(current, pushedFields);
         if (stillDirty) {
-          logger.debug(`Folder ${folder.id} changed during push — keeping sync_status=pending`);
+          logger.debug(`Folder ${folder.id} changed during push - keeping sync_status=pending`);
         }
         await folderStore.save({
           ...current,
@@ -963,7 +962,7 @@ export function pushFolderUpdate(
       if (current) {
         const stillDirty = pushedFieldsDiffer(current, fields);
         if (stillDirty) {
-          logger.debug(`Folder ${id} changed during push — keeping sync_status=pending`);
+          logger.debug(`Folder ${id} changed during push - keeping sync_status=pending`);
         }
         await folderStore.save({
           ...current,
@@ -985,7 +984,7 @@ export function pushFolderDelete(id: string): void {
       if (!res.ok) throw new Error(`DELETE /api/folders/${id}: ${res.status}`);
       // Folder is hard-deleted locally before this runs (see folder.service.ts
       // deleteFolder), so there is nothing to reconcile. We deliberately do NOT
-      // resurrect the row and clobber sync_version the way the old code did —
+      // resurrect the row and clobber sync_version the way the old code did -
       // that broke conflict detection on the rare in-flight re-sync path.
     })
   );
@@ -1020,7 +1019,7 @@ export function pushTag(tag: {
       if (current) {
         const stillDirty = pushedFieldsDiffer(current, pushedFields);
         if (stillDirty) {
-          logger.debug(`Tag ${tag.id} changed during push — keeping sync_status=pending`);
+          logger.debug(`Tag ${tag.id} changed during push - keeping sync_status=pending`);
         }
         await tagStore.save({
           ...current,
@@ -1050,7 +1049,7 @@ export function pushTagUpdate(
       if (current) {
         const stillDirty = pushedFieldsDiffer(current, fields);
         if (stillDirty) {
-          logger.debug(`Tag ${id} changed during push — keeping sync_status=pending`);
+          logger.debug(`Tag ${id} changed during push - keeping sync_status=pending`);
         }
         await tagStore.save({
           ...current,
@@ -1071,7 +1070,7 @@ export function pushTagDelete(id: string): void {
       });
       if (!res.ok) throw new Error(`DELETE /api/tags/${id}: ${res.status}`);
       // Tag is hard-deleted locally before this runs (see tag.service.ts
-      // deleteTag), so there is nothing to reconcile. No sync_version reset —
+      // deleteTag), so there is nothing to reconcile. No sync_version reset -
       // that's the same bug we removed from pushFolderDelete.
     })
   );

--- a/apps/reborn-notes/src/lib/services/shadow-index-extractor.spec.ts
+++ b/apps/reborn-notes/src/lib/services/shadow-index-extractor.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  extractShadowIndexes,
+  CryptoNotReadyError,
+  type ShadowIndexCryptoBackend
+} from './shadow-index-extractor';
+
+function makeCrypto(opts: {
+  ready: boolean;
+  decrypt?: () => Promise<unknown>;
+}): ShadowIndexCryptoBackend {
+  return {
+    isInitialized: () => opts.ready,
+    decryptObject: opts.decrypt
+      ? (vi.fn(opts.decrypt) as ShadowIndexCryptoBackend['decryptObject'])
+      : vi.fn().mockRejectedValue(new Error('unexpected decryptObject call'))
+  };
+}
+
+describe('extractShadowIndexes', () => {
+  it('throws CryptoNotReadyError when crypto manager is not initialized', async () => {
+    const crypto = makeCrypto({ ready: false });
+    await expect(extractShadowIndexes('iv:cipher', crypto)).rejects.toBeInstanceOf(
+      CryptoNotReadyError
+    );
+  });
+
+  it('propagates the error thrown by decryptObject', async () => {
+    const crypto = makeCrypto({
+      ready: true,
+      decrypt: async () => {
+        throw new Error('OperationError');
+      }
+    });
+    await expect(extractShadowIndexes('iv:cipher', crypto)).rejects.toThrow('OperationError');
+  });
+
+  it('returns defaults only when metadata_encrypted is null/empty (backward-compat)', async () => {
+    const crypto = makeCrypto({ ready: true });
+    for (const empty of [null, undefined, '']) {
+      const result = await extractShadowIndexes(empty as string | null | undefined, crypto);
+      expect(result).toEqual({ is_pinned: false, is_starred: false, tagIds: [] });
+    }
+    expect(crypto.decryptObject).not.toHaveBeenCalled();
+  });
+
+  it('returns decoded fields with sensible defaults for missing keys', async () => {
+    const crypto = makeCrypto({
+      ready: true,
+      decrypt: async () => ({ is_pinned: true, is_starred: false, tags: ['t1', 't2'] })
+    });
+    const result = await extractShadowIndexes('iv:cipher', crypto);
+    expect(result).toEqual({ is_pinned: true, is_starred: false, tagIds: ['t1', 't2'] });
+
+    const cryptoNoTags = makeCrypto({
+      ready: true,
+      decrypt: async () => ({})
+    });
+    const empty = await extractShadowIndexes('iv:cipher', cryptoNoTags);
+    expect(empty).toEqual({ is_pinned: false, is_starred: false, tagIds: [] });
+  });
+});

--- a/apps/reborn-notes/src/lib/services/shadow-index-extractor.ts
+++ b/apps/reborn-notes/src/lib/services/shadow-index-extractor.ts
@@ -1,0 +1,58 @@
+import type { NoteSensitiveMetadata } from '@reborn/types';
+
+export interface ShadowIndexes {
+  is_pinned: boolean;
+  is_starred: boolean;
+  tagIds: string[];
+}
+
+/**
+ * Minimal crypto surface used by the shadow-index extractor. Keeping this
+ * narrow lets the extractor be unit-tested without pulling in the full
+ * `@reborn/crypto` package (WASM, IDB key store, key event subsystem).
+ */
+export interface ShadowIndexCryptoBackend {
+  isInitialized(): boolean;
+  decryptObject<T>(value: string): Promise<T>;
+}
+
+export class CryptoNotReadyError extends Error {
+  constructor() {
+    super('crypto-not-ready');
+    this.name = 'CryptoNotReadyError';
+  }
+}
+
+/**
+ * Decrypt the metadata_encrypted bundle into shadow indexes (is_pinned,
+ * is_starred, tag ids). Throws on the two transient failure modes:
+ *
+ *   1. `cryptoManager` not yet initialized when the call lands (race during
+ *      login/unlock or cross-app key event), and
+ *   2. AES-GCM rejecting the ciphertext (wrong key, corrupted IV).
+ *
+ * Callers MUST catch and skip the IDB write. Silently writing defaults of
+ * `false/false` here would lock the shadow indexes into a corrupted state:
+ * the `sync_version` guard in `pullNotes` skips re-decrypt on subsequent
+ * pulls, so only a full logout+login (which clears IDB) would recover.
+ *
+ * The single non-throwing branch is `metadata_encrypted == null/empty` -
+ * backward-compat for very old notes created before the bundle existed.
+ */
+export async function extractShadowIndexes(
+  metadata_encrypted: string | undefined | null,
+  crypto: ShadowIndexCryptoBackend
+): Promise<ShadowIndexes> {
+  if (!metadata_encrypted) {
+    return { is_pinned: false, is_starred: false, tagIds: [] };
+  }
+  if (!crypto.isInitialized()) {
+    throw new CryptoNotReadyError();
+  }
+  const meta = await crypto.decryptObject<NoteSensitiveMetadata>(metadata_encrypted);
+  return {
+    is_pinned: meta.is_pinned ?? false,
+    is_starred: meta.is_starred ?? false,
+    tagIds: meta.tags ?? []
+  };
+}

--- a/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type NoteRow = {
+  id: string;
+  metadata_encrypted?: string;
+  is_pinned?: boolean;
+  is_starred?: boolean;
+};
+
+const cryptoState = {
+  initialized: true,
+  decryptImpl: vi.fn<(value: string) => Promise<unknown>>()
+};
+const noteRows: NoteRow[] = [];
+const tagRowsByNote: Map<string, string[]> = new Map();
+const saveSpy = vi.fn();
+const addTagSpy = vi.fn();
+const removeTagSpy = vi.fn();
+
+vi.mock('@reborn/crypto', () => ({
+  cryptoManager: {
+    isInitialized: () => cryptoState.initialized,
+    decryptObject: <T>(value: string) => cryptoState.decryptImpl(value) as Promise<T>
+  }
+}));
+
+vi.mock('@reborn/storage', () => ({
+  noteStore: {
+    getAll: async () => noteRows,
+    save: async (row: NoteRow) => {
+      saveSpy(row);
+      const idx = noteRows.findIndex((r) => r.id === row.id);
+      if (idx >= 0) noteRows[idx] = row;
+    }
+  },
+  noteTagQueries: {
+    getTagsForNote: async (noteId: string) => tagRowsByNote.get(noteId) ?? []
+  },
+  noteTagOperations: {
+    addTagToNote: async (noteId: string, tagId: string) => {
+      addTagSpy(noteId, tagId);
+      const existing = tagRowsByNote.get(noteId) ?? [];
+      if (!existing.includes(tagId)) tagRowsByNote.set(noteId, [...existing, tagId]);
+    },
+    removeTagFromNote: async (noteId: string, tagId: string) => {
+      removeTagSpy(noteId, tagId);
+      const existing = tagRowsByNote.get(noteId) ?? [];
+      tagRowsByNote.set(
+        noteId,
+        existing.filter((t) => t !== tagId)
+      );
+    }
+  }
+}));
+
+const { verifyAndRebuildLocalShadowIndexes } = await import('./shadow-index-reconciler.service');
+
+beforeEach(() => {
+  cryptoState.initialized = true;
+  cryptoState.decryptImpl = vi.fn();
+  noteRows.length = 0;
+  tagRowsByNote.clear();
+  saveSpy.mockReset();
+  addTagSpy.mockReset();
+  removeTagSpy.mockReset();
+});
+
+describe('verifyAndRebuildLocalShadowIndexes', () => {
+  it('rewrites shadow indexes when decrypted metadata disagrees with IDB', async () => {
+    noteRows.push({
+      id: 'note-a',
+      metadata_encrypted: 'iv:cipher',
+      is_pinned: false,
+      is_starred: false
+    });
+    cryptoState.decryptImpl.mockResolvedValue({
+      is_pinned: true,
+      is_starred: true,
+      tags: ['tag-1']
+    });
+
+    const result = await verifyAndRebuildLocalShadowIndexes();
+
+    expect(result).toEqual({ scanned: 1, reconciledNotes: 1, decryptFailed: 0 });
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'note-a', is_pinned: true, is_starred: true })
+    );
+    expect(addTagSpy).toHaveBeenCalledWith('note-a', 'tag-1');
+    expect(removeTagSpy).not.toHaveBeenCalled();
+  });
+
+  it('removes stale tag associations and adds new ones when metadata drifted', async () => {
+    noteRows.push({
+      id: 'note-b',
+      metadata_encrypted: 'iv:cipher',
+      is_pinned: true,
+      is_starred: false
+    });
+    tagRowsByNote.set('note-b', ['old-tag', 'shared-tag']);
+    cryptoState.decryptImpl.mockResolvedValue({
+      is_pinned: true,
+      is_starred: false,
+      tags: ['shared-tag', 'new-tag']
+    });
+
+    const result = await verifyAndRebuildLocalShadowIndexes();
+
+    expect(result.reconciledNotes).toBe(1);
+    expect(addTagSpy).toHaveBeenCalledWith('note-b', 'new-tag');
+    expect(removeTagSpy).toHaveBeenCalledWith('note-b', 'old-tag');
+    // is_pinned/is_starred match the IDB row, so noteStore.save must NOT run.
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('leaves IDB untouched when the metadata bundle cannot be decrypted', async () => {
+    noteRows.push({
+      id: 'note-c',
+      metadata_encrypted: 'iv:cipher',
+      is_pinned: false,
+      is_starred: false
+    });
+    cryptoState.decryptImpl.mockRejectedValue(new Error('OperationError'));
+
+    const result = await verifyAndRebuildLocalShadowIndexes();
+
+    expect(result).toEqual({ scanned: 1, reconciledNotes: 0, decryptFailed: 1 });
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(addTagSpy).not.toHaveBeenCalled();
+    expect(removeTagSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns a no-op early when the crypto manager is not initialized', async () => {
+    cryptoState.initialized = false;
+    noteRows.push({
+      id: 'note-d',
+      metadata_encrypted: 'iv:cipher',
+      is_pinned: false,
+      is_starred: false
+    });
+
+    const result = await verifyAndRebuildLocalShadowIndexes();
+
+    expect(result).toEqual({ scanned: 0, reconciledNotes: 0, decryptFailed: 0 });
+    expect(cryptoState.decryptImpl).not.toHaveBeenCalled();
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips notes without a metadata bundle without touching IDB', async () => {
+    noteRows.push({ id: 'legacy', metadata_encrypted: '', is_pinned: false, is_starred: false });
+    noteRows.push({ id: 'unset', is_pinned: false, is_starred: false });
+    cryptoState.decryptImpl.mockImplementation(async () => {
+      throw new Error('should not be called for empty metadata');
+    });
+
+    const result = await verifyAndRebuildLocalShadowIndexes();
+
+    expect(result).toEqual({ scanned: 2, reconciledNotes: 0, decryptFailed: 0 });
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(cryptoState.decryptImpl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.ts
+++ b/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.ts
@@ -1,0 +1,106 @@
+/**
+ * Post-unlock reconciliation of note shadow indexes.
+ *
+ * Background: `pullNotes()` in `notes-sync.service.ts` skips re-decrypting a
+ * note's metadata bundle whenever `serverVersion <= localNote.sync_version`,
+ * which means any IDB record left with corrupted shadow indexes (is_pinned /
+ * is_starred / tag associations defaulted to false because crypto wasn't
+ * ready during an earlier pull) is locked in: subsequent pulls cannot
+ * self-heal, only a full `clearAllUserData()` (logout+login) recovers.
+ *
+ * Phase 1 of the shadow-index unlock-race fix stops *new* corruption from
+ * landing. This reconciler is Phase 2: it walks `noteStore`, re-derives
+ * shadow indexes from `metadata_encrypted`, and rewrites the IDB row when
+ * the decrypted state disagrees with what we have stored. Designed to be
+ * called once per successful `unlockE2E()` / `reAuthenticate()` flow.
+ *
+ * Important: when AES-GCM rejects a row's ciphertext (wrong key, corrupted
+ * IV), we deliberately leave that row untouched. Overwriting shadow indexes
+ * for an undecryptable row would replace one broken state with another and
+ * potentially clobber a row whose ciphertext is fine but the key is wrong.
+ */
+import { noteStore, noteTagOperations, noteTagQueries } from '@reborn/storage';
+import type { NoteStoredLocal } from '@reborn/types';
+import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
+import { extractShadowIndexes } from './shadow-index-extractor';
+
+const logger = createLogger('Notes-ShadowReconciler');
+
+export interface ReconcileResult {
+  scanned: number;
+  reconciledNotes: number;
+  decryptFailed: number;
+}
+
+export async function verifyAndRebuildLocalShadowIndexes(): Promise<ReconcileResult> {
+  if (!cryptoManager.isInitialized()) {
+    logger.debug('Skipping reconcile - crypto manager not ready');
+    return { scanned: 0, reconciledNotes: 0, decryptFailed: 0 };
+  }
+
+  const allNotes = (await noteStore.getAll()) as NoteStoredLocal[];
+  let reconciledNotes = 0;
+  let decryptFailed = 0;
+
+  for (const note of allNotes) {
+    if (!note.metadata_encrypted) continue;
+
+    let is_pinned: boolean;
+    let is_starred: boolean;
+    let tagIds: string[];
+    try {
+      const shadow = await extractShadowIndexes(note.metadata_encrypted, cryptoManager);
+      is_pinned = shadow.is_pinned;
+      is_starred = shadow.is_starred;
+      tagIds = shadow.tagIds;
+    } catch (err) {
+      decryptFailed++;
+      logger.debug(`Decrypt failed for note ${note.id}, leaving shadow indexes untouched`, err);
+      continue;
+    }
+
+    const localPinned = !!note.is_pinned;
+    const localStarred = !!note.is_starred;
+    const currentTagIds = await noteTagQueries.getTagsForNote(note.id);
+    const toAdd = tagIds.filter((id) => !currentTagIds.includes(id));
+    const toRemove = currentTagIds.filter((id) => !tagIds.includes(id));
+
+    const pinnedDrift = localPinned !== is_pinned;
+    const starredDrift = localStarred !== is_starred;
+    const tagDrift = toAdd.length > 0 || toRemove.length > 0;
+
+    if (!pinnedDrift && !starredDrift && !tagDrift) continue;
+
+    if (pinnedDrift || starredDrift) {
+      await noteStore.save({ ...note, is_pinned, is_starred });
+    }
+    if (tagDrift) {
+      await Promise.all([
+        ...toAdd.map((tagId) =>
+          noteTagOperations
+            .addTagToNote(note.id, tagId)
+            .catch((e) => logger.warn(`Failed to add tag ${tagId} to note ${note.id}`, e))
+        ),
+        ...toRemove.map((tagId) =>
+          noteTagOperations
+            .removeTagFromNote(note.id, tagId)
+            .catch((e) => logger.warn(`Failed to remove tag ${tagId} from note ${note.id}`, e))
+        )
+      ]);
+    }
+    reconciledNotes++;
+  }
+
+  if (reconciledNotes > 0) {
+    logger.info(
+      `Reconciled ${reconciledNotes} shadow indexes after unlock (scanned ${allNotes.length}, decrypt-failed ${decryptFailed})`
+    );
+  } else {
+    logger.debug(
+      `No shadow-index drift found (scanned ${allNotes.length}, decrypt-failed ${decryptFailed})`
+    );
+  }
+
+  return { scanned: allNotes.length, reconciledNotes, decryptFailed };
+}

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
   import { notesStore } from '$lib/stores/notes.store';
   import { authStore } from '$lib/stores/auth.store';
   import { pullFromServer, pushPendingItems, refreshStoresAfterPull } from '$lib/services/notes-sync.service';
+  import { verifyAndRebuildLocalShadowIndexes } from '$lib/services/shadow-index-reconciler.service';
   import { noteIndex } from '$lib/services/note-index.svelte';
   import { cleanupNullFkFields } from '$lib/services/idb-cleanup.service';
   import { refreshPendingCount, isOnline, sessionExpired } from '$lib/stores/sync-status.store';
@@ -35,7 +36,7 @@
   let initTimeout = $state(false);
   let hasTriggeredInitialSync = $state(false);
 
-  // Auth guard — blocked until onMount finishes initialization (appReady).
+  // Auth guard - blocked until onMount finishes initialization (appReady).
   // Uses untrack on goto() to prevent reactive dependency on navigation result.
   $effect(() => {
     if (!browser || !appReady) return;
@@ -65,7 +66,7 @@
   });
 
   // Re-decrypt all stores when E2E key becomes available (e.g. after unlock/login flow).
-  // Also triggers pull from server — covers the case where onMount already ran
+  // Also triggers pull from server - covers the case where onMount already ran
   // before authentication completed (login → goto('/') stays within the same SPA session).
   $effect(() => {
     if (!browser || !$authStore.hasE2E) return;
@@ -75,7 +76,7 @@
     const runSync = async () => {
       // Re-initialize storage if the connection was terminated
       // (e.g. user deleted IndexedDB in DevTools while the app was open).
-      // initializeStorage() is idempotent — safe to call unconditionally.
+      // initializeStorage() is idempotent - safe to call unconditionally.
       if (!isDatabaseInitialized()) {
         await initializeStorage('notes');
       }
@@ -90,11 +91,18 @@
       // Build NoteIndex FIRST (in parallel with folders/tags), then refresh notesStore
       await Promise.all([foldersStore.refresh(), tagsStore.refresh(), noteIndex.build()]);
       notesStore.refresh();
-      // Push pending offline edits BEFORE pull — otherwise pullFromServer's
+      // Push pending offline edits BEFORE pull - otherwise pullFromServer's
       // version checks could mask unsynced local changes on the next write.
       await pushPendingItems().catch(() => {});
       const synced = await pullFromServer();
       if (synced) {
+        // Repair any shadow-index drift from earlier pulls where crypto wasn't
+        // ready when metadata_encrypted was decoded. sync_version guard in
+        // pullNotes hides this corruption forever otherwise; run before the
+        // post-pull refresh so the rebuilt noteIndex sees the fixed rows.
+        await verifyAndRebuildLocalShadowIndexes().catch((err) =>
+          logger.warn('Shadow-index reconcile failed', err)
+        );
         await refreshStoresAfterPull();
       }
     };
@@ -105,7 +113,7 @@
   onMount(() => {
     if (!browser) return;
 
-    // Timeout fallback — show app even if initialization stalls (e.g. slow IndexedDB)
+    // Timeout fallback - show app even if initialization stalls (e.g. slow IndexedDB)
     const timeoutId = setTimeout(() => {
       initTimeout = true;
     }, 2000);
@@ -128,43 +136,49 @@
       }
 
       // 2a. Initialize SSO auth state AFTER storage is ready and BEFORE the
-      //     cleanup migration — cleanup repairs malformed user_id in legacy
+      //     cleanup migration - cleanup repairs malformed user_id in legacy
       //     local records, which needs the current account's UUID.
       //     (reads shared localStorage from reborn-task if same origin)
       authStore.initialize();
 
       // 2b. One-shot cleanup of legacy null FK fields + malformed user_id in
-      //     IDB. Idempotent and gated by a versioned localStorage flag — runs
+      //     IDB. Idempotent and gated by a versioned localStorage flag - runs
       //     once per browser profile per migration version. Awaited so it
       //     completes before sync touches the same records. Bounded by local
       //     IDB size (typically <1s). Re-runs on next boot if user_id repair
       //     was skipped because auth wasn't ready.
       await cleanupNullFkFields(get(authStore).userId);
 
-      // 4. Mark app as ready — unblocks auth guard $effect
+      // 4. Mark app as ready - unblocks auth guard $effect
       appReady = true;
 
       // Refresh stores now that the database is initialized
       await Promise.all([foldersStore.refresh(), tagsStore.refresh()]);
 
-      // Pull sync from server (if authenticated and E2E unlocked) — then refresh local stores
+      // Pull sync from server (if authenticated and E2E unlocked) - then refresh local stores
       if ($authStore.isAuthenticated && $authStore.hasE2E) {
         hasTriggeredInitialSync = true; // prevent $effect from duplicating pull
         // Build NoteIndex in parallel with folders/tags (data already in IndexedDB from init above)
         await noteIndex.build();
         notesStore.refresh();
-        // Push pending offline edits BEFORE pull — guarantees local unsynced
+        // Push pending offline edits BEFORE pull - guarantees local unsynced
         // changes reach the server before we merge the remote state in.
         pushPendingItems()
           .catch(() => {})
           .then(() => pullFromServer())
           .then(async (synced) => {
             if (synced) {
+              // See $effect runSync above for why shadow-index reconcile runs
+              // here too: cold-start unlock with corrupted IDB rows from a
+              // previous session needs the same self-healing path.
+              await verifyAndRebuildLocalShadowIndexes().catch((err) =>
+                logger.warn('Shadow-index reconcile failed', err)
+              );
               await refreshStoresAfterPull();
             }
           })
           .catch(() => {
-            /* offline — local data remains */
+            /* offline - local data remains */
           });
       }
 
@@ -179,7 +193,7 @@
         try {
           await syncedSettings.pullAndMerge();
         } catch (err: unknown) {
-          logger.warn('Synced settings pull failed — falling back to local IDB', err);
+          logger.warn('Synced settings pull failed - falling back to local IDB', err);
         }
       }
 
@@ -247,7 +261,7 @@
   // Visual-viewport tracker: when the soft keyboard opens on iOS Safari, the
   // layout viewport doesn't shrink (100dvh stays full size) and Safari may
   // "page-shift" the layout viewport upward to keep the focused contenteditable
-  // visible — pushing our sticky header above the visible area. Mirror the
+  // visible - pushing our sticky header above the visible area. Mirror the
   // current visualViewport state into CSS vars so the mobile note panel can
   // size itself to vv.height and counter-translate by vv.offsetTop, keeping
   // the header anchored to the top of the visible area regardless of caret
@@ -262,7 +276,7 @@
       if (document.body.scrollTop !== 0) document.body.scrollTop = 0;
 
       if (!vv) return;
-      // Round to integers — sub-pixel jitter from iOS during scroll causes
+      // Round to integers - sub-pixel jitter from iOS during scroll causes
       // useless reflows.
       const h = Math.round(vv.height);
       const offsetTop = Math.round(vv.offsetTop);


### PR DESCRIPTION
The pullNotes() decoder used to silently fall back to is_pinned: false / is_starred: false whenever cryptoManager wasn't ready or AES-GCM rejected the ciphertext, then wrote the note back to IDB with the original metadata_encrypted intact. The sync_version guard above the decode step prevented every subsequent pull from re-decoding, so the corruption sat in IDB until the next logout+login wiped the database.

Phase 1 extracts the decoder into shadow-index-extractor.ts which throws CryptoNotReadyError on isInitialized() === false and propagates errors from decryptObject. The pullNotes call-site catches and returns from the map callback (skipping the save), so the next successful pull can retry without a corrupted intermediate state. Empty/null metadata_encrypted still returns defaults for backward compat with pre-bundle notes.

Phase 2 adds shadow-index-reconciler.service.ts with verifyAndRebuildLocalShadowIndexes(), which walks noteStore.getAll(), re-derives shadow indexes from metadata_encrypted, and rewrites the IDB row when the decoded state disagrees with the stored is_pinned / is_starred / tag associations. Rows whose ciphertext can't be decrypted are left untouched so we don't replace one broken state with another. The reconciler runs after pullFromServer in both +layout.svelte sync paths and in refreshAfterReauth() so existing corruption from earlier sessions self-heals after the next login or session refresh.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>