### PR TITLE
chore(deps): ignore Deno-only esbuild advisory in pnpm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
     "vaul-svelte": "1.0.0-next.7"
   },
   "pnpm": {
-    "patchedDependencies": {}
+    "patchedDependencies": {},
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-gv7w-rqvm-qjhr"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,11 +72,6 @@
     "vaul-svelte": "1.0.0-next.7"
   },
   "pnpm": {
-    "patchedDependencies": {},
-    "auditConfig": {
-      "ignoreGhsas": [
-        "GHSA-gv7w-rqvm-qjhr"
-      ]
-    }
+    "patchedDependencies": {}
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,11 @@ overrides:
   # Dev-only transitive CVE pins (Storybook, nx http-server); absent from prod bundle
   ws: '^8.20.1' # GHSA-58qx-3vcg-4xpx ws uninitialized memory disclosure
   qs: '^6.15.2' # GHSA-q8mj-m7cp-5q26 qs.stringify DoS
+auditConfig:
+  ignoreGhsas:
+    # esbuild Deno-loader RCE; unreachable here (Node-only toolchain). Remove
+    # once the esbuild override above reaches >=0.28.1 (24h maturity gate).
+    - GHSA-gv7w-rqvm-qjhr
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true


### PR DESCRIPTION
## Summary

GHSA-gv7w-rqvm-qjhr (high, published today 2026-06-12T20:08Z) flags esbuild >=0.17.0 <0.28.1: the **Deno loader module** fetches the platform binary without integrity verification, enabling RCE via a poisoned `NPM_CONFIG_REGISTRY`. Within minutes it turned the CI "Security audit" step red for every branch (first hit: PR #271), blocking the lint/check/test/build steps behind it.

This repo never runs esbuild under Deno - it is Node-only build tooling (vite / tsx transitive, prod-scoped via adapter-node), so the vulnerable code path is unreachable here. The fix adds the single advisory to `auditConfig.ignoreGhsas` in **pnpm-workspace.yaml** - no dependency or lockfile changes, `--frozen-lockfile` unaffected.

Two commits because the first put the setting under the package.json `pnpm` field: local pnpm 10 honors that location, but the pnpm 11 used in CI reads settings from pnpm-workspace.yaml (where this repo's overrides already live). The yaml location works for both versions.

Why not the real upgrade right now: the repo already overrides esbuild to 0.28.0 in pnpm-workspace.yaml, so the durable fix is a one-line bump of that override to >=0.28.1 - but 0.28.1 was published 2026-06-11T22:47Z and is still inside the 24 h `minimumReleaseAge` maturity window, and the bump needs a lockfile regen (sandbox-off). **Temporary by design** - a TODO entry tracks bumping the override and removing the ignore once 0.28.1 matures (~2026-06-12T22:47Z).

## Test plan

- Local `pnpm audit --audit-level moderate --prod` and `pnpm audit --audit-level high` both exit 0 with the advisory marked "(1 ignored)"; remaining findings are below the gate thresholds.
- CI on this PR should be fully green - the audit step no longer short-circuits the job (the first commit alone reproduced the red CI, confirming the location mattered).
- After merge: re-run checks on PR #271 (its merge ref picks this up; the branch itself needs no rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
