### PR TITLE
chore(native): native current-session + finish API_BASE sweep

### DIFF
--- a/apps/reborn-notes/src/lib/services/device-info.service.ts
+++ b/apps/reborn-notes/src/lib/services/device-info.service.ts
@@ -1,4 +1,5 @@
 import { API_BASE } from '$lib/utils/api-base';
+import { readNativeSessionId } from '$lib/utils/native-session';
 import { cryptoManager } from '@reborn/crypto';
 import { parseUserAgent, createLogger } from '@reborn/utils';
 
@@ -29,13 +30,20 @@ export async function sendEncryptedDeviceInfo(): Promise<void> {
       return;
     }
 
+    // Native sends session_id explicitly (its httpOnly session_id cookie is
+    // cross-site and undelivered). On web readNativeSessionId() is null, so the
+    // body stays { device_info_encrypted } and the request is byte-identical.
+    const payload: Record<string, string> = { device_info_encrypted: encrypted };
+    const sessionId = readNativeSessionId();
+    if (sessionId) payload.session_id = sessionId;
+
     const res = await fetch(`${API_BASE}/auth/sessions/current`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${accessToken}`
       },
-      body: JSON.stringify({ device_info_encrypted: encrypted })
+      body: JSON.stringify(payload)
     });
 
     if (!res.ok) {

--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -8,6 +8,7 @@
 import { API_BASE } from '$lib/utils/api-base';
 import { nativeAuthHeaders } from '$lib/utils/native-client';
 import { persistNativeRefreshToken } from '$lib/utils/native-auth-storage';
+import { persistNativeSessionId } from '$lib/utils/native-session';
 import { authStore, CREDENTIALS_KEY, ACCESS_TOKEN_KEY } from '$lib/stores/auth.store';
 import { sessionExpired } from '$lib/stores/sync-status.store';
 import { clearAllUserData, isDatabaseInitialized } from '@reborn/storage';
@@ -35,6 +36,8 @@ interface ReAuthResponseBody {
     access_token?: string;
     /** Present only for native clients (sent the native header). */
     refresh_token?: string;
+    /** Present only for native clients - names the current session. */
+    session_id?: string;
   };
 }
 
@@ -88,6 +91,8 @@ export async function loginInNotes(username: string, password: string): Promise<
     // Native: it arrives in the body (native header) and is persisted to secure
     // storage for createAuthFetch's native refresh path. No-op on web.
     await persistNativeRefreshToken(data.refresh_token);
+    // Native: stash session_id for the device-info PATCH + sessions-list highlight.
+    persistNativeSessionId(data.session_id);
 
     // Clear any previous user's data from IndexedDB before starting new session.
     // Prevents phantom notes when switching users or after DB wipe + re-register.
@@ -211,6 +216,8 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
   localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
   // Native: persist the rotated refresh token from the body. No-op on web.
   await persistNativeRefreshToken(data.refresh_token);
+  // Native: stash session_id for the device-info PATCH + sessions-list highlight.
+  persistNativeSessionId(data.session_id);
 
   // Credentials remain the same - touch to ensure they're still parseable
   try {
@@ -266,6 +273,8 @@ export async function verifyTotpForReauth(userId: string, code: string): Promise
   localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
   // Native: persist the rotated refresh token from the body. No-op on web.
   await persistNativeRefreshToken(data.refresh_token);
+  // Native: stash session_id for the device-info PATCH + sessions-list highlight.
+  persistNativeSessionId(data.session_id);
 
   sessionExpired.set(false);
   await refreshAfterReauth();

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -24,6 +24,7 @@ import { browser } from '$app/environment';
 import { base } from '$app/paths';
 import { API_BASE } from '$lib/utils/api-base';
 import { clearNativeRefreshToken } from '$lib/utils/native-auth-storage';
+import { clearNativeSessionId } from '$lib/utils/native-session';
 import { cryptoManager } from '@reborn/crypto';
 import { sessionExpired } from '$lib/stores/sync-status.store';
 import { createLogger } from '@reborn/utils';
@@ -257,6 +258,7 @@ function createAuthStore() {
     // Native: drop the refresh token from secure storage (no-op on web; has its
     // own internal try/catch, so this never throws).
     await clearNativeRefreshToken();
+    clearNativeSessionId();
 
     // Hard redirect — avoids reactive cascades from setting store to empty state.
     // Clearing localStorage above will also fire a storage event in reborn-task

--- a/apps/reborn-notes/src/lib/stores/connectivity.store.ts
+++ b/apps/reborn-notes/src/lib/stores/connectivity.store.ts
@@ -1,5 +1,5 @@
+import { base } from '$app/paths';
 import { browser } from '$app/environment';
-import { API_BASE } from '$lib/utils/api-base';
 import { derived, readable, type Readable } from 'svelte/store';
 import {
   getConnectivity,
@@ -9,20 +9,27 @@ import {
 
 /**
  * App-local wrapper around `@reborn/api-client`'s connectivity singleton.
- * Binds the probe endpoint to this app's health endpoint via `API_BASE`
- * (same-origin `/api/health` on web, the configured API origin on native)
- * and exposes Svelte stores for reactive consumption.
+ * Binds the probe endpoint to this app's `/api/health` and exposes Svelte
+ * stores for reactive consumption.
  *
  * Why an active probe instead of `navigator.onLine`: an active VPN tunnel
  * (e.g. Proton in airplane mode) keeps a network interface up, so the browser
  * reports `online: true` even when there is no upstream. Only a real HTTP
  * round-trip against our own origin tells the truth.
+ *
+ * NOTE: kept on the same-origin `${base}/api/health` on purpose - do NOT route
+ * it through `API_BASE`. The probe uses a HEAD request, which CapacitorHttp
+ * delivers unreliably cross-origin on native, so pointing it at the remote API
+ * made the app read "offline" while sync (normal GET/POST) worked. Real native
+ * connectivity belongs in Faza 3 via `@capacitor/network` (device network
+ * state), not an HTTP HEAD probe. On native this stays same-origin and is
+ * effectively always-online (the static shell answers `/api/health`).
  */
 
 const ssrState: ConnectivityState = { status: 'unknown', lastProbeAt: null };
 
 export const connectivityStore: ConnectivityStore | null = browser
-  ? getConnectivity({ endpoint: `${API_BASE}/health` })
+  ? getConnectivity({ endpoint: `${base}/api/health` })
   : null;
 
 export const connectivity: Readable<ConnectivityState> = connectivityStore

--- a/apps/reborn-notes/src/lib/stores/connectivity.store.ts
+++ b/apps/reborn-notes/src/lib/stores/connectivity.store.ts
@@ -1,5 +1,5 @@
-import { base } from '$app/paths';
 import { browser } from '$app/environment';
+import { API_BASE } from '$lib/utils/api-base';
 import { derived, readable, type Readable } from 'svelte/store';
 import {
   getConnectivity,
@@ -9,8 +9,9 @@ import {
 
 /**
  * App-local wrapper around `@reborn/api-client`'s connectivity singleton.
- * Binds the probe endpoint to this app's `/api/health` and exposes Svelte
- * stores for reactive consumption.
+ * Binds the probe endpoint to this app's health endpoint via `API_BASE`
+ * (same-origin `/api/health` on web, the configured API origin on native)
+ * and exposes Svelte stores for reactive consumption.
  *
  * Why an active probe instead of `navigator.onLine`: an active VPN tunnel
  * (e.g. Proton in airplane mode) keeps a network interface up, so the browser
@@ -21,7 +22,7 @@ import {
 const ssrState: ConnectivityState = { status: 'unknown', lastProbeAt: null };
 
 export const connectivityStore: ConnectivityStore | null = browser
-  ? getConnectivity({ endpoint: `${base}/api/health` })
+  ? getConnectivity({ endpoint: `${API_BASE}/health` })
   : null;
 
 export const connectivity: Readable<ConnectivityState> = connectivityStore

--- a/apps/reborn-notes/src/lib/utils/native-session.spec.ts
+++ b/apps/reborn-notes/src/lib/utils/native-session.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * native-session is gated by the build-time `IS_NATIVE` (from native-client).
+ * We flip it per-test with vi.doMock + a module reset so we can assert both the
+ * native behavior and the web byte-identical no-op (the contract that matters:
+ * a web build must never write session_id to storage or attach the header).
+ */
+const store = new Map<string, string>();
+
+beforeEach(() => {
+  store.clear();
+  vi.resetModules();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k)
+  });
+});
+
+async function loadWith(isNative: boolean) {
+  vi.doMock('$lib/utils/native-client', () => ({ IS_NATIVE: isNative }));
+  return import('./native-session');
+}
+
+describe('native-session (IS_NATIVE=true)', () => {
+  it('persists, reads back, and exposes the id as a header', async () => {
+    const m = await loadWith(true);
+    m.persistNativeSessionId('sess-1');
+    expect(m.readNativeSessionId()).toBe('sess-1');
+    expect(m.nativeSessionHeader()).toEqual({ [m.NATIVE_SESSION_HEADER]: 'sess-1' });
+  });
+
+  it('clears the id on logout', async () => {
+    const m = await loadWith(true);
+    m.persistNativeSessionId('sess-1');
+    m.clearNativeSessionId();
+    expect(m.readNativeSessionId()).toBeNull();
+    expect(m.nativeSessionHeader()).toEqual({});
+  });
+
+  it('ignores empty/nullish ids (no accidental blank write)', async () => {
+    const m = await loadWith(true);
+    m.persistNativeSessionId(undefined);
+    m.persistNativeSessionId('');
+    expect(m.readNativeSessionId()).toBeNull();
+    expect(m.nativeSessionHeader()).toEqual({});
+  });
+});
+
+describe('native-session (IS_NATIVE=false) — web byte-identical', () => {
+  it('never writes session_id and never attaches the header', async () => {
+    const m = await loadWith(false);
+    m.persistNativeSessionId('sess-1');
+    expect(m.readNativeSessionId()).toBeNull(); // nothing persisted on web
+    expect(store.size).toBe(0); // localStorage untouched
+    expect(m.nativeSessionHeader()).toEqual({});
+    expect(() => m.clearNativeSessionId()).not.toThrow();
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/native-session.ts
+++ b/apps/reborn-notes/src/lib/utils/native-session.ts
@@ -1,0 +1,60 @@
+/**
+ * Native current-session identity (Faza 2 follow-up).
+ *
+ * On web the server learns "which session is this" from the httpOnly `session_id`
+ * cookie. On native that cookie is cross-site (WebView `localhost` -> remote API)
+ * and `SameSite=Lax`, so it is never delivered - the same constraint that moved
+ * the refresh token into secure storage. Unlike the refresh token, `session_id`
+ * is NOT a secret: it is a plaintext FK the server already stores and returns per
+ * the visibility model, and every operation is still authorised by the Bearer
+ * token. So it lives in localStorage, not Keychain. It lets native clients name
+ * their current session for the device-info PATCH and the sessions-list highlight.
+ *
+ * Web stays byte-identical: `IS_NATIVE` is a build-time `false`, so every function
+ * short-circuits before touching storage and the header helper returns `{}`.
+ */
+import { IS_NATIVE } from '$lib/utils/native-client';
+
+/** Header carrying the native client's current session id to the server. */
+export const NATIVE_SESSION_HEADER = 'x-reborn-session-id';
+
+const SESSION_ID_KEY = 'reborn_session_id';
+
+/** Persist the current session id after login / 2FA. No-op on web (cookie path). */
+export function persistNativeSessionId(sessionId: string | undefined | null): void {
+  if (!IS_NATIVE || !sessionId || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(SESSION_ID_KEY, sessionId);
+  } catch {
+    /* non-critical: only the device-info / list highlight degrade, auth is unaffected */
+  }
+}
+
+/** Read the stored native session id, or null (web, or never set). */
+export function readNativeSessionId(): string | null {
+  if (!IS_NATIVE || typeof localStorage === 'undefined') return null;
+  try {
+    return localStorage.getItem(SESSION_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Drop the stored session id on logout. No-op on web. */
+export function clearNativeSessionId(): void {
+  if (!IS_NATIVE || typeof localStorage === 'undefined') return;
+  try {
+    localStorage.removeItem(SESSION_ID_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Header bag attaching the native session id to a request (sessions-list GET).
+ * Empty on web (and when none is stored) -> the request stays byte-identical.
+ */
+export function nativeSessionHeader(): Record<string, string> {
+  const id = readNativeSessionId();
+  return id ? { [NATIVE_SESSION_HEADER]: id } : {};
+}

--- a/apps/reborn-notes/src/routes/api/auth/2fa/verify/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/2fa/verify/+server.ts
@@ -101,6 +101,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
       path: '/'
     });
 
+    let nativeSessionId: string | undefined;
     try {
       const session = await prisma.userSession.create({
         data: {
@@ -110,6 +111,10 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
           is_active: true
         }
       });
+
+      // Native clients can't read the httpOnly session_id cookie below
+      // (cross-site), so capture the id to hand back in the body.
+      nativeSessionId = session.id;
 
       // Link the refresh token to this session
       await prisma.refreshToken.updateMany({
@@ -151,6 +156,8 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
     // header -> response stays byte-identical. See $lib/utils/native-client.
     if (isNativeClient(request)) {
       responseBody.refresh_token = refreshToken;
+      // Native names its current session with this (device-info, list highlight).
+      if (nativeSessionId) responseBody.session_id = nativeSessionId;
     }
 
     return json({ success: true, data: responseBody });

--- a/apps/reborn-notes/src/routes/api/auth/login/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/login/+server.ts
@@ -115,6 +115,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
       });
 
       // Track session
+      let nativeSessionId: string | undefined;
       if (result.data.user?.id) {
         try {
           const expiresAt = refreshTokenExpiryDate();
@@ -126,6 +127,10 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
               is_active: true
             }
           });
+
+          // Native clients can't read the httpOnly session_id cookie below
+          // (cross-site), so capture the id to hand back in the body.
+          nativeSessionId = session.id;
 
           // Link the refresh token (created by handleLogin) to this session
           await prisma.refreshToken.updateMany({
@@ -159,6 +164,8 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
       // (refresh token only in the httpOnly cookie). See $lib/utils/native-client.
       if (isNativeClient(request)) {
         responseBody.refresh_token = refreshToken;
+        // Native names its current session with this (device-info, list highlight).
+        if (nativeSessionId) responseBody.session_id = nativeSessionId;
       }
       return json({ success: true, data: responseBody });
     } else {

--- a/apps/reborn-notes/src/routes/api/auth/sessions/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/sessions/+server.ts
@@ -13,8 +13,11 @@ export const GET: RequestHandler = async ({ request, cookies }) => {
     if (!info) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
     // Use session_id cookie (set at login) — JWT sessionId is a random UUID that
-    // never matches UserSession.id, so cookie is the reliable source.
-    const currentSessionId = cookies.get('session_id') ?? null;
+    // never matches UserSession.id, so cookie is the reliable source. Native
+    // clients can't deliver that cookie cross-site, so they send it as a header
+    // (display-only: the list is already user-scoped via the Bearer token).
+    const currentSessionId =
+      cookies.get('session_id') ?? request.headers.get('x-reborn-session-id') ?? null;
 
     const now = new Date();
     const sessions = await prisma.userSession.findMany({

--- a/apps/reborn-notes/src/routes/api/auth/sessions/current/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/sessions/current/+server.ts
@@ -18,10 +18,16 @@ export const PATCH: RequestHandler = async ({ request, cookies }) => {
     const userId = await getUserFromToken(request.headers.get('authorization'));
     if (!userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
-    const sessionId = cookies.get('session_id');
+    const body = await request.json();
+
+    // Web identifies the session via the httpOnly session_id cookie. Native can't
+    // deliver that cookie cross-site, so it sends session_id in the body; the
+    // ownership check below (user_id match) keeps a client-supplied id safe.
+    const sessionId =
+      cookies.get('session_id') ??
+      (typeof body?.session_id === 'string' ? body.session_id : undefined);
     if (!sessionId) return json({ success: false, error: 'No active session' }, { status: 400 });
 
-    const body = await request.json();
     const deviceInfoEncrypted = body?.device_info_encrypted;
     if (!deviceInfoEncrypted || typeof deviceInfoEncrypted !== 'string') {
       return json({ success: false, error: 'Missing device_info_encrypted' }, { status: 400 });

--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -2,6 +2,7 @@
 	import { API_BASE } from '$lib/utils/api-base';
 	import { nativeAuthHeaders } from '$lib/utils/native-client';
 	import { persistNativeRefreshToken } from '$lib/utils/native-auth-storage';
+	import { persistNativeSessionId } from '$lib/utils/native-session';
 	import { browser } from '$app/environment';
 	import { resolve } from '$app/paths';
 	import { goto } from '$lib/utils/navigation';
@@ -93,6 +94,9 @@
 			// Web: refresh_token is managed exclusively via httpOnly cookie (set by server).
 			// Native: persist the body refresh token to secure storage. No-op on web.
 			await persistNativeRefreshToken(data.refresh_token);
+			// Native: 2FA users get their session created here (not at /login), so the
+			// session_id arrives in this response - stash it for device-info + list highlight.
+			persistNativeSessionId(data.session_id);
 
 			// Unlock E2E — use password saved by login page before redirect
 			const savedPassword = sessionStorage.getItem('2fa_pending_password');
@@ -113,7 +117,7 @@
 </script>
 
 <svelte:head>
-	<title>{$t('auth.two_factor.title')} — re/notes</title>
+	<title>{$t('auth.two_factor.title')} - re/notes</title>
 </svelte:head>
 
 <div class="h-dvh overflow-y-auto">

--- a/apps/reborn-notes/src/routes/settings/security/delete-account/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/delete-account/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { base } from '$app/paths';
   import { authFetch } from '$lib/utils/auth-fetch';
+  import { API_BASE } from '$lib/utils/api-base';
   import { AlertTriangle, Trash2 } from '@lucide/svelte';
   import {
     SettingsLayout,
@@ -39,7 +39,7 @@
 
     isLoading = true;
     try {
-      const response = await authFetch(`${base}/api/auth/delete-account`, {
+      const response = await authFetch(`${API_BASE}/auth/delete-account`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ password })
@@ -67,7 +67,7 @@
 </script>
 
 <svelte:head>
-  <title>{$t('security.delete_account.title')} — re/notes</title>
+  <title>{$t('security.delete_account.title')} - re/notes</title>
 </svelte:head>
 
 <SettingsLayout title={$t('security.delete_account.title')} backHref="/settings">

--- a/apps/reborn-notes/src/routes/settings/security/sessions/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/sessions/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import { authFetch } from '$lib/utils/auth-fetch';
+  import { API_BASE } from '$lib/utils/api-base';
+  import { nativeSessionHeader } from '$lib/utils/native-session';
   import { Monitor, LogOut, RefreshCw, AlertTriangle, X } from '@lucide/svelte';
   import { t } from '$lib/stores/i18n.store';
   import { authStore } from '$lib/stores/auth.store';
@@ -65,7 +66,9 @@
     isLoading = true;
     error = null;
     try {
-      const response = await authFetch(`${base}/api/auth/sessions`);
+      const response = await authFetch(`${API_BASE}/auth/sessions`, {
+        headers: nativeSessionHeader()
+      });
       const data = await response.json();
       if (data.success) {
         sessions = data.data;
@@ -85,7 +88,7 @@
     revoking = id;
     error = null;
     try {
-      const response = await authFetch(`${base}/api/auth/sessions/${id}`, {
+      const response = await authFetch(`${API_BASE}/auth/sessions/${id}`, {
         method: 'DELETE'
       });
       const data = await response.json();
@@ -108,7 +111,7 @@
     try {
       await Promise.all(
         otherSessions.map(async (s) => {
-          const response = await authFetch(`${base}/api/auth/sessions/${s.id}`, {
+          const response = await authFetch(`${API_BASE}/auth/sessions/${s.id}`, {
             method: 'DELETE'
           });
           const data = await response.json();
@@ -129,7 +132,7 @@
     showLogoutAllConfirm = false;
     try {
       // Call server to invalidate all sessions
-      await authFetch(`${base}/api/auth/logout-all`, { method: 'POST' });
+      await authFetch(`${API_BASE}/auth/logout-all`, { method: 'POST' });
       toast.success($t('security.sessions.logout_all_success'));
     } catch (err: unknown) {
       logger.warn('Server logout-all call failed:', err);
@@ -149,7 +152,7 @@
 </script>
 
 <svelte:head>
-  <title>{$t('security.sessions.title')} — re/notes</title>
+  <title>{$t('security.sessions.title')} - re/notes</title>
 </svelte:head>
 
 <SettingsLayout title={$t('security.sessions.title')} backHref="/settings">

--- a/apps/reborn-notes/src/routes/settings/security/two-factor/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/two-factor/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import { authFetch } from '$lib/utils/auth-fetch';
+  import { API_BASE } from '$lib/utils/api-base';
   import {
     Shield,
     ShieldCheck,
@@ -64,7 +64,7 @@
 
   async function fetchStatus() {
     try {
-      const response = await authFetch(`${base}/api/auth/2fa`);
+      const response = await authFetch(`${API_BASE}/auth/2fa`);
       const data = await response.json();
       if (data.success) {
         is2FAEnabled = data.data.isEnabled;
@@ -84,7 +84,7 @@
     isLoading = true;
     error = null;
     try {
-      const response = await authFetch(`${base}/api/auth/2fa`, {
+      const response = await authFetch(`${API_BASE}/auth/2fa`, {
         method: 'POST'
       });
       const data = await response.json();
@@ -113,7 +113,7 @@
     if (!verificationCode || verificationCode.length !== 6) return;
     isLoading = true;
     try {
-      const response = await authFetch(`${base}/api/auth/2fa`, {
+      const response = await authFetch(`${API_BASE}/auth/2fa`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code: verificationCode, secretEncrypted: '' })
@@ -129,7 +129,7 @@
 
         // Auto-generate recovery codes
         try {
-          const codesResponse = await authFetch(`${base}/api/auth/recovery-codes`, {
+          const codesResponse = await authFetch(`${API_BASE}/auth/recovery-codes`, {
             method: 'POST'
           });
           const codesData = await codesResponse.json();
@@ -168,7 +168,7 @@
     isDisabling = true;
     error = null;
     try {
-      const response = await authFetch(`${base}/api/auth/2fa`, {
+      const response = await authFetch(`${API_BASE}/auth/2fa`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ password: disablePassword })
@@ -257,7 +257,7 @@
 </script>
 
 <svelte:head>
-  <title>{$t('security.two_factor.page_title')} — re/notes</title>
+  <title>{$t('security.two_factor.page_title')} - re/notes</title>
 </svelte:head>
 
 <SettingsLayout title={$t('security.two_factor.title')} backHref="/settings">


### PR DESCRIPTION
## Summary

Follow-up to Faza 2 (#254). Two coherent, native-only things:

1. **Native current-session identity** - fixes the `device-info PATCH 400` seen during #254 validation and enables the sessions-list "current device" highlight on native.
2. **Finishing Faza 1's API_BASE migration** - the `settings/security/*` pages and the connectivity probe were missed and still hit the WebView origin on native.

Web is byte-identical throughout.

## Problem

- `PATCH /auth/sessions/current` (device-info) and `GET /auth/sessions` (highlight) identify the session via the httpOnly `session_id` cookie (`SameSite=Lax`). On native the WebView origin (`localhost`) and the API are cross-site, so that cookie is never delivered - the same constraint Faza 2 solved for the refresh token. Result: device-info `400 No active session`, no current-device highlight.
- Faza 1's API_BASE sweep missed `two-factor`, `delete-account`, `sessions` and `connectivity.store` - they hard-coded `${base}/api/...`, which on native (`base === ''`) points at `localhost` instead of the configured API.

## Changes

**Server (native-gated, web byte-identical):**
- `login` + `2fa/verify` return `session_id` in the body for native clients (same `x-reborn-client` gate as `refresh_token`).
- `PATCH /auth/sessions/current` accepts `session_id` from the body when the cookie is absent. The existing ownership check (session must belong to the authenticated user) keeps a client-supplied id safe.
- `GET /auth/sessions` accepts an `x-reborn-session-id` header. Display-only: the list is already Bearer-scoped, so a spoofed value only changes which row gets the badge in the caller's own view.

**Client:**
- New `native-session.ts` - `session_id` persistence in localStorage (non-secret), gated by `IS_NATIVE`. Persisted at login / 2FA / re-auth, cleared on logout, sent in the device-info PATCH body and as a header on the sessions GET.
- API_BASE sweep: `two-factor` (x5), `delete-account`, `connectivity` health probe, `sessions` page (x4).

## Security / Zero Knowledge

- `session_id` is **not** a secret: it is a plaintext FK the server already stores and returns per the visibility model, and every operation is still authorised by the Bearer token. So it lives in **localStorage, not Keychain** (Keychain would be over-engineering for a non-secret).
- **No encryption / server-visibility model change.** No new plaintext fields, no master-key involvement.
- **Web byte-identical:** `IS_NATIVE` folds to `false`, so the helpers no-op, the header bag is empty, the PATCH body is unchanged, and `API_BASE === ${base}/api` makes the swept URLs identical.

## Decisions (auto mode - for review)

- **Scope grew to include the API_BASE sweep.** While wiring the sessions-list highlight I found Faza 1's migration was incomplete (the whole `settings/security` area + connectivity still on `${base}/api`, native-broken). Folded in because it is the same native-gap family, byte-identical on web, and the highlight needs the sessions page on API_BASE anyway. Flagging since it widens the diff beyond the literal "device-info 400" ask.
- **`session_id` in localStorage, not secure storage** - justified above (non-secret; Bearer still gates access).

## Validation

- `test` 550/550, `lint` 0 errors, `svelte-check` 0/0, web `build` + `build-native` green. No new i18n keys.
- **Native emulator pending** (same harness as #254): after login, the device-info PATCH should return 200 (no more 400), and the sessions page should reach the API and show the current-device badge.

## Test plan

- **Web regression:** 2FA enable/disable, recovery-codes, delete-account, sessions list / revoke / logout-all, connectivity banner - all unchanged (`API_BASE === ${base}/api` on web).
- **Native:** device-info PATCH 200; sessions page loads + highlights the current device; 2FA and delete-account pages reach the API.

## Merge note

`chore(native)` (no version bump): native is unshipped and the web paths are byte-identical.