### PR TITLE
chore(native): keystore-wrapped master key (Faza 3c)

### DIFF
--- a/apps/reborn-notes/src/hooks.client.ts
+++ b/apps/reborn-notes/src/hooks.client.ts
@@ -10,6 +10,7 @@ if (import.meta.hot) {
 }
 import { startSwUpdateWatcher } from '$lib/services/sw-update.service';
 import { startPwaInstallPrompt } from '$lib/services/pwa-install.service';
+import { createNativeMasterKeyVault } from '$lib/utils/native-master-key-vault';
 
 // Public read-only share view (/s/<slug>) runs before the layout's onMount
 // bypass, so we have to short-circuit storage init here too. Without this
@@ -18,6 +19,17 @@ import { startPwaInstallPrompt } from '$lib/services/pwa-install.service';
 const isPublicShareRoute =
   typeof window !== 'undefined' &&
   window.location.pathname.startsWith(`${base}/s/`);
+
+// Native: persist the master key through the device vault (Android
+// Keystore / iOS Keychain-wrapped) instead of an extractable CryptoKey in
+// IndexedDB. Must be wired BEFORE the first waitForRestore() call anywhere —
+// the restoration source is decided when the lazy restore runs. Deliberately
+// outside the isPublicShareRoute guard: the injection is pure state (no IO,
+// guideline 59 rule #12 holds) and a session entered via a share deep link
+// must still use the vault once the user navigates into the app.
+if (__REBORN_NATIVE__) {
+  cryptoManager.setMasterKeyVault(createNativeMasterKeyVault());
+}
 
 // ---------------------------------------------------------------------------
 // Client-side error handler — detect offline chunk-loading failures

--- a/apps/reborn-notes/src/hooks.client.ts
+++ b/apps/reborn-notes/src/hooks.client.ts
@@ -22,7 +22,7 @@ const isPublicShareRoute =
 
 // Native: persist the master key through the device vault (Android
 // Keystore / iOS Keychain-wrapped) instead of an extractable CryptoKey in
-// IndexedDB. Must be wired BEFORE the first waitForRestore() call anywhere —
+// IndexedDB. Must be wired BEFORE the first waitForRestore() call anywhere -
 // the restoration source is decided when the lazy restore runs. Deliberately
 // outside the isPublicShareRoute guard: the injection is pure state (no IO,
 // guideline 59 rule #12 holds) and a session entered via a share deep link

--- a/apps/reborn-notes/src/lib/utils/native-master-key-vault.ts
+++ b/apps/reborn-notes/src/lib/utils/native-master-key-vault.ts
@@ -1,0 +1,62 @@
+/**
+ * Native (Capacitor) master-key vault, backed by device secure storage
+ * (iOS Keychain / Android Keystore-wrapped) via
+ * `@aparajita/capacitor-secure-storage`.
+ *
+ * Injected into the CryptoManager from `hooks.client.ts` (native builds
+ * only) so the master key is never persisted as an extractable CryptoKey in
+ * IndexedDB nor as a raw Base64 export in sessionStorage. Only the
+ * Keystore/Keychain-wrapped ciphertext touches disk; the wrapping key is
+ * non-extractable and never leaves the device (it does not ride app
+ * backups, so a restored device falls back to password unlock - same
+ * semantics as the refresh token in `native-auth-storage.ts`).
+ *
+ * Every plugin import is gated behind `__REBORN_NATIVE__`, so on the web
+ * build the whole branch (and the plugin) is dead-code-eliminated. The
+ * factory itself must also only be wired under `__REBORN_NATIVE__`: on web
+ * a no-op vault would silently disable the IndexedDB persistence path.
+ *
+ * Errors from the secure-storage layer (rare OS failures) are swallowed and
+ * degrade to "no key": the user lands on the password unlock screen and a
+ * successful unlock re-writes the entry (see `MasterKeyVault` contract).
+ */
+
+import type { MasterKeyVault } from '@reborn/crypto';
+
+const MASTER_KEY_KEY = 'master_key';
+
+/** Create the device-backed master-key vault. Call only when `__REBORN_NATIVE__`. */
+export function createNativeMasterKeyVault(): MasterKeyVault {
+  return {
+    async save(rawKeyBase64: string): Promise<void> {
+      if (!__REBORN_NATIVE__) return;
+      try {
+        const { SecureStorage } = await import('@aparajita/capacitor-secure-storage');
+        await SecureStorage.setItem(MASTER_KEY_KEY, rawKeyBase64);
+      } catch {
+        // Write failed (rare OS error). The in-memory key keeps this session
+        // working; the next cold start falls back to the unlock screen.
+      }
+    },
+
+    async load(): Promise<string | null> {
+      if (!__REBORN_NATIVE__) return null;
+      try {
+        const { SecureStorage } = await import('@aparajita/capacitor-secure-storage');
+        return await SecureStorage.getItem(MASTER_KEY_KEY);
+      } catch {
+        return null;
+      }
+    },
+
+    async clear(): Promise<void> {
+      if (!__REBORN_NATIVE__) return;
+      try {
+        const { SecureStorage } = await import('@aparajita/capacitor-secure-storage');
+        await SecureStorage.removeItem(MASTER_KEY_KEY);
+      } catch {
+        // Best-effort on logout - a failed delete must not block the flow.
+      }
+    }
+  };
+}

--- a/docs/security/security-overview.md
+++ b/docs/security/security-overview.md
@@ -51,7 +51,7 @@ The server sees the **structural graph** (which tasks belong to which list, whic
 
 1. **Registration**: A random master key is generated on the client, wrapped with a key derived from the user's password (PBKDF2 600K), and the ciphertext is sent to the server alongside the Argon2id password hash.
 2. **Login**: The server returns the encrypted master key. The client derives the wrapping key from the password and decrypts the master key locally.
-3. **Session**: The decrypted master key is persisted in IndexedDB (survives browser/PWA restarts) and restored automatically on app load. The key is cleared only on explicit logout. This matches industry practice (Standard Notes, Bitwarden, Proton Mail) - in a Zero Knowledge architecture, client-side storage protection against local device access is out of scope; ZK protects against server-side attacks.
+3. **Session**: The decrypted master key is persisted in IndexedDB (survives browser/PWA restarts) and restored automatically on app load. The key is cleared only on explicit logout. This matches industry practice (Standard Notes, Bitwarden, Proton Mail) - in a Zero Knowledge architecture, client-side storage protection against local device access is out of scope; ZK protects against server-side attacks. Native builds (Capacitor) go one step further: the key is persisted through the platform key store (Android Keystore / iOS Keychain) instead of IndexedDB, so only a hardware-wrapped ciphertext ever touches disk and the wrapping key is non-extractable.
 4. **Data operations**: All encrypt/decrypt operations use the master key via AES-GCM. The key never leaves the device.
 
 ---

--- a/packages/crypto/src/__tests__/masterKeyVault.spec.ts
+++ b/packages/crypto/src/__tests__/masterKeyVault.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * MasterKeyVault (native persistence) tests.
+ *
+ * With a vault injected (native shells), the CryptoManager must persist the
+ * master key ONLY through the vault - no extractable CryptoKey in IndexedDB,
+ * no raw Base64 export in sessionStorage - and must migrate/purge copies left
+ * by pre-vault builds. Without a vault (web) the behavior is unchanged and
+ * covered by cryptoManager.spec.ts.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { CryptoManager, type MasterKeyVault } from '../cryptoManager';
+import { arrayBufferToBase64 } from '../encryption';
+
+const TEMP_KEY = 'TEMP_MASTER_KEY_EXPORT';
+
+/** In-memory vault double with call tracking. */
+function createFakeVault(): { vault: MasterKeyVault; state: { stored: string | null } } {
+  const state: { stored: string | null } = { stored: null };
+  const vault: MasterKeyVault = {
+    save: vi.fn(async (rawKeyBase64: string) => {
+      state.stored = rawKeyBase64;
+    }),
+    load: vi.fn(async () => state.stored),
+    clear: vi.fn(async () => {
+      state.stored = null;
+    })
+  };
+  return { vault, state };
+}
+
+function freshManager(): CryptoManager {
+  // Bypass the singleton - each test wants an isolated instance.
+  return new (CryptoManager as unknown as { new (): CryptoManager })();
+}
+
+describe('CryptoManager with MasterKeyVault (native persistence)', () => {
+  describe('setMasterKey', () => {
+    it('persists the raw key (Base64) to the vault', async () => {
+      const { vault, state } = createFakeVault();
+      const manager = freshManager();
+      manager.setMasterKeyVault(vault);
+
+      const masterKey = await manager.generateMasterKey();
+      await manager.setMasterKey(masterKey);
+
+      expect(vault.save).toHaveBeenCalledTimes(1);
+      const exported = await manager.exportCurrentKey();
+      expect(state.stored).toBe(arrayBufferToBase64(new Uint8Array(exported!)));
+    });
+
+    it('does NOT write the raw key to sessionStorage in vault mode', async () => {
+      const { vault } = createFakeVault();
+      const manager = freshManager();
+      manager.setMasterKeyVault(vault);
+
+      await manager.setMasterKey(await manager.generateMasterKey());
+
+      expect(global.window?.sessionStorage.getItem(TEMP_KEY)).toBeNull();
+    });
+
+    it('still runs the encryption self-test in vault mode', async () => {
+      const { vault } = createFakeVault();
+      const manager = freshManager();
+      manager.setMasterKeyVault(vault);
+
+      await manager.setMasterKey(await manager.generateMasterKey());
+
+      expect(manager.isKeyVerified()).toBe(true);
+    });
+
+    it('keeps the in-memory key usable when the vault write fails', async () => {
+      const manager = freshManager();
+      manager.setMasterKeyVault({
+        save: vi.fn(async () => {
+          throw new Error('keystore unavailable');
+        }),
+        load: vi.fn(async () => null),
+        clear: vi.fn(async () => undefined)
+      });
+
+      await manager.setMasterKey(await manager.generateMasterKey());
+
+      expect(manager.isInitialized()).toBe(true);
+      const encrypted = await manager.encryptString('still works');
+      expect(await manager.decryptString(encrypted)).toBe('still works');
+    });
+  });
+
+  describe('restore', () => {
+    it('restores the key from the vault on a fresh instance', async () => {
+      const { vault } = createFakeVault();
+      const writer = freshManager();
+      writer.setMasterKeyVault(vault);
+      await writer.setMasterKey(await writer.generateMasterKey());
+      const encrypted = await writer.encryptString('vault roundtrip');
+
+      const reader = freshManager();
+      reader.setMasterKeyVault(vault);
+      const restored = await reader.waitForRestore();
+
+      expect(restored).toBe(true);
+      expect(reader.isInitialized()).toBe(true);
+      expect(await reader.decryptString(encrypted)).toBe('vault roundtrip');
+    });
+
+    it('resolves false on an empty vault', async () => {
+      const { vault } = createFakeVault();
+      const manager = freshManager();
+      manager.setMasterKeyVault(vault);
+
+      expect(await manager.waitForRestore()).toBe(false);
+      expect(manager.isInitialized()).toBe(false);
+    });
+
+    it('clears a corrupt vault entry and falls back to "no key"', async () => {
+      const { vault, state } = createFakeVault();
+      // Valid Base64 but not a valid AES-256 raw key (wrong length).
+      state.stored = arrayBufferToBase64(new Uint8Array(5));
+
+      const manager = freshManager();
+      manager.setMasterKeyVault(vault);
+      const restored = await manager.waitForRestore();
+
+      expect(restored).toBe(false);
+      expect(manager.isInitialized()).toBe(false);
+      expect(vault.clear).toHaveBeenCalled();
+      expect(state.stored).toBeNull();
+    });
+
+    it('degrades to "no key" when vault.load rejects', async () => {
+      const manager = freshManager();
+      const clear = vi.fn(async () => undefined);
+      manager.setMasterKeyVault({
+        save: vi.fn(async () => undefined),
+        load: vi.fn(async () => {
+          throw new Error('keystore unavailable');
+        }),
+        clear
+      });
+
+      expect(await manager.waitForRestore()).toBe(false);
+      // A transient read error must not destroy the (possibly fine) entry.
+      expect(clear).not.toHaveBeenCalled();
+    });
+
+    it('purges the legacy sessionStorage raw-key copy in vault mode', async () => {
+      global.window?.sessionStorage.setItem(TEMP_KEY, 'legacy-pre-vault-copy');
+      const { vault } = createFakeVault();
+      const manager = freshManager();
+      manager.setMasterKeyVault(vault);
+
+      await manager.waitForRestore();
+
+      expect(global.window?.sessionStorage.getItem(TEMP_KEY)).toBeNull();
+    });
+  });
+
+  describe('legacy IndexedDB migration', () => {
+    it('moves a pre-vault IDB key into the vault and purges the IDB copy', async () => {
+      const { vault, state } = createFakeVault();
+      const seed = freshManager();
+      const legacyKey = await seed.generateMasterKey();
+
+      // The node test env has no IndexedDB - satisfy the migration guard and
+      // stub the private IDB accessors (their real IO is exercised on web).
+      (globalThis as { indexedDB?: unknown }).indexedDB = {};
+      try {
+        const manager = freshManager();
+        manager.setMasterKeyVault(vault);
+        const restoreIdb = vi
+          .spyOn(manager as unknown as { restoreKeyFromIDB: () => Promise<CryptoKey | null> }, 'restoreKeyFromIDB')
+          .mockResolvedValue(legacyKey);
+        const clearIdb = vi
+          .spyOn(manager as unknown as { clearKeyFromIDB: () => Promise<void> }, 'clearKeyFromIDB')
+          .mockResolvedValue(undefined);
+
+        const restored = await manager.waitForRestore();
+
+        expect(restored).toBe(true);
+        expect(restoreIdb).toHaveBeenCalled();
+        expect(vault.save).toHaveBeenCalledTimes(1);
+        expect(state.stored).not.toBeNull();
+        expect(clearIdb).toHaveBeenCalled();
+        expect(manager.isInitialized()).toBe(true);
+      } finally {
+        delete (globalThis as { indexedDB?: unknown }).indexedDB;
+      }
+    });
+
+    it('purges (without migrating) a legacy IDB key that fails verification', async () => {
+      const { vault } = createFakeVault();
+      const seed = freshManager();
+      const legacyKey = await seed.generateMasterKey();
+
+      (globalThis as { indexedDB?: unknown }).indexedDB = {};
+      try {
+        const manager = freshManager();
+        manager.setMasterKeyVault(vault);
+        vi.spyOn(
+          manager as unknown as { restoreKeyFromIDB: () => Promise<CryptoKey | null> },
+          'restoreKeyFromIDB'
+        ).mockResolvedValue(legacyKey);
+        const clearIdb = vi
+          .spyOn(manager as unknown as { clearKeyFromIDB: () => Promise<void> }, 'clearKeyFromIDB')
+          .mockResolvedValue(undefined);
+        vi.spyOn(manager, 'verifyEncryption').mockRejectedValueOnce(new Error('broken key'));
+
+        const restored = await manager.waitForRestore();
+
+        expect(restored).toBe(false);
+        expect(manager.isInitialized()).toBe(false);
+        expect(vault.save).not.toHaveBeenCalled();
+        expect(clearIdb).toHaveBeenCalled();
+      } finally {
+        delete (globalThis as { indexedDB?: unknown }).indexedDB;
+      }
+    });
+  });
+
+  describe('clearMasterKey', () => {
+    it('clears the vault entry on logout', async () => {
+      const { vault, state } = createFakeVault();
+      const manager = freshManager();
+      manager.setMasterKeyVault(vault);
+      await manager.setMasterKey(await manager.generateMasterKey());
+      expect(state.stored).not.toBeNull();
+
+      manager.clearMasterKey();
+      // clear() is fire-and-forget - yield to the microtask queue.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(vault.clear).toHaveBeenCalled();
+      expect(state.stored).toBeNull();
+      expect(manager.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('setMasterKeyVault ordering guard', () => {
+    it('warns when the vault is injected after restoration has started', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+        /* swallow log output */
+      });
+      try {
+        const manager = freshManager();
+        await manager.waitForRestore();
+        manager.setMasterKeyVault(createFakeVault().vault);
+
+        const warned = consoleSpy.mock.calls.some((args) =>
+          args.some(
+            (a) => typeof a === 'string' && a.includes('after key restoration started')
+          )
+        );
+        expect(warned).toBe(true);
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/crypto/src/cryptoManager.ts
+++ b/packages/crypto/src/cryptoManager.ts
@@ -39,6 +39,31 @@ export type CryptoKeyEvent = 'unlocked' | 'cleared';
 
 export type KeyEventHandler = (event: CryptoKeyEvent) => void;
 
+/**
+ * Pluggable at-rest persistence for the master key (raw bytes, Base64).
+ *
+ * Default (no vault, web): the master key is persisted as an extractable
+ * CryptoKey in IndexedDB plus a raw Base64 export in sessionStorage —
+ * browsers offer no hardware-backed alternative. Native shells (Capacitor)
+ * inject a vault backed by the platform key store (Android Keystore /
+ * iOS Keychain) via `setMasterKeyVault()`: only the Keystore/Keychain-wrapped
+ * ciphertext ever touches disk and the wrapping key is non-extractable.
+ * With a vault set, the IndexedDB and sessionStorage persistence paths are
+ * disabled (and legacy copies from pre-vault builds are purged on restore).
+ *
+ * Implementations must swallow platform errors and degrade to "no key"
+ * (`load()` → null): the caller then falls back to the password unlock
+ * screen, and the next successful unlock re-writes the vault entry.
+ */
+export interface MasterKeyVault {
+  /** Persist the raw master key (Base64). */
+  save(rawKeyBase64: string): Promise<void>;
+  /** Read the persisted master key (Base64), or null when absent / on error. */
+  load(): Promise<string | null>;
+  /** Remove the persisted master key (logout / corrupt entry). */
+  clear(): Promise<void>;
+}
+
 export class CryptoManager {
   private static instance: CryptoManager;
   private masterKey: CryptoKey | null = null;
@@ -50,6 +75,7 @@ export class CryptoManager {
   private readonly IDB_KEY_ID = 'current';
   private restoreKeyAttempted = false;
   private restorePromise: Promise<boolean> | null = null;
+  private vault: MasterKeyVault | null = null;
 
   // Cross-app key event channel — single instance with a fanout list of
   // subscribers so HMR re-subscribing doesn't allocate extra channels.
@@ -81,11 +107,44 @@ export class CryptoManager {
   }
 
   /**
+   * Inject a platform key vault (native shells). MUST be called before the
+   * first waitForRestore() — the restoration source is decided when the
+   * lazy restore actually runs. Web never calls this: without a vault the
+   * IndexedDB/sessionStorage behavior below is byte-for-byte the old one.
+   */
+  public setMasterKeyVault(vault: MasterKeyVault): void {
+    if (this.restorePromise) {
+      logger.warn(
+        'setMasterKeyVault called after key restoration started — restore already used the default persistence'
+      );
+    }
+    this.vault = vault;
+  }
+
+  /**
    * Orchestrates key restoration on startup.
-   * Priority: IndexedDB (persistent) → sessionStorage (fallback) → null.
+   * Vault injected (native): vault → one-time IndexedDB migration → null.
+   * Default (web): IndexedDB (persistent) → sessionStorage (fallback) → null.
    */
   private async restoreKeyOnStartup(): Promise<boolean> {
     try {
+      // 0. Vault (native) — the platform key store is the single source of
+      // truth. IndexedDB is only consulted to migrate (then purge) a key
+      // persisted by a pre-vault build; the sessionStorage raw-key copy is
+      // purged outright (Chromium-based webviews persist Session Storage to
+      // disk, which is exactly what the vault exists to avoid).
+      if (this.vault) {
+        const restored = await this.restoreKeyFromVault();
+        if (!restored) {
+          await this.migrateLegacyKeyToVault();
+        }
+        if (typeof window !== 'undefined' && window.sessionStorage) {
+          window.sessionStorage.removeItem(this.TEMP_KEY_STORAGE_KEY);
+        }
+        this.restoreKeyAttempted = true;
+        return this.isInitialized();
+      }
+
       // 1. Try IndexedDB first (survives tab close / PWA restart)
       if (typeof window !== 'undefined' && typeof indexedDB !== 'undefined') {
         const idbKey = await this.restoreKeyFromIDB();
@@ -206,6 +265,85 @@ export class CryptoManager {
     } catch (error) {
       logger.error('Failed to clear master key from IndexedDB:', error);
     }
+  }
+
+  // ── Vault persistence (native shells) ────────────────────────
+
+  /** Persist the master key to the injected vault (raw bytes, Base64). */
+  private async persistKeyToVault(): Promise<void> {
+    if (!this.vault || !this.masterKey) return;
+    try {
+      const rawKey = await exportKey(this.masterKey);
+      await this.vault.save(arrayBufferToBase64(rawKey));
+      logger.debug('Master key persisted to vault');
+    } catch (error) {
+      // The in-memory key keeps this session working; the next cold start
+      // falls back to the unlock screen and a successful unlock re-saves.
+      logger.error('Failed to persist master key to vault:', error);
+    }
+  }
+
+  /**
+   * Restore the master key from the vault. A non-null entry that fails to
+   * import or verify is treated as corrupt and removed — self-healing: the
+   * user lands on the unlock screen and the next unlock overwrites it.
+   */
+  private async restoreKeyFromVault(): Promise<boolean> {
+    if (!this.vault) return false;
+    const rawKeyBase64 = await this.vault.load().catch(() => null);
+    if (!rawKeyBase64) return false;
+
+    try {
+      const key = await importKey(
+        base64ToArrayBuffer(rawKeyBase64),
+        'AES-GCM',
+        ['encrypt', 'decrypt'],
+        true
+      );
+      this.masterKey = key;
+      this.initialized = true;
+      await this.verifyEncryption();
+      logger.info('Successfully restored master key from vault');
+      return true;
+    } catch (error) {
+      logger.error('Vault-restored key failed to import/verify — clearing entry:', error);
+      this.masterKey = null;
+      this.initialized = false;
+      await this.vault.clear().catch(() => {
+        // Best-effort — a failed delete leaves a corrupt entry that the next
+        // restore attempt will fail (and retry clearing) the same way.
+      });
+      return false;
+    }
+  }
+
+  /**
+   * One-time migration from pre-vault builds, which persisted an extractable
+   * CryptoKey in IndexedDB: move it into the vault and purge the IDB copy so
+   * no extractable key material stays on disk.
+   */
+  private async migrateLegacyKeyToVault(): Promise<void> {
+    if (!this.vault) return;
+    if (typeof window === 'undefined' || typeof indexedDB === 'undefined') return;
+
+    const idbKey = await this.restoreKeyFromIDB();
+    if (!idbKey) return;
+
+    this.masterKey = idbKey;
+    this.initialized = true;
+    try {
+      await this.verifyEncryption();
+    } catch (verifyError) {
+      logger.error('Legacy IndexedDB key failed verification during vault migration:', verifyError);
+      this.masterKey = null;
+      this.initialized = false;
+      await this.clearKeyFromIDB();
+      return;
+    }
+
+    await this.persistKeyToVault();
+    await this.clearKeyFromIDB();
+    logger.info('Master key migrated from IndexedDB to vault');
   }
 
   /**
@@ -463,6 +601,31 @@ export class CryptoManager {
     this.masterKey = key;
     this.initialized = true;
 
+    if (this.vault) {
+      // Native: the vault is the ONLY at-rest copy — no extractable
+      // CryptoKey in IndexedDB, no raw-key export in sessionStorage
+      // (Chromium-based webviews persist Session Storage to disk). Legacy
+      // copies a pre-vault build may have written are purged defensively.
+      await this.persistKeyToVault();
+      void this.clearKeyFromIDB();
+      if (typeof window !== 'undefined' && window.sessionStorage) {
+        window.sessionStorage.removeItem(this.TEMP_KEY_STORAGE_KEY);
+      }
+
+      this.postKeyEvent('unlocked');
+
+      try {
+        // Same self-test as the web path below — a failure is logged but the
+        // in-memory key stays usable.
+        await this.verifyEncryption();
+      } catch (error) {
+        logger.error('Encryption verification after unlock failed:', error);
+      }
+
+      logger.debug('Master key set');
+      return;
+    }
+
     // Persist to IndexedDB (survives tab close / PWA restart)
     await this.persistKeyToIDB();
 
@@ -497,6 +660,13 @@ export class CryptoManager {
   public clearMasterKey(): void {
     this.masterKey = null;
     this.initialized = false;
+
+    // Clear the vault entry (native) — fire-and-forget like the IDB clear.
+    if (this.vault) {
+      this.vault.clear().catch((err) => {
+        logger.error('Failed to clear master key from vault during clearMasterKey:', err);
+      });
+    }
 
     // Clear IndexedDB (async, fire-and-forget)
     this.clearKeyFromIDB().catch((err) => {

--- a/packages/crypto/src/cryptoManager.ts
+++ b/packages/crypto/src/cryptoManager.ts
@@ -43,7 +43,7 @@ export type KeyEventHandler = (event: CryptoKeyEvent) => void;
  * Pluggable at-rest persistence for the master key (raw bytes, Base64).
  *
  * Default (no vault, web): the master key is persisted as an extractable
- * CryptoKey in IndexedDB plus a raw Base64 export in sessionStorage —
+ * CryptoKey in IndexedDB plus a raw Base64 export in sessionStorage -
  * browsers offer no hardware-backed alternative. Native shells (Capacitor)
  * inject a vault backed by the platform key store (Android Keystore /
  * iOS Keychain) via `setMasterKeyVault()`: only the Keystore/Keychain-wrapped
@@ -108,14 +108,14 @@ export class CryptoManager {
 
   /**
    * Inject a platform key vault (native shells). MUST be called before the
-   * first waitForRestore() — the restoration source is decided when the
+   * first waitForRestore() - the restoration source is decided when the
    * lazy restore actually runs. Web never calls this: without a vault the
    * IndexedDB/sessionStorage behavior below is byte-for-byte the old one.
    */
   public setMasterKeyVault(vault: MasterKeyVault): void {
     if (this.restorePromise) {
       logger.warn(
-        'setMasterKeyVault called after key restoration started — restore already used the default persistence'
+        'setMasterKeyVault called after key restoration started - restore already used the default persistence'
       );
     }
     this.vault = vault;
@@ -128,7 +128,7 @@ export class CryptoManager {
    */
   private async restoreKeyOnStartup(): Promise<boolean> {
     try {
-      // 0. Vault (native) — the platform key store is the single source of
+      // 0. Vault (native) - the platform key store is the single source of
       // truth. IndexedDB is only consulted to migrate (then purge) a key
       // persisted by a pre-vault build; the sessionStorage raw-key copy is
       // purged outright (Chromium-based webviews persist Session Storage to
@@ -285,7 +285,7 @@ export class CryptoManager {
 
   /**
    * Restore the master key from the vault. A non-null entry that fails to
-   * import or verify is treated as corrupt and removed — self-healing: the
+   * import or verify is treated as corrupt and removed - self-healing: the
    * user lands on the unlock screen and the next unlock overwrites it.
    */
   private async restoreKeyFromVault(): Promise<boolean> {
@@ -306,11 +306,11 @@ export class CryptoManager {
       logger.info('Successfully restored master key from vault');
       return true;
     } catch (error) {
-      logger.error('Vault-restored key failed to import/verify — clearing entry:', error);
+      logger.error('Vault-restored key failed to import/verify - clearing entry:', error);
       this.masterKey = null;
       this.initialized = false;
       await this.vault.clear().catch(() => {
-        // Best-effort — a failed delete leaves a corrupt entry that the next
+        // Best-effort - a failed delete leaves a corrupt entry that the next
         // restore attempt will fail (and retry clearing) the same way.
       });
       return false;
@@ -602,7 +602,7 @@ export class CryptoManager {
     this.initialized = true;
 
     if (this.vault) {
-      // Native: the vault is the ONLY at-rest copy — no extractable
+      // Native: the vault is the ONLY at-rest copy - no extractable
       // CryptoKey in IndexedDB, no raw-key export in sessionStorage
       // (Chromium-based webviews persist Session Storage to disk). Legacy
       // copies a pre-vault build may have written are purged defensively.
@@ -615,7 +615,7 @@ export class CryptoManager {
       this.postKeyEvent('unlocked');
 
       try {
-        // Same self-test as the web path below — a failure is logged but the
+        // Same self-test as the web path below - a failure is logged but the
         // in-memory key stays usable.
         await this.verifyEncryption();
       } catch (error) {
@@ -661,7 +661,7 @@ export class CryptoManager {
     this.masterKey = null;
     this.initialized = false;
 
-    // Clear the vault entry (native) — fire-and-forget like the IDB clear.
+    // Clear the vault entry (native) - fire-and-forget like the IDB clear.
     if (this.vault) {
       this.vault.clear().catch((err) => {
         logger.error('Failed to clear master key from vault during clearMasterKey:', err);

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -7,7 +7,7 @@
 
 // CryptoManager - main crypto operations class
 export { CryptoManager, cryptoManager } from './cryptoManager';
-export type { CryptoKeyEvent, KeyEventHandler } from './cryptoManager';
+export type { CryptoKeyEvent, KeyEventHandler, MasterKeyVault } from './cryptoManager';
 
 // Encryption utilities
 export {


### PR DESCRIPTION
## Summary

Faza 3c (TODO-native): na natywce master key przestaje lezec na dysku jako extractable CryptoKey w IndexedDB (+ kopia raw-Base64 w sessionStorage, ktora WebView persystuje na dysk). Zamiast tego trafia do device secure storage przez wstrzykiwany `MasterKeyVault`.

**Decyzja (bramka planu, zaakceptowana): opcja A** - sam Keystore-wrap, zero nowych zaleznosci (plugin `@aparajita/capacitor-secure-storage` w deps od Fazy 2 robi AndroidKeyStore-wrapping per-alias: na dysk trafia wylacznie ciphertext, klucz odwijajacy jest non-extractable, hardware-backed; iOS = Keychain). Biometria (soft prompt / crypto-bound) swiadomie odlozona do backlogu - vault jest jej przyszlym punktem wpiecia. Szczegoly i odrzucone opcje: `docs/development/planning/native-faza3c-plan.md` (lokalny).

Zmiany:
- `@reborn/crypto`: interfejs `MasterKeyVault` + `setMasterKeyVault()`; z vaultem persist/restore/clear ida WYLACZNIE przez vault, sciezki IDB/sessionStorage wylaczone; jednorazowa migracja klucza ze starych buildow (IDB -> vault) + czyszczenie kopii legacy; corrupt entry self-heals przez ekran unlock. Pakiet pozostaje wolny od Capacitora (inwersja jak `platform.network` z 3a).
- `reborn-notes`: `native-master-key-vault.ts` (gated `__REBORN_NATIVE__`, DCE z weba - zweryfikowane na swiezym buildzie) + wpiecie w `hooks.client.ts` przed pierwszym `waitForRestore()`.
- `docs/security/security-overview.md` (tracked): jedno zdanie o natywnej persystencji klucza.
- Testy: `masterKeyVault.spec.ts` (13 testow: persist/restore/corrupt/migracja/logout/ordering guard).

Web behawioralnie bez zmian (vault nigdy nie ustawiony); bez zmiany UX na natywce (cold start nadal bez hasla). Bonus: klucz nie wycieka backupem/transferem (Keystore key nie opuszcza urzadzenia -> po transferze re-login, spojne z refresh tokenem z Fazy 2) i jest odporny na eviction WebView storage.

## Test plan

- [x] `pnpm nx test @reborn/crypto` - 213/213 (w tym 13 nowych vault)
- [x] `pnpm nx affected -t lint test build` - zielone (8 projektow)
- [x] svelte-check 0/0 (z wstrzyknietym `PUBLIC_SITE_URL` - znany quirk)
- [x] DCE: swiezy web client bez `capacitor-secure-storage`; native bundle z wiringiem
- [ ] **Emulator (Michal):** (1) swiezy login+2FA -> unlock -> kill+reopen -> notatki BEZ hasla; (2) `adb shell run-as eu.reapps.notes cat shared_prefs/WSSecureStorageSharedPreferences.xml` -> wpis `capacitor-storage_master_key` = ciphertext, a IDB `reborn_crypto_keys` (chrome://inspect) pusty; (3) upgrade ze starego builda (klucz w IDB) -> reopen bez hasla (migracja) + IDB wyczyszczone; (4) logout -> wpis znika z prefs, ponowne wejscie wymaga hasla; (5) web smoke: unlock + cold-restart bez hasla w przegladarce (sciezka IDB nietknieta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)