### PR TITLE
feat(notes,task): add Copy markdown / Download .md to share viewer

### DIFF
--- a/apps/reborn-notes/src/routes/s/[slug]/+page.svelte
+++ b/apps/reborn-notes/src/routes/s/[slug]/+page.svelte
@@ -7,7 +7,10 @@
     AlertCircle,
     AlertOctagon,
     Ban,
+    Check,
     Clock,
+    Copy,
+    Download,
     Eye,
     EyeOff,
     KeyRound,
@@ -71,6 +74,45 @@
 
   let slug = '';
   let fragmentKey = '';
+
+  let copyStatus = $state<'idle' | 'copied' | 'failed'>('idle');
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function sanitizeFilename(name: string): string {
+    return (name.replace(/[\\/:*?"<>|\n\r\t]/g, '_').trim() || 'note').slice(0, 100);
+  }
+
+  async function handleCopyMarkdown() {
+    if (!notePayload) return;
+    try {
+      await navigator.clipboard.writeText(notePayload.content);
+      copyStatus = 'copied';
+    } catch {
+      copyStatus = 'failed';
+    }
+    if (copyResetTimer) clearTimeout(copyResetTimer);
+    copyResetTimer = setTimeout(() => {
+      copyStatus = 'idle';
+      copyResetTimer = null;
+    }, 2000);
+  }
+
+  function handleDownloadMarkdown() {
+    if (!notePayload) return;
+    const label =
+      notePayload.display_name?.trim() ||
+      notePayload.title?.trim() ||
+      $t('share.view.untitled');
+    const blob = new Blob([notePayload.content], { type: 'text/markdown; charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${sanitizeFilename(label)}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
 
   function classifyGoneCode(code: string | undefined): Stage {
     if (code === 'EXHAUSTED') return 'exhausted';
@@ -262,6 +304,45 @@
         {/if}
       </div>
     </header>
+    <!-- Recipient actions row. Ghost icon+label buttons sit right-aligned
+         under the header so they read as tools belonging to the snapshot
+         (clipboard / .md download) without competing with the content. The
+         note itself is already plaintext in the viewer's browser - these
+         shortcuts just save them from selecting/copying or screenshotting.
+         Mobile keeps icons only (label hidden < sm) so the strip stays
+         tight on narrow viewports. -->
+    <div class="mt-2 flex justify-end gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={handleCopyMarkdown}
+        title={$t('share.view.actions.copy_markdown')}
+        aria-label={$t('share.view.actions.copy_markdown')}
+        class="text-xs font-normal text-muted-foreground hover:text-foreground"
+      >
+        {#if copyStatus === 'copied'}
+          <Check class="h-3.5 w-3.5 text-green-600 dark:text-green-500" />
+          <span class="hidden sm:inline">{$t('share.view.actions.copy_done')}</span>
+        {:else if copyStatus === 'failed'}
+          <AlertCircle class="h-3.5 w-3.5 text-destructive" />
+          <span class="hidden sm:inline">{$t('share.view.actions.copy_failed')}</span>
+        {:else}
+          <Copy class="h-3.5 w-3.5" />
+          <span class="hidden sm:inline">{$t('share.view.actions.copy_markdown')}</span>
+        {/if}
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={handleDownloadMarkdown}
+        title={$t('share.view.actions.download_markdown')}
+        aria-label={$t('share.view.actions.download_markdown')}
+        class="text-xs font-normal text-muted-foreground hover:text-foreground"
+      >
+        <Download class="h-3.5 w-3.5" />
+        <span class="hidden sm:inline">{$t('share.view.actions.download_markdown')}</span>
+      </Button>
+    </div>
     {/if}
 
     <main class="flex flex-col gap-6 pb-10 pt-10">

--- a/apps/reborn-task/src/routes/s/[slug]/+page.svelte
+++ b/apps/reborn-task/src/routes/s/[slug]/+page.svelte
@@ -7,7 +7,10 @@
     AlertCircle,
     AlertOctagon,
     Ban,
+    Check,
     Clock,
+    Copy,
+    Download,
     Eye,
     EyeOff,
     KeyRound,
@@ -60,6 +63,86 @@
 
   let slug = '';
   let fragmentKey = '';
+
+  let copyStatus = $state<'idle' | 'copied' | 'failed'>('idle');
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function sanitizeFilename(name: string): string {
+    return (name.replace(/[\\/:*?"<>|\n\r\t]/g, '_').trim() || 'task').slice(0, 100);
+  }
+
+  // Tasks aren't authored in markdown - the snapshot is structured data
+  // (title + metadata + subtasks + description). We synthesize a light
+  // markdown representation that mirrors what the viewer sees: title as
+  // H1, an optional meta line for due date / completed flag, then sections
+  // for subtasks (as GFM task-list items) and free-form description. Same
+  // labels as the rendered view so the .md file reads in the recipient's
+  // locale.
+  function buildTaskMarkdown(p: NonNullable<typeof taskPayload>): string {
+    const headline =
+      p.display_name?.trim() || p.title?.trim() || $t('share.view.untitled');
+    const lines: string[] = [`# ${headline}`, ''];
+
+    const meta: string[] = [];
+    if (p.metadata.due_date) {
+      meta.push(`${$t('share.view.task.due_date_label')}: ${formatDate(p.metadata.due_date)}`);
+    }
+    if (p.metadata.is_completed) {
+      meta.push(`✓ ${$t('share.view.task.completed_badge')}`);
+    }
+    if (meta.length > 0) {
+      lines.push(...meta, '');
+    }
+
+    if (p.subtasks.length > 0) {
+      lines.push(`## ${$t('share.view.task.subtasks_label')}`, '');
+      for (const subtask of p.subtasks) {
+        const done = (subtask.metadata as { is_completed?: boolean } | undefined)?.is_completed;
+        lines.push(`- [${done ? 'x' : ' '}] ${subtask.name}`);
+      }
+      lines.push('');
+    }
+
+    if (p.description) {
+      lines.push(`## ${$t('share.view.task.description_label')}`, '', p.description, '');
+    }
+
+    return lines.join('\n').replace(/\n+$/, '\n');
+  }
+
+  async function handleCopyMarkdown() {
+    if (!taskPayload) return;
+    try {
+      await navigator.clipboard.writeText(buildTaskMarkdown(taskPayload));
+      copyStatus = 'copied';
+    } catch {
+      copyStatus = 'failed';
+    }
+    if (copyResetTimer) clearTimeout(copyResetTimer);
+    copyResetTimer = setTimeout(() => {
+      copyStatus = 'idle';
+      copyResetTimer = null;
+    }, 2000);
+  }
+
+  function handleDownloadMarkdown() {
+    if (!taskPayload) return;
+    const label =
+      taskPayload.display_name?.trim() ||
+      taskPayload.title?.trim() ||
+      $t('share.view.untitled');
+    const blob = new Blob([buildTaskMarkdown(taskPayload)], {
+      type: 'text/markdown; charset=utf-8'
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${sanitizeFilename(label)}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
 
   function classifyGoneCode(code: string | undefined): Stage {
     if (code === 'EXHAUSTED') return 'exhausted';
@@ -249,6 +332,43 @@
         {/if}
       </div>
     </header>
+    <!-- Recipient actions row. Mirrors the notes share viewer: ghost buttons
+         dimmed to match the chrome row above. For a task there is no native
+         markdown source, so the handlers synthesize a light .md (title +
+         meta + subtasks as GFM task-list + description) before copy/save -
+         see buildTaskMarkdown above. -->
+    <div class="mt-2 flex justify-end gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={handleCopyMarkdown}
+        title={$t('share.view.actions.copy_markdown')}
+        aria-label={$t('share.view.actions.copy_markdown')}
+        class="text-xs font-normal text-muted-foreground hover:text-foreground"
+      >
+        {#if copyStatus === 'copied'}
+          <Check class="h-3.5 w-3.5 text-green-600 dark:text-green-500" />
+          <span class="hidden sm:inline">{$t('share.view.actions.copy_done')}</span>
+        {:else if copyStatus === 'failed'}
+          <AlertCircle class="h-3.5 w-3.5 text-destructive" />
+          <span class="hidden sm:inline">{$t('share.view.actions.copy_failed')}</span>
+        {:else}
+          <Copy class="h-3.5 w-3.5" />
+          <span class="hidden sm:inline">{$t('share.view.actions.copy_markdown')}</span>
+        {/if}
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={handleDownloadMarkdown}
+        title={$t('share.view.actions.download_markdown')}
+        aria-label={$t('share.view.actions.download_markdown')}
+        class="text-xs font-normal text-muted-foreground hover:text-foreground"
+      >
+        <Download class="h-3.5 w-3.5" />
+        <span class="hidden sm:inline">{$t('share.view.actions.download_markdown')}</span>
+      </Button>
+    </div>
     {/if}
 
     <main class="flex flex-col gap-6 pb-10 pt-10">

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1030,6 +1030,12 @@
         },
         "cta_learn_more": "Mehr über {app} erfahren"
       },
+      "actions": {
+        "copy_markdown": "Markdown kopieren",
+        "copy_done": "Kopiert",
+        "copy_failed": "Kopieren fehlgeschlagen",
+        "download_markdown": ".md herunterladen"
+      },
       "note": {
         "tags_label": "Tags"
       }

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1030,6 +1030,12 @@
         },
         "cta_learn_more": "Learn more about {app}"
       },
+      "actions": {
+        "copy_markdown": "Copy markdown",
+        "copy_done": "Copied",
+        "copy_failed": "Copy failed",
+        "download_markdown": "Download .md"
+      },
       "note": {
         "tags_label": "Tags"
       }

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1030,6 +1030,12 @@
         },
         "cta_learn_more": "Más información sobre {app}"
       },
+      "actions": {
+        "copy_markdown": "Copiar markdown",
+        "copy_done": "Copiado",
+        "copy_failed": "Error al copiar",
+        "download_markdown": "Descargar .md"
+      },
       "note": {
         "tags_label": "Etiquetas"
       }

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1030,6 +1030,12 @@
         },
         "cta_learn_more": "En savoir plus sur {app}"
       },
+      "actions": {
+        "copy_markdown": "Copier le markdown",
+        "copy_done": "Copié",
+        "copy_failed": "Échec de la copie",
+        "download_markdown": "Télécharger en .md"
+      },
       "note": {
         "tags_label": "Étiquettes"
       }

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1030,6 +1030,12 @@
         },
         "cta_learn_more": "Dowiedz się więcej o {app}"
       },
+      "actions": {
+        "copy_markdown": "Kopiuj markdown",
+        "copy_done": "Skopiowano",
+        "copy_failed": "Nie udało się skopiować",
+        "download_markdown": "Pobierz .md"
+      },
       "note": {
         "tags_label": "Tagi"
       }

--- a/packages/i18n/src/translations/tasks/de/share.json
+++ b/packages/i18n/src/translations/tasks/de/share.json
@@ -79,6 +79,12 @@
       },
       "cta_learn_more": "Mehr über {app} erfahren"
     },
+    "actions": {
+      "copy_markdown": "Markdown kopieren",
+      "copy_done": "Kopiert",
+      "copy_failed": "Kopieren fehlgeschlagen",
+      "download_markdown": ".md herunterladen"
+    },
     "task": {
       "completed_badge": "Erledigt",
       "due_date_label": "Fällig",

--- a/packages/i18n/src/translations/tasks/en/share.json
+++ b/packages/i18n/src/translations/tasks/en/share.json
@@ -79,6 +79,12 @@
       },
       "cta_learn_more": "Learn more about {app}"
     },
+    "actions": {
+      "copy_markdown": "Copy markdown",
+      "copy_done": "Copied",
+      "copy_failed": "Copy failed",
+      "download_markdown": "Download .md"
+    },
     "task": {
       "completed_badge": "Completed",
       "due_date_label": "Due",

--- a/packages/i18n/src/translations/tasks/es/share.json
+++ b/packages/i18n/src/translations/tasks/es/share.json
@@ -79,6 +79,12 @@
       },
       "cta_learn_more": "Más información sobre {app}"
     },
+    "actions": {
+      "copy_markdown": "Copiar markdown",
+      "copy_done": "Copiado",
+      "copy_failed": "Error al copiar",
+      "download_markdown": "Descargar .md"
+    },
     "task": {
       "completed_badge": "Completada",
       "due_date_label": "Vence",

--- a/packages/i18n/src/translations/tasks/fr/share.json
+++ b/packages/i18n/src/translations/tasks/fr/share.json
@@ -79,6 +79,12 @@
       },
       "cta_learn_more": "En savoir plus sur {app}"
     },
+    "actions": {
+      "copy_markdown": "Copier le markdown",
+      "copy_done": "Copié",
+      "copy_failed": "Échec de la copie",
+      "download_markdown": "Télécharger en .md"
+    },
     "task": {
       "completed_badge": "Terminé",
       "due_date_label": "Échéance",

--- a/packages/i18n/src/translations/tasks/pl/share.json
+++ b/packages/i18n/src/translations/tasks/pl/share.json
@@ -79,6 +79,12 @@
       },
       "cta_learn_more": "Dowiedz się więcej o {app}"
     },
+    "actions": {
+      "copy_markdown": "Kopiuj markdown",
+      "copy_done": "Skopiowano",
+      "copy_failed": "Nie udało się skopiować",
+      "download_markdown": "Pobierz .md"
+    },
     "task": {
       "completed_badge": "Ukończone",
       "due_date_label": "Termin",


### PR DESCRIPTION
Two ghost-icon actions (clipboard copy + .md download) on the public share viewer for both apps so recipients have a one-click path to grab the snapshot content. Notes uses the raw markdown body; task synthesizes a light markdown (title + meta + GFM task-list subtasks + description) since tasks have no native markdown source. Reuses existing share.view.task.* labels for section headers so the .md file reads in the recipient's locale.

Per Travis Solin feedback (2026-05-17): simple variant of the "copy/save shared note" idea, no ZK implications (recipient already has plaintext in memory).

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>