### PR TITLE
chore(deps): pin ws and qs to patched versions (dev-only CVE)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,8 @@ overrides:
   '@hono/node-server': 1.19.14
   devalue: 5.8.1
   tmp@<0.2.6: 0.2.7
+  ws: ^8.20.1
+  qs: ^6.15.2
 
 importers:
 
@@ -5537,8 +5539,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -6489,8 +6491,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -11550,7 +11552,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -11913,7 +11915,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.8.0
       use-sync-external-store: 1.6.0(react@19.2.6)
-      ws: 8.20.0
+      ws: 8.21.0
     optionalDependencies:
       '@types/react': 19.2.14
       prettier: 3.8.3
@@ -12309,7 +12311,7 @@ snapshots:
 
   union@0.5.0:
     dependencies:
-      qs: 6.15.1
+      qs: 6.15.2
 
   unplugin-dts@1.0.0(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0)):
     dependencies:
@@ -12519,7 +12521,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,9 @@ overrides:
   '@hono/node-server': 1.19.14
   devalue: 5.8.1
   tmp@<0.2.6: '0.2.7'
+  # Dev-only transitive CVE pins (Storybook, nx http-server); absent from prod bundle
+  ws: '^8.20.1' # GHSA-58qx-3vcg-4xpx ws uninitialized memory disclosure
+  qs: '^6.15.2' # GHSA-q8mj-m7cp-5q26 qs.stringify DoS
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true


### PR DESCRIPTION
## Summary

Pins two dev-only transitive dependencies flagged by Dependabot (3 moderate -> 1) to patched versions via `pnpm.overrides`:

- **ws** `^8.20.1` (resolves 8.21.0) - GHSA-58qx-3vcg-4xpx, uninitialized memory disclosure, pulled in by Storybook.
- **qs** `^6.15.2` - GHSA-q8mj-m7cp-5q26, `qs.stringify` DoS, pulled in by `@nx/web > http-server`.

Both are **dev-only**: `pnpm audit --prod` is clean, neither reaches the production bundle. Defense-in-depth on the dev/build toolchain. Majors capped (`^`) so ws 9+/qs 7+ are not dragged into Storybook/nx.

The third advisory (**uuid** GHSA-w5hq-g745-h8pq) is intentionally left: the fix is a uuid v9->v11 major on Storybook (ESM/named-export breakage risk) for ~zero real exposure. Better via an upstream Storybook bump.

Touches only `pnpm-workspace.yaml` (+3) and `pnpm-lock.yaml`; no app code.

## Test plan

- `pnpm audit`: 3 -> 1 moderate (ws, qs gone; uuid remains).
- `pnpm install --frozen-lockfile` validates clean locally (pnpm 11.5.2).
- Heads-up: CI will be **red until ~02:46 UTC tomorrow** on the same minimumReleaseAge age-gate as #243 (branch inherits fresh svelte@5.56.3 / @sveltejs/kit@2.63.1 from main, <24h old). Unrelated to ws/qs; re-run after they mature.