### PR TITLE
fix(task): fan out push schedules per user + align cron to wall-clock 5min

### DIFF
--- a/apps/reborn-task/src/lib/server/push-cron.ts
+++ b/apps/reborn-task/src/lib/server/push-cron.ts
@@ -14,9 +14,11 @@
  * external coordinator. Picked over a dedicated worker per D1 decision
  * (2026-05-26).
  *
- * Lifecycle: started lazily on module import from hooks.server.ts. setInterval
- * keeps the Node event loop alive; that is intentional - the cron is part of
- * the server's normal operation, not a one-shot job.
+ * Lifecycle: started lazily on module import from hooks.server.ts. Each tick
+ * uses setTimeout aligned to the next wall-clock 5-min boundary, re-scheduling
+ * after the tick completes (see `scheduleNextTick`). That keeps the Node event
+ * loop alive; that is intentional - the cron is part of the server's normal
+ * operation, not a one-shot job.
  */
 
 import webpush from 'web-push';
@@ -32,8 +34,19 @@ const logger = createLogger('PushCron');
 const ADVISORY_LOCK_CLASSID = 0x52455042; // 'REPB'
 const ADVISORY_LOCK_OBJID = 0x50534348; // 'PSCH'
 
-/** How often we wake up to check for due schedules. */
-const TICK_MS = 60_000;
+/**
+ * How often we wake up to check for due schedules.
+ *
+ * Matched to the client-side bucket size (`SERVER_SCHEDULE_BUCKET_MS = 5 min`
+ * in push-notification.service.ts). The cron also aligns its ticks to wall
+ * clock so they fire at xx:00, xx:05, xx:10 ... instead of being phase-shifted
+ * by the process boot time. With aligned 5-min ticks, a notification scheduled
+ * at bucketed `fire_at = T` is delivered between T and T+small-jitter (just
+ * the time taken to scan + dispatch) - never up to 5 min late as it would be
+ * with an unaligned 5-min interval. End-to-end delivery window is therefore
+ * "0 to ~5 min earlier than the user's intended reminder", never later.
+ */
+const TICK_MS = 5 * 60_000;
 
 /** Maximum push attempts per schedule row before we give up. */
 const MAX_FAILURE_COUNT = 3;
@@ -42,7 +55,7 @@ const MAX_FAILURE_COUNT = 3;
 const BATCH_SIZE = 200;
 
 let started = false;
-let intervalHandle: ReturnType<typeof setInterval> | null = null;
+let tickTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
 let vapidConfigured = false;
 
 function configureVapid(): boolean {
@@ -206,32 +219,52 @@ async function runTick(): Promise<void> {
 	}
 }
 
+/**
+ * Schedule the next tick aligned to the wall-clock 5-min boundary.
+ *
+ * `Math.ceil(now / TICK_MS) * TICK_MS` picks the next multiple of TICK_MS in
+ * the epoch timeline; because TICK_MS = 300_000 ms divides evenly into the day,
+ * the boundary lands on wall-clock xx:00, xx:05, xx:10 ... regardless of the
+ * server's timezone. Re-scheduling after each tick (rather than `setInterval`)
+ * lets the alignment self-correct if a tick runs long; without this, a single
+ * slow tick would phase-shift every subsequent one.
+ */
+function scheduleNextTick(): void {
+	if (!started) return;
+	const now = Date.now();
+	const nextTickAt = Math.ceil(now / TICK_MS) * TICK_MS;
+	const delayMs = nextTickAt - now;
+	tickTimeoutHandle = setTimeout(async () => {
+		try {
+			await runTick();
+		} catch (error) {
+			logger.error('Push cron tick threw:', error);
+		}
+		scheduleNextTick();
+	}, delayMs);
+}
+
 /** Idempotent start - safe to call multiple times (HMR, test setup). */
 export function startPushCron(): void {
 	if (started) return;
 	started = true;
 
-	// Only schedule the interval if VAPID is configured to avoid spinning
-	// up a tick that immediately no-ops every minute on dev environments
-	// where VAPID is left at the placeholder.
+	// Only schedule the tick chain if VAPID is configured to avoid spinning
+	// up a no-op cron on dev environments where VAPID is left at the placeholder.
 	if (!configureVapid()) {
 		logger.info('VAPID not configured - push cron disabled');
 		return;
 	}
 
-	logger.info(`Push cron started (tick every ${TICK_MS / 1000}s)`);
-	intervalHandle = setInterval(() => {
-		void runTick().catch((error) => {
-			logger.error('Push cron tick threw:', error);
-		});
-	}, TICK_MS);
+	logger.info(`Push cron started (wall-clock aligned, tick every ${TICK_MS / 1000}s)`);
+	scheduleNextTick();
 }
 
-/** For tests - clears the interval. */
+/** For tests - clears the pending tick. */
 export function stopPushCron(): void {
-	if (intervalHandle !== null) {
-		clearInterval(intervalHandle);
-		intervalHandle = null;
+	if (tickTimeoutHandle !== null) {
+		clearTimeout(tickTimeoutHandle);
+		tickTimeoutHandle = null;
 	}
 	started = false;
 }

--- a/apps/reborn-task/src/routes/api/notifications/schedule/+server.ts
+++ b/apps/reborn-task/src/routes/api/notifications/schedule/+server.ts
@@ -1,10 +1,16 @@
 /**
  * POST /api/notifications/schedule
- *   Replace-all upsert of pending push schedules for the caller's subscription.
+ *   Replace-all upsert of pending push schedules for the caller, fanned out
+ *   across ALL of their active subscriptions.
  *   Body: { endpoint, items: [{ task_id, fire_at }] }
- *   Behavior: inside one transaction, delete all unsent schedules for the
- *   subscription, then insert the new list. Idempotent - the client can re-sync
- *   on every task change without diffing.
+ *   Behavior: in one transaction, delete every unsent schedule belonging to
+ *   the user (across devices), then insert `items × subscriptions`. The
+ *   `endpoint` is kept in the contract for authenticity/diagnostics but the
+ *   write is intentionally cross-device: each item is materialized for every
+ *   active subscription so the cron wakes every signed-in device, not only
+ *   the one that authored the task change. Idempotent - whichever device
+ *   syncs last wins, but all devices compute the same `(task_id, fire_at)`
+ *   from their identical synced task store, so the result converges.
  *
  * DELETE /api/notifications/schedule
  *   Cancel a single task's pending schedules across all of the user's
@@ -61,35 +67,49 @@ export const POST: RequestHandler = async ({ request }) => {
 
 		const { endpoint, items } = validation.data;
 
-		const subscription = await prisma.userWebPushSubscription.findFirst({
+		// Verify the caller's own subscription exists - this both proves the
+		// device is registered and guards against schedules from a logged-out
+		// or stale browser. The actual write below fans out to every active
+		// subscription of the user (multi-device delivery).
+		const callerSubscription = await prisma.userWebPushSubscription.findFirst({
 			where: { endpoint, user_id: userId, is_active: true },
 			select: { id: true }
 		});
-		if (!subscription) {
+		if (!callerSubscription) {
 			return json({ success: false, error: 'Subscription not found' }, { status: 404 });
 		}
 
-		const subscriptionId = subscription.id;
+		const subscriptions = await prisma.userWebPushSubscription.findMany({
+			where: { user_id: userId, is_active: true },
+			select: { id: true }
+		});
 
-		// Replace-all: drop everything not yet sent, then re-insert. Already-sent
-		// rows are preserved so the cron's retention sweep (D4) can audit them.
+		// Replace-all per user (cross-device). Drop every pending row of the
+		// caller, then re-materialize `items × subscriptions` so the cron wakes
+		// every signed-in device, not just the one that authored the change.
+		// Already-sent rows are preserved so the retention sweep (D4) can audit
+		// them. The same `(task_id, fire_at)` is recomputed identically on each
+		// device, so replace-all from a different device converges to the same
+		// set - no oscillation between writers.
 		await prisma.$transaction(async (tx) => {
 			await tx.pushSchedule.deleteMany({
-				where: { subscription_id: subscriptionId, sent_at: null }
+				where: { user_id: userId, sent_at: null }
 			});
-			if (items.length > 0) {
+			if (items.length > 0 && subscriptions.length > 0) {
 				await tx.pushSchedule.createMany({
-					data: items.map((item) => ({
-						user_id: userId,
-						subscription_id: subscriptionId,
-						task_id: item.task_id,
-						fire_at: new Date(item.fire_at)
-					}))
+					data: subscriptions.flatMap((sub) =>
+						items.map((item) => ({
+							user_id: userId,
+							subscription_id: sub.id,
+							task_id: item.task_id,
+							fire_at: new Date(item.fire_at)
+						}))
+					)
 				});
 			}
 		});
 
-		return json({ success: true, count: items.length });
+		return json({ success: true, count: items.length, devices: subscriptions.length });
 	} catch (error: unknown) {
 		logger.error('Schedule POST error:', error);
 		return json({ success: false, error: 'Internal server error' }, { status: 500 });

--- a/docs/security/push-notifications.md
+++ b/docs/security/push-notifications.md
@@ -50,11 +50,11 @@ The toggle is in **Settings -> Notifications -> Background notifications (server
 
 Turning it off:
 
-- The server stops receiving any reminder fire times. Past schedules for your device are deleted from the server immediately.
+- The server stops receiving any reminder fire times. Past schedules for your account are deleted from the server immediately.
 - Notifications continue to work, but only while the app is open in a foreground tab. When the app is closed or the tab is in the background, no reminder is delivered.
 - Recommended for users with elevated threat models (journalists, researchers, dissidents) who prefer the strictest Zero Knowledge posture over the convenience of background delivery.
 
-The setting is per-device. If you log into the same account on another device, that device makes its own choice.
+The setting is part of your synced account settings, so toggling it on one device flips it on every signed-in device automatically. When you turn it off, all pending server-side schedules across every device are dropped in the same transaction.
 
 ---
 
@@ -66,8 +66,10 @@ This part describes the server contract, what is stored where, and the defence-i
 
 When the user has the background-delivery toggle on, the client maintains a server-side schedule via two endpoints:
 
-- `POST /api/notifications/schedule` - replace the pending schedule for this push subscription. Body: `{ items: [{ task_id, fire_at }, ...] }`. Idempotent; the server replaces all rows for the subscription where `sent_at IS NULL` and inserts the new set.
-- `DELETE /api/notifications/schedule/:task_id` - cancel the schedule for a specific task (used when a task is completed, deleted, or has its reminder removed).
+- `POST /api/notifications/schedule` - replace the pending schedule for the account. Body: `{ endpoint, items: [{ task_id, fire_at }, ...] }`. The `endpoint` identifies the caller's push subscription and must belong to the authenticated user (rejected otherwise). The server then fans the items out across **every** active subscription registered for that user so the dispatcher can wake every signed-in device, not only the one that authored the change. Idempotent: in one transaction the server drops every row where `user_id = caller AND sent_at IS NULL` and re-inserts `items × subscriptions`.
+- `DELETE /api/notifications/schedule` - cancel the schedule for a specific task across every subscription the user has. Body: `{ task_id }`. Used when a task is completed, deleted, or has its reminder removed.
+
+Why fan-out per user instead of per subscription: the local task store is synced across devices, so every device computes the same `(task_id, fire_at)` set. If only the device that authored a change wrote schedule rows, a phone left in your pocket would never be woken. With per-user fan-out, any device that opens the application and runs a re-sync writes schedules covering every device.
 
 The client recomputes the schedule from the local task store whenever the task store changes, on `visibilitychange`, and on a 15-minute interval. The horizon is 7 days; reminders further than 7 days out are scheduled later, when they enter the window.
 
@@ -93,9 +95,13 @@ Note the absence of any encrypted-content column. There is no `payload_encrypted
 
 Pending rows (`sent_at IS NULL`) are hard-deleted when the toggle is turned off. Sent rows are retained for 7 days for delivery diagnostics and then hard-deleted.
 
+For users with multiple signed-in devices, each scheduled reminder is materialised once per active push subscription (so a user with three devices, two pending reminders, will have six rows). The total leakage is unchanged - the server already knows how many active subscriptions you have from the `UserWebPushSubscription` table - but the row count in `PushSchedule` scales with `devices × pending_reminders`.
+
 ### Dispatch path
 
-A scheduler process (held in-process for now, guarded by a Postgres advisory lock so multi-instance deployments never duplicate sends) scans `WHERE sent_at IS NULL AND fire_at <= now()` every 5 minutes. For each due row it calls `webpush.sendNotification(subscription, JSON.stringify({ type: 'task_reminder', task_id }))`.
+A scheduler process (held in-process for now, guarded by a Postgres advisory lock so multi-instance deployments never duplicate sends) scans `WHERE sent_at IS NULL AND fire_at <= now()` every 5 minutes, aligned to wall-clock 5-minute boundaries (xx:00, xx:05, xx:10 ...). For each due row it calls `webpush.sendNotification(subscription, JSON.stringify({ type: 'task_reminder', task_id }))`.
+
+Wall-clock alignment matters because it locks down the delivery window. The client floors each `fire_at` down to the previous 5-minute mark before sending; the cron then dispatches at that same wall-clock mark with only the small jitter of scan + dispatch. Net result: a reminder configured for 14:48 (15 minutes before a 15:03 deadline) is bucketed to 14:45 and dispatched around 14:45 - up to 3 minutes earlier than the user's intended fire time, never later. Without the wall-clock alignment, a phase-shifted 5-minute interval could just as easily fire the same reminder at 14:49 (a minute late), which is exactly what we want to rule out for a productivity tool.
 
 The dispatched push payload is encrypted by the `web-push` library using the subscription's `p256dh` key before it leaves our server. The browser's push service (FCM / Apple Push / Mozilla autopush) sees only opaque ciphertext. Even so, **our server briefly sees the cleartext payload** while building it - which is why that payload contains only the type tag and the task id, both already plaintext on the server. No new information is leaked at this layer.
 
@@ -117,7 +123,7 @@ The encrypted local task store is the only place the title is decrypted. The cle
 | Server compromise (database dump) | Attacker learns reminder fire times bucketed to 5 minutes, plus the existing plaintext `(task_id, user_id, updated_at)` triples. Attacker does **not** learn task titles, bodies, descriptions, list names, tag associations, completion state, starred state, or any non-reminder behavioural metadata. |
 | Push service compromise (FCM / Apple Push / Mozilla autopush) | The push service sees ciphertext payloads (encrypted by `web-push` with the subscription's p256dh key). It learns only that a wake-up was sent to a device at a particular time. |
 | Network observer (TLS-terminated) | Sees TLS-encrypted traffic. The HTTPS connection to our server is end-to-end at the TLS layer; nothing in the push pipeline weakens it. |
-| User with elevated threat model | Turn the toggle off. Reverts to local-only delivery; the server then receives **no** reminder timing data at all and the `PushSchedule` table holds no rows for that subscription. |
+| User with elevated threat model | Turn the toggle off. The setting is account-wide (synced across devices), so flipping it on any device clears the server-side schedule for every device in the same transaction. The `PushSchedule` table holds no pending rows for the account, and no reminder timing data is sent to the server until the toggle is re-enabled. |
 
 ### What this trades, and why
 


### PR DESCRIPTION
Two post-deploy fixes to the v0.26.0 push notifications pipeline:

* POST /api/notifications/schedule now replace-alls per user and materializes items × subscriptions in one transaction, so the cron wakes every signed-in device instead of only the one that authored the task change. Previously a phone left in the pocket never received a reminder.

* Push cron tick changed from 60s setInterval to a recursive setTimeout aligned to wall-clock 5-minute boundaries (xx:00, xx:05, xx:10, ...). Combined with the existing 5-min client-side bucket, this locks the delivery window to "0 to ~5 min earlier than the user's intended fire time, never later" - the plan's original intent. 5x fewer DB scans as a side benefit.