### PR TITLE
fix(deps): bump hono override to 4.12.23 to clear moderate advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   follow-redirects: 1.16.0
   fast-uri: 3.1.2
   '@babel/plugin-transform-modules-systemjs': 7.29.4
-  hono: 4.12.19
+  hono: 4.12.23
   cookie: 0.7.2
   esbuild: 0.28.0
   '@hono/node-server': 1.19.14
@@ -1751,7 +1751,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.19
+      hono: 4.12.23
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4683,8 +4683,8 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
-  hono@4.12.19:
-    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@3.0.0:
@@ -7743,9 +7743,9 @@ snapshots:
       '@hapi/hoek': 9.3.0
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.19)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.19
+      hono: 4.12.23
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -8426,13 +8426,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.14(hono@4.12.19)
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.19
+      hono: 4.12.23
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -10614,7 +10614,7 @@ snapshots:
 
   he@1.2.0: {}
 
-  hono@4.12.19: {}
+  hono@4.12.23: {}
 
   html-encoding-sniffer@3.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ overrides:
   follow-redirects: 1.16.0
   fast-uri: 3.1.2
   '@babel/plugin-transform-modules-systemjs': 7.29.4
-  hono: 4.12.19
+  hono: 4.12.23
   cookie: 0.7.2
   esbuild: 0.28.0
   '@hono/node-server': 1.19.14


### PR DESCRIPTION
Fixes the CI "Security audit" step (pnpm audit --prod --audit-level moderate), which started failing on every PR (including #234) and is now red on main itself.

Four moderate advisories were published against hono <4.12.21. hono is pulled transitively via @prisma/client > prisma > @prisma/dev > hono and directly via @hono/node-server:

- GHSA-xrhx-7g5j-rcj5 - IP restriction bypass for non-canonical IPv6
- GHSA-3hrh-pfw6-9m5x - Set-Cookie injection via sameSite/priority
- GHSA-f577-qrjj-4474 - JWT middleware accepts any Authorization scheme
- GHSA-2gcr-mfcq-wcc3 - app.mount() mis-routes percent-encoded paths

Bumps the hono override 4.12.19 to 4.12.23 in pnpm-workspace.yaml (all four fixed in >=4.12.21). hono is zero-dependency and @hono/node-server@1.19.14 peers hono@^4, so only the override and its matching lockfile entries change (no unrelated lockfile churn).

Verified locally: prod moderate audit is clean (exit 0), the lockfile passes --frozen-lockfile, and the published hono-4.12.23 tarball sha512 matches the lockfile integrity.