### PR TITLE
feat(notes): detect + merge multi-device periodic-note duplicates

### DIFF
--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -11,6 +11,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {
+    "@eslint/js": "10.0.1",
     "@sveltejs/adapter-auto": "7.0.1",
     "@sveltejs/kit": "2.63.1",
     "@sveltejs/vite-plugin-svelte": "7.1.2",
@@ -18,11 +19,16 @@
     "@types/cookie": "0.6.0",
     "@types/qrcode": "1.5.6",
     "cookie": "0.7.2",
+    "eslint": "10.4.0",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-svelte": "3.17.1",
+    "globals": "17.6.0",
     "svelte": "5.56.3",
     "svelte-check": "4.6.0",
     "tailwindcss": "4.3.0",
     "tw-animate-css": "1.4.0",
     "typescript": "6.0.3",
+    "typescript-eslint": "8.59.3",
     "vite": "8.0.13",
     "vitest": "4.1.6"
   },

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -95,6 +95,20 @@ export async function refreshStoresAfterPull(): Promise<void> {
   await Promise.all([foldersStore.refresh(), tagsStore.refresh(), noteIndex.rebuild()]);
   notesStore.refresh();
   await noteDetailService.refreshFromStorage();
+
+  // Surface multi-device periodic-note duplicates (guideline 57). Fire-and-forget
+  // so it never blocks the UI refresh; cheap when there are none (title-prefix
+  // pre-filter, zero decryption) and only decrypts on an actual collision.
+  void (async () => {
+    try {
+      const { detectAndNotifyPeriodicDuplicates } = await import(
+        '$lib/services/periodic-dedup.service'
+      );
+      await detectAndNotifyPeriodicDuplicates();
+    } catch (e) {
+      logger.warn('Periodic duplicate scan failed', e);
+    }
+  })();
 }
 
 // ── Pull sync - server → IndexedDB ───────────────────────────────

--- a/apps/reborn-notes/src/lib/services/periodic-dedup.core.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-dedup.core.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure helpers for Periodic Notes post-sync de-duplication.
+ *
+ * Kept free of `$lib` / svelte / `@reborn/ui` imports (type-only dependency on
+ * `@reborn/storage`) so it is unit-testable in the plain Node vitest env, the
+ * same split as `periodic-notes-format.ts` vs `periodic-notes.service.ts`.
+ * Orchestration (decryption, stores, toast) lives in `periodic-dedup.service.ts`.
+ */
+import type { PeriodicKind } from '@reborn/storage';
+
+export interface DedupCandidate {
+  id: string;
+  folderId: string;
+  kind: PeriodicKind;
+  anchor: string;
+  createdAt: string;
+}
+
+export interface DedupGroup {
+  folderId: string;
+  kind: PeriodicKind;
+  anchor: string;
+  /** Members sorted by createdAt ascending; `members[0]` is the canonical (oldest). */
+  members: DedupCandidate[];
+}
+
+/**
+ * Group confirmed periodic notes by `(folderId, kind, anchor)` and return only
+ * groups with more than one member. Each group's members are sorted oldest-first
+ * (by `createdAt`, tie-broken by `id` for determinism) so `members[0]` is the
+ * canonical note to keep.
+ */
+export function groupDuplicates(candidates: DedupCandidate[]): DedupGroup[] {
+  const buckets = new Map<string, DedupCandidate[]>();
+  for (const c of candidates) {
+    const key = `${c.folderId}|${c.kind}|${c.anchor}`;
+    const arr = buckets.get(key);
+    if (arr) arr.push(c);
+    else buckets.set(key, [c]);
+  }
+
+  const groups: DedupGroup[] = [];
+  for (const members of buckets.values()) {
+    if (members.length < 2) continue;
+    members.sort((a, b) => {
+      const t = a.createdAt.localeCompare(b.createdAt);
+      return t !== 0 ? t : a.id.localeCompare(b.id);
+    });
+    groups.push({
+      folderId: members[0].folderId,
+      kind: members[0].kind,
+      anchor: members[0].anchor,
+      members
+    });
+  }
+  return groups;
+}
+
+/**
+ * Build merged note content: the canonical body, then each non-empty younger
+ * body prefixed with its separator. Empty younger copies (title only, no body)
+ * contribute nothing - they are merely archived, with no stray separator.
+ */
+export function buildMergedContent(
+  canonicalContent: string,
+  additions: { content: string; separator: string }[]
+): string {
+  let acc = canonicalContent.replace(/\s+$/, '');
+  for (const a of additions) {
+    if (a.content.trim() === '') continue;
+    const block = `${a.separator}\n\n${a.content.replace(/\s+$/, '')}`;
+    acc = acc.trim() === '' ? block : `${acc}\n\n${block}`;
+  }
+  return acc;
+}

--- a/apps/reborn-notes/src/lib/services/periodic-dedup.service.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-dedup.service.ts
@@ -1,0 +1,250 @@
+/**
+ * Post-sync de-duplication for Periodic Notes (Daily / Weekly / Monthly).
+ *
+ * Why this exists: when two devices create a periodic note for the same period
+ * before either syncs, the server accepts both (their ciphertext IVs differ, so
+ * there is no natural dedup). After the 2026-05-12 locale-duplicate fix,
+ * `findExistingPeriodicNote` returns the newest match - the one-click flow shows
+ * a single note, but both copies live in the folder list.
+ *
+ * Strategy (decided 2026-06-08, see planning/notes-periodic-postsync-dedup.md):
+ * DETECT + MANUAL MERGE. We never mutate note content automatically after a
+ * background pull - that would be a trust violation (the user didn't initiate
+ * it) and the highest-risk option for the lowest-severity problem. Instead we
+ * surface a toast; the merge runs only when the user clicks it.
+ *
+ * Detection is cheap: a title-prefix pre-filter (locale-independent ISO date -
+ * the prefix both locales share, which is exactly the 2026-05-12 case) buckets
+ * candidates with zero decryption. Metadata is decrypted only for actual prefix
+ * collisions, and only stamped periodic notes count as duplicates, so a regular
+ * note that merely starts with a date inside a periodic folder is never touched.
+ */
+import { get } from 'svelte/store';
+import type { PeriodicKind } from '@reborn/storage';
+import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
+import { toastStore } from '@reborn/ui';
+import { noteIndex } from '$lib/services/note-index.svelte';
+import {
+  getNoteIncludingArchived,
+  updateNote,
+  deleteNote,
+  readNoteMetadata,
+  saveVersionSnapshot
+} from './note.service';
+import { notesStore } from '$lib/stores/notes.store';
+import { getSetting } from '$lib/utils/app-settings';
+import { t as i18nT, locale as i18nLocale } from '$lib/stores/i18n.store';
+import {
+  type DedupCandidate,
+  type DedupGroup,
+  buildMergedContent,
+  groupDuplicates
+} from './periodic-dedup.core';
+
+const logger = createLogger('PeriodicDedup');
+
+/** Matches the leading ISO date of a default-format periodic title. */
+const ISO_PREFIX_RE = /^(\d{4}-\d{2}(?:-\d{2})?)/;
+
+// ── i18n helpers ──────────────────────────────────────────────────
+
+function tr(key: string, values?: Record<string, unknown>): string {
+  return get(i18nT)(key, values ? { values } : undefined);
+}
+
+function formatCreatedAt(iso: string): string {
+  const loc = get(i18nLocale) || 'en';
+  try {
+    return new Intl.DateTimeFormat(loc, { dateStyle: 'short', timeStyle: 'short' }).format(
+      new Date(iso)
+    );
+  } catch {
+    return iso;
+  }
+}
+
+// ── Detection ─────────────────────────────────────────────────────
+
+/** Map folderId -> kind for the kinds configured as periodic on this device. */
+async function loadFolderKindMap(): Promise<Map<string, PeriodicKind>> {
+  const map = new Map<string, PeriodicKind>();
+  const settings = await getSetting('periodicNotes');
+  if (!settings) return map;
+  for (const kind of ['daily', 'weekly', 'monthly'] as PeriodicKind[]) {
+    const fid = settings[kind]?.folderId;
+    if (fid) map.set(fid, kind);
+  }
+  return map;
+}
+
+/** Read the periodic anchor stamp for a note, but only if its kind matches. */
+async function readStampAnchor(id: string, kind: PeriodicKind): Promise<string | null> {
+  const meta = await readNoteMetadata(id);
+  const stamp = meta?.periodic;
+  return stamp && stamp.kind === kind ? stamp.anchor : null;
+}
+
+/**
+ * Scan periodic folders for duplicate notes (same folder + kind + anchor).
+ * Returns groups with more than one member. Cheap unless there is an actual
+ * title-prefix collision: only colliding buckets are decrypted.
+ */
+export async function detectPeriodicDuplicates(): Promise<DedupGroup[]> {
+  if (!cryptoManager.isInitialized()) return [];
+
+  const folderKind = await loadFolderKindMap();
+  if (folderKind.size === 0) return [];
+
+  // 1. Cheap pre-filter (no crypto): bucket active periodic-folder notes by
+  //    (folderId, ISO title prefix). The ISO prefix is locale-independent, so
+  //    the cross-locale duplicate pair the 2026-05-12 fix left behind lands in
+  //    the same bucket.
+  const buckets = new Map<
+    string,
+    Array<{ id: string; folderId: string; kind: PeriodicKind }>
+  >();
+  for (const e of noteIndex.entries()) {
+    if (!e.folderId) continue;
+    const kind = folderKind.get(e.folderId);
+    if (!kind) continue;
+    const m = ISO_PREFIX_RE.exec(e.title);
+    if (!m) continue;
+    // daily/weekly titles start with a full YYYY-MM-DD; monthly with YYYY-MM.
+    if (kind === 'monthly') {
+      if (m[1].length < 7) continue;
+    } else if (m[1].length !== 10) {
+      continue;
+    }
+    const prefix = kind === 'monthly' ? m[1].slice(0, 7) : m[1];
+    const key = `${e.folderId}|${prefix}`;
+    const arr = buckets.get(key);
+    const entry = { id: e.id, folderId: e.folderId, kind };
+    if (arr) arr.push(entry);
+    else buckets.set(key, [entry]);
+  }
+
+  // 2. Confirm only collision buckets via the encrypted periodic stamp. Only
+  //    stamped notes count, so a regular note that happens to start with a date
+  //    in a periodic folder is never grouped (and so never merged).
+  const candidates: DedupCandidate[] = [];
+  for (const members of buckets.values()) {
+    if (members.length < 2) continue;
+    for (const mem of members) {
+      const anchor = await readStampAnchor(mem.id, mem.kind);
+      if (!anchor) continue;
+      candidates.push({
+        id: mem.id,
+        folderId: mem.folderId,
+        kind: mem.kind,
+        anchor,
+        createdAt: noteIndex.get(mem.id)?.createdAt ?? ''
+      });
+    }
+  }
+
+  return groupDuplicates(candidates);
+}
+
+// ── Merge ─────────────────────────────────────────────────────────
+
+function separatorFor(createdAtIso: string): string {
+  const datetime = formatCreatedAt(createdAtIso);
+  return `---\n*${tr('notes.periodic.dedup.merge_separator', { datetime })}*`;
+}
+
+/**
+ * Merge every detected duplicate group. For each group the oldest note is kept
+ * (canonical), younger copies' content is appended (with a separator), and the
+ * younger copies are moved to trash. The canonical is snapshotted to version
+ * history first, so the pre-merge state is recoverable.
+ *
+ * Re-detects at call time (does not trust a stale group list captured when the
+ * toast was shown).
+ */
+export async function mergeAllPeriodicDuplicates(): Promise<{ groups: number; archived: number }> {
+  const groups = await detectPeriodicDuplicates();
+  let mergedGroups = 0;
+  let archivedNotes = 0;
+
+  for (const group of groups) {
+    const [canonical, ...younger] = group.members;
+    const canonicalNote = await getNoteIncludingArchived(canonical.id);
+    if (!canonicalNote) continue;
+
+    const additions: { content: string; separator: string }[] = [];
+    for (const y of younger) {
+      const yNote = await getNoteIncludingArchived(y.id);
+      if (!yNote) continue;
+      additions.push({ content: yNote.content, separator: separatorFor(y.createdAt) });
+    }
+
+    const merged = buildMergedContent(canonicalNote.content, additions);
+    if (merged !== canonicalNote.content) {
+      // Snapshot the pre-merge canonical so the user can roll the merge back
+      // from version history - the one piece of this operation that isn't a
+      // plain "restore from trash".
+      await saveVersionSnapshot(canonical.id).catch((e) =>
+        logger.warn('Failed to snapshot canonical before merge', e)
+      );
+      await updateNote(canonical.id, canonicalNote.title, merged);
+    }
+
+    for (const y of younger) {
+      await deleteNote(y.id); // soft-delete -> trash (recoverable), syncs
+      archivedNotes++;
+    }
+    mergedGroups++;
+  }
+
+  notesStore.refresh();
+  return { groups: mergedGroups, archived: archivedNotes };
+}
+
+// ── Detect + notify (the post-pull hook) ──────────────────────────
+
+/**
+ * Group keys already surfaced this session. Prevents the 5-minute periodic pull
+ * from re-toasting the same unresolved duplicates. Reset after a merge so a new
+ * batch can be surfaced. folderId is a per-user UUID, so cross-user collision
+ * across a logout/login in the same tab is effectively impossible.
+ */
+const notifiedKeys = new Set<string>();
+
+async function runMerge(): Promise<void> {
+  try {
+    const { archived } = await mergeAllPeriodicDuplicates();
+    notifiedKeys.clear();
+    if (archived > 0) {
+      toastStore.success(tr('notes.periodic.dedup.merge_success', { count: archived }));
+    }
+  } catch (e) {
+    logger.error('Periodic duplicate merge failed', e);
+    toastStore.error(tr('notes.periodic.dedup.merge_error'));
+  }
+}
+
+/**
+ * Detect duplicate periodic notes and, if any new ones are found, show a toast
+ * offering a one-click merge. Fire-and-forget from `refreshStoresAfterPull()`.
+ */
+export async function detectAndNotifyPeriodicDuplicates(): Promise<void> {
+  const groups = await detectPeriodicDuplicates();
+  if (groups.length === 0) return;
+
+  const keys = groups.map((g) => `${g.folderId}|${g.kind}|${g.anchor}`);
+  if (keys.every((k) => notifiedKeys.has(k))) return; // already surfaced this session
+  for (const k of keys) notifiedKeys.add(k);
+
+  // Count of extra copies (everything beyond the canonical in each group).
+  const extra = groups.reduce((sum, g) => sum + g.members.length - 1, 0);
+
+  toastStore.warning(tr('notes.periodic.dedup.toast_title'), {
+    description: tr('notes.periodic.dedup.toast_description', { count: extra }),
+    duration: 15000,
+    action: {
+      label: tr('notes.periodic.dedup.merge_action'),
+      onClick: () => void runMerge()
+    }
+  });
+}

--- a/apps/reborn-notes/src/lib/services/periodic-dedup.spec.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-dedup.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type DedupCandidate,
+  buildMergedContent,
+  groupDuplicates
+} from './periodic-dedup.core';
+
+function candidate(over: Partial<DedupCandidate> & Pick<DedupCandidate, 'id'>): DedupCandidate {
+  return {
+    folderId: 'f1',
+    kind: 'daily',
+    anchor: '2026-06-08',
+    createdAt: '2026-06-08T10:00:00.000Z',
+    ...over
+  };
+}
+
+describe('periodic-dedup core - groupDuplicates', () => {
+  it('returns nothing when every (folder, kind, anchor) is unique', () => {
+    const groups = groupDuplicates([
+      candidate({ id: 'a', anchor: '2026-06-08' }),
+      candidate({ id: 'b', anchor: '2026-06-09' }),
+      candidate({ id: 'c', anchor: '2026-06-10' })
+    ]);
+    expect(groups).toEqual([]);
+  });
+
+  it('groups two notes sharing folder+kind+anchor and keeps the oldest first', () => {
+    const groups = groupDuplicates([
+      candidate({ id: 'younger', createdAt: '2026-06-08T12:00:00.000Z' }),
+      candidate({ id: 'older', createdAt: '2026-06-08T09:00:00.000Z' })
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].members.map((m) => m.id)).toEqual(['older', 'younger']);
+    expect(groups[0]).toMatchObject({ folderId: 'f1', kind: 'daily', anchor: '2026-06-08' });
+  });
+
+  it('does NOT group same anchor across different folders', () => {
+    const groups = groupDuplicates([
+      candidate({ id: 'a', folderId: 'f1' }),
+      candidate({ id: 'b', folderId: 'f2' })
+    ]);
+    expect(groups).toEqual([]);
+  });
+
+  it('does NOT group same anchor across different kinds', () => {
+    const groups = groupDuplicates([
+      candidate({ id: 'a', kind: 'daily', anchor: '2026-06-01' }),
+      candidate({ id: 'b', kind: 'monthly', anchor: '2026-06-01' })
+    ]);
+    expect(groups).toEqual([]);
+  });
+
+  it('handles three+ copies and orders them oldest-first', () => {
+    const groups = groupDuplicates([
+      candidate({ id: 'c', createdAt: '2026-06-08T15:00:00.000Z' }),
+      candidate({ id: 'a', createdAt: '2026-06-08T08:00:00.000Z' }),
+      candidate({ id: 'b', createdAt: '2026-06-08T11:00:00.000Z' })
+    ]);
+    expect(groups[0].members.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('breaks createdAt ties deterministically by id', () => {
+    const ts = '2026-06-08T08:00:00.000Z';
+    const groups = groupDuplicates([
+      candidate({ id: 'zeta', createdAt: ts }),
+      candidate({ id: 'alpha', createdAt: ts })
+    ]);
+    expect(groups[0].members.map((m) => m.id)).toEqual(['alpha', 'zeta']);
+  });
+
+  it('produces independent groups for distinct anchors in the same folder', () => {
+    const groups = groupDuplicates([
+      candidate({ id: 'a1', anchor: '2026-06-08' }),
+      candidate({ id: 'a2', anchor: '2026-06-08' }),
+      candidate({ id: 'b1', anchor: '2026-06-09' }),
+      candidate({ id: 'b2', anchor: '2026-06-09' })
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups.every((g) => g.members.length === 2)).toBe(true);
+  });
+});
+
+describe('periodic-dedup core - buildMergedContent', () => {
+  const SEP = '---\n*merged*';
+
+  it('appends younger content under a separator', () => {
+    const merged = buildMergedContent('canonical body', [{ content: 'younger body', separator: SEP }]);
+    expect(merged).toBe('canonical body\n\n---\n*merged*\n\nyounger body');
+  });
+
+  it('skips empty younger copies entirely (no stray separator)', () => {
+    const merged = buildMergedContent('canonical body', [
+      { content: '   \n  ', separator: SEP }
+    ]);
+    expect(merged).toBe('canonical body');
+  });
+
+  it('omits the leading separator when the canonical body is empty', () => {
+    const merged = buildMergedContent('', [{ content: 'younger body', separator: SEP }]);
+    expect(merged).toBe('---\n*merged*\n\nyounger body');
+  });
+
+  it('chains multiple non-empty additions, each with its own separator', () => {
+    const merged = buildMergedContent('A', [
+      { content: 'B', separator: '---\n*s1*' },
+      { content: 'C', separator: '---\n*s2*' }
+    ]);
+    expect(merged).toBe('A\n\n---\n*s1*\n\nB\n\n---\n*s2*\n\nC');
+  });
+
+  it('drops empty additions but keeps the non-empty ones', () => {
+    const merged = buildMergedContent('A', [
+      { content: '', separator: '---\n*s1*' },
+      { content: 'C', separator: '---\n*s2*' }
+    ]);
+    expect(merged).toBe('A\n\n---\n*s2*\n\nC');
+  });
+
+  it('trims trailing whitespace from canonical and additions', () => {
+    const merged = buildMergedContent('A   \n\n', [{ content: 'B\n\n  ', separator: SEP }]);
+    expect(merged).toBe('A\n\n---\n*merged*\n\nB');
+  });
+
+  it('returns an empty string when everything is empty', () => {
+    expect(buildMergedContent('', [{ content: '  ', separator: SEP }])).toBe('');
+  });
+});

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -170,7 +170,15 @@
         "open_settings": "Einstellungen öffnen",
         "got_it": "Verstanden"
       },
-      "errors": { "failed": "Notiz konnte nicht geöffnet werden" }
+      "errors": { "failed": "Notiz konnte nicht geöffnet werden" },
+      "dedup": {
+        "toast_title": "Doppelte periodische Notizen",
+        "toast_description": "{count, plural, one {# doppelte Notiz wurde auf einem anderen Gerät erstellt.} other {# doppelte Notizen wurden auf einem anderen Gerät erstellt.}} Mit dem Original zusammenführen?",
+        "merge_action": "Zusammenführen",
+        "merge_separator": "Aus einem Duplikat zusammengeführt, erstellt am {datetime}",
+        "merge_success": "{count, plural, one {# doppelte Notiz zusammengeführt.} other {# doppelte Notizen zusammengeführt.}}",
+        "merge_error": "Doppelte Notizen konnten nicht zusammengeführt werden. Bitte erneut versuchen."
+      }
     }
   },
   "storage": {

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -170,7 +170,15 @@
         "open_settings": "Open settings",
         "got_it": "Got it"
       },
-      "errors": { "failed": "Failed to open the note" }
+      "errors": { "failed": "Failed to open the note" },
+      "dedup": {
+        "toast_title": "Duplicate periodic notes",
+        "toast_description": "{count, plural, one {# duplicate note was created on another device.} other {# duplicate notes were created on another device.}} Merge into the original?",
+        "merge_action": "Merge",
+        "merge_separator": "Merged from a duplicate created {datetime}",
+        "merge_success": "{count, plural, one {Merged # duplicate note.} other {Merged # duplicate notes.}}",
+        "merge_error": "Could not merge duplicate notes. Please try again."
+      }
     }
   },
   "storage": {

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -170,7 +170,15 @@
         "open_settings": "Abrir ajustes",
         "got_it": "Entendido"
       },
-      "errors": { "failed": "No se pudo abrir la nota" }
+      "errors": { "failed": "No se pudo abrir la nota" },
+      "dedup": {
+        "toast_title": "Notas periódicas duplicadas",
+        "toast_description": "{count, plural, one {Se creó # nota duplicada en otro dispositivo.} other {Se crearon # notas duplicadas en otro dispositivo.}} ¿Combinar con la original?",
+        "merge_action": "Combinar",
+        "merge_separator": "Combinado desde un duplicado creado el {datetime}",
+        "merge_success": "{count, plural, one {Se combinó # nota duplicada.} other {Se combinaron # notas duplicadas.}}",
+        "merge_error": "No se pudieron combinar las notas duplicadas. Inténtalo de nuevo."
+      }
     }
   },
   "storage": {

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -170,7 +170,15 @@
         "open_settings": "Ouvrir les paramètres",
         "got_it": "Compris"
       },
-      "errors": { "failed": "Impossible d'ouvrir la note" }
+      "errors": { "failed": "Impossible d'ouvrir la note" },
+      "dedup": {
+        "toast_title": "Notes périodiques en double",
+        "toast_description": "{count, plural, one {# note en double a été créée sur un autre appareil.} other {# notes en double ont été créées sur un autre appareil.}} Fusionner dans la note originale ?",
+        "merge_action": "Fusionner",
+        "merge_separator": "Fusionné depuis un doublon créé le {datetime}",
+        "merge_success": "{count, plural, one {# note en double fusionnée.} other {# notes en double fusionnées.}}",
+        "merge_error": "Impossible de fusionner les notes en double. Veuillez réessayer."
+      }
     }
   },
   "storage": {

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -170,7 +170,15 @@
         "open_settings": "Otwórz ustawienia",
         "got_it": "Rozumiem"
       },
-      "errors": { "failed": "Nie udało się otworzyć notatki" }
+      "errors": { "failed": "Nie udało się otworzyć notatki" },
+      "dedup": {
+        "toast_title": "Zduplikowane notatki okresowe",
+        "toast_description": "{count, plural, one {# zduplikowana notatka powstała na innym urządzeniu.} few {# zduplikowane notatki powstały na innym urządzeniu.} many {# zduplikowanych notatek powstało na innym urządzeniu.} other {# zduplikowanych notatek powstało na innym urządzeniu.}} Scalić z oryginałem?",
+        "merge_action": "Scal",
+        "merge_separator": "Scalono z duplikatu utworzonego {datetime}",
+        "merge_success": "{count, plural, one {Scalono # duplikat.} few {Scalono # duplikaty.} many {Scalono # duplikatów.} other {Scalono # duplikatów.}}",
+        "merge_error": "Nie udało się scalić duplikatów. Spróbuj ponownie."
+      }
     }
   },
   "storage": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
         specifier: 14.0.0
         version: 14.0.0
     devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
       '@sveltejs/adapter-auto':
         specifier: 7.0.1
         version: 7.0.1(@sveltejs/kit@2.63.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0)))
@@ -297,6 +300,18 @@ importers:
       cookie:
         specifier: 0.7.2
         version: 0.7.2
+      eslint:
+        specifier: 10.4.0
+        version: 10.4.0(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: 10.1.8
+        version: 10.1.8(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-svelte:
+        specifier: 3.17.1
+        version: 3.17.1(eslint@10.4.0(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
+      globals:
+        specifier: 17.6.0
+        version: 17.6.0
       svelte:
         specifier: 5.56.3
         version: 5.56.3(@typescript-eslint/types@8.59.3)
@@ -312,6 +327,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      typescript-eslint:
+        specifier: 8.59.3
+        version: 8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: 8.0.13
         version: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0)


### PR DESCRIPTION
## Summary

When two devices create a periodic note (daily/weekly/monthly) for the same period before either syncs, the server keeps both copies (different ciphertext IVs, no natural dedup). After the 2026-05-12 locale-duplicate fix `findExistingPeriodicNote` returns the newest match - the one-click flow shows a single note, but both copies live in the folder list.

This closes the P3 follow-up: after a pull we scan periodic folders and, if duplicates exist, surface a toast offering a one-click merge.

**Architectural decision (agreed before implementation): DETECT + MANUAL MERGE, not auto-merge.** Auto-mutating note content after a background pull would break the sync ethos ("don't surprise the user") and is the highest-risk option for the lowest-severity problem (a cosmetic duplicate). The merge runs **only** when the user clicks the toast. Rejected: auto-merge on pull; hybrid auto-clean-empty + manual-merge-content.

### What's in the diff
- `periodic-dedup.core.ts` - pure helpers (`groupDuplicates`, `buildMergedContent`), no `$lib`/svelte/`@reborn/ui` imports so they unit-test in the Node vitest env (same split as `periodic-notes-format.ts`).
- `periodic-dedup.service.ts` - detection + merge orchestration. Detection is cheap: a locale-independent ISO title-prefix pre-filter buckets candidates with **zero crypto** (the prefix both locales share - exactly the 2026-05-12 case); metadata is decrypted only on a real prefix collision, and **only stamped periodic notes count**, so a regular dated note in a periodic folder is never touched. Merge keeps the oldest copy as canonical, appends younger bodies under an i18n separator (empty copies skipped), snapshots the canonical to version history first (rollback), and trashes the younger copies (soft-delete, recoverable).
- `notes-sync.service.ts` - `refreshStoresAfterPull()` fires `detectAndNotifyPeriodicDuplicates()` fire-and-forget (one guaranteed post-pull hook, covers all sync call sites; never blocks UI refresh).
- `notes.periodic.dedup.*` - 6 keys x 5 locales, ICU plural (PL few/many verified via intl-messageformat).
- `periodic-dedup.spec.ts` - 13 unit tests for the pure core.

**Zero Knowledge:** no schema/server changes; detection reads `metadata_encrypted` client-side only; merge reuses existing `updateNote`/`deleteNote` (pushes ciphertext like any edit). Server sees only another content PATCH + soft-delete.

## Test plan

Quality gate (green): `nx affected -t test lint check` (test 529, lint 0 errors, svelte-check 0 errors), i18n parity 925 keys, ICU messages parse+format for count=1/2/5.

Smoke (browser):
1. Two devices/profiles, both offline: create today's daily note on each, then go online. After sync on the second: toast "Duplicate periodic notes [Merge]".
2. Click [Merge] -> one note remains (oldest), younger body appended under a separator, younger copy in Trash, success toast.
3. Click "Today" after merge -> opens the merged (canonical) note.
4. Canonical's version history contains the pre-merge state (rollback works).
5. An empty younger copy is trashed without a stray separator.
6. A regular note titled e.g. "2026-06-08 shopping" (no stamp) in the Daily folder is NOT touched.
7. i18n: verify the toast in PL/EN (and DE/FR/ES if possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)