### PR TITLE
fix(notes): refresh open note view after pull sync

### DIFF
--- a/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
@@ -84,6 +84,21 @@ class NoteDetailService {
     this.startCheckpointTimer();
   }
 
+  /** Re-read the currently open note from storage after pull sync; bails when the user has unsaved edits so their work wins. */
+  async refreshFromStorage(): Promise<void> {
+    const id = this.noteId;
+    if (!id) return;
+    if (this.hasPendingChanges() || this.saveStatus === 'saving') return;
+
+    const note = await notesStore.loadNote(id);
+    if (!note) return;
+
+    if (this.title !== note.title) this.title = note.title;
+    if (this.content !== note.content) this.content = note.content;
+    const folderId = note.folder_id ?? null;
+    if (this.folderId !== folderId) this.folderId = folderId;
+  }
+
   /**
    * Set title with debounce. Captures value synchronously.
    */

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -501,4 +501,40 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(refreshIdx).toBeGreaterThan(-1);
     expect(reconcileIdx).toBeLessThan(refreshIdx);
   });
+
+  it('refreshStoresAfterPull propagates fresh content to the open note detail view', () => {
+    // Without this hop, the sidebar's noteIndex rebuilds with server data but
+    // noteDetailService keeps the stale title/content snapshot taken at
+    // loadNote() time, so Preview/Edit of the currently open note keeps
+    // rendering pre-sync content until the user navigates away and back.
+    const src = readSource('./notes-sync.service.ts');
+    const refreshFn = src.slice(
+      src.indexOf('export async function refreshStoresAfterPull'),
+      src.indexOf('// ── Pull sync')
+    );
+    expect(refreshFn).toMatch(
+      /import\s*\(\s*['"]\$lib\/services\/note-detail\.service\.svelte['"]\s*\)/
+    );
+    expect(refreshFn).toMatch(/noteDetailService\.refreshFromStorage\s*\(/);
+  });
+
+  it('noteDetailService.refreshFromStorage guards against clobbering unsaved edits', () => {
+    // A pull that lands while the user is mid-edit must NOT overwrite their
+    // in-progress title/content - hasPendingChanges() and saveStatus==='saving'
+    // both must short-circuit the refresh.
+    const src = readSource('./note-detail.service.svelte.ts');
+    const methodIdx = src.indexOf('async refreshFromStorage');
+    expect(methodIdx).toBeGreaterThan(-1);
+    const methodEnd = src.indexOf('\n  }', methodIdx);
+    expect(methodEnd).toBeGreaterThan(methodIdx);
+    const method = src.slice(methodIdx, methodEnd);
+    expect(method).toMatch(/this\.hasPendingChanges\s*\(/);
+    expect(method).toMatch(/this\.saveStatus\s*===\s*['"]saving['"]/);
+    // No-op when no note is open - guards against unrelated pulls firing the
+    // hop after the user closed the editor.
+    expect(method).toMatch(/this\.noteId/);
+    // No-op when storage returns null (note deleted on another device) -
+    // detail view stays put; the deleted note will disappear from the sidebar.
+    expect(method).toMatch(/if\s*\(\s*!note\s*\)\s*return/);
+  });
 });

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -91,9 +91,11 @@ export async function refreshStoresAfterPull(): Promise<void> {
   const { foldersStore } = await import('$lib/stores/folders.store');
   const { tagsStore } = await import('$lib/stores/tags.store');
   const { notesStore } = await import('$lib/stores/notes.store');
+  const { noteDetailService } = await import('$lib/services/note-detail.service.svelte');
 
   await Promise.all([foldersStore.refresh(), tagsStore.refresh(), noteIndex.rebuild()]);
   notesStore.refresh();
+  await noteDetailService.refreshFromStorage();
 }
 
 // ── Pull sync - server → IndexedDB ───────────────────────────────


### PR DESCRIPTION
When two devices have the same note open and one edits + syncs, the other device's sidebar refreshed but the Preview/Edit view kept rendering the stale snapshot from loadNote() until the user navigated away and back. refreshStoresAfterPull() updated noteIndex/notesStore but had no propagation channel into noteDetailService.

Add refreshFromStorage() on NoteDetailService that re-reads the open note from IndexedDB and patches title/content/folderId. Guarded by hasPendingChanges() and saveStatus==='saving' so a pull that lands while the user is mid-edit cannot clobber their work. Call it at the tail of refreshStoresAfterPull() so every sync path (manual, online transition, periodic, re-auth, initial unlock) propagates the update.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>