### PR TITLE
chore(ci): add lint to the affected CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,14 @@ jobs:
       # Setup Nx SHAs for affected commands
       - uses: nrwl/nx-set-shas@v5.0.1
 
-      # Run affected check (svelte-check), tests and build
-      # Note: removed 'lint' as it's not configured in the project
+      # Run affected lint, check (svelte-check), tests and build.
+      # lint now runs as a gate - every project has an @nx/eslint inferred lint
+      # target - so it runs first (independent of svelte-kit sync) to fail fast.
       # Targets are run in separate steps (not `-t check test build`) so that
-      # check/test/build for the same project don't run in parallel — all three
+      # check/test/build for the same project don't run in parallel; all three
       # invoke `svelte-kit sync` (directly or via the Vite plugin) and writing
       # to `.svelte-kit/types/` concurrently caused intermittent ENOENT races.
+      - run: pnpm nx affected -t lint
       - run: pnpm nx affected -t check
       - run: pnpm nx affected -t test
       - run: pnpm nx affected -t build


### PR DESCRIPTION
## Summary

Follow-up to #247 (which cleared all monorepo lint debt to 0). Now that every project lints clean, this wires `nx affected -t lint` into `ci.yml` as a blocking gate so the debt can't silently re-accumulate (there is no husky / lint-staged).

- Adds `- run: pnpm nx affected -t lint` as the **first** affected step (fail-fast, and it does not depend on `svelte-kit sync`).
- Replaces the stale `# Note: removed 'lint' as it's not configured` comment - `@nx/eslint` infers a lint target for every project.
- One-line behavioural change to CI; no source changes.

Split from #247 because GitHub blocks PAT pushes touching `.github/workflows/` without `workflow` scope, and adding the gate *after* the sweep merged is the correct order (it validates against a clean `main`).

## Test plan
- `nx affected -t lint --base=main` was green on the sweep branch before #247 merged (self-validation).
- This PR's own CI run exercises the new `lint` step against the affected graph (main is now lint-clean).