### PR TITLE
fix(notes): make last code line selectable + add copy button

### DIFF
--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -7,7 +7,9 @@
   import type { ImageLoadMode } from '@reborn/storage';
   import {
     highlightCodeToHtml,
-    triggerLanguageLoad
+    triggerLanguageLoad,
+    CODE_COPY_ICON,
+    copyCodeFromButton
   } from '$lib/editor/live-preview';
   import {
     annotateTopLevelLines,
@@ -189,7 +191,14 @@
         if (loaded) langLoadTick++;
       });
     }
-    return highlightCodeToHtml(text, info);
+    // Wrap the <pre> in a positioned container holding a top-right copy
+    // button. `.code-block` (not the scrollable <pre>) is the positioning
+    // context so the button stays pinned while wide code scrolls under it.
+    // The button lives in the sanitized {@html}; clicks are handled by
+    // delegation in `handleClick`. The label is escaped for the attribute.
+    const copyLabel = $t('editor.code_copy').replace(/"/g, '&quot;');
+    const pre = highlightCodeToHtml(text, info);
+    return `<div class="code-block"><button class="code-copy-btn" type="button" aria-label="${copyLabel}" title="${copyLabel}">${CODE_COPY_ICON}</button>${pre}</div>`;
   };
 
   md.use({ renderer });
@@ -280,6 +289,23 @@
 
   function handleClick(e: MouseEvent) {
     const target = e.target as HTMLElement;
+
+    // Copy-code button (top-right of each fenced block). `closest` resolves
+    // clicks that land on the inner <svg>/<path>. We read the rendered code
+    // back from the <code> textContent and strip the single synthetic trailing
+    // newline added for last-line selection, so the clipboard gets the
+    // original source.
+    const copyBtn = target.closest('.code-copy-btn');
+    if (copyBtn) {
+      e.preventDefault();
+      const codeEl = copyBtn.closest('.code-block')?.querySelector('pre code');
+      const code = (codeEl?.textContent ?? '').replace(/\n$/, '');
+      void copyCodeFromButton(copyBtn as HTMLElement, code, {
+        copy: $t('editor.code_copy'),
+        copied: $t('editor.code_copied')
+      });
+      return;
+    }
 
     // Task list checkbox toggle. The browser flips `checked` before the
     // click handler runs; we read the flipped value as the desired state and
@@ -563,11 +589,60 @@
     background: var(--muted);
     overflow-x: auto;
     line-height: 1.6;
+    /* Match the <code> font-size so the <pre>'s line-box strut tracks the
+       glyphs. A larger strut (inherited 1rem on mobile vs 0.875rem code) puts
+       extra space inside each line box and skews where a click maps to a line.
+       Explicit `white-space`/`user-select` keep code reliably selectable. */
+    font-size: 0.875rem;
+    white-space: pre;
+    -webkit-user-select: text;
+    user-select: text;
   }
   .preview :global(pre code) {
     padding: 0;
     background: transparent;
-    font-size: 0.875rem;
+    font-size: inherit;
+  }
+
+  /* Fenced code block + copy button. `.code-block` is the positioning context
+     (overflow visible) so the absolutely-placed button stays pinned to the
+     top-right while the <pre> (the scroll container) scrolls under it. */
+  .preview :global(.code-block) {
+    position: relative;
+  }
+  .preview :global(.code-copy-btn) {
+    position: absolute;
+    top: 0.4em;
+    right: 0.4em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.9em;
+    height: 1.9em;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 0.375em;
+    background: var(--background);
+    color: var(--muted-foreground);
+    cursor: pointer;
+    opacity: 0.55;
+    -webkit-user-select: none;
+    user-select: none;
+    transition:
+      opacity 0.12s ease,
+      color 0.12s ease,
+      border-color 0.12s ease;
+  }
+  .preview :global(.code-block:hover .code-copy-btn),
+  .preview :global(.code-copy-btn:hover),
+  .preview :global(.code-copy-btn:focus-visible) {
+    opacity: 1;
+    color: var(--foreground);
+  }
+  .preview :global(.code-copy-btn.is-copied) {
+    opacity: 1;
+    color: #16a34a;
+    border-color: #16a34a;
   }
 
   /* Syntax highlight tokens — palette mirrors editor/live-preview/theme.ts.

--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -125,6 +125,10 @@
       imageLabels: {
         load: $t('editor.image_load'),
         base64Blocked: $t('editor.image_base64_blocked')
+      },
+      codeLabels: {
+        copy: $t('editor.code_copy'),
+        copied: $t('editor.code_copied')
       }
     };
   }

--- a/apps/reborn-notes/src/lib/editor/live-preview/code-copy.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/code-copy.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared "copy code" button assets + behaviour for fenced code blocks.
+ *
+ * Both Preview (MarkdownPreview's `{@html}` string) and Live Preview
+ * (`CodeBlockWidget` DOM) render a copy button over each code block's
+ * top-right corner. The icon markup is a static, self-contained SVG (no
+ * external deps, never user input) so the same glyph appears in the rendered
+ * HTML string and the editor widget DOM. Clicking writes the raw code to the
+ * clipboard and flips the button to a transient checkmark for ~1.6s.
+ *
+ * Labels are passed in by the caller so the i18n source of truth stays in the
+ * Svelte/i18n layer rather than being duplicated here.
+ */
+
+// Clipboard + check icons (Lucide-style, 16px, `stroke="currentColor"` so they
+// follow the button's text colour). Inlined as strings for the HTML-string
+// (Preview) and DOM (`innerHTML`, Live Preview) call sites alike.
+export const CODE_COPY_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>';
+
+export const CODE_CHECK_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+
+export interface CodeCopyLabels {
+  /** Default state — also the post-revert title/aria-label. */
+  copy: string;
+  /** Shown while the transient checkmark is visible. */
+  copied: string;
+}
+
+// Per-button revert timer. A WeakMap (not a `data-` attribute) keeps the timer
+// id strongly typed across DOM/Node `setTimeout` return types and lets the
+// button be GC'd with its entry when the widget is torn down.
+const revertTimers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>();
+
+/**
+ * Write `code` to the clipboard and show a transient checkmark on `btn`.
+ * Safe to call repeatedly — a pending revert timer is cleared first. Silently
+ * no-ops if the Clipboard API is unavailable or denied (insecure context),
+ * leaving the button in its default state.
+ */
+export async function copyCodeFromButton(
+  btn: HTMLElement,
+  code: string,
+  labels: CodeCopyLabels
+): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(code);
+  } catch {
+    return;
+  }
+  showCopied(btn, labels);
+}
+
+function showCopied(btn: HTMLElement, labels: CodeCopyLabels): void {
+  btn.innerHTML = CODE_CHECK_ICON;
+  btn.title = labels.copied;
+  btn.setAttribute('aria-label', labels.copied);
+  btn.classList.add('is-copied');
+
+  const prev = revertTimers.get(btn);
+  if (prev) clearTimeout(prev);
+  const id = setTimeout(() => {
+    btn.innerHTML = CODE_COPY_ICON;
+    btn.title = labels.copy;
+    btn.setAttribute('aria-label', labels.copy);
+    btn.classList.remove('is-copied');
+    revertTimers.delete(btn);
+  }, 1600);
+  revertTimers.set(btn, id);
+}

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
@@ -502,9 +502,18 @@ describe('buildDecorations — tables', () => {
 
 describe('buildDecorations — inline images', () => {
   const LABELS = { load: 'Load image', base64Blocked: 'Embedded images blocked' };
-  const OPTS_ASK = { imageLoadMode: 'ask' as const, imageLabels: LABELS };
-  const OPTS_ALWAYS = { imageLoadMode: 'always' as const, imageLabels: LABELS };
-  const OPTS_NEVER = { imageLoadMode: 'never' as const, imageLabels: LABELS };
+  const CODE_LABELS = { copy: 'Copy code', copied: 'Copied' };
+  const OPTS_ASK = { imageLoadMode: 'ask' as const, imageLabels: LABELS, codeLabels: CODE_LABELS };
+  const OPTS_ALWAYS = {
+    imageLoadMode: 'always' as const,
+    imageLabels: LABELS,
+    codeLabels: CODE_LABELS
+  };
+  const OPTS_NEVER = {
+    imageLoadMode: 'never' as const,
+    imageLabels: LABELS,
+    codeLabels: CODE_LABELS
+  };
 
   it('replaces an image with an ImageWidget when cursor is outside', () => {
     const doc = 'before ![alt](https://example.com/img.png) after';

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
@@ -16,6 +16,7 @@ import type { Text } from '@codemirror/state';
 import type { ImageLoadMode } from '@reborn/storage';
 import { CodeBlockWidget, LinkWidget, TaskCheckboxWidget } from './widgets';
 import { ImageWidget, type ImageWidgetLabels, getLoadedImages } from './image-widget';
+import type { CodeCopyLabels } from './code-copy';
 import { TableWidget } from './table-widget';
 import { parseTable } from './table-parse';
 
@@ -27,11 +28,13 @@ import { parseTable } from './table-parse';
 export interface BuildDecorationsOptions {
   imageLoadMode: ImageLoadMode;
   imageLabels: ImageWidgetLabels;
+  codeLabels: CodeCopyLabels;
 }
 
 const DEFAULT_OPTIONS: BuildDecorationsOptions = {
   imageLoadMode: 'ask',
-  imageLabels: { load: 'Load image', base64Blocked: 'Embedded images are not supported' }
+  imageLabels: { load: 'Load image', base64Blocked: 'Embedded images are not supported' },
+  codeLabels: { copy: 'Copy code', copied: 'Copied' }
 };
 
 /**
@@ -284,7 +287,7 @@ export function buildDecorations(
           const code = extractCodeText(nodeRef.node, doc);
           ranges.push(
             Decoration.replace({
-              widget: new CodeBlockWidget(code, info),
+              widget: new CodeBlockWidget(code, info, options.codeLabels),
               block: true
             }).range(startLine.from, endLine.to)
           );

--- a/apps/reborn-notes/src/lib/editor/live-preview/highlight-html.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/highlight-html.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { escapeHtml, highlightCodeToHtml } from './highlight-html';
+import { escapeHtml, highlightCodeToHtml, normalizeCodeText } from './highlight-html';
 
 describe('escapeHtml', () => {
   it.each([
@@ -58,5 +58,30 @@ describe('highlightCodeToHtml', () => {
     const html = highlightCodeToHtml('x', 'js" onclick="alert(1)');
     expect(html).not.toContain('onclick');
     expect(html).not.toContain('alert');
+  });
+
+  it('terminates the code body with a single trailing newline', () => {
+    // The trailing newline gives the last code line a full line box so
+    // double-click / drag selection lands on it (browsers hit-test the last
+    // line of a <pre> inconsistently without it). Idempotent: pre-existing
+    // trailing blank lines collapse to exactly one.
+    expect(highlightCodeToHtml('a\nb', '')).toContain('<code>a\nb\n</code>');
+    expect(highlightCodeToHtml('a\nb\n\n', '')).toContain('<code>a\nb\n</code>');
+  });
+});
+
+describe('normalizeCodeText', () => {
+  it('appends a trailing newline when none is present', () => {
+    expect(normalizeCodeText('a\nb')).toBe('a\nb\n');
+  });
+
+  it('collapses trailing blank lines to exactly one newline', () => {
+    expect(normalizeCodeText('a\nb\n')).toBe('a\nb\n');
+    expect(normalizeCodeText('a\nb\n\n\n')).toBe('a\nb\n');
+  });
+
+  it('preserves interior blank lines and leading whitespace', () => {
+    expect(normalizeCodeText('a\n\nb')).toBe('a\n\nb\n');
+    expect(normalizeCodeText('  indented')).toBe('  indented\n');
   });
 });

--- a/apps/reborn-notes/src/lib/editor/live-preview/highlight-html.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/highlight-html.ts
@@ -40,6 +40,19 @@ export function escapeHtml(s: string): string {
 }
 
 /**
+ * Normalize fenced-code text for rendering: collapse trailing blank lines to
+ * exactly one terminating newline. The final newline gives the last code line
+ * a clean, full-height line box so double-click and drag selection land on it
+ * — browsers position/hit-test the last line of a `<pre>` inconsistently when
+ * it lacks a trailing newline (the reported "can't select the last line" /
+ * "double-click selects the line above" behaviour). Mirrors marked's default
+ * code renderer and every major highlighter (highlight.js, Prism, Shiki).
+ */
+export function normalizeCodeText(code: string): string {
+  return code.replace(/\n+$/, '') + '\n';
+}
+
+/**
  * Render syntax-highlighted code into `target` (DOM). Used by `CodeBlockWidget`.
  */
 export function renderHighlightedDom(
@@ -47,9 +60,10 @@ export function renderHighlightedDom(
   code: string,
   lang: LanguageSupport
 ): void {
-  const tree = lang.language.parser.parse(code);
+  const text = normalizeCodeText(code);
+  const tree = lang.language.parser.parse(text);
   highlightCode(
-    code,
+    text,
     tree,
     classHighlighter,
     (text, classes) => {
@@ -108,7 +122,8 @@ export function highlightCodeToHtml(code: string, info: string): string {
   const safeClass = info ? sanitizeInfoClass(info) : null;
   const codeAttrs = safeClass ? ` class="lang-${safeClass}"` : '';
   const lang = info ? getLoadedLanguage(info) : null;
-  const body = lang ? renderHighlightedHtml(code, lang) : escapeHtml(code);
+  const text = normalizeCodeText(code);
+  const body = lang ? renderHighlightedHtml(text, lang) : escapeHtml(text);
   return `<pre class="cm-lp-codeblock"><code${codeAttrs}>${body}</code></pre>`;
 }
 

--- a/apps/reborn-notes/src/lib/editor/live-preview/index.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/index.ts
@@ -26,6 +26,7 @@ import {
 import { livePreviewTheme } from './theme';
 import { codeLanguages } from './code-languages';
 import { loadedImagesField, type ImageWidgetLabels } from './image-widget';
+import type { CodeCopyLabels } from './code-copy';
 
 /**
  * Runtime options for the Live Preview extension. The Compartment in
@@ -36,6 +37,8 @@ export interface LivePreviewOptions {
   imageLoadMode?: ImageLoadMode;
   /** i18n labels used inside DOM widgets (cannot read Svelte stores there). */
   imageLabels?: ImageWidgetLabels;
+  /** i18n labels for the fenced-code copy button. */
+  codeLabels?: CodeCopyLabels;
 }
 
 const DEFAULT_LABELS: ImageWidgetLabels = {
@@ -43,10 +46,16 @@ const DEFAULT_LABELS: ImageWidgetLabels = {
   base64Blocked: 'Embedded images are not supported'
 };
 
+const DEFAULT_CODE_LABELS: CodeCopyLabels = {
+  copy: 'Copy code',
+  copied: 'Copied'
+};
+
 export function createLivePreviewExtension(options: LivePreviewOptions = {}): Extension {
   const field = createLivePreviewField({
     imageLoadMode: options.imageLoadMode ?? 'ask',
-    imageLabels: options.imageLabels ?? DEFAULT_LABELS
+    imageLabels: options.imageLabels ?? DEFAULT_LABELS,
+    codeLabels: options.codeLabels ?? DEFAULT_CODE_LABELS
   });
   return [
     field,
@@ -102,8 +111,15 @@ export { TableWidget, tableCellEditAnnotation } from './table-widget';
 export {
   highlightCodeToHtml,
   triggerLanguageLoad,
-  escapeHtml
+  escapeHtml,
+  normalizeCodeText
 } from './highlight-html';
+export {
+  CODE_COPY_ICON,
+  CODE_CHECK_ICON,
+  copyCodeFromButton,
+  type CodeCopyLabels
+} from './code-copy';
 export { codeLanguages, matchLanguage, getLoadedLanguage } from './code-languages';
 export {
   parseTable,

--- a/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
@@ -242,6 +242,14 @@ export const livePreviewTheme = EditorView.theme({
   // width from propagating up to `.cm-content` and overflowing the viewport
   // on mobile (sibling paragraphs/headings would otherwise stretch with it).
   // Margin must stay 0 — same height-map rule as line decorations.
+  // Non-scrolling positioning context for the copy button. Margin must stay 0
+  // (same CM6 height-map rule as line decorations); the inner wrap owns the
+  // horizontal scroll so the absolutely-placed button stays pinned top-right.
+  '.cm-lp-codeblock-outer': {
+    position: 'relative',
+    margin: '0',
+    maxWidth: '100%'
+  },
   '.cm-lp-codeblock-wrap': {
     margin: '0',
     maxWidth: '100%',
@@ -261,6 +269,10 @@ export const livePreviewTheme = EditorView.theme({
     margin: '0',
     borderRadius: '0.5em',
     whiteSpace: 'pre',
+    // Keep code selectable inside the widget (the rendered block sits in the
+    // contenteditable surface; be explicit rather than inherit CM6 defaults).
+    userSelect: 'text',
+    WebkitUserSelect: 'text',
     // `width: max-content` lets the <pre> grow to its longest line so the
     // wrapper's `overflow-x: auto` actually engages. `min-width: 100%` keeps
     // the muted background filling the wrapper width when code is short.
@@ -273,6 +285,39 @@ export const livePreviewTheme = EditorView.theme({
     background: 'transparent',
     padding: '0',
     fontSize: 'inherit'
+  },
+
+  // Copy button — pinned to the block's top-right, over the <pre>. Colours use
+  // app CSS vars so the button tracks light/dark via the cascade (the CM6
+  // theme stylesheet can't target `.dark` on <html> directly).
+  '.cm-lp-code-copy': {
+    position: 'absolute',
+    top: '0.4em',
+    right: '0.4em',
+    zIndex: '1',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '1.9em',
+    height: '1.9em',
+    padding: '0',
+    border: '1px solid var(--border)',
+    borderRadius: '0.375em',
+    background: 'var(--background)',
+    color: 'var(--muted-foreground)',
+    cursor: 'pointer',
+    opacity: '0.55',
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
+    transition: 'opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease'
+  },
+  '.cm-lp-codeblock-outer:hover .cm-lp-code-copy': { opacity: '1', color: 'var(--foreground)' },
+  '.cm-lp-code-copy:hover': { opacity: '1', color: 'var(--foreground)' },
+  '.cm-lp-code-copy:focus-visible': { opacity: '1', color: 'var(--foreground)' },
+  '.cm-lp-code-copy.is-copied': {
+    opacity: '1',
+    color: '#16a34a',
+    borderColor: '#16a34a'
   },
 
   // Cursor inside: per-line decoration so the raw fences and body share

--- a/apps/reborn-notes/src/lib/editor/live-preview/widgets.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/widgets.ts
@@ -18,10 +18,12 @@ import type { EditorView } from '@codemirror/view';
 import { WidgetType } from '@codemirror/view';
 import { matchLanguage, getLoadedLanguage } from './code-languages';
 import {
+  normalizeCodeText,
   renderHighlightedDom,
   sanitizeInfoClass,
   triggerLanguageLoad
 } from './highlight-html';
+import { CODE_COPY_ICON, copyCodeFromButton, type CodeCopyLabels } from './code-copy';
 
 export { sanitizeInfoClass } from './highlight-html';
 /** Backwards-compat alias for previous DOM helper name. */
@@ -119,7 +121,8 @@ function ensureLanguageLoaded(info: string): void {
 export class CodeBlockWidget extends WidgetType {
   constructor(
     readonly code: string,
-    readonly info: string | null
+    readonly info: string | null,
+    readonly labels: CodeCopyLabels
   ) {
     super();
   }
@@ -128,17 +131,25 @@ export class CodeBlockWidget extends WidgetType {
     return (
       other instanceof CodeBlockWidget &&
       other.code === this.code &&
-      other.info === this.info
+      other.info === this.info &&
+      other.labels.copy === this.labels.copy &&
+      other.labels.copied === this.labels.copied
     );
   }
 
   toDOM(): HTMLElement {
-    // Outer wrapper is the horizontal scroll container.
-    // Without this, the <pre>'s `white-space: pre` propagates a min-content
-    // width up to `.cm-content`, expanding it past the viewport on mobile and
-    // forcing sibling lines (paragraphs, headings) to overflow the screen.
-    // The wrapper's `overflow-x: auto` (set in theme.ts) creates a new BFC
-    // that contains the intrinsic width of the code so only the code scrolls.
+    // Outer (non-scrolling) wrapper anchors the absolutely-positioned copy
+    // button so it stays pinned to the top-right while the code scrolls under
+    // it. The inner `.cm-lp-codeblock-wrap` is the horizontal scroll container:
+    // without it, the <pre>'s `white-space: pre` propagates a min-content width
+    // up to `.cm-content`, expanding it past the viewport on mobile and forcing
+    // sibling lines (paragraphs, headings) to overflow the screen. The wrap's
+    // `overflow-x: auto` (set in theme.ts) creates a new BFC that contains the
+    // intrinsic width of the code so only the code scrolls. The button must sit
+    // outside that scroll container, otherwise it would scroll away / clip.
+    const outer = document.createElement('div');
+    outer.classList.add('cm-lp-codeblock-outer');
+
     const wrap = document.createElement('div');
     wrap.classList.add('cm-lp-codeblock-wrap');
 
@@ -153,7 +164,9 @@ export class CodeBlockWidget extends WidgetType {
     if (lang) {
       renderHighlightedDom(codeEl, this.code, lang);
     } else {
-      codeEl.textContent = this.code;
+      // Terminate with a trailing newline like the highlighted path so the
+      // last line stays selectable even before the language chunk loads.
+      codeEl.textContent = normalizeCodeText(this.code);
       if (this.info && matchLanguage(this.info)) {
         ensureLanguageLoaded(this.info);
       }
@@ -161,7 +174,33 @@ export class CodeBlockWidget extends WidgetType {
 
     pre.appendChild(codeEl);
     wrap.appendChild(pre);
-    return wrap;
+    outer.appendChild(this.buildCopyButton());
+    outer.appendChild(wrap);
+    return outer;
+  }
+
+  /**
+   * Copy-to-clipboard button pinned to the block's top-right. Labels are
+   * injected via the constructor (decorations build them from i18n) so this
+   * module stays free of store imports — same decoupling as `ImageWidget`. A
+   * locale change rebuilds the widget because `eq()` compares the labels.
+   * `mousedown` is prevented so clicking the button doesn't move the CM6 cursor
+   * into the block (which would swap this widget for the raw editable lines).
+   */
+  private buildCopyButton(): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'cm-lp-code-copy';
+    btn.title = this.labels.copy;
+    btn.setAttribute('aria-label', this.labels.copy);
+    btn.innerHTML = CODE_COPY_ICON;
+    btn.addEventListener('mousedown', (e) => e.preventDefault());
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      void copyCodeFromButton(btn, this.code, this.labels);
+    });
+    return btn;
   }
 
   ignoreEvent(): boolean {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -288,6 +288,8 @@
     "link_text": "Linktext",
     "note_editor": "Notiz-Editor",
     "markdown_preview": "Markdown-Vorschau",
+    "code_copy": "Code kopieren",
+    "code_copied": "Kopiert",
     "formatting": {
       "bold": "Fett",
       "italic": "Kursiv",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -288,6 +288,8 @@
     "link_text": "link text",
     "note_editor": "Note editor",
     "markdown_preview": "Markdown preview",
+    "code_copy": "Copy code",
+    "code_copied": "Copied",
     "formatting": {
       "bold": "Bold",
       "italic": "Italic",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -288,6 +288,8 @@
     "link_text": "texto del enlace",
     "note_editor": "Editor de notas",
     "markdown_preview": "Vista previa Markdown",
+    "code_copy": "Copiar código",
+    "code_copied": "Copiado",
     "formatting": {
       "bold": "Negrita",
       "italic": "Cursiva",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -288,6 +288,8 @@
     "link_text": "texte du lien",
     "note_editor": "Éditeur de notes",
     "markdown_preview": "Aperçu Markdown",
+    "code_copy": "Copier le code",
+    "code_copied": "Copié",
     "formatting": {
       "bold": "Gras",
       "italic": "Italique",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -288,6 +288,8 @@
     "link_text": "tekst linku",
     "note_editor": "Edytor notatek",
     "markdown_preview": "Podgląd Markdown",
+    "code_copy": "Skopiuj kod",
+    "code_copied": "Skopiowano",
     "formatting": {
       "bold": "Pogrubienie",
       "italic": "Kursywa",


### PR DESCRIPTION
## Summary

Fixes code-block text selection in note **Preview** and **Live Preview**, and adds a copy-to-clipboard button to each fenced block (reported by Michał).

**The selection bug.** The custom highlighter rendered `<code>` **without a trailing newline**, unlike marked's default renderer and every major highlighter (highlight.js/Prism/Shiki). Browsers hit-test the last line of such a `<pre>` inconsistently - double-click and drag-select failed on the last line, and a click sometimes selected the line above. `normalizeCodeText()` now terminates the body with exactly one newline across the **shared** pipeline (Preview HTML string, `CodeBlockWidget` DOM, and the plaintext fallback), so both modes behave identically. Verified empirically against marked 18.0.3.

**CSS hardening.** Explicit `white-space: pre` + `user-select: text`; the Preview `<pre>` font-size is aligned with `<code>` (0.875rem) so the line-box strut tracks the glyphs instead of skewing the click→line mapping on mobile.

**Copy button.** New `code-copy.ts` (SVG icons + transient checkmark, no toast dependency). Pinned top-right, **outside** the horizontal scroll container so it stays put while wide code scrolls. Preview button lives in the DOMPurify-sanitized `{@html}` (delegated click); Live Preview button is built in the widget (`mousedown` preventDefault so it doesn't push the cursor into the block). Whole task is `fix` per request (incl. the button).

**Impl note (no architectural decision).** Widget copy labels are injected via the constructor (`BuildDecorationsOptions.codeLabels`, mirroring `ImageWidget`'s `imageLabels`) rather than read from the i18n store - keeps the DOM-widget layer store-free and unit-testable (vitest doesn't resolve the `$lib` alias). New i18n keys `editor.code_copy` / `editor.code_copied` in all 5 locales.

## Test plan

Green: `test` (515), `check` (svelte-check 0 errors), `build`, i18n parity. New tests cover `normalizeCodeText` + the trailing newline in `highlightCodeToHtml`. PDF export untouched (separate pipeline). Lint failures present are **pre-existing** on `main` (verified via `git stash`: same 3 in `MarkdownPreview.svelte` + unrelated `routes/api`,`settings/*`); no new lint in changed code.

Smoke (browser):
- **Preview**: double-click the **last** line of a code block selects it; drag-select a fragment within the last line works; clicking a line selects that line (not the one above).
- **Copy button** (both modes): top-right icon copies the whole block, shows a 1.6s checkmark; in Live Preview it does **not** move the cursor into the block.
- Code blocks with **interior blank lines** keep those blank lines; **dark mode** button is legible; wide code still scrolls horizontally with the button pinned.