### PR TITLE
fix(notes): left-align "search in content" label when it wraps

### DIFF
--- a/apps/reborn-notes/src/lib/components/notes/NoteListSearchBar.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListSearchBar.svelte
@@ -61,7 +61,7 @@
       <button
         type="button"
         onclick={toggleSearchInContent}
-        class="flex min-h-[44px] md:min-h-0 items-center gap-2 md:gap-1 px-1 -mx-1 md:px-0 md:mx-0 text-sm md:text-[11px] transition-colors
+        class="flex min-h-[44px] md:min-h-0 items-center gap-2 md:gap-1 px-1 -mx-1 md:px-0 md:mx-0 text-left text-sm md:text-[11px] transition-colors
           {searchInContent
           ? 'font-medium text-primary'
           : 'text-muted-foreground hover:text-foreground'}"


### PR DESCRIPTION
## Summary
- The search-in-content checkbox label is a native `<button>`, which the UA stylesheet defaults to `text-align: center`. Tailwind Preflight does not reset that.
- On a narrow viewport the long label (e.g. PL "Szukaj w treści") wraps to a second line, and the wrapped line rendered centered instead of under the checkbox.
- Add `text-left` to the button so the label stays start-aligned even when it wraps.

CSS-only change to one component; no new i18n keys.

## Test plan
- Open Reborn Notes on a narrow viewport (or the iOS app) and type a query so the options row under the search input appears.
- Confirm the "Szukaj w treści" / "Search in content" label wraps **left-aligned** under the checkbox, not centered.
- Desktop (md+) layout unchanged.