### PR TITLE
fix(notes,task): inject localized OG meta tags for shared link unfurls

### DIFF
--- a/apps/reborn-notes/src/hooks.server.ts
+++ b/apps/reborn-notes/src/hooks.server.ts
@@ -11,6 +11,7 @@ import {
   cleanupExpiredKeys,
   cleanupExpiredShares
 } from '@reborn/database';
+import { getShareOgStrings } from '$lib/server/share-og';
 
 const logger = createLogger('notes-hooks');
 
@@ -200,7 +201,23 @@ const shareCleanupHandle: Handle = async ({ event, resolve }) => {
 
 const SUPPORTED_LOCALES_SERVER = ['en', 'pl', 'de', 'es', 'fr'] as const;
 
-// Locale detection middleware
+const SHARE_PATH_PREFIX = `${BASE}/s/`;
+
+function escAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Locale detection middleware. Also injects OG / description meta tags for
+// the public share page (/s/<slug>) so link-unfurl bots (Signal, Slack,
+// Discord, iMessage) show a localized "End-to-end encrypted snapshot of a
+// note shared with you" preview. The bots fetch the URL with no cookies and
+// usually no Accept-Language, so we fall back to 'en' by default. SSR is
+// disabled app-wide (+layout.ts), so this transformPageChunk is the only
+// chance to put crawler-visible metadata into the response.
 const localeHandle: Handle = async ({ event, resolve }) => {
   const cookieLocale = event.cookies.get('locale');
   let locale = 'en';
@@ -220,8 +237,37 @@ const localeHandle: Handle = async ({ event, resolve }) => {
     }
   }
 
+  const isSharePage = event.url.pathname.startsWith(SHARE_PATH_PREFIX);
+
   return resolve(event, {
-    transformPageChunk: ({ html }) => html.replace('%lang%', locale)
+    transformPageChunk: ({ html }) => {
+      let out = html.replace('%lang%', locale);
+      if (!isSharePage) return out;
+
+      const og = getShareOgStrings(locale);
+      const ogImage = `${event.url.origin}${BASE}/icons/icon-512.png`;
+      const pageUrl = `${event.url.origin}${event.url.pathname}`;
+      const title = escAttr(og.title);
+      const description = escAttr(og.description);
+      const tags = [
+        `<meta name="description" content="${description}" />`,
+        `<meta property="og:title" content="${title}" />`,
+        `<meta property="og:description" content="${description}" />`,
+        `<meta property="og:type" content="website" />`,
+        `<meta property="og:url" content="${escAttr(pageUrl)}" />`,
+        `<meta property="og:image" content="${escAttr(ogImage)}" />`,
+        `<meta name="twitter:card" content="summary" />`,
+        `<meta name="twitter:title" content="${title}" />`,
+        `<meta name="twitter:description" content="${description}" />`
+      ].join('\n\t\t');
+
+      // Replace the static <title> from app.html with a share-specific one
+      // and append the OG/Twitter tags so unfurlers see a coherent card.
+      return out.replace(
+        '<title>re/notes</title>',
+        `<title>${title}</title>\n\t\t${tags}`
+      );
+    }
   });
 };
 

--- a/apps/reborn-notes/src/lib/components/notes/ManageSharesDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/ManageSharesDialog.svelte
@@ -50,6 +50,7 @@
   let urlsVisible = new SvelteSet<string>();
   let previewing = $state<SharedSnapshotNotePayload | null>(null);
   let previewOpen = $state(false);
+  let previewScrollEl = $state<HTMLDivElement | null>(null);
   let revoking = $state<string | null>(null);
 
   const storeState = $derived($sharesStore);
@@ -124,6 +125,10 @@
 
   $effect(() => {
     if (open) void sharesStore.refresh();
+  });
+
+  $effect(() => {
+    if (previewOpen && previewScrollEl) previewScrollEl.scrollTop = 0;
   });
 </script>
 
@@ -318,12 +323,18 @@
 </Dialog>
 
 <Dialog bind:open={previewOpen}>
-  <DialogContent class="flex max-h-[85vh] max-w-2xl flex-col gap-0 overflow-hidden p-0">
+  <DialogContent
+    class="flex max-h-[85vh] max-w-2xl flex-col gap-0 overflow-hidden p-0"
+    onOpenAutoFocus={(e) => e.preventDefault()}
+  >
     <DialogHeader class="flex-shrink-0 border-b px-6 py-4 pr-12">
       <DialogTitle>{$t('share.list.preview_dialog_title')}</DialogTitle>
     </DialogHeader>
     {#if previewing}
-      <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-6 py-4">
+      <div
+        bind:this={previewScrollEl}
+        class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-6 py-4"
+      >
         <NoteSnapshotView payload={previewing} />
         <p class="text-xs italic text-muted-foreground">{$t('share.list.preview_hint')}</p>
       </div>

--- a/apps/reborn-notes/src/lib/server/share-og.ts
+++ b/apps/reborn-notes/src/lib/server/share-og.ts
@@ -1,0 +1,44 @@
+// Server-side OG / meta strings for the public share page (/s/<slug>).
+//
+// Lives here (not in @reborn/i18n) because:
+//   - hooks.server.ts injects these via transformPageChunk, before any
+//     client-side JS runs. svelte-i18n is async and client-only.
+//   - The strings are never rendered by the in-app UI, so they don't need
+//     to flow through the normal $t() pipeline.
+//
+// Keep parity with the SUPPORTED_LOCALES_SERVER list in hooks.server.ts.
+// Strings match the wording of share.view.password_intro in the matching
+// notes/<locale>.json (same "End-to-end encrypted snapshot of a note ..." voice)
+// so unfurl previews and the in-app gate read consistently.
+
+type ShareOgStrings = {
+  title: string;
+  description: string;
+};
+
+const STRINGS: Record<string, ShareOgStrings> = {
+  en: {
+    title: 'Shared note - re/notes',
+    description: 'End-to-end encrypted snapshot of a note shared with you.'
+  },
+  pl: {
+    title: 'Udostępniona notatka - re/notes',
+    description: 'Udostępniony dla Ciebie snapshot notatki zaszyfrowany end-to-end.'
+  },
+  de: {
+    title: 'Geteilte Notiz - re/notes',
+    description: 'Ein Ende-zu-Ende-verschlüsselter Snapshot einer Notiz, der mit dir geteilt wurde.'
+  },
+  fr: {
+    title: 'Note partagée - re/notes',
+    description: "Un instantané chiffré de bout en bout d'une note partagée avec vous."
+  },
+  es: {
+    title: 'Nota compartida - re/notes',
+    description: 'Una instantánea cifrada de extremo a extremo de una nota compartida contigo.'
+  }
+};
+
+export function getShareOgStrings(locale: string): ShareOgStrings {
+  return STRINGS[locale] ?? STRINGS.en;
+}

--- a/apps/reborn-task/src/hooks.server.ts
+++ b/apps/reborn-task/src/hooks.server.ts
@@ -11,6 +11,7 @@ import {
 	cleanupExpiredKeys,
 	cleanupExpiredShares
 } from '@reborn/database';
+import { getShareOgStrings } from '$lib/server/share-og';
 
 const BASE = process.env.PUBLIC_BASE_PATH ?? '';
 const RATE_LIMITED_AUTH = new Set([
@@ -109,7 +110,23 @@ const authHandle: Handle = async ({ event, resolve }) => {
 
 const SUPPORTED_LOCALES_SERVER = ['en', 'pl', 'de', 'es', 'fr'] as const;
 
-// Locale detection middleware
+const SHARE_PATH_PREFIX = `${BASE}/s/`;
+
+function escAttr(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+// Locale detection middleware. Also injects OG / description meta tags for
+// the public share page (/s/<slug>) so link-unfurl bots (Signal, Slack,
+// Discord, iMessage) show a localized "End-to-end encrypted snapshot of a
+// task shared with you" preview. The bots fetch the URL with no cookies and
+// usually no Accept-Language, so we fall back to 'en' by default. SSR is
+// disabled app-wide (+layout.ts), so this transformPageChunk is the only
+// chance to put crawler-visible metadata into the response.
 const localeHandle: Handle = async ({ event, resolve }) => {
 	const cookieLocale = event.cookies.get('locale');
 	let locale = 'en';
@@ -129,8 +146,35 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 		}
 	}
 
+	const isSharePage = event.url.pathname.startsWith(SHARE_PATH_PREFIX);
+
 	return resolve(event, {
-		transformPageChunk: ({ html }) => html.replace('%lang%', locale)
+		transformPageChunk: ({ html }) => {
+			let out = html.replace('%lang%', locale);
+			if (!isSharePage) return out;
+
+			const og = getShareOgStrings(locale);
+			const ogImage = `${event.url.origin}${BASE}/icons/icon-512.png`;
+			const pageUrl = `${event.url.origin}${event.url.pathname}`;
+			const title = escAttr(og.title);
+			const description = escAttr(og.description);
+			const tags = [
+				`<meta name="description" content="${description}" />`,
+				`<meta property="og:title" content="${title}" />`,
+				`<meta property="og:description" content="${description}" />`,
+				`<meta property="og:type" content="website" />`,
+				`<meta property="og:url" content="${escAttr(pageUrl)}" />`,
+				`<meta property="og:image" content="${escAttr(ogImage)}" />`,
+				`<meta name="twitter:card" content="summary" />`,
+				`<meta name="twitter:title" content="${title}" />`,
+				`<meta name="twitter:description" content="${description}" />`
+			].join('\n\t\t');
+
+			return out.replace(
+				'<title>re/task</title>',
+				`<title>${title}</title>\n\t\t${tags}`
+			);
+		}
 	});
 };
 

--- a/apps/reborn-task/src/lib/components/tasks/ManageSharesDialog.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/ManageSharesDialog.svelte
@@ -47,6 +47,7 @@
   let urlsVisible = new SvelteSet<string>();
   let previewing = $state<SharedSnapshotTaskPayload | null>(null);
   let previewOpen = $state(false);
+  let previewScrollEl = $state<HTMLDivElement | null>(null);
   let revoking = $state<string | null>(null);
 
   const storeState = $derived($sharesStore);
@@ -118,6 +119,10 @@
 
   $effect(() => {
     if (open) void sharesStore.refresh();
+  });
+
+  $effect(() => {
+    if (previewOpen && previewScrollEl) previewScrollEl.scrollTop = 0;
   });
 </script>
 
@@ -312,12 +317,18 @@
 </Dialog>
 
 <Dialog bind:open={previewOpen}>
-  <DialogContent class="flex max-h-[85vh] max-w-2xl flex-col gap-0 overflow-hidden p-0">
+  <DialogContent
+    class="flex max-h-[85vh] max-w-2xl flex-col gap-0 overflow-hidden p-0"
+    onOpenAutoFocus={(e) => e.preventDefault()}
+  >
     <DialogHeader class="flex-shrink-0 border-b px-6 py-4 pr-12">
       <DialogTitle>{$t('share.list.preview_dialog_title')}</DialogTitle>
     </DialogHeader>
     {#if previewing}
-      <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-6 py-4">
+      <div
+        bind:this={previewScrollEl}
+        class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-6 py-4"
+      >
         <TaskSnapshotView payload={previewing} />
         <p class="text-xs italic text-muted-foreground">{$t('share.list.preview_hint')}</p>
       </div>

--- a/apps/reborn-task/src/lib/server/share-og.ts
+++ b/apps/reborn-task/src/lib/server/share-og.ts
@@ -1,0 +1,41 @@
+// Server-side OG / meta strings for the public share page (/s/<slug>).
+//
+// Lives here (not in @reborn/i18n) because:
+//   - hooks.server.ts injects these via transformPageChunk, before any
+//     client-side JS runs. svelte-i18n is async and client-only.
+//   - The strings are never rendered by the in-app UI, so they don't need
+//     to flow through the normal $t() pipeline.
+//
+// Keep parity with the SUPPORTED_LOCALES_SERVER list in hooks.server.ts.
+
+type ShareOgStrings = {
+  title: string;
+  description: string;
+};
+
+const STRINGS: Record<string, ShareOgStrings> = {
+  en: {
+    title: 'Shared task - re/task',
+    description: 'End-to-end encrypted snapshot of a task shared with you.'
+  },
+  pl: {
+    title: 'Udostępnione zadanie - re/task',
+    description: 'Udostępniony dla Ciebie snapshot zadania zaszyfrowany end-to-end.'
+  },
+  de: {
+    title: 'Geteilte Aufgabe - re/task',
+    description: 'Ein Ende-zu-Ende-verschlüsselter Snapshot einer Aufgabe, der mit dir geteilt wurde.'
+  },
+  fr: {
+    title: 'Tâche partagée - re/task',
+    description: "Un instantané chiffré de bout en bout d'une tâche partagée avec vous."
+  },
+  es: {
+    title: 'Tarea compartida - re/task',
+    description: 'Una instantánea cifrada de extremo a extremo de una tarea compartida contigo.'
+  }
+};
+
+export function getShareOgStrings(locale: string): ShareOgStrings {
+  return STRINGS[locale] ?? STRINGS.en;
+}


### PR DESCRIPTION
Public share pages had no description / OG / Twitter Card meta tags, so link-unfurl bots (Signal, Slack, Discord, iMessage) only rendered the favicon, app name and bare URL with no context about what the link is.

Extend localeHandle to detect /s/<slug> paths and inject a localized title, description, OG and Twitter Card meta tags via transformPageChunk. With ssr=false set app-wide in +layout.ts this is the only place where crawler-visible metadata can land in the response
- bots never run JS, so client-side <svelte:head> is invisible to them.

Strings live in apps/*/src/lib/server/share-og.ts (5 locales each, EN fallback) rather than @reborn/i18n because svelte-i18n is async and client-only, and the strings are never rendered by in-app UI - only emitted into the HTML shell for crawlers.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>