### PR TITLE
chore(release): v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.29.0 (2026-06-11)
+
+### 🚀 Features
+
+- **notes:** deep links + native share sheet for shares (Faza 3b) ([#258](https://github.com/fundacja-reborn/reapps/pull/258))
+- **notes:** saved searches / smart folders (Travis Tier 2) ([#263](https://github.com/fundacja-reborn/reapps/pull/263))
+
 ## 0.28.0 (2026-06-09)
 
 ### 🚀 Features

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/reborn-notes",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/apps/reborn-task/package.json
+++ b/apps/reborn-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reborn-task",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/source",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "license": "AGPL-3.0-only",
   "scripts": {
     "clean": "chmod +x ./scripts/clean-all.sh && ./scripts/clean-all.sh",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/api-client",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Universal API client for Reborn apps with E2E encryption support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/auth",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/crypto",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/database",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/i18n",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "type": "module",
   "description": "Internationalization package for Reborn apps",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/platform",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/storage",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/types",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/ui",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "svelte": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/utils",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release v0.29.0. Version bump + CHANGELOG, routed through a PR because main is protected (no direct pushes).

After this merges, run `pnpm release:finalize` on main to tag v0.29.0 and create the GitHub Release.

Generated by scripts/release.mjs.