### PR TITLE
feat(notes): folder import targeting and unchanged-note skip

### DIFF
--- a/apps/reborn-notes/src/lib/components/import/ImportMarkdownToFolderDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/import/ImportMarkdownToFolderDialog.svelte
@@ -8,32 +8,53 @@
     DialogTitle,
     Button
   } from '@reborn/ui';
-  import { Upload } from '@lucide/svelte';
+  import { Upload, FolderInput } from '@lucide/svelte';
   import { t } from '$lib/stores/i18n.store';
   import {
     importMarkdownFiles,
+    importFolder,
+    type ImportFolderResult,
     type ImportMarkdownResult
   } from '$lib/services/export-import.service';
+  import {
+    countImportableMarkdownFiles,
+    getRootFolderName
+  } from '$lib/services/markdown-import-utils';
   import type { DuplicateStrategy } from '$lib/services/import-dedup-utils';
   import { notesStore } from '$lib/stores/notes.store';
   import { foldersStore } from '$lib/stores/folders.store';
+  import { tagsStore } from '$lib/stores/tags.store';
   import MarkdownImportStrategyPicker from './MarkdownImportStrategyPicker.svelte';
+  import ImportResultSummary from './ImportResultSummary.svelte';
 
   let {
     open = $bindable(false),
     files,
     folderId,
-    folderName
+    folderName,
+    mode = 'files'
   }: {
     open: boolean;
     files: File[] | null;
     folderId: string | null;
     folderName: string;
+    // 'files'  - flat .md file picker ("Import .md here")
+    // 'folder' - webkitdirectory tree import ("Import folder here")
+    mode?: 'files' | 'folder';
   } = $props();
 
   let strategy = $state<DuplicateStrategy>('rename');
+  let keepRootFolder = $state(true);
   let importing = $state(false);
-  let result = $state<ImportMarkdownResult | null>(null);
+  let result = $state<ImportMarkdownResult | ImportFolderResult | null>(null);
+
+  const rootName = $derived(mode === 'folder' && files ? getRootFolderName(files) : null);
+  const importableCount = $derived(
+    !files ? 0 : mode === 'folder' ? countImportableMarkdownFiles(files) : files.length
+  );
+  const destinationPath = $derived(
+    keepRootFolder && rootName ? `${folderName}/${rootName}` : folderName
+  );
 
   // Reset internal state every time the dialog closes — the parent decides
   // when to open it again (with fresh files / target).
@@ -45,20 +66,42 @@
     }
   });
 
+  // Default for "keep top-level folder", chosen when the dialog opens:
+  // ON (mirrors dropping a directory into a folder in a file manager), but
+  // OFF when the target folder already carries the picked directory's name -
+  // that's a re-import refreshing the folder in place, and "reapps-docs/
+  // reapps-docs" is never what the user wants there.
+  $effect(() => {
+    if (open && mode === 'folder') {
+      keepRootFolder =
+        !rootName || rootName.toLowerCase() !== folderName.trim().toLowerCase();
+    }
+  });
+
   async function runImport() {
     if (!files || !folderId) return;
     importing = true;
     result = null;
     try {
-      const r = await importMarkdownFiles(files, folderId, strategy);
-      result = r;
-      await Promise.all([notesStore.refresh(), foldersStore.refresh()]);
+      if (mode === 'folder') {
+        const r = await importFolder(files, strategy, undefined, {
+          keepRootFolder: keepRootFolder && rootName !== null,
+          targetFolderId: folderId
+        });
+        result = r;
+        await Promise.all([notesStore.refresh(), foldersStore.refresh(), tagsStore.refresh()]);
+      } else {
+        const r = await importMarkdownFiles(files, folderId, strategy);
+        result = r;
+        await Promise.all([notesStore.refresh(), foldersStore.refresh()]);
+      }
     } catch (err: unknown) {
       result = {
         imported: 0,
         duplicatesSkipped: 0,
         duplicatesOverwritten: 0,
         duplicatesRenamed: 0,
+        duplicatesUnchanged: 0,
         strippedCount: 0,
         errors: [err instanceof Error ? err.message : 'Import failed']
       };
@@ -76,68 +119,51 @@
   <DialogContent>
     <DialogHeader>
       <DialogTitle>
-        {$t('folders.import_markdown.dialog_title', { values: { name: folderName } })}
+        {#if mode === 'folder'}
+          {$t('folders.import_folder.dialog_title', { values: { name: folderName } })}
+        {:else}
+          {$t('folders.import_markdown.dialog_title', { values: { name: folderName } })}
+        {/if}
       </DialogTitle>
       <DialogDescription>
-        {$t('folders.import_markdown.dialog_description')}
+        {#if mode === 'folder'}
+          {$t('folders.import_folder.dialog_description')}
+        {:else}
+          {$t('folders.import_markdown.dialog_description')}
+        {/if}
       </DialogDescription>
     </DialogHeader>
 
     {#if files && !result}
-      <MarkdownImportStrategyPicker
-        count={files.length}
-        bind:strategy
-        promptVariant="folder"
-        radioGroupName="folder-md-import-strategy"
-      />
+      <div class="space-y-3">
+        <MarkdownImportStrategyPicker
+          count={importableCount}
+          bind:strategy
+          promptVariant="folder"
+          radioGroupName="folder-md-import-strategy"
+        />
+        {#if mode === 'folder' && rootName}
+          <label class="flex items-start gap-2 text-xs cursor-pointer">
+            <input type="checkbox" bind:checked={keepRootFolder} class="mt-0.5" />
+            <span>
+              <span class="font-medium">
+                {$t('settings_page.export_import.keep_root_label', {
+                  values: { name: rootName }
+                })}
+              </span>
+              <span class="block text-muted-foreground">
+                {$t('settings_page.export_import.keep_root_destination', {
+                  values: { path: destinationPath }
+                })}
+              </span>
+            </span>
+          </label>
+        {/if}
+      </div>
     {/if}
 
     {#if result}
-      <div
-        class="rounded-md px-3 py-2 text-xs space-y-1
-        {result.errors.length === 0
-          ? 'bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-400'
-          : 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'}"
-      >
-        {#if result.imported > 0}
-          <p>
-            {$t('settings_page.export_import.imported_count', {
-              values: { count: result.imported }
-            })}
-          </p>
-        {/if}
-        {#if result.duplicatesOverwritten > 0}
-          <p class="text-muted-foreground">
-            {$t('settings_page.export_import.dedup_count_overwritten', {
-              values: { count: result.duplicatesOverwritten }
-            })}
-          </p>
-        {/if}
-        {#if result.duplicatesRenamed > 0}
-          <p class="text-muted-foreground">
-            {$t('settings_page.export_import.dedup_count_renamed', {
-              values: { count: result.duplicatesRenamed }
-            })}
-          </p>
-        {/if}
-        {#if result.duplicatesSkipped > 0}
-          <p class="text-muted-foreground">
-            {$t('settings_page.export_import.dedup_count_skipped', {
-              values: { count: result.duplicatesSkipped }
-            })}
-          </p>
-        {/if}
-        {#if result.strippedCount > 0}
-          <p>
-            {$t('settings_page.export_import.unsafe_content_stripped', {
-              values: { count: result.strippedCount }
-            })}
-          </p>
-        {/if}
-        {#each result.errors as err}
-          <p>{err}</p>
-        {/each}
-      </div>
+      <ImportResultSummary {result} />
     {/if}
 
     <DialogFooter>
@@ -145,8 +171,12 @@
         <Button variant="outline" onclick={close} disabled={importing}>
           {$t('settings_page.export_import.cancel')}
         </Button>
-        <Button onclick={runImport} disabled={importing || !files || files.length === 0}>
-          <Upload class="mr-1.5 h-3.5 w-3.5" />
+        <Button onclick={runImport} disabled={importing || !files || importableCount === 0}>
+          {#if mode === 'folder'}
+            <FolderInput class="mr-1.5 h-3.5 w-3.5" />
+          {:else}
+            <Upload class="mr-1.5 h-3.5 w-3.5" />
+          {/if}
           {importing
             ? $t('settings_page.export_import.importing')
             : $t('settings_page.export_import.dedup_start')}

--- a/apps/reborn-notes/src/lib/components/import/ImportResultSummary.svelte
+++ b/apps/reborn-notes/src/lib/components/import/ImportResultSummary.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { t } from '$lib/stores/i18n.store';
+  import type {
+    ImportFolderResult,
+    ImportMarkdownResult
+  } from '$lib/services/export-import.service';
+
+  let {
+    result,
+    class: className = ''
+  }: {
+    result: ImportMarkdownResult | ImportFolderResult;
+    class?: string;
+  } = $props();
+
+  // Folder imports carry extra counters (created folders/tags, skip buckets).
+  // Field presence is the discriminator - no separate `kind` prop to drift.
+  const folderResult = $derived('foldersCreated' in result ? result : null);
+</script>
+
+<div
+  class="rounded-md px-3 py-2 text-xs space-y-1 {className}
+  {result.errors.length === 0
+    ? 'bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-400'
+    : 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'}"
+>
+  {#if result.imported > 0}
+    <p>
+      {#if folderResult}
+        {$t('settings_page.export_import.folder_import_summary', {
+          values: {
+            imported: folderResult.imported,
+            folders: folderResult.foldersCreated,
+            tags: folderResult.tagsCreated
+          }
+        })}
+      {:else}
+        {$t('settings_page.export_import.imported_count', {
+          values: { count: result.imported }
+        })}
+      {/if}
+    </p>
+  {/if}
+  {#if folderResult}
+    {#if folderResult.skippedHidden > 0}
+      <p class="text-muted-foreground">
+        {$t('settings_page.export_import.folder_import_skipped_hidden', {
+          values: { count: folderResult.skippedHidden }
+        })}
+      </p>
+    {/if}
+    {#if folderResult.skippedNonMarkdown > 0}
+      <p class="text-muted-foreground">
+        {$t('settings_page.export_import.folder_import_skipped_non_md', {
+          values: { count: folderResult.skippedNonMarkdown }
+        })}
+      </p>
+    {/if}
+    {#if folderResult.skippedTooLarge > 0}
+      <p class="text-muted-foreground">
+        {$t('settings_page.export_import.folder_import_skipped_too_large', {
+          values: { count: folderResult.skippedTooLarge }
+        })}
+      </p>
+    {/if}
+  {/if}
+  {#if result.duplicatesOverwritten > 0}
+    <p class="text-muted-foreground">
+      {$t('settings_page.export_import.dedup_count_overwritten', {
+        values: { count: result.duplicatesOverwritten }
+      })}
+    </p>
+  {/if}
+  {#if result.duplicatesRenamed > 0}
+    <p class="text-muted-foreground">
+      {$t('settings_page.export_import.dedup_count_renamed', {
+        values: { count: result.duplicatesRenamed }
+      })}
+    </p>
+  {/if}
+  {#if result.duplicatesSkipped > 0}
+    <p class="text-muted-foreground">
+      {$t('settings_page.export_import.dedup_count_skipped', {
+        values: { count: result.duplicatesSkipped }
+      })}
+    </p>
+  {/if}
+  {#if result.duplicatesUnchanged > 0}
+    <p class="text-muted-foreground">
+      {$t('settings_page.export_import.dedup_count_unchanged', {
+        values: { count: result.duplicatesUnchanged }
+      })}
+    </p>
+  {/if}
+  {#if result.strippedCount > 0}
+    <p>
+      {$t('settings_page.export_import.unsafe_content_stripped', {
+        values: { count: result.strippedCount }
+      })}
+    </p>
+  {/if}
+  {#each result.errors as err}
+    <p>{err}</p>
+  {/each}
+</div>

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderActionMenu.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderActionMenu.svelte
@@ -2,6 +2,7 @@
   import {
     MoreVertical,
     FolderPlus,
+    FolderInput,
     Pencil,
     Trash2,
     Upload
@@ -53,8 +54,10 @@
   let sheetOpen = $state(false);
   let deleteDialogOpen = $state(false);
   let importDialogOpen = $state(false);
+  let importMode = $state<'files' | 'folder'>('files');
   let importPendingFiles = $state<File[] | null>(null);
   let importFileInputEl = $state<HTMLInputElement | null>(null);
+  let importFolderInputEl = $state<HTMLInputElement | null>(null);
 
   function openSheet() {
     sheetOpen = true;
@@ -72,10 +75,19 @@
 
   function handleImportHere() {
     sheetOpen = false;
+    importMode = 'files';
     if (importFileInputEl) importFileInputEl.value = '';
     importFileInputEl?.click();
   }
 
+  function handleImportFolderHere() {
+    sheetOpen = false;
+    importMode = 'folder';
+    if (importFolderInputEl) importFolderInputEl.value = '';
+    importFolderInputEl?.click();
+  }
+
+  // Shared by both hidden inputs - `importMode` was set by the trigger.
   function handleImportFilesSelected(e: Event) {
     const input = e.target as HTMLInputElement;
     const files = Array.from(input.files ?? []);
@@ -143,6 +155,10 @@
           <Upload class="h-3.5 w-3.5" />
           {$t('folders.import_markdown.action')}
         </DropdownMenuItem>
+        <DropdownMenuItem onclick={handleImportFolderHere}>
+          <FolderInput class="h-3.5 w-3.5" />
+          {$t('folders.import_folder.action')}
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           class="text-destructive focus:text-destructive"
@@ -177,6 +193,10 @@
         <Upload class="mr-2 h-4 w-4" />
         {$t('folders.import_markdown.action')}
       </Button>
+      <Button variant="ghost" class="w-full justify-start" onclick={handleImportFolderHere}>
+        <FolderInput class="mr-2 h-4 w-4" />
+        {$t('folders.import_folder.action')}
+      </Button>
       <Button
         variant="ghost"
         class="w-full justify-start text-destructive hover:text-destructive"
@@ -196,11 +216,19 @@
   onConfirm={confirmDeleteFolder}
 />
 
-<!-- Hidden file input for "Import .md tutaj" — triggered from the menu -->
+<!-- Hidden file inputs for "Import .md here" / "Import folder here" - triggered from the menu -->
 <input
   bind:this={importFileInputEl}
   type="file"
   accept=".md,text/markdown"
+  multiple
+  class="hidden"
+  onchange={handleImportFilesSelected}
+/>
+<input
+  bind:this={importFolderInputEl}
+  type="file"
+  webkitdirectory
   multiple
   class="hidden"
   onchange={handleImportFilesSelected}
@@ -211,4 +239,5 @@
   files={importPendingFiles}
   folderId={folder?.id ?? null}
   folderName={folder?.name ?? ''}
+  mode={importMode}
 />

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -10,6 +10,7 @@
     ChevronRight,
     Folder,
     FolderOpen,
+    FolderInput,
     MoreHorizontal,
     FolderPlus,
     Pencil,
@@ -190,22 +191,36 @@
     folderToDelete = null;
   }
 
-  // ── Import .md to folder ────────────────────────────────────────
+  // ── Import .md files / folder tree to folder ────────────────────
   let importDialogOpen = $state(false);
+  let importMode = $state<'files' | 'folder'>('files');
   let importTargetFolder = $state<FolderWithChildren | null>(null);
   let importPendingFiles = $state<File[] | null>(null);
   let importFileInputEl = $state<HTMLInputElement | null>(null);
+  let importFolderInputEl = $state<HTMLInputElement | null>(null);
 
   function handleImportHere(folder: FolderWithChildren, e?: Event) {
     e?.stopPropagation();
     menuOpenId = null;
     folderActionSheetOpen = false;
+    importMode = 'files';
     importTargetFolder = folder;
     // Reset value so re-selecting the same files re-fires `change`.
     if (importFileInputEl) importFileInputEl.value = '';
     importFileInputEl?.click();
   }
 
+  function handleImportFolderHere(folder: FolderWithChildren, e?: Event) {
+    e?.stopPropagation();
+    menuOpenId = null;
+    folderActionSheetOpen = false;
+    importMode = 'folder';
+    importTargetFolder = folder;
+    if (importFolderInputEl) importFolderInputEl.value = '';
+    importFolderInputEl?.click();
+  }
+
+  // Shared by both hidden inputs - `importMode` was set by the trigger.
   function handleImportFilesSelected(e: Event) {
     const input = e.target as HTMLInputElement;
     const files = Array.from(input.files ?? []);
@@ -420,6 +435,10 @@
                   <Upload class="h-3.5 w-3.5" />
                   {$t('folders.import_markdown.action')}
                 </DropdownMenuItem>
+                <DropdownMenuItem onclick={(e) => handleImportFolderHere(folder, e)}>
+                  <FolderInput class="h-3.5 w-3.5" />
+                  {$t('folders.import_folder.action')}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   class="text-destructive focus:text-destructive"
@@ -497,6 +516,14 @@
       </Button>
       <Button
         variant="ghost"
+        class="w-full justify-start"
+        onclick={() => activeMenuFolder && handleImportFolderHere(activeMenuFolder)}
+      >
+        <FolderInput class="mr-2 h-4 w-4" />
+        {$t('folders.import_folder.action')}
+      </Button>
+      <Button
+        variant="ghost"
         class="w-full justify-start text-destructive hover:text-destructive"
         onclick={() => activeMenuFolder && handleDelete(activeMenuFolder)}
       >
@@ -514,11 +541,19 @@
   onConfirm={confirmDeleteFolder}
 />
 
-<!-- Hidden file input for "Import .md tutaj" — triggered from the menu -->
+<!-- Hidden file inputs for "Import .md here" / "Import folder here" - triggered from the menu -->
 <input
   bind:this={importFileInputEl}
   type="file"
   accept=".md,text/markdown"
+  multiple
+  class="hidden"
+  onchange={handleImportFilesSelected}
+/>
+<input
+  bind:this={importFolderInputEl}
+  type="file"
+  webkitdirectory
   multiple
   class="hidden"
   onchange={handleImportFilesSelected}
@@ -529,4 +564,5 @@
   files={importPendingFiles}
   folderId={importTargetFolder?.id ?? null}
   folderName={importTargetFolder?.name ?? ''}
+  mode={importMode}
 />

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -1336,7 +1336,10 @@ export async function importMarkdownFiles(
       // tagIds: undefined - the flat .md import does not manage tags (no
       // frontmatter tag resolution), so overwrite must leave the existing
       // note's tags untouched rather than wiping them with an empty set.
-      const { outcome, noteId } = await applyDuplicateStrategy({
+      // Kept un-destructured: narrowing `noteId` to `string` in the final
+      // branch relies on the discriminated union, and TS only tracks that
+      // reliably through property access, not destructured locals.
+      const dedup = await applyDuplicateStrategy({
         baseTitle,
         content: sanitized,
         folderId,
@@ -1346,16 +1349,16 @@ export async function importMarkdownFiles(
         lookup,
         strategy: duplicateStrategy
       });
-      if (outcome === 'skipped') {
+      if (dedup.outcome === 'skipped') {
         result.duplicatesSkipped++;
-      } else if (outcome === 'unchanged') {
+      } else if (dedup.outcome === 'unchanged') {
         result.duplicatesUnchanged++;
       } else {
-        if (outcome === 'overwritten') result.duplicatesOverwritten++;
-        else if (outcome === 'renamed') result.duplicatesRenamed++;
+        if (dedup.outcome === 'overwritten') result.duplicatesOverwritten++;
+        else if (dedup.outcome === 'renamed') result.duplicatesRenamed++;
         result.imported++;
         // Push the freshly-saved note (skipSync was true on the storage write).
-        const note = await noteStore.get(noteId);
+        const note = await noteStore.get(dedup.noteId);
         if (note) pushNote(note);
       }
     } catch (e: unknown) {
@@ -1394,7 +1397,13 @@ export async function importMarkdownFiles(
  */
 type DuplicateOutcomeResult =
   | { outcome: 'created' | 'overwritten' | 'renamed'; noteId: string }
-  | { outcome: 'skipped' | 'unchanged'; noteId: undefined };
+  // The two non-writing outcomes stay SEPARATE constituents (not
+  // `'skipped' | 'unchanged'` in one): control-flow exclusion (`!==` in an
+  // else-chain) only drops a constituent whose discriminant narrows to
+  // never, so a multi-literal constituent would survive both negations and
+  // `noteId` would stay `string | undefined` in the writing branch.
+  | { outcome: 'skipped'; noteId: undefined }
+  | { outcome: 'unchanged'; noteId: undefined };
 
 /**
  * Apply the selected duplicate-handling strategy for a single file.

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -56,6 +56,7 @@ import {
 import {
   computeRenamedTitle,
   findExisting,
+  isImportUnchanged,
   rememberTitle,
   folderKey,
   type DuplicateStrategy,
@@ -1257,6 +1258,12 @@ export type ImportMarkdownResult = {
   duplicatesSkipped: number;
   duplicatesOverwritten: number;
   duplicatesRenamed: number;
+  /**
+   * `overwrite` strategy only: duplicates whose stored note already matches
+   * the imported file exactly - no write, no sync push, no `updated_at` bump.
+   * Makes repeated "re-import to refresh" runs cheap and idempotent.
+   */
+  duplicatesUnchanged: number;
   errors: string[];
   strippedCount: number;
 };
@@ -1303,6 +1310,7 @@ export async function importMarkdownFiles(
     duplicatesSkipped: 0,
     duplicatesOverwritten: 0,
     duplicatesRenamed: 0,
+    duplicatesUnchanged: 0,
     errors: [],
     strippedCount: 0
   };
@@ -1325,11 +1333,14 @@ export async function importMarkdownFiles(
       result.strippedCount += stripped.length;
       const baseTitle = title ?? (file.name.replace(/\.md$/i, '') || 'Untitled');
       const { createdAt, modifiedAt } = pickImportTimestamps(parsed, file.lastModified);
+      // tagIds: undefined - the flat .md import does not manage tags (no
+      // frontmatter tag resolution), so overwrite must leave the existing
+      // note's tags untouched rather than wiping them with an empty set.
       const { outcome, noteId } = await applyDuplicateStrategy({
         baseTitle,
         content: sanitized,
         folderId,
-        tagIds: [],
+        tagIds: undefined,
         modifiedAt,
         createdAt,
         lookup,
@@ -1337,6 +1348,8 @@ export async function importMarkdownFiles(
       });
       if (outcome === 'skipped') {
         result.duplicatesSkipped++;
+      } else if (outcome === 'unchanged') {
+        result.duplicatesUnchanged++;
       } else {
         if (outcome === 'overwritten') result.duplicatesOverwritten++;
         else if (outcome === 'renamed') result.duplicatesRenamed++;
@@ -1373,14 +1386,15 @@ export async function importMarkdownFiles(
 /**
  * Per-file outcome reported by {@link applyDuplicateStrategy}.
  *
- * `skipped` does not bump the imported counter (existing note left alone);
- * the others all produce a persisted note. `noteId` is `undefined` for
- * `skipped` only — callers that bulk-push on completion should iterate
- * over the populated ids.
+ * `skipped` (existing note left alone by user choice) and `unchanged`
+ * (overwrite requested, but the stored note already matches the file) do not
+ * bump the imported counter; the others all produce a persisted note.
+ * `noteId` is `undefined` for the non-writing outcomes - callers that
+ * bulk-push on completion should iterate over the populated ids.
  */
 type DuplicateOutcomeResult =
   | { outcome: 'created' | 'overwritten' | 'renamed'; noteId: string }
-  | { outcome: 'skipped'; noteId: undefined };
+  | { outcome: 'skipped' | 'unchanged'; noteId: undefined };
 
 /**
  * Apply the selected duplicate-handling strategy for a single file.
@@ -1391,12 +1405,15 @@ type DuplicateOutcomeResult =
  * `tagIds` is the list of tag ids resolved from frontmatter (already
  * find-or-created by the caller). For `overwrite`, this REPLACES the
  * existing note's tag set — frontmatter is treated as the source of truth.
+ * `undefined` means the import path does not manage tags at all (flat .md
+ * import): tags are then ignored both for the unchanged-comparison and on
+ * overwrite (the existing note's tags survive).
  */
 async function applyDuplicateStrategy(args: {
   baseTitle: string;
   content: string;
   folderId: string | undefined;
-  tagIds: string[];
+  tagIds: string[] | undefined;
   createdAt: string | undefined;
   modifiedAt: string | undefined;
   lookup: TitleLookup;
@@ -1411,7 +1428,7 @@ async function applyDuplicateStrategy(args: {
       updatedAt: modifiedAt ?? createdAt,
       skipSync: true
     });
-    if (tagIds.length > 0) {
+    if (tagIds && tagIds.length > 0) {
       await TagService.setTagsForNote(newId, tagIds, { skipSync: true });
     }
     rememberTitle(lookup, folderId, baseTitle, newId);
@@ -1423,12 +1440,31 @@ async function applyDuplicateStrategy(args: {
   }
 
   if (strategy === 'overwrite') {
+    // Skip the write entirely when the stored note already matches the file -
+    // repeated "re-import to refresh" runs stay cheap (no re-encrypt, no sync
+    // push) and don't shuffle every note to the top of `updated_at` ordering.
+    // getNote() returns null for trashed notes, but those never reach this
+    // point: the title lookup is built from non-archived index entries only.
+    const existingNote = await NoteService.getNote(existingId);
+    if (existingNote) {
+      const existingTagIds =
+        tagIds === undefined ? [] : await noteTagQueries.getTagsForNote(existingId);
+      const unchanged = isImportUnchanged(
+        { title: existingNote.title, content: existingNote.content, tagIds: existingTagIds },
+        { title: baseTitle, content, tagIds }
+      );
+      if (unchanged) {
+        return { outcome: 'unchanged', noteId: undefined };
+      }
+    }
     await NoteService.updateNote(existingId, baseTitle, content, {
       updatedAt: modifiedAt ?? new Date().toISOString(),
       skipSync: true
     });
-    // Replace tag set with frontmatter tags (source of truth on overwrite).
-    await TagService.setTagsForNote(existingId, tagIds, { skipSync: true });
+    if (tagIds !== undefined) {
+      // Replace tag set with frontmatter tags (source of truth on overwrite).
+      await TagService.setTagsForNote(existingId, tagIds, { skipSync: true });
+    }
     return { outcome: 'overwritten', noteId: existingId };
   }
 
@@ -1442,7 +1478,7 @@ async function applyDuplicateStrategy(args: {
     updatedAt: modifiedAt ?? createdAt,
     skipSync: true
   });
-  if (tagIds.length > 0) {
+  if (tagIds && tagIds.length > 0) {
     await TagService.setTagsForNote(newId, tagIds, { skipSync: true });
   }
   rememberTitle(lookup, folderId, renamedTitle, newId);
@@ -1472,15 +1508,20 @@ function flattenFolderTree(nodes: FolderWithChildren[]): FolderLookupEntry[] {
  * any missing intermediate folders. Matches existing folders case-insensitively
  * on (parent_id, name). Mutates `lookup` so subsequent calls in the same
  * batch can reuse folders created earlier in this import.
+ *
+ * `startParentId` anchors the walk under an existing folder instead of the
+ * root level ("import folder here" from a folder's context menu). An empty
+ * path resolves to the anchor itself.
  */
 async function findOrCreateFolderByPath(
   pathSegments: string[],
   lookup: FolderLookupEntry[],
-  counter: { count: number }
+  counter: { count: number },
+  startParentId?: string
 ): Promise<string | undefined> {
-  if (pathSegments.length === 0) return undefined;
+  if (pathSegments.length === 0) return startParentId;
 
-  let parentId: string | undefined = undefined;
+  let parentId: string | undefined = startParentId;
   for (const segment of pathSegments) {
     const segmentLower = segment.toLowerCase();
     const existing = lookup.find(
@@ -1530,8 +1571,25 @@ export type ImportFolderResult = {
   duplicatesSkipped: number;
   duplicatesOverwritten: number;
   duplicatesRenamed: number;
+  /** See {@link ImportMarkdownResult.duplicatesUnchanged}. */
+  duplicatesUnchanged: number;
   strippedCount: number;
   errors: string[];
+};
+
+export type ImportFolderOptions = {
+  /**
+   * Recreate the selected directory itself as a folder (find-or-create by
+   * name, case-insensitive) instead of importing only its contents. This is
+   * what makes "import `reapps-docs`, edit locally, re-import to refresh"
+   * land in the same `reapps-docs` folder every time.
+   */
+  keepRootFolder?: boolean;
+  /**
+   * Anchor the imported tree under an existing folder instead of the root
+   * level ("import folder here" from a folder's context menu).
+   */
+  targetFolderId?: string;
 };
 
 /**
@@ -1553,11 +1611,17 @@ export type ImportFolderResult = {
  * mutates as the batch progresses, so two files in the source vault sharing
  * a name within the same directory will also be deduplicated against each
  * other (e.g. `Notes.md` + `notes.md` → `Notes.md` + `Notes (2).md`).
+ *
+ * `opts` (see {@link ImportFolderOptions}) selects where the tree lands:
+ * `keepRootFolder` recreates the selected directory itself; `targetFolderId`
+ * anchors everything under an existing folder. Combined with the `overwrite`
+ * strategy this makes re-importing the same directory an idempotent refresh.
  */
 export async function importFolder(
   files: File[],
   duplicateStrategy: DuplicateStrategy = 'rename',
-  onProgress?: ImportProgressCallback
+  onProgress?: ImportProgressCallback,
+  opts?: ImportFolderOptions
 ): Promise<ImportFolderResult> {
   const result: ImportFolderResult = {
     imported: 0,
@@ -1569,9 +1633,12 @@ export async function importFolder(
     duplicatesSkipped: 0,
     duplicatesOverwritten: 0,
     duplicatesRenamed: 0,
+    duplicatesUnchanged: 0,
     strippedCount: 0,
     errors: []
   };
+  const keepRootFolder = opts?.keepRootFolder ?? false;
+  const targetFolderId = opts?.targetFolderId;
 
   // 1. Skip files in hidden directories (.obsidian/, .trash/, etc.).
   //    Applied FIRST so we don't pollute the non-markdown counter with
@@ -1634,14 +1701,19 @@ export async function importFolder(
   // 6. Resolve every unique directory path to a folder id up-front.
   const pathToFolderId = new Map<string, string | undefined>();
   for (const file of sizedFiles) {
-    const segments = extractFolderSegments(file.webkitRelativePath);
+    const segments = extractFolderSegments(file.webkitRelativePath, keepRootFolder);
     const key = segments.join('/');
     if (pathToFolderId.has(key)) continue;
     try {
-      const folderId = await findOrCreateFolderByPath(segments, folderLookup, foldersCounter);
+      const folderId = await findOrCreateFolderByPath(
+        segments,
+        folderLookup,
+        foldersCounter,
+        targetFolderId
+      );
       pathToFolderId.set(key, folderId);
     } catch (e: unknown) {
-      pathToFolderId.set(key, undefined);
+      pathToFolderId.set(key, targetFolderId);
       result.errors.push(`Folder "${key}": ${e instanceof Error ? e.message : 'błąd'}`);
     }
   }
@@ -1661,7 +1733,7 @@ export async function importFolder(
     try {
       const raw = await file.text();
       const parsed = parseMarkdownFile(raw);
-      const segments = extractFolderSegments(file.webkitRelativePath);
+      const segments = extractFolderSegments(file.webkitRelativePath, keepRootFolder);
       const folderId = pathToFolderId.get(segments.join('/'));
 
       const fallbackTitle = file.name.replace(/\.md$/i, '') || 'Untitled';
@@ -1700,6 +1772,8 @@ export async function importFolder(
 
       if (outcome === 'skipped') {
         result.duplicatesSkipped++;
+      } else if (outcome === 'unchanged') {
+        result.duplicatesUnchanged++;
       } else {
         if (outcome === 'overwritten') result.duplicatesOverwritten++;
         else if (outcome === 'renamed') result.duplicatesRenamed++;

--- a/apps/reborn-notes/src/lib/services/import-dedup-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/import-dedup-utils.spec.ts
@@ -4,6 +4,7 @@ import {
   rememberTitle,
   findExisting,
   computeRenamedTitle,
+  isImportUnchanged,
   ROOT_FOLDER_KEY,
   MAX_TITLE_LENGTH,
   type TitleLookup
@@ -110,5 +111,60 @@ describe('computeRenamedTitle', () => {
   it('returns the first free slot, even when only the base is taken (not a sequence)', () => {
     const taken = new Set(['notes', 'notes (5)']);
     expect(computeRenamedTitle('Notes', taken)).toBe('Notes (2)');
+  });
+});
+
+describe('isImportUnchanged', () => {
+  const existing = { title: 'Notes', content: '# Hello', tagIds: ['t1', 't2'] };
+
+  it('returns true when title, content and tag set match', () => {
+    expect(
+      isImportUnchanged(existing, { title: 'Notes', content: '# Hello', tagIds: ['t2', 't1'] })
+    ).toBe(true);
+  });
+
+  it('is case-SENSITIVE on title (a title-case change is a real update)', () => {
+    expect(
+      isImportUnchanged(existing, { title: 'notes', content: '# Hello', tagIds: ['t1', 't2'] })
+    ).toBe(false);
+  });
+
+  it('returns false on any content difference', () => {
+    expect(
+      isImportUnchanged(existing, { title: 'Notes', content: '# Hello!', tagIds: ['t1', 't2'] })
+    ).toBe(false);
+  });
+
+  it('ignores tags entirely when incoming tagIds is undefined (flat .md import)', () => {
+    expect(isImportUnchanged(existing, { title: 'Notes', content: '# Hello' })).toBe(true);
+  });
+
+  it('compares tag sets order-insensitively but exactly', () => {
+    expect(
+      isImportUnchanged(existing, { title: 'Notes', content: '# Hello', tagIds: ['t1'] })
+    ).toBe(false);
+    expect(
+      isImportUnchanged(existing, {
+        title: 'Notes',
+        content: '# Hello',
+        tagIds: ['t1', 't3']
+      })
+    ).toBe(false);
+  });
+
+  it('treats an empty incoming tag list as different from existing tags', () => {
+    expect(
+      isImportUnchanged(existing, { title: 'Notes', content: '# Hello', tagIds: [] })
+    ).toBe(false);
+  });
+
+  it('uses set semantics: repeated incoming tag ids do not fake a length match', () => {
+    expect(
+      isImportUnchanged(existing, {
+        title: 'Notes',
+        content: '# Hello',
+        tagIds: ['t1', 't1']
+      })
+    ).toBe(false);
   });
 });

--- a/apps/reborn-notes/src/lib/services/import-dedup-utils.ts
+++ b/apps/reborn-notes/src/lib/services/import-dedup-utils.ts
@@ -60,6 +60,39 @@ export function findExisting(
 }
 
 /**
+ * Decide whether an `overwrite`-strategy import can skip the write entirely
+ * because the incoming file is identical to the already-stored note.
+ *
+ * Comparison is exact (case-sensitive) on title and content - a deliberate
+ * asymmetry with the case-INsensitive duplicate *detection*: "notes.md" is
+ * matched against an existing "Notes.md" (so it doesn't duplicate), but the
+ * title-case change still counts as a real update.
+ *
+ * `incoming.tagIds === undefined` means the import path does not manage tags
+ * (flat .md import) - tags are then excluded from the comparison, mirroring
+ * the overwrite behavior of leaving them untouched. When provided (folder
+ * import, frontmatter as source of truth), tag sets are compared
+ * order-insensitively.
+ */
+export function isImportUnchanged(
+  existing: { title: string; content: string; tagIds: string[] },
+  incoming: { title: string; content: string; tagIds?: string[] }
+): boolean {
+  if (existing.title !== incoming.title) return false;
+  if (existing.content !== incoming.content) return false;
+  if (incoming.tagIds === undefined) return true;
+  // Set semantics on both sides - frontmatter can repeat a tag (`tags: [a, a]`)
+  // and setTagsForNote would collapse it anyway, so duplicates must not count.
+  const existingSet = new Set(existing.tagIds);
+  const incomingSet = new Set(incoming.tagIds);
+  if (existingSet.size !== incomingSet.size) return false;
+  for (const id of incomingSet) {
+    if (!existingSet.has(id)) return false;
+  }
+  return true;
+}
+
+/**
  * Compute a non-colliding renamed title by appending ` (N)` until the slot
  * is free. Trims the base title so that the longest possible suffix
  * (` (999)` ≈ 6 chars; bounded at 9999 here for safety) still fits within

--- a/apps/reborn-notes/src/lib/services/markdown-import-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/markdown-import-utils.spec.ts
@@ -3,6 +3,8 @@ import {
   parseMarkdownFile,
   extractFolderSegments,
   containsHiddenSegment,
+  countImportableMarkdownFiles,
+  getRootFolderName,
   normalizeFrontmatterDate,
   pickImportTimestamps
 } from './markdown-import-utils';
@@ -109,6 +111,88 @@ describe('extractFolderSegments', () => {
 
   it('ignores double slashes and leading slash artifacts', () => {
     expect(extractFolderSegments('/Root//a/note.md')).toEqual(['a']);
+  });
+
+  describe('keepRoot', () => {
+    it('preserves the root directory as the first segment', () => {
+      expect(extractFolderSegments('MyVault/Projects/Web/note.md', true)).toEqual([
+        'MyVault',
+        'Projects',
+        'Web'
+      ]);
+    });
+
+    it('maps a file directly in the chosen root to [root]', () => {
+      expect(extractFolderSegments('MyVault/note.md', true)).toEqual(['MyVault']);
+    });
+
+    it('returns [] for an empty path', () => {
+      expect(extractFolderSegments('', true)).toEqual([]);
+    });
+
+    it('returns [] for a bare filename without any directory', () => {
+      expect(extractFolderSegments('note.md', true)).toEqual([]);
+    });
+  });
+});
+
+describe('getRootFolderName', () => {
+  it('reads the first segment of the first file with a relative path', () => {
+    expect(
+      getRootFolderName([
+        { name: 'a.md', webkitRelativePath: 'reapps-docs/guidelines/a.md' },
+        { name: 'b.md', webkitRelativePath: 'reapps-docs/b.md' }
+      ])
+    ).toBe('reapps-docs');
+  });
+
+  it('skips files without a relative path', () => {
+    expect(
+      getRootFolderName([
+        { name: 'pasted.md' },
+        { name: 'a.md', webkitRelativePath: 'Vault/a.md' }
+      ])
+    ).toBe('Vault');
+  });
+
+  it('tolerates leading slash artifacts', () => {
+    expect(getRootFolderName([{ name: 'a.md', webkitRelativePath: '/Vault/a.md' }])).toBe(
+      'Vault'
+    );
+  });
+
+  it('returns null when no file carries a relative path', () => {
+    expect(getRootFolderName([{ name: 'a.md' }, { name: 'b.md', webkitRelativePath: '' }])).toBe(
+      null
+    );
+  });
+
+  it('returns null for an empty list', () => {
+    expect(getRootFolderName([])).toBe(null);
+  });
+});
+
+describe('countImportableMarkdownFiles', () => {
+  it('counts only .md files outside hidden directories', () => {
+    expect(
+      countImportableMarkdownFiles([
+        { name: 'a.md', webkitRelativePath: 'Vault/a.md' },
+        { name: 'B.MD', webkitRelativePath: 'Vault/sub/B.MD' },
+        { name: 'plugin.json', webkitRelativePath: 'Vault/.obsidian/plugin.json' },
+        { name: 'trashed.md', webkitRelativePath: 'Vault/.trash/trashed.md' },
+        { name: 'image.png', webkitRelativePath: 'Vault/image.png' }
+      ])
+    ).toBe(2);
+  });
+
+  it('does not treat a hidden ROOT directory as hidden (user picked it)', () => {
+    expect(
+      countImportableMarkdownFiles([{ name: 'a.md', webkitRelativePath: '.vault/a.md' }])
+    ).toBe(1);
+  });
+
+  it('counts flat files without a relative path by extension only', () => {
+    expect(countImportableMarkdownFiles([{ name: 'a.md' }, { name: 'b.txt' }])).toBe(1);
   });
 });
 

--- a/apps/reborn-notes/src/lib/services/markdown-import-utils.ts
+++ b/apps/reborn-notes/src/lib/services/markdown-import-utils.ts
@@ -75,20 +75,63 @@ export function parseMarkdownFile(raw: string): ParsedMarkdown {
 }
 
 /**
- * Split `file.webkitRelativePath` into folder segments, stripping:
- *  - the first segment (the root vault directory the user selected — its
- *    contents are imported, not the vault itself)
- *  - the last segment (the filename)
+ * Split `file.webkitRelativePath` into folder segments, stripping the last
+ * segment (the filename) and - by default - the first segment (the root
+ * directory the user selected: its contents are imported, not the container).
  *
- * Examples:
+ * `keepRoot: true` preserves that first segment, so the selected directory
+ * itself becomes a folder in the imported tree (used by the "keep top-level
+ * folder" import option).
+ *
+ * Examples (default):
  *   "MyVault/Projects/Web/note.md"  → ["Projects", "Web"]
  *   "MyVault/note.md"               → []
  *   ""                              → []
+ * Examples (keepRoot):
+ *   "MyVault/Projects/Web/note.md"  → ["MyVault", "Projects", "Web"]
+ *   "MyVault/note.md"               → ["MyVault"]
  */
-export function extractFolderSegments(relativePath: string): string[] {
+export function extractFolderSegments(relativePath: string, keepRoot = false): string[] {
   const parts = (relativePath || '').split('/').filter(Boolean);
-  if (parts.length <= 2) return [];
-  return parts.slice(1, -1);
+  const start = keepRoot ? 0 : 1;
+  if (parts.length - 1 <= start) return [];
+  return parts.slice(start, -1);
+}
+
+/** Minimal structural slice of `File` used by the pure pre-filter helpers. */
+export type ImportFileLike = {
+  name: string;
+  webkitRelativePath?: string;
+};
+
+/**
+ * Name of the root directory the user picked, read from the first available
+ * `webkitRelativePath`. Returns `null` when no file carries a relative path
+ * (defensive - a `webkitdirectory` input always populates it in practice).
+ */
+export function getRootFolderName(files: ImportFileLike[]): string | null {
+  for (const f of files) {
+    const first = (f.webkitRelativePath || '').split('/').filter(Boolean)[0];
+    if (first) return first;
+  }
+  return null;
+}
+
+/**
+ * Mirror of the importer's pre-filter pipeline (hidden directories + `.md`
+ * extension), used to show an honest "X notes ready to import" preview
+ * before the user commits to a duplicate strategy. The per-file size cap is
+ * intentionally not mirrored here - the importer reports `skippedTooLarge`
+ * in its result instead.
+ */
+export function countImportableMarkdownFiles(files: ImportFileLike[]): number {
+  let count = 0;
+  for (const f of files) {
+    if (containsHiddenSegment(f.webkitRelativePath ?? '')) continue;
+    if (!f.name.toLowerCase().endsWith('.md')) continue;
+    count++;
+  }
+  return count;
 }
 
 /**

--- a/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
@@ -39,8 +39,13 @@
     type ImportProgress
   } from '$lib/services/export-import.service';
   import type { DuplicateStrategy } from '$lib/services/import-dedup-utils';
+  import {
+    countImportableMarkdownFiles,
+    getRootFolderName
+  } from '$lib/services/markdown-import-utils';
   import { notesStore } from '$lib/stores/notes.store';
   import MarkdownImportStrategyPicker from '$lib/components/import/MarkdownImportStrategyPicker.svelte';
+  import ImportResultSummary from '$lib/components/import/ImportResultSummary.svelte';
   import { createLogger } from '@reborn/utils';
 
   const logger = createLogger('notes:import-export');
@@ -81,7 +86,18 @@
   let pendingFolderFiles = $state<File[] | null>(null);
   let pendingFolderStrategy = $state<DuplicateStrategy>('rename');
   let pendingFolderMdCount = $state(0);
+  // Name of the directory the user picked (first webkitRelativePath segment)
+  // + whether to recreate it as the top-level folder. Default ON: "I picked
+  // folder X, I get folder X" - and re-imports of the same directory then
+  // refresh that folder in place instead of scattering content at the root.
+  let pendingFolderRootName = $state<string | null>(null);
+  let pendingFolderKeepRoot = $state(true);
   let folderProgress = $state<ImportProgress | null>(null);
+  const folderImportDestination = $derived(
+    pendingFolderKeepRoot && pendingFolderRootName !== null
+      ? pendingFolderRootName
+      : $t('nav.all_notes')
+  );
 
   // Import JSON backup
   let importingBackup = $state(false);
@@ -181,6 +197,7 @@
         duplicatesSkipped: 0,
         duplicatesOverwritten: 0,
         duplicatesRenamed: 0,
+        duplicatesUnchanged: 0,
         strippedCount: 0,
         errors: [err instanceof Error ? err.message : 'Import failed']
       };
@@ -197,31 +214,9 @@
     pendingFolderFiles = null;
     pendingFolderStrategy = 'rename';
     pendingFolderMdCount = 0;
+    pendingFolderRootName = null;
+    pendingFolderKeepRoot = true;
     folderImportInputEl?.click();
-  }
-
-  /**
-   * Mirror the importer's pre-filter logic to give the user an honest
-   * "X notatek do importu" preview before they commit to a strategy.
-   */
-  function countImportableMarkdownFiles(files: File[]): number {
-    let count = 0;
-    for (const f of files) {
-      const path = (f as File & { webkitRelativePath?: string }).webkitRelativePath ?? '';
-      // Skip hidden segments (`.obsidian/`, `.trash/`, etc.) — match service logic.
-      const parts = path.split('/').filter(Boolean);
-      let hidden = false;
-      for (let i = 1; i < parts.length; i++) {
-        if (parts[i].startsWith('.')) {
-          hidden = true;
-          break;
-        }
-      }
-      if (hidden) continue;
-      if (!f.name.toLowerCase().endsWith('.md')) continue;
-      count++;
-    }
-    return count;
   }
 
   function handleFolderFilesSelected(e: Event) {
@@ -230,20 +225,24 @@
     if (files.length === 0) return;
     pendingFolderFiles = files;
     pendingFolderMdCount = countImportableMarkdownFiles(files);
+    pendingFolderRootName = getRootFolderName(files);
   }
 
   function cancelFolderImport() {
     pendingFolderFiles = null;
     pendingFolderMdCount = 0;
+    pendingFolderRootName = null;
   }
 
   async function runFolderImport() {
     if (!pendingFolderFiles) return;
     const files = pendingFolderFiles;
     const strategy = pendingFolderStrategy;
+    const keepRootFolder = pendingFolderKeepRoot && pendingFolderRootName !== null;
     const initialMdCount = pendingFolderMdCount;
     pendingFolderFiles = null;
     pendingFolderMdCount = 0;
+    pendingFolderRootName = null;
 
     importingFolder = true;
     folderImportResult = null;
@@ -251,9 +250,14 @@
     // the importer re-applies its own filters and reports `total` precisely.
     folderProgress = { phase: 'reading', current: 0, total: initialMdCount };
     try {
-      const result = await importFolder(files, strategy, (p) => {
-        folderProgress = p;
-      });
+      const result = await importFolder(
+        files,
+        strategy,
+        (p) => {
+          folderProgress = p;
+        },
+        { keepRootFolder }
+      );
       folderImportResult = result;
       await Promise.all([
         notesStore.refresh(),
@@ -271,6 +275,7 @@
         duplicatesSkipped: 0,
         duplicatesOverwritten: 0,
         duplicatesRenamed: 0,
+        duplicatesUnchanged: 0,
         strippedCount: 0,
         errors: [err instanceof Error ? err.message : 'Import failed']
       };
@@ -640,51 +645,7 @@
           {/if}
 
           {#if importResult}
-            <div
-              class="mt-3 rounded-md px-3 py-2 text-xs space-y-1
-              {importResult.errors.length === 0
-                ? 'bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-400'
-                : 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'}"
-            >
-              {#if importResult.imported > 0}
-                <p>
-                  {$t('settings_page.export_import.imported_count', {
-                    values: { count: importResult.imported }
-                  })}
-                </p>
-              {/if}
-              {#if importResult.duplicatesOverwritten > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.dedup_count_overwritten', {
-                    values: { count: importResult.duplicatesOverwritten }
-                  })}
-                </p>
-              {/if}
-              {#if importResult.duplicatesRenamed > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.dedup_count_renamed', {
-                    values: { count: importResult.duplicatesRenamed }
-                  })}
-                </p>
-              {/if}
-              {#if importResult.duplicatesSkipped > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.dedup_count_skipped', {
-                    values: { count: importResult.duplicatesSkipped }
-                  })}
-                </p>
-              {/if}
-              {#if importResult.strippedCount && importResult.strippedCount > 0}
-                <p>
-                  {$t('settings_page.export_import.unsafe_content_stripped', {
-                    values: { count: importResult.strippedCount }
-                  })}
-                </p>
-              {/if}
-              {#each importResult.errors as err}
-                <p>{err}</p>
-              {/each}
-            </div>
+            <ImportResultSummary result={importResult} class="mt-3" />
           {/if}
         </div>
 
@@ -723,6 +684,23 @@
                 promptVariant="folder"
                 radioGroupName="folder-strategy"
               />
+              {#if pendingFolderRootName !== null}
+                <label class="flex items-start gap-2 text-xs cursor-pointer">
+                  <input type="checkbox" bind:checked={pendingFolderKeepRoot} class="mt-0.5" />
+                  <span>
+                    <span class="font-medium">
+                      {$t('settings_page.export_import.keep_root_label', {
+                        values: { name: pendingFolderRootName }
+                      })}
+                    </span>
+                    <span class="block text-muted-foreground">
+                      {$t('settings_page.export_import.keep_root_destination', {
+                        values: { path: folderImportDestination }
+                      })}
+                    </span>
+                  </span>
+                </label>
+              {/if}
               <div class="flex gap-2">
                 <button
                   type="button"
@@ -772,76 +750,7 @@
           {/if}
 
           {#if folderImportResult}
-            <div
-              class="mt-3 rounded-md px-3 py-2 text-xs space-y-1
-              {folderImportResult.errors.length === 0
-                ? 'bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-400'
-                : 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'}"
-            >
-              {#if folderImportResult.imported > 0}
-                <p>
-                  {$t('settings_page.export_import.folder_import_summary', {
-                    values: {
-                      imported: folderImportResult.imported,
-                      folders: folderImportResult.foldersCreated,
-                      tags: folderImportResult.tagsCreated
-                    }
-                  })}
-                </p>
-              {/if}
-              {#if folderImportResult.skippedHidden > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.folder_import_skipped_hidden', {
-                    values: { count: folderImportResult.skippedHidden }
-                  })}
-                </p>
-              {/if}
-              {#if folderImportResult.skippedNonMarkdown > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.folder_import_skipped_non_md', {
-                    values: { count: folderImportResult.skippedNonMarkdown }
-                  })}
-                </p>
-              {/if}
-              {#if folderImportResult.skippedTooLarge > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.folder_import_skipped_too_large', {
-                    values: { count: folderImportResult.skippedTooLarge }
-                  })}
-                </p>
-              {/if}
-              {#if folderImportResult.duplicatesOverwritten > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.dedup_count_overwritten', {
-                    values: { count: folderImportResult.duplicatesOverwritten }
-                  })}
-                </p>
-              {/if}
-              {#if folderImportResult.duplicatesRenamed > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.dedup_count_renamed', {
-                    values: { count: folderImportResult.duplicatesRenamed }
-                  })}
-                </p>
-              {/if}
-              {#if folderImportResult.duplicatesSkipped > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.dedup_count_skipped', {
-                    values: { count: folderImportResult.duplicatesSkipped }
-                  })}
-                </p>
-              {/if}
-              {#if folderImportResult.strippedCount > 0}
-                <p class="text-muted-foreground">
-                  {$t('settings_page.export_import.unsafe_content_stripped', {
-                    values: { count: folderImportResult.strippedCount }
-                  })}
-                </p>
-              {/if}
-              {#each folderImportResult.errors as err}
-                <p>{err}</p>
-              {/each}
-            </div>
+            <ImportResultSummary result={folderImportResult} class="mt-3" />
           {/if}
         </div>
 

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -239,6 +239,11 @@
       "dialog_description": "Die ausgewählten Markdown-Dateien werden in diesen Ordner importiert.",
       "dialog_close": "Schließen"
     },
+    "import_folder": {
+      "action": "Ordner hierher importieren",
+      "dialog_title": "Ordner in „{name}“ importieren",
+      "dialog_description": "Die .md-Dateien des ausgewählten Ordners werden samt Unterordnern importiert. Tags und Frontmatter-Daten bleiben erhalten."
+    },
     "errors": {
       "create_failed": "Ordner konnte nicht erstellt werden",
       "update_failed": "Ordner konnte nicht aktualisiert werden",
@@ -692,6 +697,8 @@
       "import_folder_desc": "Wählen Sie einen Ordner (z.B. ein Obsidian-Vault) — Unterordnerstruktur, Tags und Frontmatter-Daten werden beibehalten",
       "import_folder_btn": "Ordner auswählen",
       "importing_folder": "Ordner wird importiert…",
+      "keep_root_label": "Obersten Ordner „{name}“ beibehalten",
+      "keep_root_destination": "Notizen werden nach „{path}“ importiert",
       "folder_import_summary": "Importiert: {imported} Notizen, {folders} neue Ordner, {tags} neue Tags",
       "folder_import_skipped_non_md": "{count} Nicht-Markdown-Datei(en) übersprungen",
       "folder_import_skipped_too_large": "{count} Datei(en) größer als 500 KB übersprungen",
@@ -704,11 +711,12 @@
       "dedup_skip": "Duplikate überspringen",
       "dedup_skip_desc": "Bestehende Notiz unverändert lassen",
       "dedup_overwrite": "Bestehende überschreiben",
-      "dedup_overwrite_desc": "Inhalt und Tags der bestehenden Notiz mit der importierten Version ersetzen (Erstellungsdatum bleibt erhalten)",
+      "dedup_overwrite_desc": "Inhalt und Tags der bestehenden Notiz mit der importierten Version ersetzen (Erstellungsdatum bleibt erhalten; unveränderte Notizen bleiben unangetastet)",
       "dedup_start": "Import starten",
       "dedup_count_overwritten": "{count} bestehende Notiz(en) überschrieben",
       "dedup_count_renamed": "{count} Duplikat(e) unter neuem Namen importiert",
       "dedup_count_skipped": "{count} Duplikat(e) übersprungen",
+      "dedup_count_unchanged": "{count} Notiz(en) unverändert gelassen (bereits aktuell)",
       "import_backup": "Sicherung importieren",
       "import_backup_desc": "Aus einer JSON-Sicherungsdatei wiederherstellen",
       "import_json": "JSON importieren",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -239,6 +239,11 @@
       "dialog_description": "The selected Markdown files will be imported into this folder.",
       "dialog_close": "Close"
     },
+    "import_folder": {
+      "action": "Import folder here",
+      "dialog_title": "Import folder into \"{name}\"",
+      "dialog_description": "The .md files from the selected folder will be imported including subfolders. Tags and frontmatter dates are preserved."
+    },
     "errors": {
       "create_failed": "Failed to create folder",
       "update_failed": "Failed to update folder",
@@ -692,6 +697,8 @@
       "import_folder_desc": "Select a folder (e.g. an Obsidian vault) — subfolder structure, tags and frontmatter dates are preserved",
       "import_folder_btn": "Select folder",
       "importing_folder": "Importing folder…",
+      "keep_root_label": "Keep top-level folder \"{name}\"",
+      "keep_root_destination": "Notes will be imported into \"{path}\"",
       "folder_import_summary": "Imported: {imported} notes, {folders} new folders, {tags} new tags",
       "folder_import_skipped_non_md": "Skipped {count} non-markdown file(s)",
       "folder_import_skipped_too_large": "Skipped {count} file(s) larger than 500 KB",
@@ -704,11 +711,12 @@
       "dedup_skip": "Skip duplicates",
       "dedup_skip_desc": "Leave the existing note untouched",
       "dedup_overwrite": "Overwrite existing",
-      "dedup_overwrite_desc": "Replace the existing note's content and tags with the imported version (preserves creation date)",
+      "dedup_overwrite_desc": "Replace the existing note's content and tags with the imported version (preserves creation date; notes that haven't changed are left untouched)",
       "dedup_start": "Start import",
       "dedup_count_overwritten": "Overwrote {count} existing note(s)",
       "dedup_count_renamed": "Imported {count} duplicate(s) under a new name",
       "dedup_count_skipped": "Skipped {count} duplicate(s)",
+      "dedup_count_unchanged": "Left {count} note(s) unchanged (already up to date)",
       "import_backup": "Import backup",
       "import_backup_desc": "Restore from a JSON backup file",
       "import_json": "Import JSON",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -239,6 +239,11 @@
       "dialog_description": "Los archivos Markdown seleccionados se importarán a esta carpeta.",
       "dialog_close": "Cerrar"
     },
+    "import_folder": {
+      "action": "Importar carpeta aquí",
+      "dialog_title": "Importar carpeta en «{name}»",
+      "dialog_description": "Los archivos .md de la carpeta seleccionada se importarán junto con sus subcarpetas. Se conservan las etiquetas y las fechas del frontmatter."
+    },
     "errors": {
       "create_failed": "Error al crear la carpeta",
       "update_failed": "Error al actualizar la carpeta",
@@ -692,6 +697,8 @@
       "import_folder_desc": "Seleccione una carpeta (p. ej., un vault de Obsidian) — se preservan la estructura de subcarpetas, etiquetas y fechas del frontmatter",
       "import_folder_btn": "Seleccionar carpeta",
       "importing_folder": "Importando carpeta…",
+      "keep_root_label": "Mantener la carpeta raíz «{name}»",
+      "keep_root_destination": "Las notas se importarán en «{path}»",
       "folder_import_summary": "Importado: {imported} notas, {folders} carpetas nuevas, {tags} etiquetas nuevas",
       "folder_import_skipped_non_md": "{count} archivo(s) no Markdown omitido(s)",
       "folder_import_skipped_too_large": "{count} archivo(s) de más de 500 KB omitido(s)",
@@ -704,11 +711,12 @@
       "dedup_skip": "Omitir duplicados",
       "dedup_skip_desc": "Dejar la nota existente sin cambios",
       "dedup_overwrite": "Sobrescribir existente",
-      "dedup_overwrite_desc": "Reemplazar el contenido y las etiquetas de la nota existente con la versión importada (se conserva la fecha de creación)",
+      "dedup_overwrite_desc": "Reemplazar el contenido y las etiquetas de la nota existente con la versión importada (se conserva la fecha de creación; las notas sin cambios se dejan intactas)",
       "dedup_start": "Iniciar importación",
       "dedup_count_overwritten": "Se sobrescribieron {count} nota(s) existente(s)",
       "dedup_count_renamed": "Se importaron {count} duplicado(s) con un nuevo nombre",
       "dedup_count_skipped": "Se omitieron {count} duplicado(s)",
+      "dedup_count_unchanged": "Se dejaron {count} nota(s) sin cambios (ya actualizadas)",
       "import_backup": "Importar copia de seguridad",
       "import_backup_desc": "Restaurar desde un archivo de copia de seguridad JSON",
       "import_json": "Importar JSON",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -239,6 +239,11 @@
       "dialog_description": "Les fichiers Markdown sélectionnés seront importés dans ce dossier.",
       "dialog_close": "Fermer"
     },
+    "import_folder": {
+      "action": "Importer un dossier ici",
+      "dialog_title": "Importer un dossier dans « {name} »",
+      "dialog_description": "Les fichiers .md du dossier sélectionné seront importés avec leurs sous-dossiers. Les tags et les dates du frontmatter sont préservés."
+    },
     "errors": {
       "create_failed": "Échec de la création du dossier",
       "update_failed": "Échec de la mise à jour du dossier",
@@ -692,6 +697,8 @@
       "import_folder_desc": "Sélectionnez un dossier (par ex. un coffre Obsidian) — la structure des sous-dossiers, les tags et les dates du frontmatter sont préservés",
       "import_folder_btn": "Sélectionner un dossier",
       "importing_folder": "Importation du dossier…",
+      "keep_root_label": "Conserver le dossier racine « {name} »",
+      "keep_root_destination": "Les notes seront importées dans « {path} »",
       "folder_import_summary": "Importé : {imported} notes, {folders} nouveaux dossiers, {tags} nouveaux tags",
       "folder_import_skipped_non_md": "{count} fichier(s) non Markdown ignoré(s)",
       "folder_import_skipped_too_large": "{count} fichier(s) de plus de 500 Ko ignoré(s)",
@@ -704,11 +711,12 @@
       "dedup_skip": "Ignorer les doublons",
       "dedup_skip_desc": "Laisser la note existante intacte",
       "dedup_overwrite": "Remplacer l'existante",
-      "dedup_overwrite_desc": "Remplacer le contenu et les tags de la note existante par la version importée (la date de création est conservée)",
+      "dedup_overwrite_desc": "Remplacer le contenu et les tags de la note existante par la version importée (la date de création est conservée ; les notes inchangées restent intactes)",
       "dedup_start": "Lancer l'import",
       "dedup_count_overwritten": "{count} note(s) existante(s) remplacée(s)",
       "dedup_count_renamed": "{count} doublon(s) importé(s) sous un nouveau nom",
       "dedup_count_skipped": "{count} doublon(s) ignoré(s)",
+      "dedup_count_unchanged": "{count} note(s) inchangée(s) (déjà à jour)",
       "import_backup": "Importer une sauvegarde",
       "import_backup_desc": "Restaurer à partir d'un fichier de sauvegarde JSON",
       "import_json": "Importer JSON",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -239,6 +239,11 @@
       "dialog_description": "Wybrane pliki Markdown zostaną zaimportowane do tego folderu.",
       "dialog_close": "Zamknij"
     },
+    "import_folder": {
+      "action": "Importuj folder tutaj",
+      "dialog_title": "Importuj folder do „{name}”",
+      "dialog_description": "Pliki .md z wybranego folderu zostaną zaimportowane wraz z podfolderami. Tagi i daty z frontmattera zostaną zachowane."
+    },
     "errors": {
       "create_failed": "Nie udało się utworzyć folderu",
       "update_failed": "Nie udało się zaktualizować folderu",
@@ -692,6 +697,8 @@
       "import_folder_desc": "Wybierz folder (np. vault Obsidian) — struktura podfolderów, tagi i daty z frontmatter zostaną zachowane",
       "import_folder_btn": "Wybierz folder",
       "importing_folder": "Importowanie folderu…",
+      "keep_root_label": "Zachowaj folder główny „{name}”",
+      "keep_root_destination": "Notatki trafią do „{path}”",
       "folder_import_summary": "Zaimportowano: {imported} notatek, {folders} nowych folderów, {tags} nowych tagów",
       "folder_import_skipped_non_md": "Pominięto {count} plików nie-markdown",
       "folder_import_skipped_too_large": "Pominięto {count} plików przekraczających 500 KB",
@@ -704,11 +711,12 @@
       "dedup_skip": "Pomiń duplikat",
       "dedup_skip_desc": "Zostaw istniejącą notatkę bez zmian",
       "dedup_overwrite": "Zastąp istniejącą",
-      "dedup_overwrite_desc": "Nadpisz treść i tagi importowaną wersją (zachowuje datę utworzenia)",
+      "dedup_overwrite_desc": "Nadpisz treść i tagi importowaną wersją (zachowuje datę utworzenia; notatki bez zmian pozostają nietknięte)",
       "dedup_start": "Rozpocznij import",
       "dedup_count_overwritten": "Zastąpiono {count} istniejących notatek",
       "dedup_count_renamed": "Zaimportowano {count} duplikatów z nową nazwą",
       "dedup_count_skipped": "Pominięto {count} duplikatów",
+      "dedup_count_unchanged": "Pozostawiono {count} notatek bez zmian (już aktualne)",
       "import_backup": "Importuj kopię zapasową",
       "import_backup_desc": "Przywróć z pliku kopii zapasowej JSON",
       "import_json": "Importuj JSON",


### PR DESCRIPTION
## Summary

Makes "import a local docs directory, edit on disk, re-import to refresh" a first-class workflow:

- **Keep top-level folder** checkbox (default ON) in Settings > Import folder: the selected directory itself is recreated (find-or-create, case-insensitive) instead of spilling its contents into the root level. Re-importing `reapps-docs` lands in the same `reapps-docs` folder every time.
- **"Import folder here"** action in both folder context menus (sidebar tree + folder header): imports a directory tree, with subfolders, anchored under the chosen folder. Reuses the existing import dialog via a `mode` prop.
- **Unchanged-note skip on overwrite**: the overwrite strategy now compares title/content/tags first and reports "left N unchanged" instead of rewriting identical notes - no re-encrypt, no sync push, no `updated_at` shuffle. Re-import becomes an idempotent refresh.
- **Tag-wipe fix**: flat .md import passed `tagIds: []` into overwrite, silently clearing the existing note's tags; it now leaves tags untouched (that path never managed tags). Folder import keeps frontmatter as tag source of truth.
- New shared `ImportResultSummary` component renders all four result panels; i18n +6 keys x 5 locales, parity green.

### Decisions to review

1. Settings keep-root checkbox **defaults ON** (file-manager intuition; the label shows the actual folder name). One-time Obsidian-vault migrators can untick.
2. Folder-context dialog defaults the checkbox **OFF when the target folder name equals the picked directory name** (re-import refresh in place; `reapps-docs/reapps-docs` nesting is never wanted there), ON otherwise.
3. Overwrite semantics change from "always rewrite" to "rewrite only when different" (per-duplicate decrypt + compare; trashed notes are never matched - lookup is non-archived only).

## Test plan

Smoke (web, any locale):
1. Settings > Import folder > pick `reapps-docs`, leave checkbox ON, strategy "Keep both copies" > expect a top-level `reapps-docs` folder mirroring the subfolder tree.
2. Edit one local .md, re-run the same import with **Overwrite existing** > summary should show 1 overwritten + rest "left unchanged"; only the edited note bumps in "recently updated".
3. Right-click a folder > "Import folder here" > pick a directory > expect it nested under that folder; label shows destination path. Re-pick the same directory after renaming the target folder to match it > checkbox should default to unticked.
4. Folder menu > "Import .md here" with Overwrite on a note that has tags added in-app > tags must survive.
5. `pnpm nx affected -t test lint typecheck` green; `node scripts/check-i18n-parity.mjs --namespace=notes` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)