### PR TITLE
fix(notes): push pending content before delete for archived notes

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -276,6 +276,35 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(between).toMatch(/await\s+Promise\.allSettled/);
   });
 
+  it('pushPendingItems sends PATCH before DELETE for archived notes with server-side history', () => {
+    // Regression for the "orphaned note edit" pull-warn loop on archived
+    // notes (incident 2026-05-17, note 050a8227-bbfe-437e-b703-98f8ef7804bd):
+    // when a content PATCH push silently failed before the user archived the
+    // note, pushPendingItems used to send only DELETE, which doesn't carry
+    // ciphertext. Server kept stale ciphertext, pull's orphan-edit branch
+    // flagged the row pending again, push DELETE'd again, loop. The fix sends
+    // PATCH (via pushNoteUpdate) before DELETE (via pushNoteDelete), gated by
+    // sync_version > 0 so notes that never reached the server stay local-only.
+    const src = readSource('./notes-sync.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function pushPendingItems'),
+      src.indexOf('/** Retry a function with exponential backoff')
+    );
+
+    // Locate the archived-pending loop and assert it gates on sync_version.
+    const loopIdx = fn.search(/for\s*\(\s*const\s+n\s+of\s+pendingArchivedNotes\s*\)/);
+    expect(loopIdx).toBeGreaterThan(-1);
+    const loopBody = fn.slice(loopIdx);
+    expect(loopBody).toMatch(/n\.sync_version\s*\?\?\s*0\)?\s*>\s*0/);
+
+    // PATCH (pushNoteUpdate) must appear before DELETE (pushNoteDelete).
+    const patchIdx = loopBody.search(/pushNoteUpdate\s*\(/);
+    const deleteIdx = loopBody.search(/pushNoteDelete\s*\(/);
+    expect(patchIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeGreaterThan(-1);
+    expect(patchIdx).toBeLessThan(deleteIdx);
+  });
+
   it('importJsonBackup defers all pushes to pushPendingItems (ordering)', () => {
     // Production reproduction: backup with 7 folders + 85 notes triggered ~25
     // simultaneous "POST /api/notes 404 Folder not found" errors during import

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -628,12 +628,25 @@ export async function pushPendingItems(): Promise<void> {
     )
   );
 
-  // Retry archived-pending notes via DELETE (see partition comment above).
-  // pushNoteDelete is itself serialized per-entity, so if a POST for the same
-  // note is still in the chain (e.g. first-time create+archive), the DELETE
-  // waits for it to land.
+  // Retry archived-pending notes. For notes that exist on the server
+  // (sync_version > 0) we PATCH the content first, then DELETE. Without the
+  // PATCH, a row whose last update push silently failed before being archived
+  // keeps a server-side ciphertext that diverges from local - pull's orphan-
+  // edit reconciliation flags it forever (mark pending → push DELETE only →
+  // pull still sees drift → mark pending …) and "1 pending" wedges in the UI.
+  // pushNoteUpdate + pushNoteDelete are serialized per-entity, so DELETE waits
+  // for PATCH to land. Notes with sync_version === 0 never reached the server,
+  // so there is nothing to update or delete remotely - skip both.
   for (const n of pendingArchivedNotes) {
-    pushNoteDelete(n.id);
+    if ((n.sync_version ?? 0) > 0) {
+      pushNoteUpdate(n.id, {
+        title_encrypted: n.title_encrypted,
+        content_encrypted: n.content_encrypted,
+        folder_id: n.folder_id ?? null,
+        metadata_encrypted: n.metadata_encrypted ?? undefined
+      });
+      pushNoteDelete(n.id);
+    }
   }
 
   // Push pending note versions


### PR DESCRIPTION
When a content update push (PATCH) silently failed before the user archived a note, pushPendingItems used to retry only via DELETE, which carries no ciphertext. The server kept stale ciphertext, pull's orphan-edit reconciliation flagged the row pending again, push DELETE'd again - "1 pending" wedged in the UI indefinitely until the trash was emptied.

Now the archived-pending loop sends pushNoteUpdate before pushNoteDelete when sync_version > 0 (note exists on the server). Notes that never reached the server (sync_version === 0) skip both - nothing to sync. serializePerEntity guarantees PATCH lands before DELETE on the wire.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>