### PR TITLE
fix(share): close manage dialog before opening create dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Built by [Reborn Foundation](https://reborn.org.pl) (Poland), a European non-pro
 - **Full-text search** with operators - `list:Inbox`, `due:<7d`, `is:overdue`, `has:link`, … ([reference](docs/search-operators.md))
 - **Trash & recovery** - restore deleted tasks within 30 days
 - **Import & export** - JSON backup and restore
-- **Read-only share links** - send a frozen snapshot of a task (with its subtasks) via an encrypted public URL; the snapshot key lives in the URL fragment so the server never sees it. Optional password, expiry, and view-count limit; revoke anytime.
+- **Read-only share links** - send a frozen snapshot of a task (with its subtasks) via an encrypted public URL; the snapshot key lives in the URL fragment so the server never sees it. Optional password, expiry, and view-count limit; revoke anytime ([blog post](https://reapps.eu/blog/sharing-notes-tasks-zero-knowledge-snapshots/)).
 
 ### re/notes - Encrypted notes & documents
 
@@ -63,7 +63,7 @@ Built by [Reborn Foundation](https://reborn.org.pl) (Poland), a European non-pro
 - **Full-text search** with operators - `tag:work`, `folder:projects/active`, `created:<7d`, `has:link`, `-tag:archived`, … ([reference](docs/search-operators.md))
 - **Trash & recovery** - safely delete and restore notes
 - **Import & export** - Markdown, JSON, or encrypted backup; import single `.md` files or entire folders with subfolders (e.g., an Obsidian vault) preserving directory structure
-- **Read-only share links** - publish a frozen snapshot of a note via an encrypted public URL; the snapshot key lives in the URL fragment so the server never sees it. Optional password, expiry, and view-count limit; revoke anytime.
+- **Read-only share links** - publish a frozen snapshot of a note via an encrypted public URL; the snapshot key lives in the URL fragment so the server never sees it. Optional password, expiry, and view-count limit; revoke anytime ([blog post](https://reapps.eu/blog/sharing-notes-tasks-zero-knowledge-snapshots/)).
 
 ### Shared features
 

--- a/apps/reborn-notes/src/lib/components/notes/NoteShareIndicator.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteShareIndicator.svelte
@@ -27,6 +27,11 @@
       onCreateNew?.();
     }
   }
+
+  function handleCreateNew() {
+    dialogOpen = false;
+    onCreateNew?.();
+  }
 </script>
 
 {#if noteId}
@@ -50,6 +55,6 @@
   </button>
 
   {#if count > 0}
-    <ManageSharesDialog bind:open={dialogOpen} sourceId={noteId} {onCreateNew} />
+    <ManageSharesDialog bind:open={dialogOpen} sourceId={noteId} onCreateNew={handleCreateNew} />
   {/if}
 {/if}

--- a/apps/reborn-task/src/lib/components/tasks/TaskShareIndicator.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/TaskShareIndicator.svelte
@@ -26,6 +26,11 @@
       onCreateNew?.();
     }
   }
+
+  function handleCreateNew() {
+    dialogOpen = false;
+    onCreateNew?.();
+  }
 </script>
 
 {#if taskId}
@@ -49,6 +54,6 @@
   </button>
 
   {#if count > 0}
-    <ManageSharesDialog bind:open={dialogOpen} sourceId={taskId} {onCreateNew} />
+    <ManageSharesDialog bind:open={dialogOpen} sourceId={taskId} onCreateNew={handleCreateNew} />
   {/if}
 {/if}


### PR DESCRIPTION
Both ManageSharesDialog and ShareNoteDialog/ShareTaskDialog used the same z-50 from bits-ui Dialog.Portal, so opening the create dialog from inside the manage dialog rendered it behind, with stacked overlays dimming the wrong layer. Close the manage dialog first instead - users can re-open it from the share indicator (count auto-updates after creation).

Also link the announcement blog post from the README share entries.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>