### PR TITLE
chore(release): open a PR instead of pushing the bump to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "release:dry": "node scripts/release.mjs --dry-run",
     "release:patch": "node scripts/release.mjs --specifier=patch",
     "release:minor": "node scripts/release.mjs --specifier=minor",
-    "release:major": "node scripts/release.mjs --specifier=major"
+    "release:major": "node scripts/release.mjs --specifier=major",
+    "release:finalize": "node scripts/release.mjs --finalize"
   },
   "private": true,
   "devDependencies": {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,38 +1,41 @@
 #!/usr/bin/env node
-// Release wrapper for the Nx monorepo.
+// PR-based release wrapper for the Nx monorepo.
 //
-// Two reasons this script exists instead of calling `nx release` directly:
+// `main` is protected (no direct pushes; PR + required CI check). So the release
+// version bump cannot be pushed straight to main like `nx release` wants. This
+// wrapper splits a release into two phases:
 //
-// 1. Private manifest sync. nx release skips package.json files marked
-//    "private": true and never touches the workspace-root package.json.
-//    In this repo the root + apps + @reborn/i18n are all private, so a
-//    plain nx release leaves them stale - and apps/*/vite.config.ts injects
-//    __APP_VERSION__ from the root manifest, so the UI version freezes
-//    at the old number.
+//   pnpm release            Phase 1. Compute the bump from conventional commits
+//                           since the last tag, write the new versions + a
+//                           CHANGELOG entry, commit them on a `release/vX`
+//                           branch, push it, and open a PR. No tag, no push to
+//                           main, no GitHub Release yet.
+//   <review + merge the PR> The release PR goes through CI + review like any
+//                           other change and lands the bump on main.
+//   pnpm release:finalize   Phase 2. Tag main's HEAD as vX, push the tag, and
+//                           create the GitHub Release from the CHANGELOG entry.
 //
-// 2. Whole-repo conventional commits detection. nx release's built-in
-//    conventionalCommits mode bumps each project only when commits touched
-//    that project's files. In this monorepo the product ships from apps/**
-//    (which are private: true and therefore excluded from the release group),
-//    so `fix(auth): ...` that only edits apps/** would produce no bump.
-//    We instead scan the entire git history since the last tag and compute
-//    a single specifier for the whole fixed-version release group.
+// Why a wrapper at all (besides PR routing):
+//   1. Private manifest sync. nx release skips `"private": true` package.json
+//      files (root + apps + @reborn/i18n) and never touches the workspace-root
+//      manifest, yet apps/*/vite.config.ts injects __APP_VERSION__ from the root
+//      manifest, so we sync those four by hand to the workspace version.
+//   2. Whole-repo conventional-commits detection. The product ships from apps/**
+//      (private, excluded from the release group), so a `fix(...)` touching only
+//      apps/** would yield no bump under nx's per-project detection. We instead
+//      scan the whole history since the last tag and compute one specifier.
 //
-// Flow:
-//   1. Determine specifier (explicit --specifier=… wins; otherwise scan commits).
-//   2. If nothing releasable → exit 0.
-//   3. releaseVersion() with that specifier (gitCommit/Tag=false, stageChanges).
-//   4. Sync the four private manifests to the same version, git add them.
-//   5. releaseChangelog() - one commit + tag covering public + private bumps.
+// GitHub token: from the macOS keychain via `git credential` (the same source as
+// `git push` and gh-helper.mjs), never `gh`. See ~/.claude/CLAUDE.md.
 import { releaseChangelog, releaseVersion } from 'nx/release/index.js';
 import { readFile, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// fileURLToPath (not url.pathname) so spaces in the repo path are decoded
-// from %20 to real spaces - otherwise cwd points to a nonexistent dir and
-// every spawned git call fails with ENOENT on paths like "Projekty Dev".
+// fileURLToPath (not url.pathname) so spaces in the repo path are decoded from
+// %20 to real spaces - otherwise cwd points to a nonexistent dir and every
+// spawned git call fails with ENOENT on paths like "Projekty Dev".
 const ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 const PRIVATE_MANIFESTS = [
@@ -44,6 +47,7 @@ const PRIVATE_MANIFESTS = [
 
 const argv = process.argv.slice(2);
 const dryRun = argv.includes('--dry-run');
+const finalize = argv.includes('--finalize');
 const firstRelease = argv.includes('--first-release');
 const verbose = argv.includes('--verbose');
 const specifierArg = argv.find((a) => a.startsWith('--specifier='));
@@ -59,55 +63,134 @@ function git(args) {
 	return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8' }).trim();
 }
 
-// nx.json configures `createRelease: "github"`, so nx calls the GitHub REST API
-// and reads its token from GITHUB_TOKEN/GH_TOKEN only. With neither set it falls
-// back to ~/.config/gh/hosts.yml; when the gh session is missing or expired that
-// file parses to undefined and nx crashes ("Cannot read properties of undefined
-// (reading 'github.com')") - even in --dry-run, which still inits the client to
-// preview the changelog.
-//
-// Per ~/.claude/CLAUDE.md this machine does NOT depend on `gh` (its keychain/
-// trustd path is unreliable under the Claude sandbox and its token expires). The
-// canonical token lives in the macOS keychain and is retrievable with the same
-// `git credential` call that `git push` and gh-helper.mjs use (per-repo via
-// useHttpPath, converting the SSH remote to https form). Source it there and
-// never touch gh. The token is never logged.
-function ensureGithubToken() {
-	if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) return;
-	try {
-		const remote = git(['remote', 'get-url', 'origin']);
-		const u = new URL(remote.replace(/^git@([^:]+):/, 'https://$1/'));
-		const input = `protocol=https\nhost=${u.host}\npath=${u.pathname.replace(/^\//, '')}\n\n`;
-		const out = execFileSync('git', ['-c', 'credential.useHttpPath=true', 'credential', 'fill'], {
-			cwd: ROOT,
-			input,
-			encoding: 'utf-8'
-		});
-		const token = out.match(/^password=(.+)$/m)?.[1];
-		if (token) {
-			process.env.GH_TOKEN = token;
-			console.log('[release] Sourced GitHub token from git credential (keychain).');
-			return;
-		}
-		console.warn(`[release] git credential returned no token for ${u.host}.`);
-	} catch (err) {
-		console.warn(
-			'[release] Could not source a GitHub token from git credential. GitHub ' +
-				'Release creation and changelog PR links may fail. Set GITHUB_TOKEN/GH_TOKEN ' +
-				'manually if needed.' + (verbose ? `\n${err}` : '')
+// owner/repo from the origin remote (handles both git@ and https forms).
+function repoSlug() {
+	const url = git(['remote', 'get-url', 'origin']);
+	const m = url.match(/github\.com[:/]+([^/]+)\/(.+?)(?:\.git)?$/);
+	if (!m) throw new Error('[release] Could not parse owner/repo from origin: ' + url);
+	return { owner: m[1], repo: m[2] };
+}
+
+// GitHub token from the macOS keychain via `git credential` (per-repo, the same
+// source as `git push` and gh-helper.mjs). Never `gh`, never logged.
+function githubToken() {
+	const url = git(['remote', 'get-url', 'origin']);
+	const u = new URL(url.replace(/^git@([^:]+):/, 'https://$1/'));
+	const input = `protocol=https\nhost=${u.host}\npath=${u.pathname.replace(/^\//, '')}\n\n`;
+	const out = execFileSync('git', ['-c', 'credential.useHttpPath=true', 'credential', 'fill'], {
+		cwd: ROOT,
+		input,
+		encoding: 'utf-8'
+	});
+	const m = out.match(/^password=(.+)$/m);
+	if (!m) throw new Error('[release] git credential returned no token (is the keychain unlocked?).');
+	return m[1];
+}
+
+async function gh(token, method, path, body) {
+	const res = await fetch(`https://api.github.com${path}`, {
+		method,
+		headers: {
+			authorization: `Bearer ${token}`,
+			accept: 'application/vnd.github+json',
+			'content-type': 'application/json',
+			'user-agent': 'reapps-release-script'
+		},
+		body: body ? JSON.stringify(body) : undefined
+	});
+	const json = await res.json().catch(() => ({}));
+	if (!res.ok) {
+		throw new Error(
+			`[release] GitHub ${method} ${path} -> ${res.status}: ${json.message || ''} ${JSON.stringify(json.errors || '')}`
 		);
 	}
+	return json;
+}
+
+// The CHANGELOG body for a version: the lines under "## x.y.z (date)" up to the
+// next "## " heading.
+async function changelogSection(version) {
+	const lines = (await readFile(resolve(ROOT, 'CHANGELOG.md'), 'utf-8')).split('\n');
+	const start = lines.findIndex((l) => l === `## ${version}` || l.startsWith(`## ${version} `));
+	if (start === -1) return '';
+	let end = lines.findIndex((l, i) => i > start && l.startsWith('## '));
+	if (end === -1) end = lines.length;
+	return lines.slice(start + 1, end).join('\n').trim();
 }
 
 function getLastReleaseTag() {
 	try {
-		const tags = git(['tag', '--list', 'v*', '--sort=-v:refname'])
-			.split('\n')
-			.filter(Boolean);
+		const tags = git(['tag', '--list', 'v*', '--sort=-v:refname']).split('\n').filter(Boolean);
 		return tags[0] ?? null;
 	} catch {
 		return null;
 	}
+}
+
+// ===================================================================
+// Phase 2: finalize a merged release PR (tag + push tag + GitHub Release).
+// ===================================================================
+if (finalize) {
+	const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+	if (branch !== 'main') {
+		console.error(`[release] --finalize must run on main (currently on "${branch}"). Merge the release PR, then run it from main.`);
+		process.exit(1);
+	}
+	git(['fetch', 'origin', 'main', '--tags']);
+	try {
+		git(['merge', '--ff-only', 'origin/main']);
+	} catch {
+		// not fast-forwardable - handled by the divergence check below
+	}
+	if (git(['rev-parse', 'HEAD']) !== git(['rev-parse', 'origin/main'])) {
+		console.error('[release] Local main is not in sync with origin/main. Pull the merged release PR first (git pull --ff-only).');
+		process.exit(1);
+	}
+
+	const version = JSON.parse(await readFile(resolve(ROOT, 'package.json'), 'utf-8')).version;
+	const tag = `v${version}`;
+
+	if (git(['tag', '--list', tag])) {
+		console.error(`[release] Tag ${tag} already exists locally - already finalized?`);
+		process.exit(1);
+	}
+	if (git(['ls-remote', '--tags', 'origin', tag])) {
+		console.error(`[release] Tag ${tag} already exists on origin - ${tag} is already released.`);
+		process.exit(1);
+	}
+
+	const head = git(['rev-parse', '--short', 'HEAD']);
+	console.log(`\n[release] Finalizing ${tag} on ${head}.`);
+	if (dryRun) {
+		console.log(`[release] [dry-run] would: git tag -a ${tag}; git push origin ${tag}; create GitHub Release from CHANGELOG.`);
+		process.exit(0);
+	}
+
+	git(['tag', '-a', tag, '-m', tag, 'HEAD']);
+	git(['push', 'origin', tag]);
+	console.log(`[release] Tagged and pushed ${tag}.`);
+
+	const token = githubToken();
+	const { owner, repo } = repoSlug();
+	const body = await changelogSection(version);
+	const release = await gh(token, 'POST', `/repos/${owner}/${repo}/releases`, {
+		tag_name: tag,
+		name: tag,
+		body,
+		draft: false,
+		prerelease: false
+	});
+	console.log(`[release] GitHub Release created: ${release.html_url}`);
+	process.exit(0);
+}
+
+// ===================================================================
+// Phase 1: open a release PR (bump + changelog on a release/vX branch).
+// ===================================================================
+const startBranch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+if (!dryRun && startBranch !== 'main') {
+	console.error(`[release] Run releases from main (currently on "${startBranch}").`);
+	process.exit(1);
 }
 
 // Matches: type(scope)!: description  OR  type: description
@@ -142,7 +225,7 @@ function computeSpecifierFromCommits() {
 		}
 		if (type === 'feat') bump('minor');
 		else if (type === 'fix' || type === 'perf') bump('patch');
-		// docs/chore/refactor/test/ci/style/build → no bump
+		// docs/chore/refactor/test/ci/style/build -> no bump
 	}
 
 	return highest;
@@ -191,7 +274,7 @@ for (const relPath of PRIVATE_MANIFESTS) {
 	}
 	syncedFiles.push(relPath);
 	console.log(
-		`[release] ${dryRun ? '[dry-run] would sync' : 'synced'} ${relPath}: ${previous} → ${workspaceVersion}`
+		`[release] ${dryRun ? '[dry-run] would sync' : 'synced'} ${relPath}: ${previous} -> ${workspaceVersion}`
 	);
 }
 
@@ -199,10 +282,36 @@ if (!dryRun && syncedFiles.length > 0) {
 	execFileSync('git', ['add', '--', ...syncedFiles], { stdio: 'inherit', cwd: ROOT });
 }
 
-// nx inits the GitHub client (and may hit the API for changelog PR/author data)
-// in dry-run too, so source a real token in both modes - a placeholder would 401.
-ensureGithubToken();
+// Move the staged bump onto a release branch so main is never written to
+// directly. The staged changes follow the checkout (the branch starts at main's
+// HEAD, so there is no conflict); releaseChangelog then commits them there.
+const releaseBranch = `release/v${workspaceVersion}`;
+if (!dryRun) {
+	const localExists = git(['branch', '--list', releaseBranch]);
+	const remoteExists = git(['ls-remote', '--heads', 'origin', releaseBranch]);
+	if (localExists || remoteExists) {
+		console.error(`[release] Branch ${releaseBranch} already exists - finish or delete the in-flight release first.`);
+		process.exit(1);
+	}
+	git(['checkout', '-b', releaseBranch]);
+}
 
+// nx initialises a GitHub client while GENERATING the changelog (to resolve PR
+// references) even with createRelease:false, so it needs a token in the env -
+// otherwise it falls back to the (missing/expired) gh CLI config and crashes.
+// We also need the token to push the branch and open the PR. Source it from the
+// keychain up front (see githubToken() / ~/.claude/CLAUDE.md).
+let token;
+try {
+	token = githubToken();
+	process.env.GH_TOKEN = token;
+} catch (err) {
+	console.error('[release] Could not source a GitHub token from git credential (is the keychain unlocked?).' + (verbose ? `\n${err}` : ''));
+	process.exit(1);
+}
+
+// gitTag/gitPush/createRelease all off: the tag, push to main and GitHub Release
+// happen in `--finalize` after the PR merges.
 await releaseChangelog({
 	dryRun,
 	firstRelease,
@@ -210,6 +319,36 @@ await releaseChangelog({
 	version: workspaceVersion,
 	versionData: projectsVersionData,
 	gitCommit: true,
-	gitTag: true,
+	gitTag: false,
+	gitPush: false,
+	createRelease: false,
 	stageChanges: true
 });
+
+if (dryRun) {
+	console.log(
+		`\n[release] [dry-run] would push ${releaseBranch} and open a PR to main, then 'pnpm release:finalize' after merge.`
+	);
+	process.exit(0);
+}
+
+execFileSync('git', ['push', '-u', 'origin', releaseBranch], { stdio: 'inherit', cwd: ROOT });
+
+const { owner, repo } = repoSlug();
+const pr = await gh(token, 'POST', `/repos/${owner}/${repo}/pulls`, {
+	title: `chore(release): v${workspaceVersion}`,
+	head: releaseBranch,
+	base: 'main',
+	body:
+		`Release v${workspaceVersion}. Version bump + CHANGELOG, routed through a PR ` +
+		`because main is protected (no direct pushes).\n\n` +
+		`After this merges, run \`pnpm release:finalize\` on main to tag v${workspaceVersion} ` +
+		`and create the GitHub Release.\n\n` +
+		`Generated by scripts/release.mjs.`
+});
+
+// Leave the working copy back on a clean main; the bump lives on the PR branch.
+git(['checkout', 'main']);
+
+console.log(`\n[release] Release PR opened: ${pr.html_url}`);
+console.log('[release] After it is reviewed and merged, run: pnpm release:finalize');


### PR DESCRIPTION
## Summary

`main` is protected (no direct pushes; PR + required CI), so nx's `pnpm release` crashed at its final push to `main` (`GH013: Repository rule violations`). Releases now go through a PR like everything else, in two phases.

## New flow

```bash
pnpm release            # bump + CHANGELOG on a release/vX branch, push, open a PR
# review + merge the PR (CI + approval)
pnpm release:finalize   # on main after merge: tag vX, push the tag, create the GitHub Release
```

`main` never receives a direct commit push; the tag + GitHub Release are created in the finalize step after the PR merges (tag pushes are not blocked by the branch ruleset).

## Changes

- `scripts/release.mjs`:
  - Phase 1 (default): compute the bump, write versions + CHANGELOG, commit on `release/vX`, push it, and open a PR via the GitHub API. `gitTag:false, gitPush:false, createRelease:false`; `main` is left untouched.
  - Phase 2 (`--finalize`): tag main's HEAD, push the tag, create the GitHub Release from the CHANGELOG entry.
  - GitHub token sourced from the macOS keychain via `git credential` (never `gh`), and exported before `releaseChangelog` because nx initialises a GitHub client during changelog generation even with `createRelease:false`.
- `package.json`: adds the `release:finalize` script.

## Validation

- `node --check` passes.
- `pnpm release:dry`: no bump -> "nothing to release"; forced `--specifier=patch` -> previews `release/v0.x` + "would open a PR", no real push.
- Finalize guard verified (refuses to run off `main`).
- The finalize tag + Release path was exercised manually for v0.26.6 (same logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)