### PR TITLE
fix(task): show QuickAddTask on empty task lists

### DIFF
--- a/apps/reborn-task/src/lib/components/tasks/QuickAddTask.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/QuickAddTask.svelte
@@ -34,6 +34,8 @@
 	let inputEl = $state<HTMLTextAreaElement | null>(null);
 	let selectedListId = $state('');
 	let isFocused = $state(false);
+	let listSelectOpen = $state(false);
+	let blurHideTimer: ReturnType<typeof setTimeout> | undefined;
 
 	// Keep selectedListId in sync when listId prop changes, or default list loads
 	$effect(() => {
@@ -60,8 +62,10 @@
 		}
 	});
 
-	// Show list selector row only when input is focused or has content
-	let showListRow = $derived(showListSelect && (isFocused || title.length > 0));
+	// Show list selector while typing/focused, or while the list dropdown is open
+	let showListRow = $derived(
+		showListSelect && (isFocused || title.length > 0 || listSelectOpen)
+	);
 
 	export function focus() {
 		inputEl?.focus();
@@ -146,13 +150,18 @@
 	}
 
 	function handleFocus() {
+		if (blurHideTimer !== undefined) {
+			clearTimeout(blurHideTimer);
+			blurHideTimer = undefined;
+		}
 		isFocused = true;
 	}
 
 	function handleBlur() {
-		// Delay to allow click on dropdown before hiding
-		setTimeout(() => {
-			isFocused = false;
+		if (blurHideTimer !== undefined) clearTimeout(blurHideTimer);
+		blurHideTimer = setTimeout(() => {
+			blurHideTimer = undefined;
+			if (!listSelectOpen) isFocused = false;
 		}, 200);
 	}
 </script>
@@ -178,10 +187,12 @@
 	</div>
 
 	{#if showListRow && $activeLists.length > 0}
-		<div class="flex items-center gap-2 pl-1">
+		<!-- preventDefault keeps textarea focused so the row is not unmounted mid-click -->
+		<div class="flex items-center gap-2 pl-1" onmousedown={(e) => e.preventDefault()}>
 			<span class="text-xs text-muted-foreground shrink-0">{$t('task.quick_add.add_to_list')}</span>
 			<Select
 				type="single"
+				bind:open={listSelectOpen}
 				value={selectedListId}
 				onValueChange={(v) => (selectedListId = v)}
 			>

--- a/apps/reborn-task/src/lib/components/tasks/TaskList.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/TaskList.svelte
@@ -247,7 +247,8 @@
 		<div class="flex justify-center py-8">
 			<LoadingSpinner />
 		</div>
-	{:else if tasks.length === 0}
+	{:else}
+		{#if tasks.length === 0}
 		<div class="text-center py-12 text-muted-foreground">
 			{#if $sessionExpired}
 				<p>{$t('auth.session.empty_no_data')}</p>
@@ -255,7 +256,7 @@
 				<p>{$t('task.empty_list')}</p>
 			{/if}
 		</div>
-	{:else}
+		{:else}
 		<!-- Lista zadań aktywnych -->
 		{#if activeTasks.length === 0}
 			<div class="text-center py-8 text-muted-foreground">
@@ -289,12 +290,15 @@
 			</div>
 		{/if}
 
+		{/if}
+
 		<!-- Quick add task -->
 		<div class="mt-3">
 			<QuickAddTask bind:this={quickAddRef} {listId} />
 		</div>
 
 		<!-- Sekcja zadań wykonanych (jeśli istnieją) -->
+		{#if tasks.length > 0}
 		{#if completedTasks.length > 0}
 			<div class="mt-6">
 				<Accordion type="single">
@@ -340,6 +344,7 @@
 					</AccordionItem>
 				</Accordion>
 			</div>
+		{/if}
 		{/if}
 	{/if}
 </div>


### PR DESCRIPTION
## Summary

`QuickAddTask` was only rendered when `tasks.length > 0`. New or empty task lists therefore had no quick-add input, and the header **+** button called `focusQuickAdd()` on an unmounted component (no console error).

## Steps to reproduce

1. Sign up / log in
2. Create a new task list (e.g. `newtasks`)
3. Open the empty list
4. Try **+** or **Add a task…** — nothing happens

## Fix

Always render `QuickAddTask` after the empty/task list block so the first task can be added.

## Tested

- Self-hosted re/task v0.26.5 (`7bd9451`)
- After fix: quick-add input visible on empty lists; `POST /api/tasks` returns 201