### PR TITLE
feat(ui): support heart link in icon nav (both apps)

### DIFF
--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -31,7 +31,8 @@
     CalendarCheck,
     CalendarRange,
     CalendarDays,
-    Share2
+    Share2,
+    Heart
   } from '@lucide/svelte';
   import * as Tooltip from '@reborn/ui/components/tooltip';
   import * as DropdownMenu from '@reborn/ui/components/dropdown-menu';
@@ -72,6 +73,14 @@
   let loggingOut = $state(false);
   let userSheetOpen = $state(false);
   let sharesDialogOpen = $state(false);
+
+  // Donations page on the foundation site (EN + PL only). Plain <a target="_blank">
+  // leaves the app: new tab on web, SYSTEM browser in the native shell (the
+  // webview origin is localhost, so Capacitor opens external hosts externally) -
+  // Apple 3.2.2(iv) requires collecting donations outside the app.
+  const SITE_URL: string =
+    (import.meta.env.PUBLIC_SITE_URL as string | undefined) ?? 'https://reapps.eu';
+  const supportUrl = $derived(`${SITE_URL}${$i18nLocale === 'pl' ? '/pl' : ''}/support`);
 
   async function handleOpenShares() {
     const ok = await requireActiveSession({
@@ -460,6 +469,28 @@
     </Tooltip.Root>
 
     <div class="flex-1"></div>
+
+    <!-- Support (donation page, leaves the app) -->
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <!-- eslint-disable svelte/no-navigation-without-resolve (external URL, leaves the app) -->
+          <a
+            {...props}
+            href={supportUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg text-muted-foreground
+                   hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
+            aria-label={$t('nav.support')}
+          >
+            <Heart class="h-6 w-6 md:h-5 md:w-5" />
+          </a>
+          <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content side="right" sideOffset={6}>{$t('nav.support')}</Tooltip.Content>
+    </Tooltip.Root>
 
     <!-- Settings -->
     <Tooltip.Root>

--- a/apps/reborn-task/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-task/src/lib/components/layout/IconNav.svelte
@@ -23,7 +23,8 @@
 		Trash2,
 		Settings,
 		LogOut,
-		Share2
+		Share2,
+		Heart
 	} from '@lucide/svelte';
 	import {
 		overdueTasks,
@@ -37,7 +38,7 @@
 	import { Button, Sheet, SheetContent, SheetHeader, SheetTitle } from '@reborn/ui';
 	import { session } from '$lib/stores/auth.store';
 	import { goto } from '$lib/utils/navigation';
-	import { t } from '$lib/stores/i18n.store';
+	import { t, locale as i18nLocale } from '$lib/stores/i18n.store';
 	import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
 	import { activeSharesCount } from '$lib/stores/shares.store';
 	import { requireActiveSession } from '$lib/utils/require-active-session';
@@ -60,6 +61,14 @@
 	const isMobileQuery = useIsMobile();
 	let loggingOut = $state(false);
 	let userSheetOpen = $state(false);
+
+	// Donations page on the foundation site (EN + PL only). Plain <a target="_blank">
+	// leaves the app: new tab on web, SYSTEM browser in the native shell (the
+	// webview origin is localhost, so Capacitor opens external hosts externally) -
+	// Apple 3.2.2(iv) requires collecting donations outside the app.
+	const SITE_URL: string =
+		(import.meta.env.PUBLIC_SITE_URL as string | undefined) ?? 'https://reapps.eu';
+	const supportUrl = $derived(`${SITE_URL}${$i18nLocale === 'pl' ? '/pl' : ''}/support`);
 	let sharesDialogOpen = $state(false);
 
 	async function handleOpenShares() {
@@ -407,6 +416,28 @@
 		</Tooltip.Root>
 
 		<div class="flex-1"></div>
+
+		<!-- Support (donation page, leaves the app) -->
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<!-- eslint-disable svelte/no-navigation-without-resolve (external URL, leaves the app) -->
+					<a
+						{...props}
+						href={supportUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg text-muted-foreground
+                   hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
+						aria-label={$t('nav.support')}
+					>
+						<Heart class="h-6 w-6 md:h-5 md:w-5" />
+					</a>
+					<!-- eslint-enable svelte/no-navigation-without-resolve -->
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content side="right" sideOffset={6}>{$t('nav.support')}</Tooltip.Content>
+		</Tooltip.Root>
 
 		<!-- Settings -->
 		<Tooltip.Root>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -20,7 +20,8 @@
     "open_reborn_task": "re/task öffnen",
     "no_folder": "Kein Ordner",
     "back": "Zurück",
-    "search": "Suchen"
+    "search": "Suchen",
+    "support": "Unterstütze uns"
   },
   "notes": {
     "title": "Notizen",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -20,7 +20,8 @@
     "open_reborn_task": "Open re/task",
     "no_folder": "No Folder",
     "back": "Back",
-    "search": "Search"
+    "search": "Search",
+    "support": "Support us"
   },
   "notes": {
     "title": "Notes",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -20,7 +20,8 @@
     "open_reborn_task": "Abrir re/task",
     "no_folder": "Sin carpeta",
     "back": "Atrás",
-    "search": "Buscar"
+    "search": "Buscar",
+    "support": "Apóyanos"
   },
   "notes": {
     "title": "Notas",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -20,7 +20,8 @@
     "open_reborn_task": "Ouvrir re/task",
     "no_folder": "Aucun dossier",
     "back": "Retour",
-    "search": "Rechercher"
+    "search": "Rechercher",
+    "support": "Soutenez-nous"
   },
   "notes": {
     "title": "Notes",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -20,7 +20,8 @@
     "open_reborn_task": "Otwórz re/task",
     "no_folder": "Bez folderu",
     "back": "Wróć",
-    "search": "Szukaj"
+    "search": "Szukaj",
+    "support": "Wesprzyj nas"
   },
   "notes": {
     "title": "Notatki",

--- a/packages/i18n/src/translations/tasks/de/nav.json
+++ b/packages/i18n/src/translations/tasks/de/nav.json
@@ -4,5 +4,6 @@
   "search": "Suche",
   "settings": "Einstellungen",
   "completed": "Erledigt",
-  "shares": "Freigaben"
+  "shares": "Freigaben",
+  "support": "Unterstütze uns"
 }

--- a/packages/i18n/src/translations/tasks/en/nav.json
+++ b/packages/i18n/src/translations/tasks/en/nav.json
@@ -4,5 +4,6 @@
   "search": "Search",
   "settings": "Settings",
   "completed": "Completed",
-  "shares": "Shares"
+  "shares": "Shares",
+  "support": "Support us"
 }

--- a/packages/i18n/src/translations/tasks/es/nav.json
+++ b/packages/i18n/src/translations/tasks/es/nav.json
@@ -4,5 +4,6 @@
   "search": "Buscar",
   "settings": "Ajustes",
   "completed": "Completadas",
-  "shares": "Compartidos"
+  "shares": "Compartidos",
+  "support": "Apóyanos"
 }

--- a/packages/i18n/src/translations/tasks/fr/nav.json
+++ b/packages/i18n/src/translations/tasks/fr/nav.json
@@ -4,5 +4,6 @@
   "search": "Recherche",
   "settings": "Paramètres",
   "completed": "Terminées",
-  "shares": "Partages"
+  "shares": "Partages",
+  "support": "Soutenez-nous"
 }

--- a/packages/i18n/src/translations/tasks/pl/nav.json
+++ b/packages/i18n/src/translations/tasks/pl/nav.json
@@ -4,5 +4,6 @@
   "search": "Szukaj",
   "settings": "Ustawienia",
   "completed": "Wykonane",
-  "shares": "Udostępnienia"
+  "shares": "Udostępnienia",
+  "support": "Wesprzyj nas"
 }


### PR DESCRIPTION
## Summary

Adds a heart icon to the vertical icon rail (above Settings) in re/notes and re/task, linking to the foundation donation page:

- `https://reapps.eu/support` (the `/pl` variant for the Polish locale; DE/FR/ES fall back to EN since the site has only those two languages) - the page itself ships in reapps-www PR #4
- plain `<a target="_blank" rel="noopener noreferrer">`: a new tab on web, the **system browser** in the native shell (webview origin is localhost, Capacitor opens external hosts externally; no `allowNavigation` in config) - this is the store-compliant donation path: Apple guideline 3.2.2(iv) requires collecting funds outside the app for non-approved nonprofits, Google Play exempts tax-exempt donations from Play Billing
- no new dependencies; `Heart` comes from the already-used `@lucide/svelte`
- new `nav.support` i18n key in all 5 locales for both apps (notes per-locale files + tasks `nav.json`); `check-i18n-parity.mjs` green
- eslint `svelte/no-navigation-without-resolve` handled with the existing disable/enable pattern (MarkdownPreview precedent) - the rule reports on the `href` attribute line, so `disable-next-line` before the tag cannot catch it

## Test plan

- `pnpm nx affected -t test lint check` green; `pnpm nx run-many -t build -p reborn-notes reborn-task` exit 0
- Smoke (web): heart shows above the gear in the desktop rail in both apps; tooltip says "Support us"/"Wesprzyj nas" per locale; click opens the donation page in a new tab; PL app locale lands on `/pl/support`
- Smoke (native, later with the 1.1 build): tap opens the system browser, not an in-app webview

🤖 Generated with [Claude Code](https://claude.com/claude-code)