### PR TITLE
chore(lint): clear monorepo-wide ESLint debt

### DIFF
--- a/apps/reborn-notes/eslint.config.js
+++ b/apps/reborn-notes/eslint.config.js
@@ -40,5 +40,16 @@ export default [
       'no-undef': 'off',
       '@typescript-eslint/triple-slash-reference': 'off'
     }
+  },
+  {
+    // Destructuring a prop solely to omit it from a `...rest` spread is a
+    // deliberate pattern (e.g. stripping refreshToken from a response body so
+    // it's never serialized), not dead code. Excludes *.svelte.ts, where
+    // no-unused-vars stays off (template usage is invisible to the TS rule).
+    files: ['**/*.ts'],
+    ignores: ['**/*.svelte.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }]
+    }
   }
 ];

--- a/apps/reborn-notes/src/hooks.server.ts
+++ b/apps/reborn-notes/src/hooks.server.ts
@@ -247,7 +247,7 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 
   return resolve(event, {
     transformPageChunk: ({ html }) => {
-      let out = html
+      const out = html
         .replace('%lang%', locale)
         .replace('%init_loading_msg%', initLoadingMsg)
         .replace('%stall_msg%', stallMsg)

--- a/apps/reborn-notes/src/hooks.server.ts
+++ b/apps/reborn-notes/src/hooks.server.ts
@@ -4,7 +4,6 @@ import { sequence } from '@sveltejs/kit/hooks';
 import { authLimiter, refreshLimiter, registerLimiter, powLimiter } from '$lib/server/rate-limit';
 import { getClientIp } from '$lib/server/client-ip';
 import { verifyToken } from '@reborn/auth/server';
-import { createLogger } from '@reborn/utils';
 import {
   findIdempotencyKey,
   storeIdempotencyResponse,
@@ -13,8 +12,6 @@ import {
 } from '@reborn/database';
 import { getShareOgStrings } from '$lib/server/share-og';
 import { getAppLoadingStrings } from '$lib/server/app-loading-strings';
-
-const logger = createLogger('notes-hooks');
 
 // ── Rate-limited auth routes ──────────────────────────────────────
 

--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -41,7 +41,9 @@
   let {
     content = '',
     class: className = '',
+    // eslint-disable-next-line no-useless-assignment -- $bindable prop default (set by parent via bind:), not dead
     scrollEl = $bindable<HTMLElement | null>(null),
+    // eslint-disable-next-line no-useless-assignment -- $bindable prop default (set by parent via bind:), not dead
     contentEl = $bindable<HTMLElement | null>(null),
     imageLoadMode = 'ask' as ImageLoadMode,
     loadAllImagesHint,
@@ -395,12 +397,14 @@
         <span class="load-all-images-hint">
           {loadAllImagesHint}
           {#if settingsLinkLabel && settingsLinkHref}
+            <!-- eslint-disable svelte/no-navigation-without-resolve (settingsLinkHref is pre-resolved by the caller) -->
             <a
               href={settingsLinkHref}
               class="load-all-images-settings-link"
               data-sveltekit-preload-data="off"
               data-sveltekit-preload-code="off"
             >
+            <!-- eslint-enable svelte/no-navigation-without-resolve -->
               {settingsLinkLabel}
             </a>
           {/if}

--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -326,7 +326,7 @@
 
   // ── Multi-select state ─────────────────────────────────────────
   let selectionMode = $state(false);
-  let selectedIds = $state(new SvelteSet<string>());
+  let selectedIds = new SvelteSet<string>();
   // Anchor for shift-click range selection (desktop). Tracks the last toggled id.
   let lastAnchorId = $state<string | null>(null);
   let bulkDeleteDialogOpen = $state(false);

--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -25,6 +25,7 @@
   let {
     isMobile,
     activeTrash,
+    // eslint-disable-next-line no-useless-assignment -- $bindable prop default (set by parent via bind:), not dead
     viewMode = $bindable('edit'),
     effectiveViewMode,
     historyMode = $bindable<HistoryMode>('closed'),

--- a/apps/reborn-notes/src/lib/components/notes/ShareGate.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/ShareGate.svelte
@@ -48,12 +48,14 @@
     <h1 class="text-lg font-semibold">{title}</h1>
     <p class="text-sm text-muted-foreground">{hint}</p>
     {#if cta}
+      <!-- eslint-disable svelte/no-navigation-without-resolve (external URL; resolve() is for internal routes only) -->
       <a
         href={cta.href}
         target="_blank"
         rel="noopener noreferrer"
         class="text-sm text-primary underline-offset-2 hover:underline"
       >
+      <!-- eslint-enable svelte/no-navigation-without-resolve -->
         {cta.label}
       </a>
     {/if}

--- a/apps/reborn-notes/src/lib/editor/bullet-anchor.ts
+++ b/apps/reborn-notes/src/lib/editor/bullet-anchor.ts
@@ -25,7 +25,7 @@ import { EditorView } from '@codemirror/view';
 export const BULLET_ANCHOR = '​';
 
 const BULLET_PREFIX_RE = /^[-+*] $/;
-const LIST_LINE_WITH_CONTENT_RE = /^(\s*)(?:[-+*]|\d+[.)])\s+(.*[^\s​].*)$/;
+const LIST_LINE_WITH_CONTENT_RE = /^(\s*)(?:[-+*]|\d+[.)])\s+(.*[^\s\u200B].*)$/;
 
 /**
  * Decides whether `prefixLine` should append `BULLET_ANCHOR` after the

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -438,7 +438,9 @@ export function toSearchEntity(
     tagIds: entry.tagIds,
     folderId: entry.folderId ?? null,
     listId: null,
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- plain immutable timestamp in a returned value, not reactive state
     createdAt: new Date(entry.createdAt),
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- plain immutable timestamp in a returned value, not reactive state
     updatedAt: new Date(entry.updatedAt),
     dueAt: null,
     flags: {

--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -23,6 +23,17 @@ export interface LoginResult {
   masterKeySalt?: string;
 }
 
+/** Minimal shape of the JSON body returned by the re-auth endpoints. */
+interface ReAuthResponseBody {
+  success?: boolean;
+  error?: string;
+  data?: {
+    twoFactorRequired?: boolean;
+    userId?: string;
+    access_token?: string;
+  };
+}
+
 /**
  * Log in with username + password.
  * On success: credentials are saved to localStorage (SSO-compatible with reborn-task),
@@ -170,7 +181,7 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
 
   if (res.status === 401) return { kind: 'invalid_password' };
 
-  let body: any;
+  let body: ReAuthResponseBody;
   try {
     body = await res.json();
   } catch {
@@ -226,7 +237,7 @@ export async function verifyTotpForReauth(userId: string, code: string): Promise
     return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
   }
 
-  let body: any;
+  let body: ReAuthResponseBody;
   try {
     body = await res.json();
   } catch {

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -38,8 +38,7 @@ import {
   isSyncing,
   syncError,
   lastSyncedAt,
-  refreshPendingCount,
-  sessionExpired
+  refreshPendingCount
 } from '$lib/stores/sync-status.store';
 import { authFetch } from '$lib/utils/auth-fetch';
 import { validateEncryptedPayload } from '@reborn/crypto';

--- a/apps/reborn-notes/src/lib/utils/navigation.ts
+++ b/apps/reborn-notes/src/lib/utils/navigation.ts
@@ -23,6 +23,7 @@ export function goto(href: string, opts?: Parameters<typeof _goto>[1]): ReturnTy
 		!href.startsWith(base + '/') &&
 		href !== base
 	) {
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- resolveHref is resolve() cast to accept dynamic, base-prefixed strings
 		return _goto(resolveHref(href), opts);
 	}
 	// eslint-disable-next-line svelte/no-navigation-without-resolve -- path already includes base or is external

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -975,8 +975,9 @@
     type RnWindow = Window & { __rnPopstateHandler?: (e: PopStateEvent) => void };
 
     // Remove old persistent handler if re-mounting (e.g., returning from /settings)
-    if ((window as RnWindow).__rnPopstateHandler) {
-      window.removeEventListener('popstate', (window as RnWindow).__rnPopstateHandler);
+    const existingHandler = (window as RnWindow).__rnPopstateHandler;
+    if (existingHandler) {
+      window.removeEventListener('popstate', existingHandler);
     }
 
     let mounted = true;

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -971,9 +971,12 @@
       history.pushState({ _rn: 'app' }, '');
     }
 
+    // window carries a custom popstate handler ref that must survive re-mounts
+    type RnWindow = Window & { __rnPopstateHandler?: (e: PopStateEvent) => void };
+
     // Remove old persistent handler if re-mounting (e.g., returning from /settings)
-    if ((window as any).__rnPopstateHandler) {
-      window.removeEventListener('popstate', (window as any).__rnPopstateHandler);
+    if ((window as RnWindow).__rnPopstateHandler) {
+      window.removeEventListener('popstate', (window as RnWindow).__rnPopstateHandler);
     }
 
     let mounted = true;
@@ -1009,7 +1012,7 @@
       }
     }
 
-    (window as any).__rnPopstateHandler = handlePopstate;
+    (window as RnWindow).__rnPopstateHandler = handlePopstate;
     window.addEventListener('popstate', handlePopstate);
 
     function handleBeforeUnload(e: BeforeUnloadEvent) {

--- a/apps/reborn-notes/src/routes/api/auth/2fa/verify/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/auth/2fa/verify/server.spec.ts
@@ -91,7 +91,7 @@ function createMockEvent(body: unknown) {
 async function callEndpoint(body: unknown) {
 	const { POST } = await import('./+server');
 	const event = createMockEvent(body);
-	const response = await (POST as Function)(event);
+	const response = await (POST as unknown as (event: unknown) => Promise<Response>)(event);
 	const data = await response.json();
 	return { response, data, status: response.status };
 }

--- a/apps/reborn-notes/src/routes/api/auth/refresh/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/auth/refresh/server.spec.ts
@@ -52,7 +52,7 @@ function createMockEvent(cookieHeader: string) {
 async function callRefresh(cookieHeader: string) {
 	const { POST } = await import('./+server');
 	const event = createMockEvent(cookieHeader);
-	const response = await (POST as Function)(event);
+	const response = await (POST as unknown as (event: unknown) => Promise<Response>)(event);
 	return { response, status: response.status };
 }
 

--- a/apps/reborn-notes/src/routes/api/health/+server.ts
+++ b/apps/reborn-notes/src/routes/api/health/+server.ts
@@ -9,7 +9,7 @@ declare const __APP_VERSION__: string;
 export const HEAD: RequestHandler = () => new Response(null, { status: 200 });
 
 export const GET: RequestHandler = async () => {
-	let dbStatus = 'unknown';
+	let dbStatus: 'ok' | 'error';
 
 	try {
 		await prisma.$queryRaw`SELECT 1`;

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -203,6 +203,7 @@
           <h2 class="text-lg font-semibold mb-3">{$t('settings_page.security.title')}</h2>
           <div class="space-y-1">
             {#each securityItems as item}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
             <a href={resolveHref(item.href)} class={itemClasses}>
                 <item.icon class="h-5 w-5 text-muted-foreground shrink-0" />
                 <div class="flex-1 min-w-0">

--- a/apps/reborn-task/eslint.config.js
+++ b/apps/reborn-task/eslint.config.js
@@ -44,5 +44,16 @@ export default [
 			// Triple-slash references are valid in .d.ts files
 			'@typescript-eslint/triple-slash-reference': 'off'
 		}
+	},
+	{
+		// Destructuring a prop solely to omit it from a `...rest` spread is a
+		// deliberate pattern (e.g. stripping refreshToken from a response body
+		// so it's never serialized), not dead code. Excludes *.svelte.ts, where
+		// no-unused-vars stays off (template usage is invisible to the TS rule).
+		files: ['**/*.ts'],
+		ignores: ['**/*.svelte.ts'],
+		rules: {
+			'@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }]
+		}
 	}
 ];

--- a/apps/reborn-task/src/hooks.server.ts
+++ b/apps/reborn-task/src/hooks.server.ts
@@ -164,7 +164,7 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 
 	return resolve(event, {
 		transformPageChunk: ({ html }) => {
-			let out = html
+			const out = html
 				.replace('%lang%', locale)
 				.replace('%init_loading_msg%', initLoadingMsg)
 				.replace('%stall_msg%', stallMsg)

--- a/apps/reborn-task/src/lib/components/share/ShareGate.svelte
+++ b/apps/reborn-task/src/lib/components/share/ShareGate.svelte
@@ -37,12 +37,14 @@
     <h1 class="text-lg font-semibold">{title}</h1>
     <p class="text-sm text-muted-foreground">{hint}</p>
     {#if cta}
+      <!-- eslint-disable svelte/no-navigation-without-resolve (external URL; resolve() is for internal routes only) -->
       <a
         href={cta.href}
         target="_blank"
         rel="noopener noreferrer"
         class="text-sm text-primary underline-offset-2 hover:underline"
       >
+      <!-- eslint-enable svelte/no-navigation-without-resolve -->
         {cta.label}
       </a>
     {/if}

--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -21,6 +21,17 @@ import { sessionExpired } from '$lib/stores/session-expired.store';
 
 const logger = createLogger('AuthOperationsService');
 
+/** Minimal shape of the JSON body returned by the re-auth endpoints. */
+interface ReAuthResponseBody {
+	success?: boolean;
+	error?: string;
+	data?: {
+		twoFactorRequired?: boolean;
+		userId?: string;
+		access_token?: string;
+	};
+}
+
 // Use globalThis to ensure true singleton across hot reloads
 declare global {
 	var __authServiceInitialized: boolean | undefined;
@@ -878,7 +889,7 @@ export class AuthOperationsService {
 
 		if (res.status === 401) return { kind: 'invalid_password' };
 
-		let body: any;
+		let body: ReAuthResponseBody;
 		try {
 			body = await res.json();
 		} catch {
@@ -929,7 +940,7 @@ export class AuthOperationsService {
 			return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
 		}
 
-		let body: any;
+		let body: ReAuthResponseBody;
 		try {
 			body = await res.json();
 		} catch {

--- a/apps/reborn-task/src/lib/services/task-title-index.svelte.ts
+++ b/apps/reborn-task/src/lib/services/task-title-index.svelte.ts
@@ -96,7 +96,7 @@ const BATCH_SIZE = 100;
 async function decryptTaskEntry(
 	enc: TaskEncryptedBooleans
 ): Promise<({ id: string } & TaskIndexEntry) | null> {
-	let title = '';
+	let title: string;
 	try {
 		title = await cryptoManager.decryptText(enc.title_encrypted);
 	} catch {

--- a/apps/reborn-task/src/lib/utils/navigation.ts
+++ b/apps/reborn-task/src/lib/utils/navigation.ts
@@ -23,6 +23,7 @@ export function goto(href: string, opts?: Parameters<typeof _goto>[1]): ReturnTy
 		!href.startsWith(base + '/') &&
 		href !== base
 	) {
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- resolveHref is resolve() cast to accept dynamic, base-prefixed strings
 		return _goto(resolveHref(href), opts);
 	}
 	// eslint-disable-next-line svelte/no-navigation-without-resolve -- path already includes base or is external

--- a/apps/reborn-task/src/routes/api/auth/2fa/verify/server.spec.ts
+++ b/apps/reborn-task/src/routes/api/auth/2fa/verify/server.spec.ts
@@ -92,7 +92,7 @@ function createMockEvent(body: unknown) {
 async function callEndpoint(body: unknown) {
 	const { POST } = await import('./+server');
 	const event = createMockEvent(body);
-	const response = await (POST as Function)(event);
+	const response = await (POST as unknown as (event: unknown) => Promise<Response>)(event);
 	const data = await response.json();
 	return { response, data, status: response.status };
 }

--- a/apps/reborn-task/src/routes/api/auth/refresh/server.spec.ts
+++ b/apps/reborn-task/src/routes/api/auth/refresh/server.spec.ts
@@ -52,7 +52,7 @@ function createMockEvent(cookieHeader: string) {
 async function callRefresh(cookieHeader: string) {
 	const { POST } = await import('./+server');
 	const event = createMockEvent(cookieHeader);
-	const response = await (POST as Function)(event);
+	const response = await (POST as unknown as (event: unknown) => Promise<Response>)(event);
 	return { response, status: response.status };
 }
 

--- a/apps/reborn-task/src/routes/api/health/+server.ts
+++ b/apps/reborn-task/src/routes/api/health/+server.ts
@@ -9,7 +9,7 @@ declare const __APP_VERSION__: string;
 export const HEAD: RequestHandler = () => new Response(null, { status: 200 });
 
 export const GET: RequestHandler = async () => {
-	let dbStatus = 'unknown';
+	let dbStatus: 'ok' | 'error';
 
 	try {
 		await prisma.$queryRaw`SELECT 1`;

--- a/apps/reborn-task/src/routes/auth/register/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/register/+page.svelte
@@ -70,7 +70,7 @@
 			};
 		} catch (error: unknown) {
 			logger.error('Failed to prepare registration data:', error);
-			throw new Error('Failed to prepare registration data');
+			throw new Error('Failed to prepare registration data', { cause: error });
 		}
 	}
 

--- a/apps/reborn-task/src/routes/settings/+page.svelte
+++ b/apps/reborn-task/src/routes/settings/+page.svelte
@@ -238,6 +238,7 @@
 				<h2 class="text-lg font-semibold mb-3">{section.title}</h2>
 				<div class="space-y-1">
 					{#each section.items as item}
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 					<a href={resolveHref(item.href)} class={itemClasses}>
 							<item.icon class="h-5 w-5 text-muted-foreground shrink-0" />
 							<div class="flex-1 min-w-0">
@@ -259,6 +260,7 @@
 			<!-- Auth method links -->
 			<div class="space-y-1">
 				{#each securityItems as item}
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 				<a href={resolveHref(item.href)} class={itemClasses}>
 						<item.icon class="h-5 w-5 text-muted-foreground shrink-0" />
 						<div class="flex-1 min-w-0">
@@ -325,6 +327,7 @@
 				<h2 class="text-lg font-semibold mb-3">{section.title}</h2>
 				<div class="space-y-1">
 					{#each section.items as item}
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 					<a href={resolveHref(item.href)} class={itemClasses}>
 							<item.icon class="h-5 w-5 text-muted-foreground shrink-0" />
 							<div class="flex-1 min-w-0">

--- a/apps/reborn-task/src/service-worker.ts
+++ b/apps/reborn-task/src/service-worker.ts
@@ -473,7 +473,7 @@ sw.addEventListener('push', (event) => {
 		return;
 	}
 
-	let payload: unknown = null;
+	let payload: unknown;
 	try {
 		payload = event.data.json();
 	} catch {

--- a/packages/api-client/src/__tests__/client-401-refresh.spec.ts
+++ b/packages/api-client/src/__tests__/client-401-refresh.spec.ts
@@ -35,8 +35,8 @@ function ensureBrowserGlobals() {
       window: { localStorage: Storage; addEventListener: () => void; removeEventListener: () => void };
     }).window = {
       localStorage: (globalThis as { localStorage: Storage }).localStorage,
-      addEventListener: () => {},
-      removeEventListener: () => {}
+      addEventListener: () => {/* no-op test stub */},
+      removeEventListener: () => {/* no-op test stub */}
     };
   }
 }

--- a/packages/api-client/src/core/client.ts
+++ b/packages/api-client/src/core/client.ts
@@ -45,12 +45,12 @@ export class ApiClient {
       headers: config.headers || {},
       onRequest: config.onRequest || ((c) => c),
       onResponse: config.onResponse || ((r) => r),
-      onError: config.onError || (() => {}),
+      onError: config.onError || (() => {/* no-op default */}),
       // Default: no refresh handler installed → treat 401s as transient (no
       // retry, no session-expired UI). Apps wire `authFetch.refresh()` in
       // through the public constructor.
       onUnauthorized: config.onUnauthorized || (async () => 'transient'),
-      onSessionExpired: config.onSessionExpired || (() => {})
+      onSessionExpired: config.onSessionExpired || (() => {/* no-op default */})
     };
 
     // Initialize utilities
@@ -471,12 +471,12 @@ export class ApiClient {
   private extractEntityInfo(url: string, config: RequestConfig): Partial<QueuedRequest> {
     // Extract entity type and ID from URL patterns
     const patterns = [
-      { regex: /\/tasks\/([^\/]+)/, type: 'task' as EntityType },
-      { regex: /\/tasklists\/([^\/]+)/, type: 'task_list' as EntityType },
-      { regex: /\/subtasks\/([^\/]+)/, type: 'sub_task' as EntityType },
-      { regex: /\/notes\/([^\/]+)/, type: 'note' as EntityType },
-      { regex: /\/folders\/([^\/]+)/, type: 'folder' as EntityType },
-      { regex: /\/tags\/([^\/]+)/, type: 'tag' as EntityType }
+      { regex: /\/tasks\/([^/]+)/, type: 'task' as EntityType },
+      { regex: /\/tasklists\/([^/]+)/, type: 'task_list' as EntityType },
+      { regex: /\/subtasks\/([^/]+)/, type: 'sub_task' as EntityType },
+      { regex: /\/notes\/([^/]+)/, type: 'note' as EntityType },
+      { regex: /\/folders\/([^/]+)/, type: 'folder' as EntityType },
+      { regex: /\/tags\/([^/]+)/, type: 'tag' as EntityType }
     ];
 
     for (const pattern of patterns) {

--- a/packages/api-client/src/interceptors/auth.ts
+++ b/packages/api-client/src/interceptors/auth.ts
@@ -4,7 +4,7 @@ import type { RequestConfig, RequestInterceptor } from '../types';
  * Auth interceptor to add authorization headers
  */
 export class AuthInterceptor implements RequestInterceptor {
-  private currentUrl: string = '';
+  private currentUrl = '';
 
   setCurrentUrl(url: string): void {
     this.currentUrl = url;

--- a/packages/api-client/src/interceptors/encryption.ts
+++ b/packages/api-client/src/interceptors/encryption.ts
@@ -19,7 +19,7 @@ import { detectPlaintextLeaks, validateEncryptedPayload } from '@reborn/crypto';
  * surfacing the bug at the call site instead of leaking data.
  */
 export class EncryptionInterceptor implements RequestInterceptor {
-  private currentUrl: string = '';
+  private currentUrl = '';
 
   setCurrentUrl(url: string): void {
     this.currentUrl = url;

--- a/packages/api-client/src/utils/id-resolver.ts
+++ b/packages/api-client/src/utils/id-resolver.ts
@@ -271,7 +271,7 @@ export class IdResolver {
       logger.info(`Imported ${mappings.length} ID mappings`);
     } catch (error) {
       logger.error('Failed to import mappings:', error);
-      throw new Error('Invalid mapping data');
+      throw new Error('Invalid mapping data', { cause: error });
     }
   }
 

--- a/packages/api-client/src/utils/offline-queue.ts
+++ b/packages/api-client/src/utils/offline-queue.ts
@@ -199,7 +199,7 @@ export class OfflineQueue {
       logger.info(`Imported ${queue.length} requests to offline queue`);
     } catch (error) {
       logger.error('Failed to import queue:', error);
-      throw new Error('Invalid queue data');
+      throw new Error('Invalid queue data', { cause: error });
     }
   }
 }

--- a/packages/api-client/src/utils/retry-manager.ts
+++ b/packages/api-client/src/utils/retry-manager.ts
@@ -7,9 +7,9 @@ const logger = createLogger('RetryManager');
  */
 export class RetryManager {
   constructor(
-    private maxRetries: number = 3,
-    private baseDelay: number = 1000,
-    private maxDelay: number = 30000
+    private maxRetries = 3,
+    private baseDelay = 1000,
+    private maxDelay = 30000
   ) {}
 
   /**

--- a/packages/auth/src/__tests__/AuthService.onStorageInit.spec.ts
+++ b/packages/auth/src/__tests__/AuthService.onStorageInit.spec.ts
@@ -37,7 +37,7 @@ function makeStorage(existingCreds?: AuthCredentials): IAuthStorage {
       creds = null;
     }),
     getUserSettings: vi.fn(async () => null),
-    saveUserSettings: vi.fn(async () => {})
+    saveUserSettings: vi.fn(async () => {/* no-op */})
   };
 }
 

--- a/packages/auth/src/services/SessionManager.ts
+++ b/packages/auth/src/services/SessionManager.ts
@@ -135,7 +135,7 @@ export class SessionManager implements ISessionManager {
   /**
    * Set user authentication
    */
-  setAuthenticated(user: AuthUser, hasE2E: boolean = true): void {
+  setAuthenticated(user: AuthUser, hasE2E = true): void {
     this.setSession({
       isAuthenticated: true,
       isInitialized: true,

--- a/packages/auth/src/utils/authApiClient.ts
+++ b/packages/auth/src/utils/authApiClient.ts
@@ -28,7 +28,7 @@ export function createAuthApiClient(options: AuthApiClientOptions = {}): IAuthAp
 
   const makeRequest = async (
     path: string,
-    method: string = 'GET',
+    method = 'GET',
     body?: any
   ): Promise<any> => {
     const response = await fetchFn(`${baseUrl}${path}`, {

--- a/packages/auth/src/utils/jwt.ts
+++ b/packages/auth/src/utils/jwt.ts
@@ -121,7 +121,7 @@ export async function generateTokens(userId: string, sessionId?: string): Promis
     return { accessToken, refreshToken };
   } catch (error) {
     logger.error('Token generation failed:', error);
-    throw new Error('Failed to generate tokens');
+    throw new Error('Failed to generate tokens', { cause: error });
   }
 }
 
@@ -228,7 +228,7 @@ export async function generateSingleUseToken(
     return token;
   } catch (error) {
     logger.error('Single-use token generation failed:', error);
-    throw new Error('Failed to generate single-use token');
+    throw new Error('Failed to generate single-use token', { cause: error });
   }
 }
 

--- a/packages/auth/src/utils/jwt.ts
+++ b/packages/auth/src/utils/jwt.ts
@@ -207,7 +207,7 @@ export async function verifyToken(
 export async function generateSingleUseToken(
   userId: string,
   purpose: string,
-  expiryMinutes: number = 30
+  expiryMinutes = 30
 ): Promise<string> {
   try {
     const secret = getJwtSecret();

--- a/packages/crypto/src/__tests__/cryptoManager.spec.ts
+++ b/packages/crypto/src/__tests__/cryptoManager.spec.ts
@@ -445,7 +445,7 @@ describe('CryptoManager', () => {
       // setTimeout used by waitForRestore must be cleared so the warning
       // callback never runs after the race has been won. The logger emits
       // through console.log, so spy there and filter for the warning text.
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {/* swallow log output */});
 
       const newManager = new (CryptoManager as any)();
       const result = await newManager.waitForRestore();

--- a/packages/crypto/src/cryptoManager.ts
+++ b/packages/crypto/src/cryptoManager.ts
@@ -427,7 +427,7 @@ export class CryptoManager {
         window.sessionStorage.removeItem(this.CRYPTO_VERIFIED_KEY);
       }
 
-      throw new Error('Encryption verification failed');
+      throw new Error('Encryption verification failed', { cause: error });
     }
   }
 
@@ -451,7 +451,7 @@ export class CryptoManager {
       return key;
     } catch (error) {
       logger.error('Error generating master key', error);
-      throw new Error('Failed to generate master key');
+      throw new Error('Failed to generate master key', { cause: error });
     }
   }
 
@@ -559,7 +559,7 @@ export class CryptoManager {
       };
     } catch (error) {
       logger.error('Error encrypting master key', error);
-      throw new Error('Failed to encrypt master key');
+      throw new Error('Failed to encrypt master key', { cause: error });
     }
   }
 
@@ -604,7 +604,7 @@ export class CryptoManager {
       return masterKey;
     } catch (error) {
       logger.error('Error decrypting master key', error);
-      throw new Error('Failed to decrypt master key');
+      throw new Error('Failed to decrypt master key', { cause: error });
     }
   }
 
@@ -630,7 +630,7 @@ export class CryptoManager {
       };
     } catch (error) {
       logger.error('Error encrypting data', error);
-      throw new Error('Failed to encrypt data');
+      throw new Error('Failed to encrypt data', { cause: error });
     }
   }
 
@@ -662,7 +662,7 @@ export class CryptoManager {
       )) as T | string;
     } catch (error) {
       logger.error('Error decrypting data', error);
-      throw new Error('Failed to decrypt data');
+      throw new Error('Failed to decrypt data', { cause: error });
     }
   }
 
@@ -779,7 +779,7 @@ export class CryptoManager {
       logger.debug('CryptoManager initialized with key');
     } catch (error) {
       logger.error('Failed to initialize with key:', error);
-      throw new Error('Failed to initialize CryptoManager with key');
+      throw new Error('Failed to initialize CryptoManager with key', { cause: error });
     }
   }
 
@@ -804,7 +804,7 @@ export class CryptoManager {
       return null;
     } catch (error) {
       logger.error('Failed to export current master key:', error);
-      throw new Error('Failed to export master key');
+      throw new Error('Failed to export master key', { cause: error });
     }
   }
 

--- a/packages/crypto/src/encryption.ts
+++ b/packages/crypto/src/encryption.ts
@@ -71,7 +71,7 @@ export async function deriveKeyFromPassword(
     );
   } catch (error) {
     logger.error('Error deriving key from password', error);
-    throw new Error('Failed to derive key from password');
+    throw new Error('Failed to derive key from password', { cause: error });
   }
 }
 
@@ -126,7 +126,7 @@ export async function encryptData(
     };
   } catch (error) {
     logger.error('Error encrypting data', error);
-    throw new Error('Failed to encrypt data');
+    throw new Error('Failed to encrypt data', { cause: error });
   }
 }
 
@@ -174,14 +174,14 @@ export async function decryptData<T = string>(
         return JSON.parse(decryptedString) as T;
       } catch (e) {
         logger.error('Error parsing decrypted data as JSON', e);
-        throw new Error('Failed to parse decrypted data as JSON');
+        throw new Error('Failed to parse decrypted data as JSON', { cause: e });
       }
     }
 
     return decryptedString as unknown as T;
   } catch (error) {
     logger.error('Error decrypting data', error);
-    throw new Error('Failed to decrypt data');
+    throw new Error('Failed to decrypt data', { cause: error });
   }
 }
 
@@ -258,7 +258,8 @@ export function base64ToArrayBuffer(base64: string): Uint8Array {
     logger.error('Failed to convert base64 to ArrayBuffer:', error);
     logger.error('Input base64 string:', base64);
     throw new Error(
-      `Failed to decode base64 string: ${error instanceof Error ? error.message : String(error)}`
+      `Failed to decode base64 string: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error }
     );
   }
 }
@@ -274,7 +275,7 @@ export async function exportKey(key: CryptoKey): Promise<Uint8Array> {
     return new Uint8Array(rawKey);
   } catch (error) {
     logger.error('Error exporting key', error);
-    throw new Error('Failed to export key');
+    throw new Error('Failed to export key', { cause: error });
   }
 }
 
@@ -302,6 +303,6 @@ export async function importKey(
     );
   } catch (error) {
     logger.error('Error importing key', error);
-    throw new Error('Failed to import key');
+    throw new Error('Failed to import key', { cause: error });
   }
 }

--- a/packages/crypto/src/keyManager.ts
+++ b/packages/crypto/src/keyManager.ts
@@ -32,7 +32,7 @@ export async function generateMasterKeyForUser(password: string): Promise<{
     return result;
   } catch (error) {
     logger.error('Failed to generate master key for user', error);
-    throw new Error('Failed to generate master key');
+    throw new Error('Failed to generate master key', { cause: error });
   }
 }
 

--- a/packages/crypto/src/password/index.ts
+++ b/packages/crypto/src/password/index.ts
@@ -108,7 +108,7 @@ export async function hashPassword(password: string, saltBase64?: string): Promi
     return result;
   } catch (error) {
     logger.error('Password hashing failed:', error);
-    throw new Error('Failed to hash password');
+    throw new Error('Failed to hash password', { cause: error });
   }
 }
 
@@ -145,7 +145,7 @@ export async function hashPasswordPBKDF2(password: string, saltBase64?: string):
     return `pbkdf2:${PBKDF2_ITERATIONS}:${salt}:${hash}`;
   } catch (error) {
     logger.error('PBKDF2 password hashing failed:', error);
-    throw new Error('Failed to hash password');
+    throw new Error('Failed to hash password', { cause: error });
   }
 }
 
@@ -174,7 +174,7 @@ export async function verifyPassword(password: string, hashString: string): Prom
     throw new Error('Unknown hash format');
   } catch (error) {
     logger.error('Password verification failed:', error);
-    throw new Error('Failed to verify password');
+    throw new Error('Failed to verify password', { cause: error });
   }
 }
 

--- a/packages/crypto/src/password/index.ts
+++ b/packages/crypto/src/password/index.ts
@@ -266,7 +266,7 @@ async function verifyPBKDF2(password: string, hashString: string): Promise<boole
  * NOTE: This doesn't actually generate a bcrypt salt, just returns a format string
  * @deprecated Use generateSalt() instead
  */
-export async function generateBcryptSalt(rounds: number = 12): Promise<string> {
+export async function generateBcryptSalt(rounds = 12): Promise<string> {
   logger.warn('generateBcryptSalt called - bcrypt is not supported in browser');
   throw new Error('Bcrypt is not supported in browser environment');
 }

--- a/packages/crypto/src/snapshot.ts
+++ b/packages/crypto/src/snapshot.ts
@@ -112,7 +112,7 @@ export async function decryptSnapshotPayload<T = unknown>(
     return decrypted as T;
   } catch (error) {
     logger.error('Snapshot payload decryption failed (wrong key or tampered ciphertext)');
-    throw new Error('Snapshot decryption failed');
+    throw new Error('Snapshot decryption failed', { cause: error });
   }
 }
 

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -226,7 +226,7 @@ async function main(): Promise<void> {
     // Generate excerpt from content (first 200 chars, plain text)
     const plainText = note.content[lang]
       .replace(/#{1,6}\s/g, '')
-      .replace(/[*_`~\[\]]/g, '')
+      .replace(/[*_`~[\]]/g, '')
       .replace(/\n+/g, ' ')
       .trim();
     const excerpt = plainText.slice(0, 200);

--- a/packages/storage/eslint.config.mjs
+++ b/packages/storage/eslint.config.mjs
@@ -10,8 +10,15 @@ export default [
         {
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
-            '{projectRoot}/vite.config.{js,ts,mjs,mts}'
-          ]
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+            '{projectRoot}/vitest.config.{js,ts,mjs,mts}'
+          ],
+          // None of these are bundled runtime deps of this library, so they
+          // need not appear in "dependencies":
+          //  - vitest, tsup: test runner / bundler (devDependencies only)
+          //  - svelte: marked `external` in tsup.config.ts; the consuming app
+          //    provides it (a peer), it is not bundled into dist.
+          ignoredDependencies: ['vitest', 'tsup', 'svelte']
         }
       ]
     },

--- a/packages/storage/src/core/database.ts
+++ b/packages/storage/src/core/database.ts
@@ -44,7 +44,7 @@ class DatabaseManager {
     // Check current database version before opening
     try {
       const existingDb = await openDB(config.name, undefined, {
-        blocking: () => {}
+        blocking: () => {/* no-op: nothing to release on a version-change block */}
       });
       const currentVersion = existingDb.version;
       existingDb.close();

--- a/packages/storage/src/stores/base.store.ts
+++ b/packages/storage/src/stores/base.store.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries -- base.store is lazy-loaded via dynamic import in initializeStorage; the static @reborn/types value import (DB_CONFIG) is intentional
 import { DB_CONFIG } from '@reborn/types';
 import type { StoreDefinition } from '../core/database';
 import { createLogger } from '@reborn/utils';

--- a/packages/storage/src/stores/note-history.store.ts
+++ b/packages/storage/src/stores/note-history.store.ts
@@ -1,4 +1,5 @@
 import { IndexedDBStore } from '../core/store';
+// eslint-disable-next-line @nx/enforce-module-boundaries -- reachable via the lazy ./stores barrel; the static @reborn/types value import (MAX_NOTE_VERSIONS) is intentional
 import { MAX_NOTE_VERSIONS, type NoteHistoryEntry } from '@reborn/types';
 
 export const noteHistoryStore = new IndexedDBStore<NoteHistoryEntry>({

--- a/packages/storage/src/stores/note.store.ts
+++ b/packages/storage/src/stores/note.store.ts
@@ -129,7 +129,7 @@ export const noteQueries = {
   /**
    * Get recently updated notes
    */
-  getRecent: async (limit: number = 10): Promise<NoteStoredLocal[]> => {
+  getRecent: async (limit = 10): Promise<NoteStoredLocal[]> => {
     const notes = await noteQueries.getActive();
     return notes
       .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
@@ -216,7 +216,7 @@ export const noteOperations = {
   /**
    * Permanently delete archived notes older than specified days
    */
-  cleanArchived: async (daysOld: number = 90): Promise<number> => {
+  cleanArchived: async (daysOld = 90): Promise<number> => {
     const archived = await noteQueries.getArchived();
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - daysOld);

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -15,7 +15,7 @@ export type DateFormat = (typeof DATE_FORMATS)[number]['key'];
  * Converts a local date to UTC for storage
  * Sets the time to noon UTC to avoid timezone issues
  */
-export function toUTC(date: Date | string | null, hasTime: boolean = false): string | null {
+export function toUTC(date: Date | string | null, hasTime = false): string | null {
   if (!date) return null;
   const d = date instanceof Date ? date : new Date(date);
   if (isNaN(d.getTime())) return null;
@@ -32,7 +32,7 @@ export function toUTC(date: Date | string | null, hasTime: boolean = false): str
 /**
  * Converts a UTC date string to local date object
  */
-export function toLocal(dateStr: string | null, hasTime: boolean = false): Date | null {
+export function toLocal(dateStr: string | null, hasTime = false): Date | null {
   if (!dateStr) return null;
   const date = new Date(dateStr);
   if (isNaN(date.getTime())) return null;
@@ -51,7 +51,7 @@ export function toLocal(dateStr: string | null, hasTime: boolean = false): Date 
 export function formatDateForDisplay(
   dateStr: string | null,
   format: DateFormat,
-  locale: string = 'en'
+  locale = 'en'
 ): string {
   if (!dateStr) return '';
   const date = new Date(dateStr);
@@ -82,7 +82,7 @@ export function getLocalTimeZone(): string {
 /**
  * Formats a date according to the specified format and locale
  */
-export function formatDate(date: Date, format: DateFormat, locale: string = 'en'): string {
+export function formatDate(date: Date, format: DateFormat, locale = 'en'): string {
   // For 'd MMMM yyyy' format, use direct toLocaleDateString which handles it better
   if (format === 'd MMMM yyyy') {
     return date.toLocaleDateString(locale, {

--- a/packages/utils/src/user-agent.ts
+++ b/packages/utils/src/user-agent.ts
@@ -8,8 +8,8 @@
 export function parseUserAgent(ua?: string | null): string {
   if (!ua) return 'Unknown';
 
-  let browser = '';
-  let os = '';
+  let browser: string;
+  let os: string;
 
   // Browser detection (order matters: Edge contains "Chrome", Chrome contains "Safari")
   if (ua.includes('Firefox')) browser = 'Firefox';


### PR DESCRIPTION
## Summary

Clears **all 100 ESLint errors across the monorepo** (8 of 11 projects) so the codebase is lint-clean - prep for wiring `nx affected -t lint` into CI as a blocking gate (follow-up, see note below).

The TODO scoped this as a `reborn-notes` sweep, but the audit found the debt was monorepo-wide: notes 25, task 17, crypto 22, api-client 17, auth 6, storage 6, utils 6, database 1 (types/i18n/ui were already clean). A meaningful `nx affected -t lint` gate needs the whole graph clean (affected lints dependents too), so this does the full sweep. **Result: 0 errors in all 11 projects** - only intentional `warn`-level findings remain (require-each-key, package-level no-explicit-any, no-non-null-assertion).

Five commits, split by risk for review:
1. mechanical `eslint --fix` (no-inferrable-types, prefer-const), workspace-wide
2. reborn-notes + reborn-task
3. non-ZK packages (utils, api-client, database)
4. **crypto/auth/storage - ZK-sensitive, isolated for careful review**
5. typecheck-narrowing fix (svelte-check caught the RnWindow cast in notes)

### Decisions worth a look
- **`{ cause }` on 22 re-throws in crypto/auth/storage** (preserve-caught-error). Behaviour-preserving and ZK-safe: the original error is already logged at each site, the user-facing message is unchanged, the caught values are Web Crypto / JSON failures (never key material), and `Error.cause` is client-only (never serialised to the server).
- **`ignoreRestSiblings`** enabled in both app eslint configs - destructuring `refreshToken` to keep it out of the response `...rest` is deliberate (the token goes to the httpOnly cookie only), not dead code.
- **storage `@nx/dependency-checks`: `ignoredDependencies: ['vitest','tsup','svelte']`** - none are bundled runtime deps (test runner / bundler / externalised peer). `svelte/store` is used in `core/store.ts`; declaring `svelte` as a `peerDependency` is the cleaner long-term fix but was deferred (forces a lockfile regen) and left as a backlog follow-up.
- **`no-navigation-without-resolve` (9) and `no-useless-assignment` on `$bindable` defaults** - all false positives (aliased `resolve`, external `target=_blank` links, pre-resolved hrefs, Svelte 5 runes); resolved with documented `eslint-disable` comments.

No `package.json` / `pnpm-lock.yaml` changes, so `pnpm install --frozen-lockfile` is unaffected.

> **CI gate follow-up:** the matching `chore(ci): add lint to the affected gate` commit (one line in `ci.yml`) is ready but **can't be pushed with the current token** - it lacks the `workflow` scope, and GitHub blocks PAT pushes that touch `.github/workflows/`. Adding the gate *after* this merges is also the correct order (so it validates against a clean `main`). I'll open it as a small follow-up PR once this lands and the token has `workflow` scope (or you can drop in the one-liner).

## Test plan
- `nx run-many -t lint --all` -> **0 errors across 11 projects** (warnings only)
- `nx run-many -t check --all` -> 0 errors (both apps, svelte-check)
- `nx run-many -t build` (all packages) -> OK
- `nx run-many -t test --all` -> all pass (notes 515, task 41, + packages)
- `nx affected -t lint --base=main` -> green (self-validates the upcoming gate)
- Purely internal (lint / types); no user-facing change to smoke-test.