### PR TITLE
chore(release): v0.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.26.6 (2026-06-04)
+
+### 🩹 Fixes
+
+- **deps:** bump dompurify to 3.4.8 (XSS, GHSA-87xg-pxx2-7hvx) ([#229](https://github.com/fundacja-reborn/reapps/pull/229))
+- **task:** quick-add fixes for empty lists, list selector, and submit UX ([#228](https://github.com/fundacja-reborn/reapps/pull/228), [#227](https://github.com/fundacja-reborn/reapps/issues/227))
+
 ## 0.26.5 (2026-05-29)
 
 ### 🩹 Fixes

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/reborn-notes",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/apps/reborn-task/package.json
+++ b/apps/reborn-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reborn-task",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/source",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "clean": "chmod +x ./scripts/clean-all.sh && ./scripts/clean-all.sh",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/api-client",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "description": "Universal API client for Reborn apps with E2E encryption support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/auth",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/crypto",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/database",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/i18n",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "private": true,
   "type": "module",
   "description": "Internationalization package for Reborn apps",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/storage",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/types",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/ui",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "svelte": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/utils",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Release v0.26.6

Version bump + changelog for the next release, routed through a PR because `main` is protected (direct pushes are blocked by the ruleset). `pnpm release` generated the bumps + CHANGELOG entry; this PR lands them on `main`. After merge, the `v0.26.6` git tag and the GitHub Release are created on the merged commit.

### Included (from CHANGELOG)
- **deps:** bump dompurify to 3.4.8 (XSS, GHSA-87xg-pxx2-7hvx) (#229)
- **task:** quick-add fixes for empty lists, list selector, and submit UX (#228, #227)

### Changes
- `0.26.5` -> `0.26.6` across all `@reborn/*` packages, both apps, and the root manifest.
- `CHANGELOG.md` entry for `0.26.6`.

Manifests + changelog only - no code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)