### PR TITLE
fix(ui): gate share dialogs on active session, fix programmatic re-auth close

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -27,6 +27,7 @@
   import { SidebarTrigger } from '@reborn/ui/sidebar';
   import { t } from '$lib/stores/i18n.store';
   import { sessionExpired, isInitialSync } from '$lib/stores/sync-status.store';
+  import { requireActiveSession } from '$lib/utils/require-active-session';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
   import ConfirmDialog from './shared/ConfirmDialog.svelte';
   import NoteListItemComponent from './notes/NoteListItem.svelte';
@@ -98,8 +99,12 @@
   let shareNoteId = $state<string | null>(null);
   let shareNoteTitle = $state<string>('');
 
-  function handleShare(note: NoteListItem, e?: Event) {
+  async function handleShare(note: NoteListItem, e?: Event) {
     e?.stopPropagation();
+    const ok = await requireActiveSession({
+      description: $t('share.session_required.create')
+    });
+    if (!ok) return;
     shareNoteId = note.id;
     shareNoteTitle = note.title ?? '';
     shareDialogOpen = true;

--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -45,6 +45,7 @@
   import { formatRange } from '$lib/services/periodic-notes-format';
   import type { PeriodicKind } from '@reborn/storage';
   import { activeSharesCount } from '$lib/stores/shares.store';
+  import { requireActiveSession } from '$lib/utils/require-active-session';
   import ManageSharesDialog from '../notes/ManageSharesDialog.svelte';
 
   let {
@@ -71,6 +72,14 @@
   let loggingOut = $state(false);
   let userSheetOpen = $state(false);
   let sharesDialogOpen = $state(false);
+
+  async function handleOpenShares() {
+    const ok = await requireActiveSession({
+      description: $t('share.session_required.view')
+    });
+    if (!ok) return;
+    sharesDialogOpen = true;
+  }
 
   // Refresh `now` every minute so tooltips stay accurate across midnight /
   // week boundary / month boundary without forcing the user to reload.
@@ -218,7 +227,7 @@
     <!-- Shares (always visible, count badge when > 0) -->
     <button
       type="button"
-      onclick={() => (sharesDialogOpen = true)}
+      onclick={handleOpenShares}
       class="flex flex-1 flex-col items-center gap-0.5 rounded-md py-2 px-1.5 text-xs transition-colors
         text-muted-foreground hover:bg-sidebar-accent/60"
       aria-label={$t('nav.shares')}
@@ -395,7 +404,7 @@
           <button
             {...props}
             type="button"
-            onclick={() => (sharesDialogOpen = true)}
+            onclick={handleOpenShares}
             class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg
                    text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
             aria-label={$t('nav.shares')}

--- a/apps/reborn-notes/src/lib/components/notes/NoteShareIndicator.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteShareIndicator.svelte
@@ -2,6 +2,7 @@
   import { Share2 } from '@lucide/svelte';
   import { t } from '$lib/stores/i18n.store';
   import { sharesBySourceId } from '$lib/stores/shares.store';
+  import { requireActiveSession } from '$lib/utils/require-active-session';
   import ManageSharesDialog from './ManageSharesDialog.svelte';
 
   let {
@@ -20,16 +21,28 @@
     return $sharesBySourceId.get(noteId)?.length ?? 0;
   });
 
-  function handleClick() {
-    if (count > 0) {
+  async function handleClick() {
+    // Capture count at click time. We don't re-read after the await: the user's
+    // intent was determined when they clicked (view vs. create), and re-reading
+    // the reactive count could pick a different branch if a sync arrived during
+    // the gate.
+    const hadShares = count > 0;
+    const reason = hadShares ? 'share.session_required.view' : 'share.session_required.create';
+    const ok = await requireActiveSession({ description: $t(reason) });
+    if (!ok) return;
+    if (hadShares) {
       dialogOpen = true;
     } else {
       onCreateNew?.();
     }
   }
 
-  function handleCreateNew() {
+  async function handleCreateNew() {
     dialogOpen = false;
+    const ok = await requireActiveSession({
+      description: $t('share.session_required.create')
+    });
+    if (!ok) return;
     onCreateNew?.();
   }
 </script>
@@ -54,7 +67,8 @@
     {/if}
   </button>
 
-  {#if count > 0}
-    <ManageSharesDialog bind:open={dialogOpen} sourceId={noteId} onCreateNew={handleCreateNew} />
-  {/if}
+  <!-- Always mounted (gated by dialogOpen) so that a sync arriving mid-creation
+       cannot dynamically mount this dialog and cover the success view inside
+       ShareNoteDialog. -->
+  <ManageSharesDialog bind:open={dialogOpen} sourceId={noteId} onCreateNew={handleCreateNew} />
 {/if}

--- a/apps/reborn-notes/src/lib/stores/shares.store.ts
+++ b/apps/reborn-notes/src/lib/stores/shares.store.ts
@@ -3,6 +3,7 @@ import { browser } from '$app/environment';
 import { base } from '$app/paths';
 import { authFetch } from '$lib/utils/auth-fetch';
 import { connectivityStore } from '$lib/stores/connectivity.store';
+import { sessionExpired } from '$lib/stores/sync-status.store';
 import { refreshQuota } from '$lib/stores/storage-quota.store';
 import {
   cryptoManager,
@@ -183,6 +184,20 @@ function createSharesStore() {
         prevStatus = conn.status;
       });
     }
+    // Auto-refresh when the session is re-established after expiry. Without
+    // this, a ManageSharesDialog opened during expiry keeps showing the stale
+    // "Couldn't refresh" banner even though the user has signed in again.
+    let prevExpired = get(sessionExpired);
+    sessionExpired.subscribe((expired) => {
+      if (
+        prevExpired === true
+        && expired === false
+        && cryptoManager.isInitialized()
+      ) {
+        void refresh();
+      }
+      prevExpired = expired;
+    });
   }
 
   return {

--- a/apps/reborn-notes/src/lib/utils/require-active-session.ts
+++ b/apps/reborn-notes/src/lib/utils/require-active-session.ts
@@ -1,0 +1,12 @@
+import { createRequireActiveSession } from '@reborn/ui';
+import { sessionExpired } from '$lib/stores/sync-status.store';
+
+/**
+ * Gate for user-initiated actions that need a live server session (share,
+ * manage shares, ...). When the session is healthy or the browser is offline
+ * resolves `true` immediately; otherwise opens the singleton re-auth modal
+ * mounted in `+layout.svelte` and resolves with the outcome.
+ *
+ * See `docs/development/planning/share-dialog-session-expired-gate.md`.
+ */
+export const requireActiveSession = createRequireActiveSession({ sessionExpired });

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -25,7 +25,7 @@
   import { refreshPendingCount, isOnline, sessionExpired } from '$lib/stores/sync-status.store';
   import { initI18n, setLocale, locale } from '$lib/stores/i18n.store';
   import { reAuthenticate, verifyTotpForReauth } from '$lib/services/notes-auth.service';
-  import { SessionExpiredBanner } from '@reborn/ui';
+  import { SessionExpiredBanner, RequireSessionModal } from '@reborn/ui';
   import LoadingScreen from '$lib/components/LoadingScreen.svelte';
   import { createLogger } from '@reborn/utils';
 
@@ -351,6 +351,11 @@
   <div class="svelte-app-ready" style="display: contents">
     <SessionExpiredBanner
       visible={$sessionExpired && navigator.onLine}
+      username={$authStore.username ?? ''}
+      onReAuth={reAuthenticate}
+      onVerifyTotp={verifyTotpForReauth}
+    />
+    <RequireSessionModal
       username={$authStore.username ?? ''}
       onReAuth={reAuthenticate}
       onVerifyTotp={verifyTotpForReauth}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -75,6 +75,7 @@
   import { goto } from '$lib/utils/navigation';
   import { createScrollSync } from '$lib/utils/scroll-sync';
   import { createEditorAdapter, createPreviewAdapter } from '$lib/utils/line-adapter';
+  import { requireActiveSession } from '$lib/utils/require-active-session';
   import type { EditorView } from '@codemirror/view';
 
   type ViewMode = 'edit' | 'split' | 'preview';
@@ -228,10 +229,14 @@
   let shareNoteId = $state<string | null>(null);
   let shareNoteTitle = $state<string>('');
 
-  function handleDetailShare(noteArg?: NoteListItem) {
+  async function handleDetailShare(noteArg?: NoteListItem) {
     detailActionSheetOpen = false;
     const target = noteArg ?? detailMenuNote;
     if (!target) return;
+    const ok = await requireActiveSession({
+      description: $t('share.session_required.create')
+    });
+    if (!ok) return;
     shareNoteId = target.id;
     shareNoteTitle = target.title ?? '';
     shareDialogOpen = true;

--- a/apps/reborn-task/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-task/src/lib/components/layout/IconNav.svelte
@@ -40,6 +40,7 @@
 	import { t } from '$lib/stores/i18n.store';
 	import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
 	import { activeSharesCount } from '$lib/stores/shares.store';
+	import { requireActiveSession } from '$lib/utils/require-active-session';
 	import ManageSharesDialog from '$lib/components/tasks/ManageSharesDialog.svelte';
 
 	let {
@@ -60,6 +61,14 @@
 	let loggingOut = $state(false);
 	let userSheetOpen = $state(false);
 	let sharesDialogOpen = $state(false);
+
+	async function handleOpenShares() {
+		const ok = await requireActiveSession({
+			description: $t('share.session_required.view')
+		});
+		if (!ok) return;
+		sharesDialogOpen = true;
+	}
 
 	function getUserInitial(username: string | null): string {
 		if (!username) return '?';
@@ -205,7 +214,7 @@
 		<!-- Shares (always visible, count badge when > 0) -->
 		<button
 			type="button"
-			onclick={() => (sharesDialogOpen = true)}
+			onclick={handleOpenShares}
 			class="flex flex-1 flex-col items-center gap-0.5 rounded-md py-2 px-1.5 text-xs transition-colors
 				text-muted-foreground hover:bg-sidebar-accent/60"
 			aria-label={$t('nav.shares')}
@@ -349,7 +358,7 @@
 					<button
 						{...props}
 						type="button"
-						onclick={() => (sharesDialogOpen = true)}
+						onclick={handleOpenShares}
 						class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg
 							text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
 						aria-label={$t('nav.shares')}

--- a/apps/reborn-task/src/lib/components/tasks/TaskShareIndicator.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/TaskShareIndicator.svelte
@@ -2,6 +2,7 @@
   import { Share2 } from '@lucide/svelte';
   import { t } from '$lib/stores/i18n.store';
   import { sharesBySourceId } from '$lib/stores/shares.store';
+  import { requireActiveSession } from '$lib/utils/require-active-session';
   import ManageSharesDialog from './ManageSharesDialog.svelte';
 
   let {
@@ -19,16 +20,27 @@
     return $sharesBySourceId.get(taskId)?.length ?? 0;
   });
 
-  function handleClick() {
-    if (count > 0) {
+  async function handleClick() {
+    // Capture count at click time - the user's intent was decided when they
+    // clicked (view vs. create). Re-reading after the await could mis-route if
+    // a sync arrived during the gate.
+    const hadShares = count > 0;
+    const reason = hadShares ? 'share.session_required.view' : 'share.session_required.create';
+    const ok = await requireActiveSession({ description: $t(reason) });
+    if (!ok) return;
+    if (hadShares) {
       dialogOpen = true;
     } else {
       onCreateNew?.();
     }
   }
 
-  function handleCreateNew() {
+  async function handleCreateNew() {
     dialogOpen = false;
+    const ok = await requireActiveSession({
+      description: $t('share.session_required.create')
+    });
+    if (!ok) return;
     onCreateNew?.();
   }
 </script>
@@ -53,7 +65,8 @@
     {/if}
   </button>
 
-  {#if count > 0}
-    <ManageSharesDialog bind:open={dialogOpen} sourceId={taskId} onCreateNew={handleCreateNew} />
-  {/if}
+  <!-- Always mounted (gated by dialogOpen) so a sync arriving mid-creation
+       cannot dynamically mount this dialog and cover the success view inside
+       ShareTaskDialog. -->
+  <ManageSharesDialog bind:open={dialogOpen} sourceId={taskId} onCreateNew={handleCreateNew} />
 {/if}

--- a/apps/reborn-task/src/lib/stores/shares.store.ts
+++ b/apps/reborn-task/src/lib/stores/shares.store.ts
@@ -3,6 +3,7 @@ import { browser } from '$app/environment';
 import { base } from '$app/paths';
 import { authFetch } from '$lib/utils/auth-fetch';
 import { connectivityStore } from '$lib/stores/connectivity.store';
+import { sessionExpired } from '$lib/stores/session-expired.store';
 import {
 	cryptoManager,
 	buildShareUrl,
@@ -174,6 +175,20 @@ function createSharesStore() {
 				prevStatus = conn.status;
 			});
 		}
+		// Auto-refresh when the session is re-established after expiry. Without
+		// this, a ManageSharesDialog opened during expiry keeps showing the stale
+		// "Couldn't refresh" banner even though the user has signed in again.
+		let prevExpired = get(sessionExpired);
+		sessionExpired.subscribe((expired) => {
+			if (
+				prevExpired === true
+				&& expired === false
+				&& cryptoManager.isInitialized()
+			) {
+				void refresh();
+			}
+			prevExpired = expired;
+		});
 	}
 
 	return {

--- a/apps/reborn-task/src/lib/utils/require-active-session.ts
+++ b/apps/reborn-task/src/lib/utils/require-active-session.ts
@@ -1,0 +1,12 @@
+import { createRequireActiveSession } from '@reborn/ui';
+import { sessionExpired } from '$lib/stores/session-expired.store';
+
+/**
+ * Gate for user-initiated actions that need a live server session (share,
+ * manage shares, ...). When the session is healthy or the browser is offline
+ * resolves `true` immediately; otherwise opens the singleton re-auth modal
+ * mounted in `+layout.svelte` and resolves with the outcome.
+ *
+ * See `docs/development/planning/share-dialog-session-expired-gate.md`.
+ */
+export const requireActiveSession = createRequireActiveSession({ sessionExpired });

--- a/apps/reborn-task/src/routes/(app)/+layout.svelte
+++ b/apps/reborn-task/src/routes/(app)/+layout.svelte
@@ -41,6 +41,7 @@
 	import { TaskSelectPlaceholder, FilterViewPlaceholder } from '$lib/components/tasks';
 	import { page } from '$app/stores';
 	import { goto } from '$lib/utils/navigation';
+	import { requireActiveSession } from '$lib/utils/require-active-session';
 	import { session } from '$lib/stores/auth.store';
 	import { t } from '$lib/stores/i18n.store';
 	import { activeLists, taskListStore } from '$lib/stores/decrypted-lists.store';
@@ -277,6 +278,16 @@
 	// Share dialog state (read-only public snapshot)
 	let shareDialogOpen = $state(false);
 	let shareDialogTask = $state<TaskDecrypted | null>(null);
+
+	async function openShareDialogForCurrentTask() {
+		if (!currentTask) return;
+		const ok = await requireActiveSession({
+			description: $t('share.session_required.create')
+		});
+		if (!ok) return;
+		shareDialogTask = currentTask;
+		shareDialogOpen = true;
+	}
 
 	// Current list for header
 	let currentList = $derived(
@@ -1137,12 +1148,7 @@
 								onOpenMoveDialog={() => {
 									if (currentTask) layoutStore.openMoveTaskDialog(currentTask);
 								}}
-								onOpenShareDialog={() => {
-									if (currentTask) {
-										shareDialogTask = currentTask;
-										shareDialogOpen = true;
-									}
-								}}
+								onOpenShareDialog={openShareDialogForCurrentTask}
 								onOpenDeleteDialog={() => {
 									if (currentTask) layoutStore.openTaskDeleteDialog(currentTask);
 								}}
@@ -1233,12 +1239,7 @@
 								onOpenMoveDialog={() => {
 									if (currentTask) layoutStore.openMoveTaskDialog(currentTask);
 								}}
-								onOpenShareDialog={() => {
-									if (currentTask) {
-										shareDialogTask = currentTask;
-										shareDialogOpen = true;
-									}
-								}}
+								onOpenShareDialog={openShareDialogForCurrentTask}
 								onOpenDeleteDialog={() => {
 									if (currentTask) layoutStore.openTaskDeleteDialog(currentTask);
 								}}

--- a/apps/reborn-task/src/routes/+layout.svelte
+++ b/apps/reborn-task/src/routes/+layout.svelte
@@ -10,7 +10,7 @@
 	import { sessionExpired } from '$lib/stores/session-expired.store';
 	import { syncService } from '$lib/services/sync.service';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
-	import { SessionExpiredBanner } from '@reborn/ui';
+	import { SessionExpiredBanner, RequireSessionModal } from '@reborn/ui';
 	import LoadingScreen from '$lib/components/LoadingScreen.svelte';
 	import { Toaster } from '@reborn/ui';
 	import type { Snippet } from 'svelte';
@@ -298,6 +298,11 @@
 {#if $session?.isInitialized || initTimeout || isPublicShareRoute}
 	<SessionExpiredBanner
 		visible={$sessionExpired && navigator.onLine}
+		username={$session?.user?.username ?? ''}
+		onReAuth={(password) => authOperationsService.reAuthenticate(password)}
+		onVerifyTotp={(userId, code) => authOperationsService.verifyTotpForReauth(userId, code)}
+	/>
+	<RequireSessionModal
 		username={$session?.user?.username ?? ''}
 		onReAuth={(password) => authOperationsService.reAuthenticate(password)}
 		onVerifyTotp={(userId, code) => authOperationsService.verifyTotpForReauth(userId, code)}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1093,6 +1093,10 @@
       "empty_for_note": "Diese Notiz hat keine aktiven Freigaben.",
       "empty_for_task": "Diese Aufgabe hat keine aktiven Freigaben.",
       "create_new_cta": "Neue Freigabe erstellen"
+    },
+    "session_required": {
+      "view": "Bitte melde dich erneut an, um deine aktiven Freigaben zu sehen.",
+      "create": "Bitte melde dich erneut an, um eine Freigabe zu erstellen."
     }
   }
 }

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1093,6 +1093,10 @@
       "empty_for_note": "This note has no active shares.",
       "empty_for_task": "This task has no active shares.",
       "create_new_cta": "Create new share"
+    },
+    "session_required": {
+      "view": "Sign in again to view your active shares.",
+      "create": "Sign in again to create a share."
     }
   }
 }

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1093,6 +1093,10 @@
       "empty_for_note": "Esta nota no tiene compartidos activos.",
       "empty_for_task": "Esta tarea no tiene compartidos activos.",
       "create_new_cta": "Crear nuevo compartido"
+    },
+    "session_required": {
+      "view": "Vuelve a iniciar sesión para ver tus compartidos activos.",
+      "create": "Vuelve a iniciar sesión para crear un compartido."
     }
   }
 }

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1093,6 +1093,10 @@
       "empty_for_note": "Cette note n'a aucun partage actif.",
       "empty_for_task": "Cette tâche n'a aucun partage actif.",
       "create_new_cta": "Créer un nouveau partage"
+    },
+    "session_required": {
+      "view": "Reconnectez-vous pour voir vos partages actifs.",
+      "create": "Reconnectez-vous pour créer un partage."
     }
   }
 }

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1093,6 +1093,10 @@
       "empty_for_note": "Ta notatka nie ma aktywnych udostępnień.",
       "empty_for_task": "To zadanie nie ma aktywnych udostępnień.",
       "create_new_cta": "Utwórz nowe udostępnienie"
+    },
+    "session_required": {
+      "view": "Zaloguj się ponownie, aby zobaczyć aktywne udostępnienia.",
+      "create": "Zaloguj się ponownie, aby utworzyć udostępnienie."
     }
   }
 }

--- a/packages/i18n/src/translations/tasks/de/share.json
+++ b/packages/i18n/src/translations/tasks/de/share.json
@@ -147,5 +147,9 @@
     "empty_for_note": "Diese Notiz hat keine aktiven Freigaben.",
     "empty_for_task": "Diese Aufgabe hat keine aktiven Freigaben.",
     "create_new_cta": "Neue Freigabe erstellen"
+  },
+  "session_required": {
+    "view": "Bitte melde dich erneut an, um deine aktiven Freigaben zu sehen.",
+    "create": "Bitte melde dich erneut an, um eine Freigabe zu erstellen."
   }
 }

--- a/packages/i18n/src/translations/tasks/en/share.json
+++ b/packages/i18n/src/translations/tasks/en/share.json
@@ -147,5 +147,9 @@
     "empty_for_note": "This note has no active shares.",
     "empty_for_task": "This task has no active shares.",
     "create_new_cta": "Create new share"
+  },
+  "session_required": {
+    "view": "Sign in again to view your active shares.",
+    "create": "Sign in again to create a share."
   }
 }

--- a/packages/i18n/src/translations/tasks/es/share.json
+++ b/packages/i18n/src/translations/tasks/es/share.json
@@ -147,5 +147,9 @@
     "empty_for_note": "Esta nota no tiene compartidos activos.",
     "empty_for_task": "Esta tarea no tiene compartidos activos.",
     "create_new_cta": "Crear nuevo compartido"
+  },
+  "session_required": {
+    "view": "Vuelve a iniciar sesión para ver tus compartidos activos.",
+    "create": "Vuelve a iniciar sesión para crear un compartido."
   }
 }

--- a/packages/i18n/src/translations/tasks/fr/share.json
+++ b/packages/i18n/src/translations/tasks/fr/share.json
@@ -147,5 +147,9 @@
     "empty_for_note": "Cette note n'a aucun partage actif.",
     "empty_for_task": "Cette tâche n'a aucun partage actif.",
     "create_new_cta": "Créer un nouveau partage"
+  },
+  "session_required": {
+    "view": "Reconnectez-vous pour voir vos partages actifs.",
+    "create": "Reconnectez-vous pour créer un partage."
   }
 }

--- a/packages/i18n/src/translations/tasks/pl/share.json
+++ b/packages/i18n/src/translations/tasks/pl/share.json
@@ -147,5 +147,9 @@
     "empty_for_note": "Ta notatka nie ma aktywnych udostępnień.",
     "empty_for_task": "To zadanie nie ma aktywnych udostępnień.",
     "create_new_cta": "Utwórz nowe udostępnienie"
+  },
+  "session_required": {
+    "view": "Zaloguj się ponownie, aby zobaczyć aktywne udostępnienia.",
+    "create": "Zaloguj się ponownie, aby utworzyć udostępnienie."
   }
 }

--- a/packages/ui/src/components/auth/ReAuthModal.svelte
+++ b/packages/ui/src/components/auth/ReAuthModal.svelte
@@ -26,15 +26,21 @@
   let {
     open = $bindable(false),
     username = '',
+    description,
     onSubmitPassword,
-    onSubmitTotp
+    onSubmitTotp,
+    onClose
   } = $props<{
     open?: boolean;
     username?: string;
+    /** Optional override for the password-step description text. Defaults to `auth.session.reauth_description`. */
+    description?: string;
     /** Called with the password. Returns a ReAuthResult. */
     onSubmitPassword?: (password: string) => Promise<ReAuthResult>;
     /** Called with a TOTP or recovery code once 2FA is required. */
     onSubmitTotp?: (userId: string, code: string) => Promise<ReAuthResult>;
+    /** Called when the dialog closes. Receives `true` if a re-auth succeeded, `false` if cancelled. */
+    onClose?: (success: boolean) => void;
   }>();
 
   type Step = 'password' | 'totp';
@@ -47,6 +53,7 @@
   let pendingUserId = $state<string | null>(null);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let succeeded = $state(false);
 
   function resetAll() {
     step = 'password';
@@ -57,12 +64,25 @@
     pendingUserId = null;
     loading = false;
     error = null;
+    succeeded = false;
   }
 
-  function handleOpenChange(isOpen: boolean) {
-    open = isOpen;
-    if (!isOpen) resetAll();
-  }
+  // bits-ui only fires onOpenChange when it INTERNALLY toggles open (X click,
+  // Escape, click-outside). Setting `open = false` programmatically from a
+  // success branch bypasses that callback, so we use a $effect to detect every
+  // open → closed transition. `prevOpen` is a plain JS var so the assignment
+  // inside the effect doesn't retrigger it.
+  let prevOpen = false;
+  $effect(() => {
+    const isOpen = open;
+    if (isOpen === prevOpen) return;
+    prevOpen = isOpen;
+    if (!isOpen) {
+      const wasSuccess = succeeded;
+      resetAll();
+      onClose?.(wasSuccess);
+    }
+  });
 
   function describeResult(result: ReAuthResult): string | null {
     switch (result.kind) {
@@ -97,8 +117,8 @@
       };
 
       if (result.kind === 'ok') {
+        succeeded = true;
         open = false;
-        resetAll();
         return;
       }
 
@@ -138,8 +158,8 @@
       };
 
       if (result.kind === 'ok') {
+        succeeded = true;
         open = false;
-        resetAll();
         return;
       }
 
@@ -152,13 +172,13 @@
   }
 </script>
 
-<Dialog bind:open onOpenChange={handleOpenChange}>
+<Dialog bind:open>
   <DialogContent class="sm:max-w-md">
     {#if step === 'password'}
       <DialogHeader>
         <DialogTitle>{$t('auth.session.reauth_title')}</DialogTitle>
         <DialogDescription>
-          {$t('auth.session.reauth_description')}
+          {description ?? $t('auth.session.reauth_description')}
         </DialogDescription>
       </DialogHeader>
 

--- a/packages/ui/src/components/auth/RequireSessionModal.svelte
+++ b/packages/ui/src/components/auth/RequireSessionModal.svelte
@@ -1,0 +1,61 @@
+<!--
+  @component
+  Singleton re-auth modal driven by `requireSessionPromptStore`. Mounted once
+  per app in `+layout.svelte` and triggered imperatively by `requireActiveSession()`.
+
+  Same flow as SessionExpiredBanner's modal (password → optional TOTP), but
+  the description text is customisable per call site so the user understands
+  which action triggered the prompt.
+-->
+<script lang="ts">
+  import ReAuthModal from './ReAuthModal.svelte';
+  import { requireSessionPromptStore } from './require-session';
+  import type { ReAuthResult } from './reauth-types';
+
+  let {
+    username = '',
+    onReAuth,
+    onVerifyTotp
+  } = $props<{
+    username?: string;
+    onReAuth?: (password: string) => Promise<ReAuthResult>;
+    onVerifyTotp?: (userId: string, code: string) => Promise<ReAuthResult>;
+  }>();
+
+  let open = $state(false);
+  let description = $state<string | undefined>(undefined);
+  let pendingResolve: ((ok: boolean) => void) | null = null;
+
+  // Subscribe to the imperative store. When state.open flips to true a new
+  // requireActiveSession() call is awaiting; capture its resolver and open the
+  // dialog. When it flips back to false (either because we resolved it or some
+  // other caller reset the store), make sure we don't double-resolve.
+  $effect(() => {
+    const unsubscribe = requireSessionPromptStore.subscribe((state) => {
+      if (state.open) {
+        pendingResolve = state.resolve;
+        description = state.description;
+        open = true;
+      } else {
+        pendingResolve = null;
+        open = false;
+      }
+    });
+    return unsubscribe;
+  });
+
+  function handleClose(success: boolean) {
+    const resolver = pendingResolve;
+    pendingResolve = null;
+    if (resolver) resolver(success);
+  }
+</script>
+
+<ReAuthModal
+  bind:open
+  {username}
+  {description}
+  onSubmitPassword={onReAuth}
+  onSubmitTotp={onVerifyTotp}
+  onClose={handleClose}
+/>

--- a/packages/ui/src/components/auth/index.ts
+++ b/packages/ui/src/components/auth/index.ts
@@ -11,4 +11,11 @@ export { default as UnlockE2E } from './UnlockE2E.svelte';
 export { default as UnlockPage } from './UnlockPage.svelte';
 export { default as SessionExpiredBanner } from './SessionExpiredBanner.svelte';
 export { default as ReAuthModal } from './ReAuthModal.svelte';
+export { default as RequireSessionModal } from './RequireSessionModal.svelte';
+export {
+  createRequireActiveSession,
+  requireSessionPromptStore,
+  type RequireActiveSessionOptions,
+  type RequireSessionPromptState
+} from './require-session';
 export type { ReAuthResult } from './reauth-types';

--- a/packages/ui/src/components/auth/require-session.ts
+++ b/packages/ui/src/components/auth/require-session.ts
@@ -1,0 +1,52 @@
+import { writable, get, type Readable } from 'svelte/store';
+
+/**
+ * State of the singleton "session required" prompt. When `open`, the modal is
+ * mounted in the layout and is awaiting either a successful re-auth or a
+ * cancellation; `resolve` is called exactly once with the outcome.
+ */
+export type RequireSessionPromptState =
+  | { open: false }
+  | { open: true; description?: string; resolve: (ok: boolean) => void };
+
+export const requireSessionPromptStore = writable<RequireSessionPromptState>({ open: false });
+
+export interface RequireActiveSessionOptions {
+  /** Optional override for the description shown in the re-auth modal. */
+  description?: string;
+}
+
+export interface CreateRequireActiveSessionDeps {
+  /** Per-app `sessionExpired` store (writable or readonly). */
+  sessionExpired: Readable<boolean>;
+}
+
+/**
+ * Factory that binds a per-app `sessionExpired` store to a `requireActiveSession`
+ * helper. Each app calls this once (in `$lib/utils/require-active-session.ts`)
+ * and re-exports the resulting function for use in entry-point components.
+ *
+ * Returns `true` immediately when the session is healthy or the browser is
+ * offline (no point prompting for credentials we can't validate); otherwise
+ * opens the singleton modal and resolves with the user's outcome.
+ */
+export function createRequireActiveSession({ sessionExpired }: CreateRequireActiveSessionDeps) {
+  return async function requireActiveSession(
+    opts: RequireActiveSessionOptions = {}
+  ): Promise<boolean> {
+    const expired = get(sessionExpired);
+    const online = typeof navigator !== 'undefined' ? navigator.onLine : true;
+    if (!expired || !online) return true;
+
+    return new Promise<boolean>((resolve) => {
+      requireSessionPromptStore.set({
+        open: true,
+        description: opts.description,
+        resolve: (ok) => {
+          requireSessionPromptStore.set({ open: false });
+          resolve(ok);
+        }
+      });
+    });
+  };
+}


### PR DESCRIPTION
Adds a require-active-session gate that runs before opening share / manage share dialogs in both Notes and Task. When the session has expired and the browser is online the gate opens a dedicated re-auth modal (with contextual copy via the new ReAuthModal `description` prop) instead of letting the target dialog open and surface raw "Couldn't refresh" or "Unauthorized" errors. Successful re-auth resumes the original action with fresh data; cancellation drops it and leaves the top banner in place.

Fixes four issues uncovered during smoke testing:

- bits-ui Dialog only fires onOpenChange when its internal setter toggles open (X / Escape / click-outside). Setting `open = false` programmatically in ReAuthModal's success branch bypassed the setter, so the onClose callback never fired -- the gate's Promise hung after re-auth and the modal kept stale TOTP state on next open. Replaces the callback with a $effect tracking the open transition so user-close and programmatic-close go through the same cleanup path.

- A successful share creation flips `count` 0->1, which dynamically mounted ManageSharesDialog and covered the ShareNoteDialog success view. Mounts ManageSharesDialog unconditionally now (visibility driven only by its bound `open` state).

- sharesStore did not auto-refresh after the session was restored, so the amber "Couldn't refresh" banner persisted past re-auth. Adds a sessionExpired subscription that triggers refresh on the true -> false transition, mirroring the existing online-connectivity hook.

Full analysis and per-app wiring: docs/development/planning/share-dialog-session-expired-gate.md Updated guideline: docs/development/guidelines/31-session-expiry-handling.md

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>