### PR TITLE
fix(notes): keep caret at click position on plain list content in Live Preview

### DIFF
--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
@@ -3,7 +3,7 @@ import { EditorState } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
 import { Strikethrough, Table, TaskList } from '@lezer/markdown';
 import type { DecorationSet } from '@codemirror/view';
-import { buildDecorations, isAnySelectionInRange } from './decorations';
+import { buildDecorations, isAnySelectionInRange, resolveListClickForward } from './decorations';
 import { TableWidget } from './table-widget';
 import { ImageWidget } from './image-widget';
 import { TaskCheckboxWidget } from './widgets';
@@ -679,5 +679,126 @@ describe('buildDecorations — GFM task list', () => {
 
     const listMarkPos = doc.indexOf('- [ ] inner');
     expect(hasHiddenRange(ranges, nestedLineFrom, listMarkPos)).toBe(true);
+  });
+});
+
+describe('resolveListClickForward — padding-zone vs content gate', () => {
+  // The handler `livePreviewListClickForward` exists to bump clicks landing
+  // *before* the rendered content (in the hidden marker / leading whitespace /
+  // ::before bullet zone) to the first content character. The pure helper
+  // tested here decides yes/no. Two regression families:
+  //
+  //   - Click on actual content text → MUST return null. Plain (unstyled) list
+  //     content has no wrapping span, so its DOM clicks bubble up to `.cm-line`
+  //     and the handler used to slam every such click to `contentStart`, even
+  //     though the user clicked far past the marker.
+  //   - Click in padding/marker zone → MUST return { contentStart } so the
+  //     original #146/#153 fix (no caret stuck before a hidden `- `) keeps
+  //     working.
+
+  it('returns null for a click on plain content text in a bullet item', () => {
+    const doc = '- hello world\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const clickInContent = doc.indexOf('world'); // somewhere past the `- `
+    expect(resolveListClickForward(state, clickInContent)).toBeNull();
+  });
+
+  it('returns { contentStart } for a click at the start of the line (padding/hidden marker)', () => {
+    const doc = '- hello world\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    // pos = 0 → before/inside the hidden `- ` marker
+    const result = resolveListClickForward(state, 0);
+    expect(result).not.toBeNull();
+    // Content starts after `- ` → position 2
+    expect(result?.contentStart).toBe(2);
+  });
+
+  it('returns { contentStart } for a click inside the hidden marker range', () => {
+    const doc = '- hello world\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    // pos = 1 → between `-` and the space (still in the hidden marker zone)
+    const result = resolveListClickForward(state, 1);
+    expect(result?.contentStart).toBe(2);
+  });
+
+  it('returns null at the exact contentStart boundary (click on first content char)', () => {
+    const doc = '- hello world\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    // pos = 2 → exactly at `h` of `hello`; CM6 default placement is correct
+    expect(resolveListClickForward(state, 2)).toBeNull();
+  });
+
+  it('returns null for a click on plain content text in an ordered item', () => {
+    const doc = '1. ordered content\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const clickInContent = doc.indexOf('content');
+    expect(resolveListClickForward(state, clickInContent)).toBeNull();
+  });
+
+  it('returns { contentStart } for a click at the start of an ordered item', () => {
+    const doc = '1. ordered content\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const result = resolveListClickForward(state, 0);
+    // `1. ` is 3 chars long
+    expect(result?.contentStart).toBe(3);
+  });
+
+  it('returns null for a click on content of a task item (past the `- [ ] `)', () => {
+    const doc = '- [ ] buy milk\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const clickInContent = doc.indexOf('milk');
+    expect(resolveListClickForward(state, clickInContent)).toBeNull();
+  });
+
+  it('returns { contentStart } past the task marker for a click at start of a task item', () => {
+    const doc = '- [ ] buy milk\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const result = resolveListClickForward(state, 0);
+    // `- [ ] ` is 6 chars long → content starts at 6
+    expect(result?.contentStart).toBe(6);
+  });
+
+  it('returns { contentStart } for a click inside the raw `[ ]` of a task item', () => {
+    // When the cursor is on the line, raw `- [ ] ` is visible. Clicking inside
+    // the `[ ]` should still bump to contentStart (consistent with original
+    // handler behavior — avoids landing between `- ` and `[` which collides
+    // with the checkbox widget replace range).
+    const doc = '- [ ] buy milk\n\nbody';
+    const state = makeState(doc, 8); // cursor on the line, raw marker visible
+    const clickInsideMarker = 3; // pos of the space inside `[ ]`
+    const result = resolveListClickForward(state, clickInsideMarker);
+    expect(result?.contentStart).toBe(6);
+  });
+
+  it('returns null for a click outside any list (paragraph text)', () => {
+    const doc = 'just a paragraph\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    expect(resolveListClickForward(state, 5)).toBeNull();
+  });
+
+  it('returns null for a click on content of a nested bullet item', () => {
+    // Nested list — depth 2 bullet. Clicking on the content text inside the
+    // nested item must NOT be forwarded; the bug was that nested clicks were
+    // also being slammed to contentStart.
+    const doc = '- outer\n  - inner content\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const clickInContent = doc.indexOf('content');
+    expect(resolveListClickForward(state, clickInContent)).toBeNull();
+  });
+
+  it('returns { contentStart } past the inner marker for a click on the inner ListMark', () => {
+    // Nested items: the leading whitespace of the inner item belongs to the
+    // OUTER ListItem in the lezer-markdown tree (it's part of the outer
+    // item's indented continuation). The inner ListItem range starts at the
+    // inner ListMark — so the syntax-tree-driven helper can only recognize
+    // "padding click on the inner item" when pos lands on the inner marker
+    // itself. Anything left of that resolves to the outer item.
+    const doc = '- outer\n  - inner content\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const innerMarkerPos = doc.indexOf('- inner'); // 10 (the `-`)
+    const result = resolveListClickForward(state, innerMarkerPos);
+    expect(result).not.toBeNull();
+    // contentStart = innerMarkerPos + 2 (past `- `)
+    expect(result?.contentStart).toBe(innerMarkerPos + 2);
   });
 });

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
@@ -646,18 +646,91 @@ export const livePreviewAtomicRanges = EditorView.atomicRanges.of((view) => {
 });
 
 /**
+ * Resolves a click position inside a list-item line to a forward target, or
+ * null if the click should be left to CM6's native selection handling.
+ *
+ * Returns `{ contentStart }` only when `pos` lies in the "padding/marker zone"
+ * (before the first character of actual content) — that's the case the
+ * `livePreviewListClickForward` handler exists to fix (#146/#153). When `pos`
+ * is already at or past `contentStart`, the user clicked on real content text
+ * and CM6's default `posAtCoords` selection is exactly right; forwarding would
+ * destroy the intended caret position (#XXX bug: clicks on unstyled list
+ * content were being slammed to `contentStart` because plain text nodes have
+ * `.cm-line` as their event target).
+ *
+ * Extracted as a pure function so the gate is unit-testable without mounting
+ * a DOM EditorView.
+ */
+export function resolveListClickForward(
+  state: EditorState,
+  pos: number
+): { contentStart: number } | null {
+  const tree = syntaxTree(state);
+  // Resolve with both biases and prefer the deepest (tightest-range) ListItem
+  // containing `pos`. Neither bias alone is sufficient:
+  //  - Leftward (-1) is right for clicks at the END of a line (would otherwise
+  //    spill into the next sibling), and is needed inside content.
+  //  - Rightward (+1) is right for the very start of a top-level item
+  //    (pos === 0; leftward would resolve to `Document` and the walk would
+  //    fail) and for the inner ListMark of a nested item (leftward returns the
+  //    OUTER ListItem because the inner item's leading whitespace belongs to
+  //    the outer item's range in the lezer-markdown tree).
+  // Picking the smaller of the two ranges gives the deepest nesting at every
+  // boundary case.
+  const walk = (n: SyntaxNode | null): SyntaxNode | null => {
+    let p = n;
+    while (p && p.type.name !== 'ListItem') p = p.parent;
+    return p;
+  };
+  const itemLeft = walk(tree.resolveInner(pos, -1));
+  const itemRight = walk(tree.resolveInner(pos, 1));
+  let item: SyntaxNode | null;
+  if (!itemLeft) item = itemRight;
+  else if (!itemRight) item = itemLeft;
+  else item = itemRight.to - itemRight.from < itemLeft.to - itemLeft.from ? itemRight : itemLeft;
+  if (!item) return null;
+  const n = item;
+
+  // For task items, anchor the cursor after the task marker (`[ ] ` / `[x] `)
+  // — otherwise the user lands between `- ` and `[`, which collides with the
+  // checkbox widget replace range and feels off.
+  const taskChild = findFirstChild(n, 'Task');
+  const taskMarker = taskChild ? findFirstChild(taskChild, 'TaskMarker') : null;
+  let contentStart: number;
+  if (taskMarker) {
+    const next = state.doc.sliceString(taskMarker.to, taskMarker.to + 1);
+    contentStart = next === ' ' ? taskMarker.to + 1 : taskMarker.to;
+  } else {
+    const listMark = findFirstChild(n, 'ListMark');
+    if (!listMark) return null;
+    const next = state.doc.sliceString(listMark.to, listMark.to + 1);
+    contentStart = next === ' ' ? listMark.to + 1 : listMark.to;
+  }
+
+  if (pos >= contentStart) return null;
+  return { contentStart };
+}
+
+/**
  * Forwards a click in the "padding zone" of a list-item line (the area left
  * of the marker and over the rendered `::before` bullet) to the content start
- * (position right after `- ` / `1. `). Without this, CM6's `posAtCoords` maps
- * such clicks to `itemLine.from`, which then bumps to `listMark.from` via
- * the atomic prefix — leaving the cursor BEFORE the marker, where the user
- * has to manually arrow-right twice to start typing.
+ * (position right after `- ` / `1. ` / `- [ ] `). Without this, CM6's
+ * `posAtCoords` maps such clicks to `itemLine.from`, which then bumps to
+ * `listMark.from` via the atomic prefix — leaving the cursor BEFORE the
+ * marker, where the user has to manually arrow-right twice to start typing.
  *
- * Trigger condition: `event.target` is the `.cm-line` element itself (i.e.
- * the click did NOT land on any text node / span inside the line). When the
- * user clicks an actual character — including the marker once it's revealed
- * (cursor on line) — `target` is a child span and we let CM6's default
- * selection handling run, so the caret lands exactly where clicked.
+ * Two-stage gate:
+ *  1. `event.target === .cm-line` — fast reject for clicks that landed on a
+ *     wrapping span (highlighted tokens like `**bold**`, `*italic*`, code,
+ *     widgets); CM6's default selection already handles those correctly.
+ *  2. `pos >= contentStart` — reject clicks resolving to actual content text.
+ *     Plain (unstyled) list content has no wrapping span, so its text nodes
+ *     bubble events up to `.cm-line` — the target check alone would treat
+ *     every such click as a padding-zone click and slam the caret to
+ *     `contentStart`, losing the user's intended position. Comparing the
+ *     resolved doc position against `contentStart` distinguishes a real
+ *     padding-zone click (pos lands in hidden marker / leading whitespace,
+ *     i.e. < contentStart) from a content click (pos >= contentStart).
  */
 export const livePreviewListClickForward = EditorView.domEventHandlers({
   mousedown(event, view) {
@@ -675,33 +748,11 @@ export const livePreviewListClickForward = EditorView.domEventHandlers({
     const pos = view.posAtCoords({ x: event.clientX, y: event.clientY }, false);
     if (pos === null) return false;
 
-    const tree = syntaxTree(view.state);
-    let n: SyntaxNode | null = tree.resolveInner(pos, -1);
-    while (n && n.type.name !== 'ListItem') n = n.parent;
-    if (!n) return false;
-
-    // For task items, anchor the cursor after the task marker (`[ ] ` / `[x] `)
-    // — otherwise the user lands between `- ` and `[`, which collides with the
-    // checkbox widget replace range and feels off.
-    const taskChild = findFirstChild(n, 'Task');
-    const taskMarker = taskChild ? findFirstChild(taskChild, 'TaskMarker') : null;
-    if (taskMarker) {
-      const next = view.state.doc.sliceString(taskMarker.to, taskMarker.to + 1);
-      const contentStart = next === ' ' ? taskMarker.to + 1 : taskMarker.to;
-      event.preventDefault();
-      view.dispatch({ selection: { anchor: contentStart } });
-      view.focus();
-      return true;
-    }
-
-    const listMark = findFirstChild(n, 'ListMark');
-    if (!listMark) return false;
-
-    const next = view.state.doc.sliceString(listMark.to, listMark.to + 1);
-    const contentStart = next === ' ' ? listMark.to + 1 : listMark.to;
+    const result = resolveListClickForward(view.state, pos);
+    if (!result) return false;
 
     event.preventDefault();
-    view.dispatch({ selection: { anchor: contentStart } });
+    view.dispatch({ selection: { anchor: result.contentStart } });
     view.focus();
     return true;
   }


### PR DESCRIPTION
The `livePreviewListClickForward` handler (added in #153 to bump padding-zone clicks past the hidden list marker) filtered solely on `target.classList.contains('cm-line')`. Plain (unstyled) list content has no wrapping span, so its text nodes bubble events up to `.cm-line` itself - the handler treated every such click as a padding-zone click and slammed the caret to `contentStart`, losing the user's intended position. Styled fragments (`**bold**`, `*italic*`, `~~strike~~`, `` `code` ``, link/image widgets) target their own spans, which is why clicks inside them already worked.

Add a second gate: after resolving `pos = view.posAtCoords(...)`, only forward when `pos < contentStart`. Clicks resolving to actual content text fall through to CM6's native selection so the caret lands exactly where clicked. The padding-zone fix from #153 still applies because those clicks resolve to positions inside the hidden marker / leading whitespace.

Extract the decision into a pure `resolveListClickForward(state, pos)` helper so the gate is unit-testable without mounting a DOM EditorView. The helper tries both leftward and rightward `resolveInner` biases and picks the tightest enclosing `ListItem`. Neither bias alone is correct at boundary positions: leftward at `pos == 0` resolves to `Document`, and at the inner `ListMark` of a nested item leftward returns the outer `ListItem` (the inner item's leading whitespace belongs to the outer item's range in the lezer-markdown tree).

Add 13 regression tests covering: plain content clicks in bullet / ordered / task items (must NOT forward), padding-zone and hidden-marker clicks (MUST forward), boundary at `contentStart`, click on raw `[ ]` of a task item, click outside any list, and the inner `ListMark` of a nested item.