### PR TITLE
fix(deps): bump dompurify to 3.4.8 (XSS, GHSA-87xg-pxx2-7hvx)

### DIFF
--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -59,7 +59,7 @@
     "@reborn/utils": "workspace:*",
     "@replit/codemirror-lang-svelte": "6.0.0",
     "diff": "9.0.0",
-    "dompurify": "3.4.4",
+    "dompurify": "3.4.8",
     "html2canvas-pro": "2.0.2",
     "jspdf": "4.2.1",
     "jszip": "3.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,8 +247,8 @@ importers:
         specifier: 9.0.0
         version: 9.0.0
       dompurify:
-        specifier: 3.4.4
-        version: 3.4.4
+        specifier: 3.4.8
+        version: 3.4.8
       html2canvas-pro:
         specifier: 2.0.2
         version: 2.0.2
@@ -4241,9 +4241,8 @@ packages:
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
-  dompurify@3.4.4:
-    resolution: {integrity: sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==}
-    deprecated: Fixed a security issue introduced in 3.4.4
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   dotenv-cli@11.0.0:
     resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
@@ -10142,7 +10141,7 @@ snapshots:
       '@types/trusted-types': 2.0.7
     optional: true
 
-  dompurify@3.4.4:
+  dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary

`dompurify@3.4.4` carries a high-severity XSS advisory ([GHSA-87xg-pxx2-7hvx](https://github.com/advisories/GHSA-87xg-pxx2-7hvx)), patched in 3.4.5. `reborn-notes` pinned `3.4.4`, so the CI **Security audit** step (`pnpm audit --audit-level moderate --prod`) exits non-zero and fails on every branch (it runs before `check`/`test`/`build`, so those never execute).

This bumps dompurify to **3.4.8** (latest 3.4.x, patch-level, no API changes).

## Scope

- `apps/reborn-notes/package.json`: `dompurify` `3.4.4` -> `3.4.8`
- `pnpm-lock.yaml`: dompurify entries only (importer + resolution/integrity + snapshot). The transitive `dompurify@3.4.2` and all other deps (incl. `@emnapi/*`) are untouched.
- Verified locally: `pnpm install --frozen-lockfile` reports "Lockfile is up to date"; `pnpm audit --audit-level moderate --prod` and `--audit-level high` both exit 0.

## Why separate

Security dependency fix, unrelated to feature work. Merging this first unblocks CI repo-wide (including #228, which is otherwise red on the same audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)