### PR TITLE
fix(notes,task): localize app-loading stall and offline banners

### DIFF
--- a/apps/reborn-notes/src/app.html
+++ b/apps/reborn-notes/src/app.html
@@ -42,10 +42,12 @@
 		     inline dark-mode script in <head> runs BEFORE this renders, so the
 		     .dark class is already set on <html> when the selectors below apply.
 		-->
-		<div id="app-loading">
+		<div id="app-loading"
+			data-stall-msg="%stall_msg%"
+			data-offline-msg="%offline_msg%">
 			<div class="app-loading__inner">
 				<div class="app-loading__spinner"></div>
-				<p>Loading re/notes...</p>
+				<p>%init_loading_msg%</p>
 			</div>
 		</div>
 		<style nonce="%sveltekit.nonce%">
@@ -93,17 +95,19 @@
 			(function(){
 				var el=document.getElementById('app-loading');
 				if(!el)return;
+				var stallMsg=el.dataset.stallMsg||'';
+				var offlineMsg=el.dataset.offlineMsg||'';
 				var offline=typeof navigator!=='undefined'&&!navigator.onLine;
 				// On iOS Safari PWA cold starts `navigator.serviceWorker.controller` is
 				// transiently null even when a service worker is registered and will
 				// soon take control, so the previous `!controller` probe produced a
 				// false "Brak połączenia" screen. Only fail fast when the browser has
-				// no Service Worker API at all — otherwise let the 15s stall timeout
+				// no Service Worker API at all - otherwise let the 15s stall timeout
 				// below decide.
 				var noSW=typeof navigator!=='undefined'&&!('serviceWorker' in navigator);
 				if(offline&&noSW){
 					el.querySelector('.app-loading__spinner').style.display='none';
-					el.querySelector('p').textContent='Brak połączenia z siecią. Połącz się i spróbuj ponownie.';
+					el.querySelector('p').textContent=offlineMsg;
 					return;
 				}
 				setTimeout(function(){
@@ -111,9 +115,9 @@
 						el.querySelector('.app-loading__spinner').style.display='none';
 						var p=el.querySelector('p');
 						if(navigator.onLine){
-							p.textContent='Ładowanie trwa dłużej niż zwykle. Spróbuj odświeżyć stronę.';
+							p.textContent=stallMsg;
 						}else{
-							p.textContent='Brak połączenia z siecią. Połącz się i spróbuj ponownie.';
+							p.textContent=offlineMsg;
 						}
 					}
 				},15000);

--- a/apps/reborn-notes/src/hooks.server.ts
+++ b/apps/reborn-notes/src/hooks.server.ts
@@ -12,6 +12,7 @@ import {
   cleanupExpiredShares
 } from '@reborn/database';
 import { getShareOgStrings } from '$lib/server/share-og';
+import { getAppLoadingStrings } from '$lib/server/app-loading-strings';
 
 const logger = createLogger('notes-hooks');
 
@@ -239,9 +240,18 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 
   const isSharePage = event.url.pathname.startsWith(SHARE_PATH_PREFIX);
 
+  const loading = getAppLoadingStrings(locale);
+  const initLoadingMsg = escAttr(loading.initLoading);
+  const stallMsg = escAttr(loading.stall);
+  const offlineMsg = escAttr(loading.offline);
+
   return resolve(event, {
     transformPageChunk: ({ html }) => {
-      let out = html.replace('%lang%', locale);
+      let out = html
+        .replace('%lang%', locale)
+        .replace('%init_loading_msg%', initLoadingMsg)
+        .replace('%stall_msg%', stallMsg)
+        .replace('%offline_msg%', offlineMsg);
       if (!isSharePage) return out;
 
       const og = getShareOgStrings(locale);

--- a/apps/reborn-notes/src/lib/server/app-loading-strings.ts
+++ b/apps/reborn-notes/src/lib/server/app-loading-strings.ts
@@ -1,0 +1,47 @@
+// Server-side strings for the pre-boot fallback in app.html.
+//
+// Lives here (not in @reborn/i18n) because:
+//   - hooks.server.ts injects these via transformPageChunk, before any
+//     client-side JS runs. svelte-i18n is async and client-only.
+//   - These strings are visible only during cold-start stall / offline-no-SW
+//     fallback, so they don't flow through the normal $t() pipeline.
+//
+// Keep parity with the SUPPORTED_LOCALES_SERVER list in hooks.server.ts.
+
+type AppLoadingStrings = {
+  initLoading: string; // <p>Loading re/notes...</p>
+  stall: string; // shown after 15s if app hasn't booted (online)
+  offline: string; // shown immediately when offline + no SW, or after 15s + offline
+};
+
+const STRINGS: Record<string, AppLoadingStrings> = {
+  en: {
+    initLoading: 'Loading re/notes...',
+    stall: 'Loading is taking longer than usual. Try refreshing the page.',
+    offline: 'No network connection. Reconnect and try again.'
+  },
+  pl: {
+    initLoading: 'Ładowanie re/notes...',
+    stall: 'Ładowanie trwa dłużej niż zwykle. Spróbuj odświeżyć stronę.',
+    offline: 'Brak połączenia z siecią. Połącz się i spróbuj ponownie.'
+  },
+  de: {
+    initLoading: 're/notes wird geladen...',
+    stall: 'Das Laden dauert länger als gewöhnlich. Versuche, die Seite neu zu laden.',
+    offline: 'Keine Netzwerkverbindung. Verbinde dich erneut und versuche es nochmals.'
+  },
+  fr: {
+    initLoading: 'Chargement de re/notes...',
+    stall: "Le chargement prend plus de temps que d'habitude. Essayez d'actualiser la page.",
+    offline: 'Pas de connexion réseau. Reconnectez-vous et réessayez.'
+  },
+  es: {
+    initLoading: 'Cargando re/notes...',
+    stall: 'La carga está tardando más de lo habitual. Intenta recargar la página.',
+    offline: 'Sin conexión de red. Reconéctate e inténtalo de nuevo.'
+  }
+};
+
+export function getAppLoadingStrings(locale: string): AppLoadingStrings {
+  return STRINGS[locale] ?? STRINGS.en;
+}

--- a/apps/reborn-task/src/app.html
+++ b/apps/reborn-task/src/app.html
@@ -32,10 +32,12 @@
 		     inline dark-mode script in <head> runs BEFORE this renders, so the
 		     .dark class is already set on <html> when the selectors below apply.
 		-->
-		<div id="app-loading">
+		<div id="app-loading"
+			data-stall-msg="%stall_msg%"
+			data-offline-msg="%offline_msg%">
 			<div class="app-loading__inner">
 				<div class="app-loading__spinner"></div>
-				<p>Loading re/task...</p>
+				<p>%init_loading_msg%</p>
 			</div>
 		</div>
 		<style nonce="%sveltekit.nonce%">
@@ -83,17 +85,19 @@
 			(function(){
 				var el=document.getElementById('app-loading');
 				if(!el)return;
+				var stallMsg=el.dataset.stallMsg||'';
+				var offlineMsg=el.dataset.offlineMsg||'';
 				var offline=typeof navigator!=='undefined'&&!navigator.onLine;
 				// On iOS Safari PWA cold starts `navigator.serviceWorker.controller` is
 				// transiently null even when a service worker is registered and will
 				// soon take control, so the previous `!controller` probe produced a
 				// false "Brak połączenia" screen. Only fail fast when the browser has
-				// no Service Worker API at all — otherwise let the 15s stall timeout
+				// no Service Worker API at all - otherwise let the 15s stall timeout
 				// below decide.
 				var noSW=typeof navigator!=='undefined'&&!('serviceWorker' in navigator);
 				if(offline&&noSW){
 					el.querySelector('.app-loading__spinner').style.display='none';
-					el.querySelector('p').textContent='Brak połączenia z siecią. Połącz się i spróbuj ponownie.';
+					el.querySelector('p').textContent=offlineMsg;
 					return;
 				}
 				setTimeout(function(){
@@ -101,9 +105,9 @@
 						el.querySelector('.app-loading__spinner').style.display='none';
 						var p=el.querySelector('p');
 						if(navigator.onLine){
-							p.textContent='Ładowanie trwa dłużej niż zwykle. Spróbuj odświeżyć stronę.';
+							p.textContent=stallMsg;
 						}else{
-							p.textContent='Brak połączenia z siecią. Połącz się i spróbuj ponownie.';
+							p.textContent=offlineMsg;
 						}
 					}
 				},15000);

--- a/apps/reborn-task/src/hooks.server.ts
+++ b/apps/reborn-task/src/hooks.server.ts
@@ -12,6 +12,7 @@ import {
 	cleanupExpiredShares
 } from '@reborn/database';
 import { getShareOgStrings } from '$lib/server/share-og';
+import { getAppLoadingStrings } from '$lib/server/app-loading-strings';
 
 const BASE = process.env.PUBLIC_BASE_PATH ?? '';
 const RATE_LIMITED_AUTH = new Set([
@@ -148,9 +149,18 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 
 	const isSharePage = event.url.pathname.startsWith(SHARE_PATH_PREFIX);
 
+	const loading = getAppLoadingStrings(locale);
+	const initLoadingMsg = escAttr(loading.initLoading);
+	const stallMsg = escAttr(loading.stall);
+	const offlineMsg = escAttr(loading.offline);
+
 	return resolve(event, {
 		transformPageChunk: ({ html }) => {
-			let out = html.replace('%lang%', locale);
+			let out = html
+				.replace('%lang%', locale)
+				.replace('%init_loading_msg%', initLoadingMsg)
+				.replace('%stall_msg%', stallMsg)
+				.replace('%offline_msg%', offlineMsg);
 			if (!isSharePage) return out;
 
 			const og = getShareOgStrings(locale);

--- a/apps/reborn-task/src/lib/server/app-loading-strings.ts
+++ b/apps/reborn-task/src/lib/server/app-loading-strings.ts
@@ -1,0 +1,47 @@
+// Server-side strings for the pre-boot fallback in app.html.
+//
+// Lives here (not in @reborn/i18n) because:
+//   - hooks.server.ts injects these via transformPageChunk, before any
+//     client-side JS runs. svelte-i18n is async and client-only.
+//   - These strings are visible only during cold-start stall / offline-no-SW
+//     fallback, so they don't flow through the normal $t() pipeline.
+//
+// Keep parity with the SUPPORTED_LOCALES_SERVER list in hooks.server.ts.
+
+type AppLoadingStrings = {
+	initLoading: string; // <p>Loading re/task...</p>
+	stall: string; // shown after 15s if app hasn't booted (online)
+	offline: string; // shown immediately when offline + no SW, or after 15s + offline
+};
+
+const STRINGS: Record<string, AppLoadingStrings> = {
+	en: {
+		initLoading: 'Loading re/task...',
+		stall: 'Loading is taking longer than usual. Try refreshing the page.',
+		offline: 'No network connection. Reconnect and try again.'
+	},
+	pl: {
+		initLoading: 'Ładowanie re/task...',
+		stall: 'Ładowanie trwa dłużej niż zwykle. Spróbuj odświeżyć stronę.',
+		offline: 'Brak połączenia z siecią. Połącz się i spróbuj ponownie.'
+	},
+	de: {
+		initLoading: 're/task wird geladen...',
+		stall: 'Das Laden dauert länger als gewöhnlich. Versuche, die Seite neu zu laden.',
+		offline: 'Keine Netzwerkverbindung. Verbinde dich erneut und versuche es nochmals.'
+	},
+	fr: {
+		initLoading: 'Chargement de re/task...',
+		stall: "Le chargement prend plus de temps que d'habitude. Essayez d'actualiser la page.",
+		offline: 'Pas de connexion réseau. Reconnectez-vous et réessayez.'
+	},
+	es: {
+		initLoading: 'Cargando re/task...',
+		stall: 'La carga está tardando más de lo habitual. Intenta recargar la página.',
+		offline: 'Sin conexión de red. Reconéctate e inténtalo de nuevo.'
+	}
+};
+
+export function getAppLoadingStrings(locale: string): AppLoadingStrings {
+	return STRINGS[locale] ?? STRINGS.en;
+}


### PR DESCRIPTION
Pre-boot inline <script> in app.html had Polish strings hardcoded for the 15s stall message and the offline fallback, so English (and other-locale) users hitting cold-start >15s saw "Ladowanie trwa dluzej niz zwykle..." regardless of their language. Most visible on shared-note URLs, which reach external recipients with cold caches (no installed SW).

Inject the three strings (init / stall / offline) server-side via the existing transformPageChunk in localeHandle, same mechanism that handles %lang% and OG meta tags on /s/<slug>. Strings live in $lib/server/app-loading-strings.ts per app, 5 locales (EN/PL/DE/FR/ES), mirroring the share-og.ts pattern. data-attribute approach (data-stall-msg / data-offline-msg on #app-loading) gives a single escaping path (HTML attribute) safe for FR apostrophes.

Reported-by: Travis Solin <@computrav> Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>