### PR TITLE
feat(notes): render horizontal rule (---) in Live Preview

### DIFF
--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
@@ -416,6 +416,68 @@ describe('buildDecorations — fenced code blocks', () => {
   });
 });
 
+describe('buildDecorations — horizontal rule', () => {
+  it('hides the raw "---" and styles the line as a rule when cursor is outside', () => {
+    const doc = 'a\n\n---\n\nb';
+    // line "---" → from 3, to 6; cursor in "b" (pos 8)
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+
+    expect(classAt(ranges, 3, 3)).toBe('cm-lp-hr-line');
+    expect(hasHiddenRange(ranges, 3, 6)).toBe(true);
+  });
+
+  it('reveals the raw "---" (dimmed, no line styling) when cursor is on the line', () => {
+    const doc = 'a\n\n---\n\nb';
+    const state = makeState(doc, 4); // cursor between the dashes
+    const ranges = asRanges(buildDecorations(state));
+
+    // Raw chars shown for editing — not hidden, marked visible (dimmed)
+    expect(hasHiddenRange(ranges, 3, 6)).toBe(false);
+    expect(classAt(ranges, 3, 6)).toBe('cm-lp-mark');
+    // No divider line styling while editing (would overlap the raw text)
+    expect(classAt(ranges, 3, 3)).toBeUndefined();
+  });
+
+  it.each([
+    ['dashes', 'a\n\n---\n\nb'],
+    ['asterisks', 'a\n\n***\n\nb'],
+    ['underscores', 'a\n\n___\n\nb']
+  ])('recognises the %s thematic-break form', (_label, doc) => {
+    const state = makeState(doc, doc.length - 1); // cursor in trailing "b"
+    const ranges = asRanges(buildDecorations(state));
+    expect(classAt(ranges, 3, 3)).toBe('cm-lp-hr-line');
+    expect(hasHiddenRange(ranges, 3, 6)).toBe(true);
+  });
+
+  it('renders a rule on the very first line', () => {
+    const doc = '---\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+    expect(classAt(ranges, 0, 0)).toBe('cm-lp-hr-line');
+    expect(hasHiddenRange(ranges, 0, 3)).toBe(true);
+  });
+
+  it('does NOT treat a setext H2 underline ("Title\\n---") as a horizontal rule', () => {
+    // `---` directly under a paragraph line is a Setext heading underline
+    // (SetextHeading2), not a thematic break — must not get hr styling.
+    const doc = 'Title\n---\n\nbody';
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+    expect(ranges.find((r) => r.spec.class === 'cm-lp-hr-line')).toBeUndefined();
+  });
+
+  it('coexists with other block constructs (heading above the rule)', () => {
+    const doc = '# H\n\n---\n\nbody';
+    // "# H" 0-2, rule "---" at 5-8, cursor in "body"
+    const state = makeState(doc, doc.length - 1);
+    const ranges = asRanges(buildDecorations(state));
+    expect(classAt(ranges, 0, 0)).toBe('cm-lp-h1-line');
+    expect(classAt(ranges, 5, 5)).toBe('cm-lp-hr-line');
+    expect(hasHiddenRange(ranges, 5, 8)).toBe(true);
+  });
+});
+
 describe('buildDecorations — empty / no markdown', () => {
   it('returns no decorations for an empty document', () => {
     const state = makeState('', 0);

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
@@ -70,6 +70,7 @@ const EM_MARK = Decoration.mark({ class: 'cm-lp-em' });
 const STRIKE_MARK = Decoration.mark({ class: 'cm-lp-strike' });
 const INLINE_CODE_MARK = Decoration.mark({ class: 'cm-lp-code' });
 const BLOCKQUOTE_LINE = Decoration.line({ class: 'cm-lp-blockquote-line' });
+const HR_LINE = Decoration.line({ class: 'cm-lp-hr-line' });
 
 // Visual cap on list nesting. Tapered ramp in `theme.ts` keeps even d12
 // (~14.5em ≈ 232px) usable on a 360px viewport; CommonMark realistically
@@ -304,6 +305,30 @@ export function buildDecorations(
           if (n === startLine.number) deco = CODE_LINE_FIRST;
           else if (n === endLine.number && lineCount > 0) deco = CODE_LINE_LAST;
           ranges.push(deco.range(ln.from));
+        }
+        return false;
+      }
+
+      // ─── Horizontal rule / thematic break (---, ***, ___) ────────
+      // Cursor off the line → hide the raw marker chars and paint the (now
+      // empty) line as a divider via a centered CSS border (`cm-lp-hr-line`),
+      // mirroring Preview's <hr>. Cursor on the line → reveal the raw `---`
+      // dimmed so it stays editable — same away-renders / caret-edits pattern
+      // as headings and blockquotes.
+      //
+      // A thematic break occupies the whole line and has no other content, so
+      // we hide `line.from..line.to` rather than the node range. That also
+      // cleanly covers the up-to-3-space indented form (where the node starts
+      // after the leading spaces) without leaving stray whitespace visible.
+      // Hiding the full line stays WITHIN the line (no trailing newline), so a
+      // plain inline replace suffices — no `block: true` needed.
+      if (name === 'HorizontalRule') {
+        const line = doc.lineAt(from);
+        if (!isAnySelectionInRange(state, line.from, line.to)) {
+          ranges.push(HR_LINE.range(line.from));
+          if (line.to > line.from) ranges.push(HIDDEN.range(line.from, line.to));
+        } else if (line.to > line.from) {
+          ranges.push(VISIBLE_MARK.range(line.from, line.to));
         }
         return false;
       }

--- a/apps/reborn-notes/src/lib/editor/live-preview/index.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/index.ts
@@ -6,11 +6,12 @@
  * NoteEditor.svelte based on the user's `editorMode` setting.
  *
  * Scope: ATX headings, **bold**, *italic*, `inline code`, links (incl. note:UUID),
- * blockquote, bullet/ordered lists, GFM task lists (`- [ ]` / `- [x]` with an
- * interactive checkbox widget), fenced code blocks (```lang ... ```), GFM
- * tables (always rendered as an editable widget — Obsidian-style), and inline
- * images (`![alt](url)` — placeholder/auto-load per user preference, raw
- * markdown when the cursor is inside the image range).
+ * blockquote, horizontal rules (`---` / `***` / `___` rendered as a divider,
+ * raw when the cursor is on the line), bullet/ordered lists, GFM task lists
+ * (`- [ ]` / `- [x]` with an interactive checkbox widget), fenced code blocks
+ * (```lang ... ```), GFM tables (always rendered as an editable widget —
+ * Obsidian-style), and inline images (`![alt](url)` — placeholder/auto-load
+ * per user preference, raw markdown when the cursor is inside the image range).
  */
 import type { Extension } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';

--- a/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
@@ -138,6 +138,28 @@ export const livePreviewTheme = EditorView.theme({
     fontStyle: 'italic'
   },
 
+  // Horizontal rule (thematic break) — the raw `---`/`***`/`___` is hidden by
+  // a full-line replace, leaving an empty line we paint a centered divider on
+  // via `::before`. Padding (not margin) gives vertical breathing room without
+  // de-syncing the CM6 height map (same rule as headings). The 1px border
+  // mirrors MarkdownPreview's <hr> (`border-top: 1px solid var(--border)`).
+  '.cm-lp-hr-line': {
+    position: 'relative',
+    paddingTop: '0.75em',
+    paddingBottom: '0.75em'
+  },
+  '.cm-lp-hr-line::before': {
+    content: '""',
+    position: 'absolute',
+    left: '0',
+    right: '0',
+    top: '50%',
+    borderTop: '1px solid var(--border)',
+    // Pseudo-element must not swallow clicks — the caret needs to land on the
+    // line to switch back to the raw, editable `---`.
+    pointerEvents: 'none'
+  },
+
   // Bullet list — depth-aware padding + ::before bullet.
   //
   // Tapered ramp (mirrored in MarkdownPreview.svelte's `[data-d{N}]` rules):


### PR DESCRIPTION
## Summary

Thematic breaks (`---` / `***` / `___`) showed as **raw markdown** in the Live Preview editor and only rendered as `<hr>` in Preview - the only CommonMark block element rendered in Preview but skipped in Live Preview. This adds it, with full editability.

- New `HorizontalRule` branch in `buildDecorations` (`decorations.ts`) following the existing **away-renders / caret-edits** pattern (same as headings, blockquote, lists):
  - **Cursor off the line** → raw chars hidden via full-line `Decoration.replace`, line styled as a divider (`cm-lp-hr-line`).
  - **Cursor on the line** → raw `---` revealed, dimmed (`cm-lp-mark`), editable.
- `cm-lp-hr-line::before` paints `border-top: 1px solid var(--border)` - mirrors `MarkdownPreview.svelte`'s `<hr>`. Vertical spacing via `padding` (not `margin` - CM6 height-map rule).

### Implementation decisions (not architectural - flagged for fast review)

- **Line-decoration + full-line replace, not a block widget** (unlike FencedCode/Table). Rationale: editability. A block widget makes the line non-navigable by arrow keys (caret skips it) and an `<hr>` has nothing to edit "inside" like a contenteditable table - the user needs to reach the raw `---`. The line-decoration keeps a real, clickable/navigable line that expands to raw `---` when the caret lands on it.
- **Hide `line.from..line.to` (whole line), not the node range** - a thematic break occupies the whole line; this also covers the ≤3-leading-space form and leaves no stray whitespace. Stays within the line (no `\n`), so a plain inline replace suffices (no `block: true`).
- **Setext H2 (`Title\n---`) untouched** - lezer parses it as `SetextHeading2`, not `HorizontalRule`, so the branch doesn't fire (consistent with Preview, where it's a heading).

**Zero Knowledge / i18n:** no schema/server/API change (pure client-side rendering of already-decrypted content); no new i18n keys (no UI strings).

## Test plan

Automated (all green):
- `nx build reborn-notes` ✓
- `nx test reborn-notes` ✓ (543 tests, +6 new HR cases: hide-when-outside, raw-when-on-line, `---`/`***`/`___` forms, first-line, setext-is-not-hr, coexists-with-heading)
- `nx lint reborn-notes` ✓ (0 errors)
- `nx check reborn-notes` (svelte-check) ✓ (0 errors)

Manual smoke (Live Preview mode, reborn-notes):
1. Type `---` on its own line (blank line above) → renders as a horizontal divider.
2. Click / arrow onto the line → shows raw `---` (dimmed), editable; arrow away → divider again.
3. Verify `***` and `___` render the same way.
4. Verify `Title` followed by `---` on the next line still renders as an **H2 heading** (not a divider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)