### PR TITLE
fix(notes): stop Safari clipping 2-digit ordered-list markers in preview

### DIFF
--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -526,11 +526,11 @@
     margin-top: 0.25em;
   }
 
-  /* Tapered indent ramp — mirrors the bullet/ordered depth rules in
+  /* Tapered indent ramp - mirrors the bullet/ordered depth rules in
      editor/live-preview/theme.ts so Preview and Live Preview render nested
      lists with the same geometry. The renderer in this component stamps
      data-d="N" on every ul/ol (1..12, clamped). margin-left here is the
-     delta from the parent list's content edge — d2..d12 stack on top of the
+     delta from the parent list's content edge - d2..d12 stack on top of the
      d1 base (1.5em), giving cumulative offsets that match Live Preview's
      absolute paddings. d2 has the larger 2.5em step so a nested item sits
      visibly past the parent's content; d3..d6 keep the 1.5em rhythm; d7..d12
@@ -538,6 +538,23 @@
   .preview :global(ul[data-d='1']),
   .preview :global(ol[data-d='1']) {
     margin-left: 1.5em;
+  }
+  /* First-level ol gets extra room: outside markers hang LEFT of the li
+     content edge, and `.preview` is a scroll container (overflow-auto), so
+     anything past its padding box is clipped. 1.5em fits a 2-digit marker
+     ("10.") with ~1px slack in Blink/Gecko, but WebKit lays the marker out
+     with a wider marker-to-content gap and clips the leading digit (#262,
+     Safari macOS/iOS). 2em covers 2 digits in all engines (GitHub uses the
+     same value); 100+ item lists escalate to 2.75em for the third digit.
+     Only d1 is at risk - nested lists hang markers over ancestor indents,
+     which sit safely inside the clip box. Live Preview is unaffected (the
+     number there is source text, not a ::marker), so this is a deliberate
+     0.5em divergence from .cm-lp-ordered-d1. */
+  .preview :global(ol[data-d='1']) {
+    margin-left: 2em;
+  }
+  .preview :global(ol[data-d='1']:has(> li:nth-child(100))) {
+    margin-left: 2.75em;
   }
   .preview :global(ul[data-d='2']),
   .preview :global(ol[data-d='2']) {

--- a/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/theme.ts
@@ -162,7 +162,11 @@ export const livePreviewTheme = EditorView.theme({
 
   // Bullet list — depth-aware padding + ::before bullet.
   //
-  // Tapered ramp (mirrored in MarkdownPreview.svelte's `[data-d{N}]` rules):
+  // Tapered ramp (mirrored in MarkdownPreview.svelte's `[data-d{N}]` rules,
+  // with one deliberate exception: Preview renders first-level ol at 2em so
+  // Safari doesn't clip 2-digit ::marker numbers at the scroll-container
+  // edge - see the ol[data-d='1'] comment there. Here the number is source
+  // text, never a marker, so 1.5em stays safe):
   //   d1 → 1.5em (preserves the historical first-level indent)
   //   d2 → 4em   (krok +2.5em — a noticeable visual step so a nested item
   //               doesn't sit in the same column as the parent's content)


### PR DESCRIPTION
## Summary

Fixes #262 - on Safari (macOS + iOS, including the iOS PWA), numbered lists with 10+ items rendered with the leading digit of the marker cut off ("10." showed as "0.") in both the in-app Markdown preview and the public share view.

Root cause: the preview container is a scroll container (`overflow-auto`), which clips at its padding box. First-level `ol` reserved only `1.5em` (21px at desktop 14px) for the outside `::marker`, and a 2-digit Roboto marker (~19.6px) fits in Blink/Gecko with about 1px of slack - but WebKit positions outside markers with a wider marker-to-content gap, pushing the leading digit past the clip edge. The borderline-pixel budget also explains why the bug does not reproduce on every Safari build.

Fix:
- first-level `ol[data-d='1']` indent 1.5em → **2em** (the GitHub norm; fits 2-digit markers in all engines),
- escalation to **2.75em** via `:has(> li:nth-child(100))` for 100+ item lists (3-digit markers); on engines without `:has` this degrades to today's behavior,
- nested lists untouched (their markers hang over ancestor indents, safely inside the clip box),
- Live Preview untouched (`.cm-lp-ordered-d1` stays 1.5em - the number there is source text, not a `::marker`); the deliberate 0.5em divergence is documented in both files,
- PDF export unaffected (separate CSS-counter numbering).

Known edge left out: `start="100"`+ lists with fewer than 100 items would still clip the hundreds digit in Safari (exotic markdown).

## Test plan

- [ ] Note with a 12+ item numbered list → preview mode: all markers fully visible (the reporter's share URL in #262 reproduces this directly)
- [ ] Same note via public share view on Safari (macOS, and iOS if available)
- [ ] Sanity check in Chrome/Firefox: first-level numbered lists indent 7px deeper than before, bullets and nested lists unchanged
- [ ] 100+ item numbered list: markers visible (indent widens to 2.75em)

Checks: `nx affected lint + test` green (611 notes tests); no `typecheck` target for reborn-notes (only `check`/svelte-check) - change is CSS + comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)