### PR TITLE
fix(task): quick-add fixes for empty lists, list selector, and submit UX

### DIFF
--- a/apps/reborn-task/src/lib/components/tasks/QuickAddTask.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/QuickAddTask.svelte
@@ -7,6 +7,7 @@
 -->
 <script lang="ts">
 	import { Plus } from '@lucide/svelte';
+	import { onDestroy } from 'svelte';
 	import { t } from '$lib/stores/i18n.store';
 	import { taskOperationsService } from '$lib/services/task-operations.service';
 	import { toastStore } from '@reborn/ui';
@@ -34,6 +35,8 @@
 	let inputEl = $state<HTMLTextAreaElement | null>(null);
 	let selectedListId = $state('');
 	let isFocused = $state(false);
+	let listSelectOpen = $state(false);
+	let blurHideTimer: ReturnType<typeof setTimeout> | undefined;
 
 	// Keep selectedListId in sync when listId prop changes, or default list loads
 	$effect(() => {
@@ -60,8 +63,12 @@
 		}
 	});
 
-	// Show list selector row only when input is focused or has content
-	let showListRow = $derived(showListSelect && (isFocused || title.length > 0));
+	// Show the list selector row while typing/focused, or while its dropdown is
+	// open. Clicking into the dropdown blurs the textarea, so without the
+	// listSelectOpen term the row would unmount mid-selection.
+	let showListRow = $derived(
+		showListSelect && (isFocused || title.length > 0 || listSelectOpen)
+	);
 
 	export function focus() {
 		inputEl?.focus();
@@ -146,15 +153,28 @@
 	}
 
 	function handleFocus() {
+		// A refocus cancels any pending hide scheduled by a previous blur.
+		if (blurHideTimer !== undefined) {
+			clearTimeout(blurHideTimer);
+			blurHideTimer = undefined;
+		}
 		isFocused = true;
 	}
 
 	function handleBlur() {
-		// Delay to allow click on dropdown before hiding
-		setTimeout(() => {
-			isFocused = false;
+		// Defer hiding so a click landing on the list selector (or its open
+		// dropdown) does not collapse the row mid-interaction. Keep the row while
+		// the dropdown is open; the next genuine blur collapses it.
+		if (blurHideTimer !== undefined) clearTimeout(blurHideTimer);
+		blurHideTimer = setTimeout(() => {
+			blurHideTimer = undefined;
+			if (!listSelectOpen) isFocused = false;
 		}, 200);
 	}
+
+	onDestroy(() => {
+		if (blurHideTimer !== undefined) clearTimeout(blurHideTimer);
+	});
 </script>
 
 <div class="flex flex-col gap-1.5 {className}">
@@ -182,6 +202,7 @@
 			<span class="text-xs text-muted-foreground shrink-0">{$t('task.quick_add.add_to_list')}</span>
 			<Select
 				type="single"
+				bind:open={listSelectOpen}
 				value={selectedListId}
 				onValueChange={(v) => (selectedListId = v)}
 			>

--- a/apps/reborn-task/src/lib/components/tasks/QuickAddTask.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/QuickAddTask.svelte
@@ -6,7 +6,7 @@
 	Supports contextual metadata: section-aware auto-set of due_date, is_starred, etc.
 -->
 <script lang="ts">
-	import { Plus } from '@lucide/svelte';
+	import { Plus, ArrowUp } from '@lucide/svelte';
 	import { onDestroy } from 'svelte';
 	import { t } from '$lib/stores/i18n.store';
 	import { taskOperationsService } from '$lib/services/task-operations.service';
@@ -69,6 +69,9 @@
 	let showListRow = $derived(
 		showListSelect && (isFocused || title.length > 0 || listSelectOpen)
 	);
+
+	// Show the inline submit button (and reserve room for it) once there is text.
+	let hasContent = $derived(title.trim().length > 0);
 
 	export function focus() {
 		inputEl?.focus();
@@ -180,7 +183,7 @@
 <div class="flex flex-col gap-1.5 {className}">
 	<div class="relative">
 		<Plus
-			class="absolute left-2.5 top-3 h-4 w-4 text-muted-foreground pointer-events-none"
+			class="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
 		/>
 		<textarea
 			bind:this={inputEl}
@@ -192,9 +195,26 @@
 			onblur={handleBlur}
 			disabled={isCreating}
 			rows={1}
-			class="w-full resize-none overflow-hidden rounded-md border bg-background py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground
-				focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+			class="block w-full resize-none overflow-hidden rounded-md border bg-background py-2 pl-9 text-sm placeholder:text-muted-foreground
+				focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 {hasContent
+				? 'pr-11'
+				: 'pr-3'}"
 		></textarea>
+		{#if hasContent}
+			<!-- Submit affordance for pointer/touch; keyboard users press Enter.
+			     preventDefault on mousedown keeps the textarea focused through the click. -->
+			<button
+				type="button"
+				onmousedown={(e) => e.preventDefault()}
+				onclick={handleSubmit}
+				disabled={isCreating}
+				aria-label={$t('task.quick_add.submit')}
+				title={$t('task.quick_add.submit')}
+				class="absolute right-1.5 top-1/2 -translate-y-1/2 inline-flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 cursor-pointer"
+			>
+				<ArrowUp class="h-4 w-4" />
+			</button>
+		{/if}
 	</div>
 
 	{#if showListRow && $activeLists.length > 0}
@@ -204,7 +224,13 @@
 				type="single"
 				bind:open={listSelectOpen}
 				value={selectedListId}
-				onValueChange={(v) => (selectedListId = v)}
+				onValueChange={(v) => {
+					selectedListId = v;
+					// Hand focus back to the textarea so Enter creates the task
+					// instead of reopening the selector. bits-ui restores focus to
+					// the trigger on close, so defer past that.
+					setTimeout(() => inputEl?.focus(), 0);
+				}}
 			>
 				<SelectTrigger class="h-7 text-xs truncate flex-1 min-w-0">
 					{$activeLists.find((l) => l.id === selectedListId)?.name ??

--- a/apps/reborn-task/src/lib/components/tasks/TaskList.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/TaskList.svelte
@@ -247,21 +247,21 @@
 		<div class="flex justify-center py-8">
 			<LoadingSpinner />
 		</div>
-	{:else if tasks.length === 0}
-		<div class="text-center py-12 text-muted-foreground">
-			{#if $sessionExpired}
-				<p>{$t('auth.session.empty_no_data')}</p>
-			{:else}
-				<p>{$t('task.empty_list')}</p>
-			{/if}
-		</div>
 	{:else}
-		<!-- Lista zadań aktywnych -->
-		{#if activeTasks.length === 0}
+		{#if tasks.length === 0}
+			<div class="text-center py-12 text-muted-foreground">
+				{#if $sessionExpired}
+					<p>{$t('auth.session.empty_no_data')}</p>
+				{:else}
+					<p>{$t('task.empty_list')}</p>
+				{/if}
+			</div>
+		{:else if activeTasks.length === 0}
 			<div class="text-center py-8 text-muted-foreground">
 				<p>{$t('taskList.no_active_tasks')}</p>
 			</div>
 		{:else}
+			<!-- Lista zadań aktywnych -->
 			<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 			<div
 				class="space-y-2"
@@ -289,7 +289,10 @@
 			</div>
 		{/if}
 
-		<!-- Quick add task -->
+		<!-- Quick add - renderowany też dla pustej listy (pierwsze zadanie).
+		     Celowo widoczny także przy wygasłej sesji: master key jest zachowany,
+		     więc zapis idzie do IndexedDB i synchronizuje się po re-auth (offline-first,
+		     patrz 31-session-expiry-handling.md - nie blokujemy pracy lokalnej). -->
 		<div class="mt-3">
 			<QuickAddTask bind:this={quickAddRef} {listId} />
 		</div>

--- a/packages/i18n/src/translations/tasks/de/task.json
+++ b/packages/i18n/src/translations/tasks/de/task.json
@@ -232,6 +232,7 @@
   "empty_state": "Keine Aufgaben",
   "quick_add": {
     "placeholder": "Aufgabe hinzuf\u00fcgen...",
+    "submit": "Aufgabe hinzuf\u00fcgen",
     "add_to_list": "Hinzuf\u00fcgen zu:",
     "hint_today": "Aufgabe mit heutigem Datum",
     "hint_starred": "Markierte Aufgabe",

--- a/packages/i18n/src/translations/tasks/en/task.json
+++ b/packages/i18n/src/translations/tasks/en/task.json
@@ -232,6 +232,7 @@
   "empty_state": "No tasks",
   "quick_add": {
     "placeholder": "Add a task...",
+    "submit": "Add task",
     "add_to_list": "Add to:",
     "hint_today": "Task with today's date",
     "hint_starred": "Starred task",

--- a/packages/i18n/src/translations/tasks/es/task.json
+++ b/packages/i18n/src/translations/tasks/es/task.json
@@ -232,6 +232,7 @@
   "empty_state": "Sin tareas",
   "quick_add": {
     "placeholder": "Añadir una tarea...",
+    "submit": "Añadir tarea",
     "add_to_list": "Añadir a:",
     "hint_today": "Tarea con la fecha de hoy",
     "hint_starred": "Tarea destacada",

--- a/packages/i18n/src/translations/tasks/fr/task.json
+++ b/packages/i18n/src/translations/tasks/fr/task.json
@@ -232,6 +232,7 @@
   "empty_state": "Aucune t\u00e2che",
   "quick_add": {
     "placeholder": "Ajouter une t\u00e2che...",
+    "submit": "Ajouter la t\u00e2che",
     "add_to_list": "Ajouter \u00e0 :",
     "hint_today": "T\u00e2che avec la date d'aujourd'hui",
     "hint_starred": "T\u00e2che favorite",

--- a/packages/i18n/src/translations/tasks/pl/task.json
+++ b/packages/i18n/src/translations/tasks/pl/task.json
@@ -232,6 +232,7 @@
   "empty_state": "Brak zadań",
   "quick_add": {
     "placeholder": "Dodaj zadanie...",
+    "submit": "Dodaj zadanie",
     "add_to_list": "Dodaj do:",
     "hint_today": "Zadanie z dzisiejszą datą",
     "hint_starred": "Zadanie z gwiazdką",


### PR DESCRIPTION
## Summary

Three fixes to the task quick-add, reimplemented internally per our no-external-PR policy. The first two reproduce the issues reported in #227; the third is an additional UX fix found during review.

- **Empty lists** (`d7632f3`): `QuickAddTask` only mounted when `tasks.length > 0`, so empty lists had no quick-add input and the header **+** focused an unmounted component. It now renders for empty lists too, including offline / expired-session (master key is preserved, see `31-session-expiry-handling.md`).
- **List selector stability** (`33543dd`): in filter views the inline "Add to list" selector unmounted ~200ms after its dropdown opened (textarea blur collapsed the row), making selection impossible. The row now stays mounted while the dropdown is open; the blur timer is cancellable and cleared on destroy.
- **Submit UX** (`2a85938`): after picking a list, focus stayed on the selector trigger so Enter reopened the dropdown instead of creating the task. Focus now returns to the input (Enter submits, desktop and mobile), and a submit button appears at the input's trailing edge for pointer/touch.

## Credit

Reported-by: @esmocode (#227). Thank you for the report - clear repro steps and a correct diagnosis. Per policy we do not merge external PRs, but the report drove these fixes; credited via `Reported-by:` trailers here and to be thanked in the release notes.

## Validation

- `svelte-check`: 0 errors / 0 warnings
- i18n parity (tasks namespace): OK - new `task.quick_add.submit` across en/pl/de/fr/es
- Smoke-tested by maintainer: empty lists, completed-only lists, expired session, filter-view selector, Enter-to-submit, button alignment (desktop + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)