### PR TITLE
chore(native): native auth refresh via secure-storage (Faza 2)

### DIFF
--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@aparajita/capacitor-secure-storage": "8.0.0",
     "@capacitor/android": "8.4.0",
     "@capacitor/core": "8.4.0",
     "@codemirror/autocomplete": "6.20.3",

--- a/apps/reborn-notes/src/app.d.ts
+++ b/apps/reborn-notes/src/app.d.ts
@@ -3,6 +3,8 @@
 
 declare global {
   const __APP_VERSION__: string;
+  /** Build-time native (Capacitor) flag. `false` on web (see vite.config.ts define). */
+  const __REBORN_NATIVE__: boolean;
 
   namespace App {
     interface Error {

--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -6,6 +6,8 @@
  * This allows Notes to authenticate users independently - without reborn-task.
  */
 import { API_BASE } from '$lib/utils/api-base';
+import { nativeAuthHeaders } from '$lib/utils/native-client';
+import { persistNativeRefreshToken } from '$lib/utils/native-auth-storage';
 import { authStore, CREDENTIALS_KEY, ACCESS_TOKEN_KEY } from '$lib/stores/auth.store';
 import { sessionExpired } from '$lib/stores/sync-status.store';
 import { clearAllUserData, isDatabaseInitialized } from '@reborn/storage';
@@ -31,6 +33,8 @@ interface ReAuthResponseBody {
     twoFactorRequired?: boolean;
     userId?: string;
     access_token?: string;
+    /** Present only for native clients (sent the native header). */
+    refresh_token?: string;
   };
 }
 
@@ -43,7 +47,7 @@ export async function loginInNotes(username: string, password: string): Promise<
   try {
     const res = await fetch(`${API_BASE}/auth/login`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...nativeAuthHeaders() },
       body: JSON.stringify({ username, password })
     });
 
@@ -80,7 +84,10 @@ export async function loginInNotes(username: string, password: string): Promise<
     };
     localStorage.setItem(CREDENTIALS_KEY, JSON.stringify(credentials));
     localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
-    // Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
+    // Web: refresh_token is managed exclusively via httpOnly cookie (set by server).
+    // Native: it arrives in the body (native header) and is persisted to secure
+    // storage for createAuthFetch's native refresh path. No-op on web.
+    await persistNativeRefreshToken(data.refresh_token);
 
     // Clear any previous user's data from IndexedDB before starting new session.
     // Prevents phantom notes when switching users or after DB wipe + re-register.
@@ -166,7 +173,7 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
   try {
     res = await fetch(`${API_BASE}/auth/login`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...nativeAuthHeaders() },
       body: JSON.stringify({ username, password })
     });
   } catch (err) {
@@ -202,6 +209,8 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
   if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
 
   localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
+  // Native: persist the rotated refresh token from the body. No-op on web.
+  await persistNativeRefreshToken(data.refresh_token);
 
   // Credentials remain the same - touch to ensure they're still parseable
   try {
@@ -224,7 +233,7 @@ export async function verifyTotpForReauth(userId: string, code: string): Promise
   try {
     res = await fetch(`${API_BASE}/auth/2fa/verify`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...nativeAuthHeaders() },
       body: JSON.stringify({ userId, code })
     });
   } catch (err) {
@@ -255,6 +264,8 @@ export async function verifyTotpForReauth(userId: string, code: string): Promise
   if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
 
   localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
+  // Native: persist the rotated refresh token from the body. No-op on web.
+  await persistNativeRefreshToken(data.refresh_token);
 
   sessionExpired.set(false);
   await refreshAfterReauth();

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -213,7 +213,7 @@ function createAuthStore() {
    * Uses hard redirect (`window.location.href`) instead of Svelte store update
    * to avoid reactive cascades (empty stores, effect_update_depth_exceeded).
    */
-  function logout(): void {
+  async function logout(): Promise<void> {
     if (!browser) return;
     // Reset session expired flag — this is an intentional logout, not expiry
     sessionExpired.set(false);
@@ -240,16 +240,23 @@ function createAuthStore() {
     cryptoManager.clearMasterKey();
     localStorage.removeItem(CREDENTIALS_KEY);
     localStorage.removeItem(ACCESS_TOKEN_KEY);
-    // Native: drop the refresh token from secure storage too (best-effort,
-    // fire-and-forget). No-op on web (DCE'd).
-    void clearNativeRefreshToken();
 
-    // Clear all user data from IndexedDB to prevent cross-user data leakage.
-    // Fire-and-forget — the hard redirect below will complete the logout even
-    // if the clear takes a moment.
-    import('@reborn/storage').then(({ clearAllUserData }) =>
-      clearAllUserData().catch((err) => logger.error('Failed to clear IndexedDB on logout:', err))
-    );
+    // Await the data-clearing steps BEFORE the hard redirect. window.location.href
+    // reloads the page/WebView, which aborts any in-flight IndexedDB transaction —
+    // a fire-and-forget clear here would race the reload and leave orphan notes
+    // (seen on native when the next session points at a different backend). The
+    // critical synchronous logout state (cleared localStorage + in-memory master
+    // key above) is already applied, so callers see a logged-out state immediately;
+    // only the redirect waits. Best-effort: failures are logged, never block logout.
+    try {
+      const { clearAllUserData } = await import('@reborn/storage');
+      await clearAllUserData();
+    } catch (err) {
+      logger.error('Failed to clear IndexedDB on logout:', err);
+    }
+    // Native: drop the refresh token from secure storage (no-op on web; has its
+    // own internal try/catch, so this never throws).
+    await clearNativeRefreshToken();
 
     // Hard redirect — avoids reactive cascades from setting store to empty state.
     // Clearing localStorage above will also fire a storage event in reborn-task

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -23,6 +23,7 @@ import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import { base } from '$app/paths';
 import { API_BASE } from '$lib/utils/api-base';
+import { clearNativeRefreshToken } from '$lib/utils/native-auth-storage';
 import { cryptoManager } from '@reborn/crypto';
 import { sessionExpired } from '$lib/stores/sync-status.store';
 import { createLogger } from '@reborn/utils';
@@ -239,6 +240,9 @@ function createAuthStore() {
     cryptoManager.clearMasterKey();
     localStorage.removeItem(CREDENTIALS_KEY);
     localStorage.removeItem(ACCESS_TOKEN_KEY);
+    // Native: drop the refresh token from secure storage too (best-effort,
+    // fire-and-forget). No-op on web (DCE'd).
+    void clearNativeRefreshToken();
 
     // Clear all user data from IndexedDB to prevent cross-user data leakage.
     // Fire-and-forget — the hard redirect below will complete the logout even

--- a/apps/reborn-notes/src/lib/utils/auth-fetch.ts
+++ b/apps/reborn-notes/src/lib/utils/auth-fetch.ts
@@ -1,6 +1,8 @@
 import { API_BASE } from '$lib/utils/api-base';
 import { createAuthFetch } from '@reborn/auth';
 import { sessionExpired } from '$lib/stores/sync-status.store';
+import { IS_NATIVE } from '$lib/utils/native-client';
+import { persistNativeRefreshToken, readNativeRefreshToken } from '$lib/utils/native-auth-storage';
 
 /**
  * App-level singleton of the authenticated fetch wrapper.
@@ -13,6 +15,12 @@ import { sessionExpired } from '$lib/stores/sync-status.store';
  * Usage: drop-in replacement for `fetch()` in authenticated pages.
  */
 export const authFetch = createAuthFetch({
-  refreshUrl: `${API_BASE}/auth/refresh`,
+  // Native: dedicated body-token endpoint + secure-storage refresh token.
+  // Web: the cookie-based endpoint with no refreshTokenStore (byte-identical -
+  // IS_NATIVE folds to false, so the native branch is dead-code-eliminated).
+  refreshUrl: IS_NATIVE ? `${API_BASE}/auth/refresh-native` : `${API_BASE}/auth/refresh`,
+  refreshTokenStore: IS_NATIVE
+    ? { get: readNativeRefreshToken, set: persistNativeRefreshToken }
+    : undefined,
   onSessionExpired: () => sessionExpired.set(true)
 });

--- a/apps/reborn-notes/src/lib/utils/native-auth-probe.ts
+++ b/apps/reborn-notes/src/lib/utils/native-auth-probe.ts
@@ -1,0 +1,54 @@
+/**
+ * Dev-only native refresh probe (Faza 2 validation). Native build only.
+ *
+ * Exposes `window.__rebornAuthProbe(n?)` so the rotated-refresh-token path can be
+ * validated on the emulator without waiting 15 minutes per natural refresh. Run
+ * it from the remote webview console (Android: chrome://inspect) AFTER logging in:
+ *
+ *   await __rebornAuthProbe(5)
+ *
+ * It fires N sequential `authFetch.refresh()` calls and, for each, checks that a
+ * fresh access token came back AND the secure-storage refresh token actually
+ * rotated. The point is to prove that >=3 rotations survive without the server's
+ * token-reuse detector revoking the family (which would surface as a NULL result
+ * and a dead session). A single NULL/ERROR aborts the run.
+ *
+ * Gated behind `__REBORN_NATIVE__`, so it is dead-code-eliminated from the web
+ * build and never attaches on web. Temporary - remove before Faza 5 store prep.
+ */
+import { authFetch } from '$lib/utils/auth-fetch';
+import { readNativeRefreshToken } from '$lib/utils/native-auth-storage';
+
+export function installNativeAuthProbe(): void {
+  if (!__REBORN_NATIVE__ || typeof window === 'undefined') return;
+
+  (window as unknown as Record<string, unknown>).__rebornAuthProbe = async (
+    n = 5
+  ): Promise<string[]> => {
+    const out: string[] = [];
+    for (let i = 1; i <= n; i++) {
+      try {
+        const before = await readNativeRefreshToken();
+        const accessToken = await authFetch.refresh();
+        const after = await readNativeRefreshToken();
+        const rotated = !!after && after !== before;
+        const line = accessToken
+          ? `#${i}: OK  access=...${accessToken.slice(-8)}  refreshRotated=${rotated}`
+          : `#${i}: NULL (session gone - refresh failed / family revoked)`;
+        out.push(line);
+        // eslint-disable-next-line no-console
+        console.log('[rebornAuthProbe]', line);
+        if (!accessToken) break;
+      } catch (err) {
+        const line = `#${i}: ERROR ${err instanceof Error ? err.message : String(err)}`;
+        out.push(line);
+        // eslint-disable-next-line no-console
+        console.error('[rebornAuthProbe]', line);
+        break;
+      }
+    }
+    // eslint-disable-next-line no-console
+    console.log('[rebornAuthProbe] done', out);
+    return out;
+  };
+}

--- a/apps/reborn-notes/src/lib/utils/native-auth-storage.ts
+++ b/apps/reborn-notes/src/lib/utils/native-auth-storage.ts
@@ -1,0 +1,61 @@
+/**
+ * Native (Capacitor) refresh-token persistence, backed by device secure storage
+ * (iOS Keychain / Android Keystore-encrypted) via
+ * `@aparajita/capacitor-secure-storage`.
+ *
+ * The refresh token cannot ride a cross-origin httpOnly cookie in the native
+ * shell, so it lives here instead. Every plugin import is gated behind
+ * `__REBORN_NATIVE__`, so on the web build the whole branch (and the plugin) is
+ * dead-code-eliminated and each function is an inert no-op / null.
+ *
+ * This stores the rotating session refresh token only - NOT the master key. The
+ * master key never leaves the device unencrypted and is never written here.
+ *
+ * Errors from the secure-storage layer (rare OS failures) are swallowed and
+ * degrade to "no token": a read failure surfaces as a missing session
+ * (re-login), and createAuthFetch's refresh path handles `null` cleanly. This
+ * keeps a broken secure-storage call from throwing out of the refresh flow.
+ */
+
+const REFRESH_TOKEN_KEY = 'refresh_token';
+
+/** Persist the (rotated) refresh token after login / refresh. No-op on web. */
+export async function persistNativeRefreshToken(
+  token: string | null | undefined
+): Promise<void> {
+  if (!token) return;
+  if (__REBORN_NATIVE__) {
+    try {
+      const { SecureStorage } = await import('@aparajita/capacitor-secure-storage');
+      await SecureStorage.setItem(REFRESH_TOKEN_KEY, token);
+    } catch {
+      // Write failed (rare OS error). The current access token is still valid for
+      // its lifetime; the next refresh will find no usable token and prompt re-login.
+    }
+  }
+}
+
+/** Read the persisted refresh token, or null if none / on error. null on web. */
+export async function readNativeRefreshToken(): Promise<string | null> {
+  if (__REBORN_NATIVE__) {
+    try {
+      const { SecureStorage } = await import('@aparajita/capacitor-secure-storage');
+      return await SecureStorage.getItem(REFRESH_TOKEN_KEY);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/** Remove the persisted refresh token (logout). No-op on web. */
+export async function clearNativeRefreshToken(): Promise<void> {
+  if (__REBORN_NATIVE__) {
+    try {
+      const { SecureStorage } = await import('@aparajita/capacitor-secure-storage');
+      await SecureStorage.removeItem(REFRESH_TOKEN_KEY);
+    } catch {
+      // Best-effort on logout - a failed delete must not block the logout flow.
+    }
+  }
+}

--- a/apps/reborn-notes/src/lib/utils/native-client.spec.ts
+++ b/apps/reborn-notes/src/lib/utils/native-client.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { isNativeClient, NATIVE_CLIENT_HEADER, NATIVE_CLIENT_VALUE } from './native-client';
+
+function reqWith(headers: Record<string, string>): Request {
+  return new Request('http://localhost/api/auth/login', { method: 'POST', headers });
+}
+
+describe('isNativeClient', () => {
+  it('is true when the native client header is present with the native value', () => {
+    expect(isNativeClient(reqWith({ [NATIVE_CLIENT_HEADER]: NATIVE_CLIENT_VALUE }))).toBe(true);
+  });
+
+  it('is case-insensitive on the header name (Fetch spec normalizes casing)', () => {
+    expect(isNativeClient(reqWith({ 'X-Reborn-Client': 'native' }))).toBe(true);
+  });
+
+  it('is false when the header is absent (web client - byte-identical path)', () => {
+    expect(isNativeClient(reqWith({}))).toBe(false);
+  });
+
+  it('is false for any other value (no accidental opt-in)', () => {
+    expect(isNativeClient(reqWith({ [NATIVE_CLIENT_HEADER]: 'web' }))).toBe(false);
+    expect(isNativeClient(reqWith({ [NATIVE_CLIENT_HEADER]: 'Native' }))).toBe(false);
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/native-client.ts
+++ b/apps/reborn-notes/src/lib/utils/native-client.ts
@@ -32,3 +32,20 @@ export const NATIVE_CLIENT_VALUE = 'native';
 export function isNativeClient(request: Request): boolean {
   return request.headers.get(NATIVE_CLIENT_HEADER) === NATIVE_CLIENT_VALUE;
 }
+
+/**
+ * Build-time native (Capacitor) flag - `false` on the web build, so native-only
+ * branches are dead-code-eliminated and the web bundle stays byte-identical.
+ * Defined via `__REBORN_NATIVE__` in vite.config.ts (and as `false` in vitest).
+ */
+export const IS_NATIVE: boolean = __REBORN_NATIVE__;
+
+/**
+ * Headers a native client must add to token-issuing requests (login, 2fa,
+ * register, change-password) so the server returns the refresh token in the
+ * body. Empty on web -> request headers are unchanged. Spread into a fetch's
+ * `headers`: `{ 'Content-Type': 'application/json', ...nativeAuthHeaders() }`.
+ */
+export function nativeAuthHeaders(): Record<string, string> {
+  return IS_NATIVE ? { [NATIVE_CLIENT_HEADER]: NATIVE_CLIENT_VALUE } : {};
+}

--- a/apps/reborn-notes/src/lib/utils/native-client.ts
+++ b/apps/reborn-notes/src/lib/utils/native-client.ts
@@ -1,0 +1,34 @@
+/**
+ * Native (Capacitor) client signaling - shared client/server contract.
+ *
+ * The native shell loads its code locally and talks to the API cross-origin,
+ * so it cannot use the httpOnly `refresh_token` cookie the web client relies on
+ * (a `SameSite=Lax` cookie is never sent on a cross-site request). Instead the
+ * native client identifies itself with this header on token-issuing requests,
+ * and the server additionally returns the rotated refresh token in the response
+ * BODY so the native client can persist it in device secure storage
+ * (Keychain / Keystore). See `docs/development/planning/native-faza2-plan.md`.
+ *
+ * Web clients never send this header, so every web response stays byte-identical
+ * to before - the refresh token remains exclusively in the httpOnly cookie and
+ * is never exposed to client-side JS.
+ *
+ * Pure + web-standard (`Request`/`Headers` only), so this module is safe to
+ * import from both `+server.ts` handlers and client code.
+ */
+
+/** Header a native client sends to opt into the body-token transport. */
+export const NATIVE_CLIENT_HEADER = 'x-reborn-client';
+
+/** Value of {@link NATIVE_CLIENT_HEADER} that marks the native shell. */
+export const NATIVE_CLIENT_VALUE = 'native';
+
+/**
+ * True when the request comes from the native shell (carries the native client
+ * header). Server-side gate for the additive "refresh token in body" branch on
+ * token-issuing endpoints. `Headers.get` is case-insensitive per the Fetch
+ * spec, so header casing from the native HTTP layer does not matter.
+ */
+export function isNativeClient(request: Request): boolean {
+  return request.headers.get(NATIVE_CLIENT_HEADER) === NATIVE_CLIENT_VALUE;
+}

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import '../app.css';
   import { onMount, untrack } from 'svelte';
+  import { installNativeAuthProbe } from '$lib/utils/native-auth-probe';
   import { get } from 'svelte/store';
   import { Toaster } from '@reborn/ui';
   import { browser } from '$app/environment';
@@ -116,6 +117,9 @@
 
   onMount(() => {
     if (!browser) return;
+
+    // Native-only dev probe for refresh-token rotation validation (no-op on web).
+    installNativeAuthProbe();
 
     // Timeout fallback - show app even if initialization stalls (e.g. slow IndexedDB)
     const timeoutId = setTimeout(() => {

--- a/apps/reborn-notes/src/routes/api/auth/2fa/verify/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/2fa/verify/+server.ts
@@ -6,6 +6,7 @@ import { prisma } from '@reborn/database';
 import { v4 as uuidv4 } from 'uuid';
 import * as OTPAuth from 'otpauth';
 import { twoFactorLockout } from '$lib/server/rate-limit';
+import { isNativeClient } from '$lib/utils/native-client';
 
 const logger = createLogger('Notes-2FA-Verify');
 const ISSUER = 'Reborn Apps';
@@ -134,20 +135,25 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 
     logger.info(`2FA verification successful for user ${user.username}`);
 
-    return json({
-      success: true,
-      data: {
-        user: {
-          id: user.id,
-          username: user.username,
-          created_at: user.created_at.toISOString(),
-          updated_at: user.updated_at.toISOString()
-        },
-        encryptedMasterKey: user.master_key_encrypted,
-        masterKeySalt: user.master_key_salt,
-        access_token: accessToken
-      }
-    });
+    const responseBody: Record<string, unknown> = {
+      user: {
+        id: user.id,
+        username: user.username,
+        created_at: user.created_at.toISOString(),
+        updated_at: user.updated_at.toISOString()
+      },
+      encryptedMasterKey: user.master_key_encrypted,
+      masterKeySalt: user.master_key_salt,
+      access_token: accessToken
+    };
+    // Native (Capacitor) client persists the refresh token in secure storage (it
+    // cannot use the httpOnly cookie cross-origin). Web clients send no native
+    // header -> response stays byte-identical. See $lib/utils/native-client.
+    if (isNativeClient(request)) {
+      responseBody.refresh_token = refreshToken;
+    }
+
+    return json({ success: true, data: responseBody });
   } catch (error: unknown) {
     logger.error('2FA verify error:', error);
     return json({ success: false, error: 'Internal server error' }, { status: 500 });

--- a/apps/reborn-notes/src/routes/api/auth/2fa/verify/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/auth/2fa/verify/server.spec.ts
@@ -72,12 +72,12 @@ function expectedHash(code: string): string {
 	return createHash('sha256').update(normalized).digest('hex');
 }
 
-function createMockEvent(body: unknown) {
+function createMockEvent(body: unknown, extraHeaders?: Record<string, string>) {
 	const cookieStore = new Map<string, string>();
 	return {
 		request: new Request('http://localhost/api/auth/2fa/verify', {
 			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+			headers: { 'Content-Type': 'application/json', ...extraHeaders },
 			body: JSON.stringify(body)
 		}),
 		cookies: {
@@ -88,9 +88,9 @@ function createMockEvent(body: unknown) {
 	};
 }
 
-async function callEndpoint(body: unknown) {
+async function callEndpoint(body: unknown, extraHeaders?: Record<string, string>) {
 	const { POST } = await import('./+server');
-	const event = createMockEvent(body);
+	const event = createMockEvent(body, extraHeaders);
 	const response = await (POST as unknown as (event: unknown) => Promise<Response>)(event);
 	const data = await response.json();
 	return { response, data, status: response.status };
@@ -263,8 +263,25 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
 		expect(data.data.access_token).toBe('mock-access');
-		// refresh_token is sent as httpOnly cookie, not in JSON body
+		// Web client: refresh_token goes out ONLY as the httpOnly cookie, never in
+		// the JSON body (byte-identical to before the native path was added).
+		expect(data.data.refresh_token).toBeUndefined();
 		expect(mockLockout.reset).toHaveBeenCalledWith(MOCK_USER_ID);
+	});
+
+	// (m) Native client (x-reborn-client: native) → refresh_token ALSO in body so
+	//     the native shell can persist it in secure storage. The httpOnly cookie is
+	//     still set too; native simply ignores it.
+	it('returns refresh_token in the body for the native client', async () => {
+		const { status, data } = await callEndpoint(
+			{ userId: MOCK_USER_ID, code: '123456' },
+			{ 'x-reborn-client': 'native' }
+		);
+
+		expect(status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.data.access_token).toBe('mock-access');
+		expect(data.data.refresh_token).toBe('mock-refresh');
 	});
 
 	// (k) userId > 36 characters → 400 (notes-specific validation)

--- a/apps/reborn-notes/src/routes/api/auth/change-password/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/change-password/+server.ts
@@ -11,6 +11,7 @@ import {
   refreshTokenExpiryDate
 } from '@reborn/auth/server';
 import { changePasswordLockout } from '$lib/server/rate-limit';
+import { isNativeClient } from '$lib/utils/native-client';
 
 const logger = createLogger('Notes-ChangePassword');
 
@@ -106,10 +107,15 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
     });
 
     logger.info(`Password changed for user ${userId}`);
-    return json({
-      success: true,
-      data: { access_token: newTokens.accessToken }
-    });
+    const responseBody: Record<string, unknown> = { access_token: newTokens.accessToken };
+    // change-password revokes ALL of the user's refresh tokens and issues a fresh
+    // one, so a native client MUST receive the new token to re-persist in secure
+    // storage - otherwise its stored token is dead and the next refresh fails.
+    // Gated by the native header -> web stays byte-identical (cookie only).
+    if (isNativeClient(request)) {
+      responseBody.refresh_token = newTokens.refreshToken;
+    }
+    return json({ success: true, data: responseBody });
   } catch (error: unknown) {
     logger.error('Change password error:', error);
     return json({ success: false, error: 'Internal server error' }, { status: 500 });

--- a/apps/reborn-notes/src/routes/api/auth/login/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/login/+server.ts
@@ -8,6 +8,7 @@ import {
 } from '@reborn/auth/server';
 import { prisma } from '@reborn/database';
 import { loginLockout } from '$lib/server/rate-limit';
+import { isNativeClient } from '$lib/utils/native-client';
 import { createLogger } from '@reborn/utils';
 
 const logger = createLogger('Notes-Login');
@@ -148,13 +149,18 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
       }
 
       const { refreshToken, accessToken, ...responseData } = result.data;
-      return json({
-        success: true,
-        data: {
-          ...responseData,
-          access_token: accessToken
-        }
-      });
+      const responseBody: Record<string, unknown> = {
+        ...responseData,
+        access_token: accessToken
+      };
+      // Native (Capacitor) client cannot use the httpOnly cookie cross-origin, so
+      // it additionally receives the refresh token in the body to persist in secure
+      // storage. Web clients send no native header -> response stays byte-identical
+      // (refresh token only in the httpOnly cookie). See $lib/utils/native-client.
+      if (isNativeClient(request)) {
+        responseBody.refresh_token = refreshToken;
+      }
+      return json({ success: true, data: responseBody });
     } else {
       // Record failed login attempt for per-username lockout
       loginLockout.recordFailure(username);

--- a/apps/reborn-notes/src/routes/api/auth/refresh-native/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/refresh-native/+server.ts
@@ -1,0 +1,74 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { createLogger } from '@reborn/utils';
+import { handleRefreshToken, createDefaultHandlerOptions } from '@reborn/auth/server';
+import { prisma } from '@reborn/database';
+
+const logger = createLogger('NotesAuthRefreshNative');
+
+/**
+ * POST /api/auth/refresh-native - access-token refresh for the native (Capacitor) client.
+ *
+ * The native shell cannot use the httpOnly `refresh_token` cookie the web client
+ * relies on: it loads cross-origin, where a `SameSite=Lax` cookie is never sent.
+ * Instead the native client holds the refresh token in device secure storage
+ * (Keychain / Keystore) and presents it in the request BODY here; on success the
+ * rotated token comes back in the body for the client to re-persist. Rotation
+ * and token-family reuse detection are identical to the web `/auth/refresh`
+ * (same `handleRefreshToken`) - only the transport differs.
+ *
+ * Security model (see native-faza2-plan.md "sekcja bezpieczeństwa"):
+ *  - The token is read ONLY from the body, never from a cookie. A web-origin XSS
+ *    attacker cannot read the httpOnly cookie, so it cannot supply a valid token
+ *    here - the cookie-based web session stays protected and this endpoint adds
+ *    no exfiltration path for web.
+ *  - No cookie is set. Native auth state lives entirely in the body round-trip +
+ *    secure storage; nothing is parked in the native HTTP cookie jar.
+ *  - The web `/auth/refresh` endpoint is a SEPARATE handler and is left untouched,
+ *    so there is zero regression risk to the web refresh path (B1 - osobny endpoint).
+ */
+export const POST: RequestHandler = async ({ request }) => {
+  try {
+    let body: { refresh_token?: unknown };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return json({ success: false, error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const refreshToken = body?.refresh_token;
+    if (!refreshToken || typeof refreshToken !== 'string') {
+      return json({ success: false, error: 'No refresh token provided' }, { status: 401 });
+    }
+
+    const result = await handleRefreshToken(
+      { refresh_token: refreshToken },
+      createDefaultHandlerOptions({
+        user: prisma.user,
+        refreshToken: prisma.refreshToken
+      })
+    );
+
+    if (result.success && result.data?.refreshToken) {
+      const { refreshToken: newRefreshToken, accessToken, ...responseData } = result.data;
+      return json({
+        success: true,
+        data: {
+          ...responseData,
+          access_token: accessToken,
+          // Unlike the web endpoint, the rotated refresh token IS returned here -
+          // the native client persists it in secure storage for the next refresh.
+          refresh_token: newRefreshToken
+        }
+      });
+    }
+
+    return json(
+      { success: false, error: result.error || 'Token refresh failed' },
+      { status: 401 }
+    );
+  } catch (error: unknown) {
+    logger.error('Native token refresh error:', error);
+    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+};

--- a/apps/reborn-notes/src/routes/api/auth/refresh-native/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/auth/refresh-native/server.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────
+//
+// Same approach as ../refresh/server.spec.ts: `handleRefreshToken` runs for
+// real, we stub `@reborn/database` so `refreshToken.findUnique` is a `vi.fn()`.
+// findUnique -> null makes the handler short-circuit to a failure (401), so no
+// JWT signing path needs mocking. We assert on WHAT reached findUnique to prove
+// the token is read from the BODY (never a cookie).
+
+const mockPrisma = {
+	user: {} as Record<string, never>,
+	refreshToken: {
+		findUnique: vi.fn(),
+		create: vi.fn(),
+		updateMany: vi.fn(),
+		deleteMany: vi.fn()
+	}
+};
+
+vi.mock('@reborn/database', () => ({ prisma: mockPrisma }));
+
+vi.mock('@reborn/utils', () => ({
+	createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function createMockEvent(init: { body?: string; cookie?: string }) {
+	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+	if (init.cookie) headers['Cookie'] = init.cookie;
+	return {
+		request: new Request('http://localhost/api/auth/refresh-native', {
+			method: 'POST',
+			headers,
+			body: init.body
+		})
+	};
+}
+
+async function callRefreshNative(init: { body?: string; cookie?: string }) {
+	const { POST } = await import('./+server');
+	const event = createMockEvent(init);
+	const response = await (POST as unknown as (event: unknown) => Promise<Response>)(event);
+	const data = await response.json();
+	return { response, data, status: response.status };
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// findUnique -> null: handler short-circuits to a refresh failure (401).
+	mockPrisma.refreshToken.findUnique.mockResolvedValue(null);
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('POST /api/auth/refresh-native (reborn-notes)', () => {
+	it('reads the refresh token from the request BODY and looks it up', async () => {
+		const value = 'native-refresh-token-abc';
+		const { status } = await callRefreshNative({ body: JSON.stringify({ refresh_token: value }) });
+
+		expect(mockPrisma.refreshToken.findUnique).toHaveBeenCalledTimes(1);
+		expect(mockPrisma.refreshToken.findUnique).toHaveBeenCalledWith(
+			expect.objectContaining({ where: { token: value } })
+		);
+		expect(status).toBe(401); // findUnique -> null -> 401, expected
+	});
+
+	it('returns 401 and does not hit the DB when the body has no token', async () => {
+		const { status, data } = await callRefreshNative({ body: JSON.stringify({}) });
+
+		expect(status).toBe(401);
+		expect(data.success).toBe(false);
+		expect(mockPrisma.refreshToken.findUnique).not.toHaveBeenCalled();
+	});
+
+	it('returns 400 on an invalid (non-JSON) body', async () => {
+		const { status, data } = await callRefreshNative({ body: 'not-json' });
+
+		expect(status).toBe(400);
+		expect(data.success).toBe(false);
+		expect(mockPrisma.refreshToken.findUnique).not.toHaveBeenCalled();
+	});
+
+	it('ignores a refresh_token COOKIE - body-only contract (web XSS cannot abuse it)', async () => {
+		// A cookie token must NOT be honored here: the endpoint only reads the body.
+		const { status } = await callRefreshNative({
+			body: JSON.stringify({}),
+			cookie: 'refresh_token=cookie-token-should-be-ignored'
+		});
+
+		expect(status).toBe(401);
+		expect(mockPrisma.refreshToken.findUnique).not.toHaveBeenCalled();
+	});
+});

--- a/apps/reborn-notes/src/routes/api/auth/register/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/register/+server.ts
@@ -6,6 +6,7 @@ import {
   REFRESH_TOKEN_TTL_SECONDS
 } from '@reborn/auth/server';
 import { prisma } from '@reborn/database';
+import { isNativeClient } from '$lib/utils/native-client';
 import { createLogger } from '@reborn/utils';
 
 const logger = createLogger('Notes-Register');
@@ -39,17 +40,18 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
       }
 
       const { refreshToken, accessToken, ...responseData } = result.data;
-      return json(
-        {
-          success: true,
-          data: {
-            ...responseData,
-            access_token: accessToken
-            // refresh_token is sent exclusively via httpOnly cookie — never in response body
-          }
-        },
-        { status: 201 }
-      );
+      const responseBody: Record<string, unknown> = {
+        ...responseData,
+        access_token: accessToken
+        // Web: refresh_token is sent exclusively via httpOnly cookie, never in the body.
+      };
+      // Native client persists the refresh token in secure storage (cross-origin
+      // cannot use the httpOnly cookie). Gated by the native header -> web stays
+      // byte-identical. See $lib/utils/native-client.
+      if (isNativeClient(request)) {
+        responseBody.refresh_token = refreshToken;
+      }
+      return json({ success: true, data: responseBody }, { status: 201 });
     } else {
       return json({ error: result.error }, { status: 400 });
     }

--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { API_BASE } from '$lib/utils/api-base';
+	import { nativeAuthHeaders } from '$lib/utils/native-client';
+	import { persistNativeRefreshToken } from '$lib/utils/native-auth-storage';
 	import { browser } from '$app/environment';
 	import { resolve } from '$app/paths';
 	import { goto } from '$lib/utils/navigation';
@@ -62,7 +64,7 @@
 		try {
 			const res = await fetch(`${API_BASE}/auth/2fa/verify`, {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json', ...nativeAuthHeaders() },
 				body: JSON.stringify({ userId, code: codeToVerify })
 			});
 			const body = await res.json();
@@ -88,7 +90,9 @@
 			};
 			localStorage.setItem(CREDENTIALS_KEY, JSON.stringify(credentials));
 			localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
-			// Note: refresh_token is managed exclusively via httpOnly cookie (set by server)
+			// Web: refresh_token is managed exclusively via httpOnly cookie (set by server).
+			// Native: persist the body refresh token to secure storage. No-op on web.
+			await persistNativeRefreshToken(data.refresh_token);
 
 			// Unlock E2E — use password saved by login page before redirect
 			const savedPassword = sessionStorage.getItem('2fa_pending_password');

--- a/apps/reborn-notes/src/routes/settings/security/password/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/password/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { base } from '$app/paths';
+  import { API_BASE } from '$lib/utils/api-base';
   import { authFetch } from '$lib/utils/auth-fetch';
   import { Lock, AlertTriangle } from '@lucide/svelte';
   import {
@@ -68,7 +68,7 @@
       const { encryptedMasterKey: newEncryptedMasterKey, salt: newMasterKeySalt } =
         await cryptoManager.encryptMasterKey(masterKey, newPassword);
 
-      const response = await authFetch(`${base}/api/auth/change-password`, {
+      const response = await authFetch(`${API_BASE}/auth/change-password`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/apps/reborn-notes/vite.config.ts
+++ b/apps/reborn-notes/vite.config.ts
@@ -8,7 +8,11 @@ const rootPkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json')
 
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify(rootPkg.version)
+    __APP_VERSION__: JSON.stringify(rootPkg.version),
+    // Build-time native flag. Statically `false` on the web build, so every
+    // `if (__REBORN_NATIVE__)` branch (and the secure-storage plugin behind it)
+    // is dead-code-eliminated - keeping the web bundle byte-identical.
+    __REBORN_NATIVE__: JSON.stringify(process.env.BUILD_TARGET === 'native')
   },
   plugins: [tailwindcss(), sveltekit()],
   // Load .env from monorepo root

--- a/apps/reborn-notes/vitest.config.ts
+++ b/apps/reborn-notes/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config';
 import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  // Tests run as the web build: the native flag is statically false.
+  define: {
+    __REBORN_NATIVE__: 'false'
+  },
   // Resolve SvelteKit's `$lib` alias so specs can import real (unmocked)
   // `$lib/...` modules - e.g. `$lib/utils/native-client`. Existing specs that
   // `vi.mock('$lib/...')` are unaffected (the mock still matches the specifier).

--- a/apps/reborn-notes/vitest.config.ts
+++ b/apps/reborn-notes/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  // Resolve SvelteKit's `$lib` alias so specs can import real (unmocked)
+  // `$lib/...` modules - e.g. `$lib/utils/native-client`. Existing specs that
+  // `vi.mock('$lib/...')` are unaffected (the mock still matches the specifier).
+  resolve: {
+    alias: {
+      $lib: fileURLToPath(new URL('./src/lib', import.meta.url))
+    }
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/packages/auth/src/__tests__/auth-fetch.spec.ts
+++ b/packages/auth/src/__tests__/auth-fetch.spec.ts
@@ -16,6 +16,17 @@ function makeStorage(initial: string | null = null): AuthFetchTokenStorage & { v
   } as never;
 }
 
+/** In-memory native refresh-token store (stands in for Keychain/Keystore). */
+function makeRefreshStore(initial: string | null = null) {
+  const state = { value: initial };
+  return {
+    get: () => state.value,
+    set: (t: string) => {
+      state.value = t;
+    }
+  };
+}
+
 describe('createAuthFetch', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -679,5 +690,77 @@ describe('createAuthFetch', () => {
     expect(await authFetch.refresh()).toBeNull(); // populate cache
     storage.setAccessToken('t2-pre-auth'); // change key so next call isn't short-circuited
     expect(await authFetch.refresh()).toBe('t2'); // success clears cache
+  });
+
+  // --- Native mode (refresh token in body + secure storage, no cookie) ---
+  //
+  // When `refreshTokenStore` is provided (Capacitor shell), the refresh token
+  // cannot ride a cross-origin httpOnly cookie, so it is read from secure
+  // storage, sent in the POST body, and the rotated token from the response is
+  // written back. Web mode (no store) keeps the empty-body + cookie flow.
+
+  it('native mode: sends the stored refresh token in the body and persists the rotated one', async () => {
+    const storage = makeStorage('access-old');
+    const refreshStore = makeRefreshStore('refresh-old');
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { access_token: 'access-new', refresh_token: 'refresh-new' }
+        }),
+        { status: 200 }
+      )
+    );
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh-native',
+      storage,
+      refreshTokenStore: refreshStore,
+      fetchImpl
+    });
+
+    const newToken = await authFetch.refresh();
+
+    expect(newToken).toBe('access-new');
+    expect(storage.getAccessToken()).toBe('access-new');
+    // Rotated refresh token persisted for the next refresh.
+    expect(refreshStore.get()).toBe('refresh-new');
+    // The stored refresh token went out in the body (not a cookie).
+    const body = JSON.parse((fetchImpl.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ refresh_token: 'refresh-old' });
+  });
+
+  it('native mode: returns null with no network call when no refresh token is stored', async () => {
+    const storage = makeStorage('access-old');
+    const refreshStore = makeRefreshStore(null);
+    const fetchImpl = vi.fn();
+
+    const authFetch = createAuthFetch({
+      refreshUrl: '/api/auth/refresh-native',
+      storage,
+      refreshTokenStore: refreshStore,
+      fetchImpl,
+      gracePeriodMs: 0
+    });
+
+    expect(await authFetch.refresh()).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('web mode (no refreshTokenStore): posts an empty body - byte-identical to before', async () => {
+    const storage = makeStorage('old');
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: true, data: { access_token: 'new' } }), {
+          status: 200
+        })
+      );
+
+    const authFetch = createAuthFetch({ refreshUrl: '/api/auth/refresh', storage, fetchImpl });
+
+    await authFetch.refresh();
+
+    expect((fetchImpl.mock.calls[0][1] as RequestInit).body).toBe('{}');
   });
 });

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -40,7 +40,12 @@ export { withRefreshLock } from './utils/refresh-lock';
 
 // Authenticated fetch wrapper with single-flight 401 refresh + retry
 export { createAuthFetch, TransientRefreshError } from './utils/auth-fetch';
-export type { AuthFetch, AuthFetchConfig, AuthFetchTokenStorage } from './utils/auth-fetch';
+export type {
+  AuthFetch,
+  AuthFetchConfig,
+  AuthFetchTokenStorage,
+  AuthFetchRefreshTokenStore
+} from './utils/auth-fetch';
 
 // Export guards
 export {

--- a/packages/auth/src/utils/auth-fetch.ts
+++ b/packages/auth/src/utils/auth-fetch.ts
@@ -27,6 +27,19 @@ export interface AuthFetchTokenStorage {
   setAccessToken: (token: string) => void;
 }
 
+/**
+ * Refresh-token store for the native (Capacitor) client. The refresh token
+ * cannot ride an httpOnly cookie cross-origin, so it lives in device secure
+ * storage (Keychain / Keystore) and is shuttled through the refresh body. Async
+ * because the native secure-storage plugin is async; may also be sync (web).
+ */
+export interface AuthFetchRefreshTokenStore {
+  /** Read the persisted refresh token (null when none / logged out). */
+  get: () => Promise<string | null> | string | null;
+  /** Persist the rotated refresh token after a successful refresh. */
+  set: (token: string) => Promise<void> | void;
+}
+
 export interface AuthFetchConfig {
   /** Absolute or relative URL of the POST /auth/refresh endpoint. */
   refreshUrl: string;
@@ -36,6 +49,14 @@ export interface AuthFetchConfig {
   onSessionExpired?: () => void;
   /** Token storage adapter — defaults to localStorage 'access_token'. */
   storage?: AuthFetchTokenStorage;
+  /**
+   * Native refresh-token store. When provided, the wrapper runs in NATIVE mode:
+   * the refresh token is read from this store and sent in the POST body, and the
+   * rotated token from the response is written back. Web clients omit this and
+   * keep the cookie-based flow (empty body, browser attaches the httpOnly cookie)
+   * — behaviour is byte-identical when `refreshTokenStore` is undefined.
+   */
+  refreshTokenStore?: AuthFetchRefreshTokenStore;
   /** Override fetch impl (tests). Defaults to globalThis.fetch. */
   fetchImpl?: typeof fetch;
   /**
@@ -118,12 +139,22 @@ export function createAuthFetch(config: AuthFetchConfig): AuthFetch {
     const current = storage.getAccessToken();
     if (current && current !== tokenBeforeLock) return current;
 
+    // Native mode: the refresh token lives in device secure storage (it cannot
+    // ride a cross-origin cookie), so send it in the body. Web mode sends an
+    // empty body and relies on the same-origin httpOnly cookie.
+    let requestBody = '{}';
+    if (config.refreshTokenStore) {
+      const storedRefresh = await config.refreshTokenStore.get();
+      if (!storedRefresh) return null; // nothing persisted → session is gone
+      requestBody = JSON.stringify({ refresh_token: storedRefresh });
+    }
+
     let refreshRes: Response;
     try {
       refreshRes = await fetchImpl(config.refreshUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({})
+        body: requestBody
       });
     } catch (err) {
       // Network error / DNS / timeout — server is unreachable, not an expiry.
@@ -150,7 +181,7 @@ export function createAuthFetch(config: AuthFetchConfig): AuthFetch {
       );
     }
 
-    let data: { success?: boolean; data?: { access_token?: string } };
+    let data: { success?: boolean; data?: { access_token?: string; refresh_token?: string } };
     try {
       data = (await refreshRes.json()) as typeof data;
     } catch (err) {
@@ -162,6 +193,13 @@ export function createAuthFetch(config: AuthFetchConfig): AuthFetch {
     // 200 OK with `success:false` is a deliberate expiry signal from the
     // server (e.g. invalid_grant). Treat as definitive.
     if (!data.success || !data.data?.access_token) return null;
+
+    // Native mode: persist the rotated refresh token for the next refresh. The
+    // native endpoint always returns it; if it were ever absent we keep the old
+    // one (the next refresh would fail cleanly rather than break silently).
+    if (config.refreshTokenStore && data.data.refresh_token) {
+      await config.refreshTokenStore.set(data.data.refresh_token);
+    }
 
     const newToken = data.data.access_token;
     storage.setAccessToken(newToken);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
 
   apps/reborn-notes:
     dependencies:
+      '@aparajita/capacitor-secure-storage':
+        specifier: 8.0.0
+        version: 8.0.0
       '@capacitor/android':
         specifier: 8.4.0
         version: 8.4.0(@capacitor/core@8.4.0)
@@ -749,28 +752,28 @@ importers:
         version: link:../types
       '@storybook/addon-essentials':
         specifier: 8.6.14
-        version: 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-interactions':
         specifier: 8.6.14
-        version: 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-links':
         specifier: 10.4.2
-        version: 10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-svelte-csf':
         specifier: 5.1.2
-        version: 5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/blocks':
         specifier: 8.6.14
-        version: 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/svelte':
         specifier: 10.4.2
-        version: 10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
+        version: 10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       '@storybook/svelte-vite':
         specifier: 10.4.2
-        version: 10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/test':
         specifier: 8.6.15
-        version: 8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.1.2
         version: 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -791,7 +794,7 @@ importers:
         version: 8.5.15
       storybook:
         specifier: 10.4.2
-        version: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte:
         specifier: 5.56.3
         version: 5.56.3(@typescript-eslint/types@8.59.3)
@@ -844,6 +847,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aparajita/capacitor-secure-storage@8.0.0':
+    resolution: {integrity: sha512-oYnwSjdIh23aRNgz8982+TmFvQH/2yZkEdw1iIg+H2ziFJoOVELPTc7u6Ez2HwOuDIW5AGqBX75GvrzQ+D70Qg==}
+    engines: {node: '>=20.0.0'}
 
   '@ark/schema@0.56.0':
     resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
@@ -1473,6 +1480,11 @@ packages:
     peerDependencies:
       '@capacitor/core': ^8.4.0
 
+  '@capacitor/app@8.1.0':
+    resolution: {integrity: sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
   '@capacitor/cli@8.4.0':
     resolution: {integrity: sha512-5Z9RKHxiqJYRTLrfMeZmzR4qrlg5B85MxsWZ5goyXsLkO3bgpW9a1qV/6fR1SX9s5gwLza5y7PZVwITl/hDJ7g==}
     engines: {node: '>=22.0.0'}
@@ -1480,6 +1492,16 @@ packages:
 
   '@capacitor/core@8.4.0':
     resolution: {integrity: sha512-LrS1xPIrqLtJABBIPDGXxxKmI9OyesrzWw8DiHbxhSC9JoiLUleUAJlX1a0LWIVLRbuY4Szgf9huFeRqYH2SAQ==}
+
+  '@capacitor/ios@8.4.0':
+    resolution: {integrity: sha512-tnwstEdbTJ2nHAfoAwnurXgYRscWeLY+IIGdz69o24gN2Crfj9Xc0TWo8L5uFLF1LmpbUywH1IT0U1oHV8c+CA==}
+    peerDependencies:
+      '@capacitor/core': ^8.4.0
+
+  '@capacitor/keyboard@8.0.3':
+    resolution: {integrity: sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
 
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
@@ -1899,89 +1921,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2186,21 +2224,25 @@ packages:
     resolution: {integrity: sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.5':
     resolution: {integrity: sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.5':
     resolution: {integrity: sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.5':
     resolution: {integrity: sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.5':
     resolution: {integrity: sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==}
@@ -2347,96 +2389,112 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-gnu@0.130.0':
     resolution: {integrity: sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-arm64-musl@0.130.0':
     resolution: {integrity: sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.130.0':
     resolution: {integrity: sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.130.0':
     resolution: {integrity: sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.130.0':
     resolution: {integrity: sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.130.0':
     resolution: {integrity: sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.130.0':
     resolution: {integrity: sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-musl@0.130.0':
     resolution: {integrity: sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -2544,41 +2602,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -2803,36 +2869,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2930,66 +3002,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -3296,36 +3381,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.40':
     resolution: {integrity: sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.40':
     resolution: {integrity: sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.40':
     resolution: {integrity: sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.40':
     resolution: {integrity: sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.40':
     resolution: {integrity: sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.40':
     resolution: {integrity: sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==}
@@ -3404,24 +3495,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -5100,24 +5195,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6807,6 +6906,14 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@aparajita/capacitor-secure-storage@8.0.0':
+    dependencies:
+      '@capacitor/android': 8.4.0(@capacitor/core@8.4.0)
+      '@capacitor/app': 8.1.0(@capacitor/core@8.4.0)
+      '@capacitor/core': 8.4.0
+      '@capacitor/ios': 8.4.0(@capacitor/core@8.4.0)
+      '@capacitor/keyboard': 8.0.3(@capacitor/core@8.4.0)
+
   '@ark/schema@0.56.0':
     dependencies:
       '@ark/util': 0.56.0
@@ -7631,6 +7738,10 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.4.0
 
+  '@capacitor/app@8.1.0(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
+
   '@capacitor/cli@8.4.0':
     dependencies:
       '@ionic/cli-framework-output': 2.2.8
@@ -7656,6 +7767,14 @@ snapshots:
   '@capacitor/core@8.4.0':
     dependencies:
       tslib: 2.8.1
+
+  '@capacitor/ios@8.4.0(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
+
+  '@capacitor/keyboard@8.0.3(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
 
   '@codemirror/autocomplete@6.20.3':
     dependencies:
@@ -8729,14 +8848,6 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
     optional: true
 
@@ -9099,102 +9210,102 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-actions@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-actions@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-backgrounds@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-controls@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-docs@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@storybook/blocks': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/csf-plugin': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/blocks': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/csf-plugin': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-essentials@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@storybook/addon-actions': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-backgrounds': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-controls': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-docs': 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-highlight': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-measure': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-outline': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-toolbars': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-viewport': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/addon-actions': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-backgrounds': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-controls': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-docs': 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-highlight': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-measure': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-outline': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-toolbars': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-viewport': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-highlight@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/addon-interactions@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-interactions@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/test': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/test': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       polished: 4.3.1
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-links@10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.6
 
-  '@storybook/addon-measure@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-measure@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-outline@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-outline@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@storybook/csf': 0.1.13
-      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
+      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
       es-toolkit: 1.46.1
       esrap: 1.4.9
       magic-string: 0.30.21
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
       svelte-ast-print: 0.4.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -9202,28 +9313,28 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@storybook/addon-toolbars@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-toolbars@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/addon-viewport@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-viewport@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/blocks@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/blocks@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/icons': 1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@storybook/builder-vite@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/builder-vite@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -9231,18 +9342,18 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/csf-plugin@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.0
       rollup: 4.60.3
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@storybook/csf-plugin@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/csf-plugin@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       unplugin: 1.16.1
 
   '@storybook/csf@0.1.13':
@@ -9261,31 +9372,31 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@storybook/instrumenter@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/instrumenter@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/instrumenter@8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/instrumenter@8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/svelte-vite@10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/svelte-vite@10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/builder-vite': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
+      '@storybook/builder-vite': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       magic-string: 0.30.21
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
       svelte2tsx: 0.7.55(svelte@5.56.3(@typescript-eslint/types@8.59.3))(typescript@5.9.3)
       typescript: 5.9.3
@@ -9295,34 +9406,34 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))':
+  '@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
       ts-dedent: 2.2.0
       type-fest: 5.7.0
 
-  '@storybook/test@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/test@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/test@8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/test@8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/instrumenter': 8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
     dependencies:
@@ -11804,32 +11915,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
-    optionalDependencies:
-      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
-      '@oxc-resolver/binding-android-arm64': 11.19.1
-      '@oxc-resolver/binding-darwin-arm64': 11.19.1
-      '@oxc-resolver/binding-darwin-x64': 11.19.1
-      '@oxc-resolver/binding-freebsd-x64': 11.19.1
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
-      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
-      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
-      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
-      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
-      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
-      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
-      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -12457,7 +12542,7 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -12469,7 +12554,7 @@ snapshots:
       esbuild: 0.28.0
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       recast: 0.23.11
       semver: 7.8.0
       use-sync-external-store: 1.6.0(react@19.2.6)


### PR DESCRIPTION
## Summary

Faza 2 of the Capacitor native workstream: a native-capable auth **refresh** path that does not depend on the cross-origin httpOnly refresh cookie. On native the WebView origin (`localhost`) and the API (`10.0.2.2` / remote) are cross-site, so a `SameSite=Lax` httpOnly cookie is never delivered. This PR routes the refresh token through OS secure storage instead, while leaving the **web flow byte-identical**.

Web users are unaffected: no native header is sent, the refresh body stays empty `{}`, and the cookie-only path is unchanged.

## Decisions (user-approved up front)

These were agreed before implementation (decision gate), not taken unilaterally:

- **Strategy B - token in OS secure storage.** The rotated refresh token is persisted in iOS Keychain / Android Keystore (AES-GCM) via `@aparajita/capacitor-secure-storage` 8.0.0 (MIT). Rationale: the cross-site httpOnly cookie is undeliverable on native; the platform secret store is the blessed home for a long-lived credential.
- **Transport B1 - separate endpoint.** New `POST /api/auth/refresh-native` reads the refresh token from the **request body only** (never a cookie), rotates via the same `handleRefreshToken`, returns the rotated token in the body, and sets **no** cookie. The web `POST /api/auth/refresh` is untouched.
- **Plugin choice.** `@aparajita/capacitor-secure-storage` v8 - MIT, AGPL-3.0 compatible, store-distributable. Approved as a new runtime dep.
- **Dev-probe harness.** `window.__rebornAuthProbe(n)` (native build only) fires N sequential refreshes and asserts the secure-storage token actually rotated each time, to prove >=3 rotations survive without the server's reuse-detector revoking the family. Temporary; removed before store prep.

## Zero Knowledge preserved

- The **master key is never touched** by this change, and the refresh token is **not** a decryption secret. No plaintext user data crosses the server; no new plaintext schema fields.
- Refresh-token **rotation + family reuse-detection are unchanged** - the native endpoint calls the same `handleRefreshToken`. A stale/replayed token still revokes the family.
- Secure-storage read/write failures **degrade to re-login**, never crash (each call has its own try/catch and swallows to `null`).
- The native flag is **build-time** (`__REBORN_NATIVE__` via `BUILD_TARGET=native`). Plugin import and the dev probe are **dead-code-eliminated from the web bundle** (verified absent in the web client build, present in `build-native`).

## Shared-package change (web-safe)

`packages/auth` `auth-fetch.ts` gains an optional async `refreshTokenStore` (get/set). When absent (web) the refresh body is empty `{}` and behavior is byte-identical to before. Native injects a store backed by Keychain/Keystore. This is the only shared-package touch; everything else is `apps/reborn-notes`.

## Bonus: logout-race fix (`fix(notes)`, commit 3b3ffe2)

`logout()` now **awaits** `clearAllUserData()` (and the native secure-storage clear) **before** the hard redirect. Previously the clear was fire-and-forget and raced `window.location.href` reloading the WebView, which aborts the in-flight IndexedDB transaction and leaves orphan notes - this surfaced as `404` on `/versions` when the next session pointed at a different backend. The critical synchronous logout state (cleared localStorage + in-memory master key) is still applied before the first `await`, so callers see a logged-out state immediately; only the redirect waits.

## Validation (Android emulator against localprod)

- kill / reopen the app **without re-entering the password** - master key restored from the `reborn_crypto_keys` IndexedDB (PWA parity).
- login -> 2FA -> `sessions/current` over CapacitorHttp; `SecureStorage.internalSetItem` (Keychain write of the rotated refresh token) observed in the native bridge log.
- after an app-data reset: 122 notes, "Synced", **no `/versions` 404s**.
- CI gates: `svelte-check` 0/0, lint 0, web build + `build-native` green, `nx affected -t test` exit 0 (no reborn-task regression).

## Known follow-ups (NOT in this PR)

- **Native "current session" gap.** `PATCH /api/auth/sessions/current` (device-info) returns `400` on native because it identifies the session via the same cross-site `session_id` httpOnly cookie. Non-critical and cosmetic: `device_info_encrypted` stays null and the session list cannot highlight the current device. Same root-cause family as this PR; planned as its own small thread (return `session_id` to native at login/2FA and send it explicitly, mirroring the refresh-token approach).
- **safe-area CSS injection TypeError** (red console error) - belongs to the Faza 1 native shell, unrelated to auth.

## Merge note - squash type

The branch is 7x `chore(native)` + 1x `fix(notes)`. If you want the logout fix to drive a patch release, squash as `fix(notes):`; otherwise `chore(native):` (no bump) and it ships with the next release. Your call at merge.

## Test plan

- **Web regression:** login / logout / 15-min refresh on web unchanged (no native header -> cookie-only refresh, empty body). Verify a normal web session still refreshes and logs out cleanly.
- **Native:** covered by the emulator validation above; re-runnable via `__rebornAuthProbe(5)` from the remote WebView console after login.