### PR TITLE
chore(ci): drop automerge from Renovate vulnerabilityAlerts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -71,8 +71,6 @@
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],
-    "automerge": true,
-    "automergeType": "pr",
     "semanticCommitType": "fix",
     "minimumReleaseAge": "3 days"
   },


### PR DESCRIPTION
## Summary

Removes `automerge` + `automergeType` from `vulnerabilityAlerts` in `.github/renovate.json`, so Renovate **no longer auto-merges security updates**. They are still created immediately, labelled `security`, typed `fix`, and held 3 days by `minimumReleaseAge` - but now require a deliberate manual merge.

**Why (mechanism, not the originally-planned per-package fix):** Renovate injects `vulnerabilityAlerts` via `force` (highest precedence, appended after user `packageRules` - see `lib/workers/repository/process/vulnerabilities.ts`), so `automerge:true` was forced on *every* security fix for *every* package. A per-package `packageRules` carve-out (the originally-planned approach) is a no-op on the security path; there is no `matchVulnerabilityAlerts` matcher nor nested `packageRules` support. The only effective lever is the global flag.

**Why dropping it is safe / better:** the `main` ruleset already requires a human approval, so no Renovate PR merges unattended anyway. Security-automerge therefore added almost no value (approval was always manual) while creating a footgun - approving a PR merged it instantly, including a breaking major. Dropping it closes:
- the cookie / `@hono/node-server` major-bump concern (cookie v1 caused a refresh-token regression, rollback 2026-05-11), and
- the general risk of any breaking security update sliding in on approval.

Non-security majors were already covered by the existing generic major rule (`automerge:false`). `platformAutomerge:true` is left in place but currently inert (nothing automerges); kept for forward-compatibility if automerge is ever re-enabled.

This is a deliberate **policy** change (global, more conservative) - approved before implementing.

## Test plan

`renovate.json` is bot config - no nx target (test/lint/typecheck/build) touches it.
- [x] `jq` parse: valid JSON.
- [x] Confirmed `0` occurrences of `automerge:true` anywhere in the config after the change.
- [ ] (post-merge, optional) On the next Renovate run, a security update should appear as a PR **without** auto-merge enabled, still labelled `security`.