### PR TITLE
chore(release): route fetch through the sandbox proxy (undici)

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -33,6 +33,20 @@ import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// In a sandbox (e.g. Claude Code) the network is tunneled through a proxy
+// (HTTPS_PROXY). Node's fetch (undici) ignores it by default and tries a direct
+// connect, which the sandbox blocks (EPERM) - both for our GitHub API calls and
+// nx's changelog client. Route fetch through the proxy when one is set; a no-op
+// outside a sandbox. Must run before any fetch (nx's client is created later).
+if (process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy) {
+	try {
+		const { setGlobalDispatcher, EnvHttpProxyAgent } = await import('undici');
+		setGlobalDispatcher(new EnvHttpProxyAgent());
+	} catch {
+		// undici not resolvable - fetch stays direct (fine outside a sandbox)
+	}
+}
+
 // fileURLToPath (not url.pathname) so spaces in the repo path are decoded from
 // %20 to real spaces - otherwise cwd points to a nonexistent dir and every
 // spawned git call fails with ENOENT on paths like "Projekty Dev".


### PR DESCRIPTION
## Summary

In a sandbox (e.g. Claude Code) the network is tunneled through `HTTPS_PROXY`. Node's `fetch` (undici) ignores it by default and tries a direct `connect()`, which the sandbox blocks with `EPERM`. So `release.mjs`'s GitHub API calls (open the release PR in phase 1, create the GitHub Release in `--finalize`) and nx's changelog client failed inside the sandbox and needed `dangerouslyDisableSandbox`.

## Fix

Set undici's `EnvHttpProxyAgent` as the global dispatcher when a proxy env var is present, before any `fetch` runs (so nx's client picks it up too). It is a no-op outside a sandbox (no proxy env, normal direct connections), so local `pnpm release` is unaffected.

Result: the full release flow (`pnpm release` -> PR -> merge -> `pnpm release:finalize`) runs headless in the sandbox (e.g. `/remote-control`) without disabling it.

## Validation

- `node --check` passes; `pnpm release:dry` unchanged.
- `EnvHttpProxyAgent` confirmed to make Node `fetch` reach `api.github.com` through the sandbox proxy (the same mechanism, tested standalone).
- Companion change (outside this repo): `~/.config/git/gh-helper.mjs` switched from Node `fetch` to `curl` (also proxy-aware) - this very PR was opened by it from inside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)