### PR TITLE
fix(task): route notification clicks to PWA window under sub-path

### DIFF
--- a/apps/reborn-task/src/lib/services/push-notification.service.ts
+++ b/apps/reborn-task/src/lib/services/push-notification.service.ts
@@ -346,7 +346,12 @@ class PushNotificationService {
 						title: task.title,
 						body,
 						fireAt,
-						url: `/tasks/${task.id}`
+						// Must include PUBLIC_BASE_PATH so notificationclick navigates
+						// to the correct route under sub-path deployments (prod runs
+						// the app under /task). The server-assisted path builds the
+						// URL in service-worker.ts using `${base}/tasks/...` from the
+						// SW registration scope; this client path mirrors that.
+						url: `${PUBLIC_BASE_PATH}/tasks/${task.id}`
 					}
 				});
 			}

--- a/apps/reborn-task/src/routes/manifest.webmanifest/+server.ts
+++ b/apps/reborn-task/src/routes/manifest.webmanifest/+server.ts
@@ -26,6 +26,15 @@ export const GET: RequestHandler = () => {
 		start_url: base ? `${base}/` : '/',
 		scope: base ? `${base}/` : '/',
 		display: 'standalone',
+		// Route in-scope URLs (notification clicks, deep links) to the installed
+		// PWA window instead of a browser tab. Without this, Android Chrome opens
+		// `clients.openWindow(url)` from the notificationclick handler in a regular
+		// browser tab even when the PWA is installed.
+		// `navigate-existing`: focus & navigate an open PWA window if any.
+		// `handle_links: preferred`: when no PWA window is open, prefer launching
+		// the PWA over the browser for URLs within scope. Chromium >= 102 / 96.
+		launch_handler: { client_mode: 'navigate-existing' },
+		handle_links: 'preferred',
 		background_color: '#ffffff',
 		theme_color: '#43a047',
 		orientation: 'portrait-primary',


### PR DESCRIPTION
Two independent bugs hit notification clicks once VAPID was unblocked:

1. The local SW scheduling path posted a URL of `/tasks/<id>` without PUBLIC_BASE_PATH, so reminders fired while the app was open landed on the origin root and 404'd under the /task sub-path deployment. The server-assisted path already prefixed `base` from the SW scope - the client path now mirrors that.

2. The PWA manifest lacked `launch_handler` and `handle_links`, so Android Chrome opened `clients.openWindow(url)` from notificationclick in a browser tab even when the PWA was installed. Adding `client_mode: navigate-existing` plus `handle_links: preferred` routes in-scope URLs to the installed PWA window.