### PR TITLE
feat(notes): local-only / no-account mode + upgrade to account

### DIFF
--- a/apps/reborn-notes/src/lib/components/LocalModeWelcome.svelte
+++ b/apps/reborn-notes/src/lib/components/LocalModeWelcome.svelte
@@ -1,0 +1,75 @@
+<!--
+  First-run explainer for local-only / no-account mode. Shown exactly once per
+  browser profile: the marker is written the moment the dialog opens, so any way
+  of dismissing it (button, Esc, overlay) still counts as "seen". The copy is
+  deliberately honest about the trade-off (no server, no cloud recovery) - this
+  is the privacy pitch, not fine print. See planning/local-only-no-account-plan.md.
+-->
+<script lang="ts">
+  import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+    Button
+  } from '@reborn/ui';
+  import { browser } from '$app/environment';
+  import { authStore } from '$lib/stores/auth.store';
+  import { t } from '$lib/stores/i18n.store';
+
+  const WELCOMED_KEY = 'reborn_local_mode_welcomed';
+  let open = $state(false);
+
+  $effect(() => {
+    if (!browser) return;
+    if ($authStore.isLocalOnly && localStorage.getItem(WELCOMED_KEY) !== '1') {
+      open = true;
+      // Mark as seen on open so it shows exactly once regardless of how it's closed.
+      try {
+        localStorage.setItem(WELCOMED_KEY, '1');
+      } catch {
+        /* private mode / storage disabled - worst case it shows again, harmless */
+      }
+    }
+  });
+</script>
+
+<Dialog bind:open>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>{$t('local_mode.welcome.title')}</DialogTitle>
+      <DialogDescription>{$t('local_mode.welcome.subtitle')}</DialogDescription>
+    </DialogHeader>
+
+    <ul class="space-y-3 py-2 text-sm text-muted-foreground">
+      <li class="flex gap-2">
+        <span aria-hidden="true">•</span>
+        <span>{$t('local_mode.welcome.point_storage')}</span>
+      </li>
+      <li class="flex gap-2">
+        <span aria-hidden="true">•</span>
+        <span>{$t('local_mode.welcome.point_encrypted')}</span>
+      </li>
+      <li class="flex gap-2">
+        <span aria-hidden="true">•</span>
+        <span>{$t('local_mode.welcome.point_no_sync')}</span>
+      </li>
+      <li class="flex gap-2 font-medium text-foreground">
+        <span aria-hidden="true">•</span>
+        <span>{$t('local_mode.welcome.point_no_recovery')}</span>
+      </li>
+      <li class="flex gap-2">
+        <span aria-hidden="true">•</span>
+        <span>{$t('local_mode.welcome.point_upgrade')}</span>
+      </li>
+    </ul>
+
+    <DialogFooter>
+      <Button onclick={() => (open = false)}>
+        {$t('local_mode.welcome.cta')}
+      </Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>

--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -33,6 +33,8 @@
   import { requireActiveSession } from '$lib/utils/require-active-session';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
   import ConfirmDialog from './shared/ConfirmDialog.svelte';
+  import AccountRequiredDialog from './shared/AccountRequiredDialog.svelte';
+  import { authStore } from '$lib/stores/auth.store';
   import NoteListItemComponent from './notes/NoteListItem.svelte';
   import NoteActionSheet from './notes/NoteActionSheet.svelte';
   import ShareNoteDialog from './notes/ShareNoteDialog.svelte';
@@ -109,9 +111,16 @@
   let shareDialogOpen = $state(false);
   let shareNoteId = $state<string | null>(null);
   let shareNoteTitle = $state<string>('');
+  // Local-only mode has no server session: sharing can't work, so nudge the
+  // user toward an account instead of opening a dialog whose calls would 401.
+  let accountRequiredOpen = $state(false);
 
   async function handleShare(note: NoteListItem, e?: Event) {
     e?.stopPropagation();
+    if ($authStore.isLocalOnly) {
+      accountRequiredOpen = true;
+      return;
+    }
     const ok = await requireActiveSession({
       description: $t('share.session_required.create')
     });
@@ -1161,3 +1170,5 @@
 {#if shareNoteId}
   <ShareNoteDialog bind:open={shareDialogOpen} noteId={shareNoteId} noteTitle={shareNoteTitle} />
 {/if}
+
+<AccountRequiredDialog bind:open={accountRequiredOpen} />

--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -32,7 +32,8 @@
     CalendarRange,
     CalendarDays,
     Share2,
-    Heart
+    Heart,
+    UserPlus
   } from '@lucide/svelte';
   import * as Tooltip from '@reborn/ui/components/tooltip';
   import * as DropdownMenu from '@reborn/ui/components/dropdown-menu';
@@ -48,6 +49,7 @@
   import { activeSharesCount } from '$lib/stores/shares.store';
   import { requireActiveSession } from '$lib/utils/require-active-session';
   import ManageSharesDialog from '../notes/ManageSharesDialog.svelte';
+  import AccountRequiredDialog from '../shared/AccountRequiredDialog.svelte';
 
   let {
     activeSection = $bindable<Section>('all'),
@@ -73,6 +75,8 @@
   let loggingOut = $state(false);
   let userSheetOpen = $state(false);
   let sharesDialogOpen = $state(false);
+  // Local-only mode: sharing needs a server account - nudge to register instead.
+  let accountRequiredOpen = $state(false);
 
   // Donations page on the foundation site (EN + PL only). Plain <a target="_blank">
   // leaves the app: new tab on web, SYSTEM browser in the native shell (the
@@ -83,6 +87,10 @@
   const supportUrl = $derived(`${SITE_URL}${$i18nLocale === 'pl' ? '/pl' : ''}/support`);
 
   async function handleOpenShares() {
+    if ($authStore.isLocalOnly) {
+      accountRequiredOpen = true;
+      return;
+    }
     const ok = await requireActiveSession({
       description: $t('share.session_required.view')
     });
@@ -556,15 +564,25 @@
                   {getUserInitial($authStore.username)}
                 </span>
                 <div class="grid flex-1 text-start text-sm leading-tight">
-                  <span class="truncate font-medium">{$authStore.username ?? '—'}</span>
+                  <span class="truncate font-medium"
+                    >{$authStore.username ?? $t('local_mode.menu_title')}</span
+                  >
                   <span class="truncate text-xs text-muted-foreground"
-                    >{$t('nav.e2ee_account')}</span
+                    >{$authStore.isLocalOnly
+                      ? $t('local_mode.menu_hint')
+                      : $t('nav.e2ee_account')}</span
                   >
                 </div>
               </div>
             </DropdownMenu.Label>
             <DropdownMenu.Separator />
             <DropdownMenu.Group>
+              {#if $authStore.isLocalOnly}
+                <DropdownMenu.Item onclick={() => goto('/auth/register')}>
+                  <UserPlus class="h-4 w-4" />
+                  {$t('local_mode.register')}
+                </DropdownMenu.Item>
+              {/if}
               <DropdownMenu.Item onclick={() => goto('/settings')}>
                 <Settings class="h-4 w-4" />
                 {$t('nav.settings')}
@@ -589,6 +607,7 @@
 
 <!-- Shares manage dialog (mounted once, used by both nav modes) -->
 <ManageSharesDialog bind:open={sharesDialogOpen} sourceId={null} />
+<AccountRequiredDialog bind:open={accountRequiredOpen} />
 
 <!-- Mobile: User menu Sheet -->
 <Sheet bind:open={userSheetOpen}>
@@ -603,15 +622,28 @@
             {getUserInitial($authStore.username)}
           </span>
           <div class="grid flex-1 text-start text-sm leading-tight">
-            <span class="truncate font-medium">{$authStore.username ?? '—'}</span>
+            <span class="truncate font-medium">{$authStore.username ?? $t('local_mode.menu_title')}</span>
             <span class="truncate text-xs font-normal text-muted-foreground"
-              >{$t('nav.e2ee_account')}</span
+              >{$authStore.isLocalOnly ? $t('local_mode.menu_hint') : $t('nav.e2ee_account')}</span
             >
           </div>
         </div>
       </SheetTitle>
     </SheetHeader>
     <div class="mt-4 space-y-1">
+      {#if $authStore.isLocalOnly}
+        <Button
+          variant="ghost"
+          class="w-full justify-start min-h-11"
+          onclick={() => {
+            userSheetOpen = false;
+            goto('/auth/register');
+          }}
+        >
+          <UserPlus class="mr-2 h-5 w-5" />
+          {$t('local_mode.register')}
+        </Button>
+      {/if}
       <Button
         variant="ghost"
         class="w-full justify-start min-h-11"

--- a/apps/reborn-notes/src/lib/components/shared/AccountRequiredDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/shared/AccountRequiredDialog.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import ConfirmDialog from './ConfirmDialog.svelte';
+  import { goto } from '$lib/utils/navigation';
+  import { t } from '$lib/stores/i18n.store';
+
+  // Shown when an account-only action (e.g. sharing) is attempted in local-only
+  // mode. Confirm routes to registration - which adopts the local master key and
+  // keeps existing notes (see register/+page.svelte upgrade path); cancel just
+  // dismisses. Reuses the create-account copy so the wording stays in one place.
+  let { open = $bindable(false) }: { open?: boolean } = $props();
+</script>
+
+<ConfirmDialog
+  bind:open
+  title={$t('local_mode.share_title')}
+  description={$t('settings_page.account.create_desc')}
+  confirmText={$t('settings_page.account.create')}
+  cancelText={$t('common.cancel')}
+  onConfirm={() => goto('/auth/register')}
+/>

--- a/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
@@ -11,7 +11,8 @@
     WifiOff,
     AlertCircle,
     CloudUpload,
-    AlertTriangle
+    AlertTriangle,
+    HardDrive
   } from '@lucide/svelte';
   import { syncStatus, type SyncStatusType } from '$lib/stores/sync-status.store';
   import { pullFromServer, pushPendingItems, refreshStoresAfterPull } from '$lib/services/notes-sync.service';
@@ -20,7 +21,12 @@
   let manualSyncing = $state(false);
 
   async function handleSync() {
-    if (manualSyncing || $syncStatus.status === 'syncing' || $syncStatus.status === 'offline')
+    if (
+      manualSyncing ||
+      $syncStatus.status === 'syncing' ||
+      $syncStatus.status === 'offline' ||
+      $syncStatus.status === 'local_only'
+    )
       return;
 
     manualSyncing = true;
@@ -51,6 +57,8 @@
         return RefreshCw;
       case 'session_expired':
         return AlertTriangle;
+      case 'local_only':
+        return HardDrive;
     }
   }
 
@@ -70,6 +78,8 @@
         return 'text-amber-500 dark:text-amber-400';
       case 'session_expired':
         return 'text-destructive';
+      case 'local_only':
+        return 'text-muted-foreground';
     }
   }
 
@@ -89,6 +99,8 @@
         return $t('sync_status.not_synced');
       case 'session_expired':
         return $t('sync_status.session_expired');
+      case 'local_only':
+        return $t('sync_status.local_only');
     }
   }
 
@@ -108,6 +120,7 @@
     $syncStatus.status !== 'offline' &&
       $syncStatus.status !== 'syncing' &&
       $syncStatus.status !== 'session_expired' &&
+      $syncStatus.status !== 'local_only' &&
       !manualSyncing
   );
   let isSessionExpired = $derived($syncStatus.status === 'session_expired');

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -602,6 +602,42 @@ async function pullNotes(): Promise<void> {
 // ── Push helpers - IndexedDB → server ────────────────────────────
 
 /**
+ * Mark every local record (folders, tags, saved searches, notes) as pending so
+ * the next push uploads it. Used when a local-only (no-account) session
+ * upgrades to a real account: everything was created offline and never synced,
+ * so it all has to reach the server. The records keep their existing
+ * master-key ciphertext (the account adopts the same key), so no re-encryption
+ * is needed - only the sync flag changes. Idempotent: rows already pending are
+ * left untouched. The server assigns ownership from the JWT, so user_id is not
+ * rewritten here; the next pull converges it.
+ */
+export async function markAllLocalDataPending(): Promise<void> {
+  const [folders, tags, savedSearches, notes] = await Promise.all([
+    folderStore.getAll() as Promise<FolderEncrypted[]>,
+    tagStore.getAll() as Promise<TagEncrypted[]>,
+    savedSearchStore.getAll() as Promise<SavedSearchEncrypted[]>,
+    noteStore.getAll() as Promise<NoteStoredLocal[]>
+  ]);
+
+  const ops: Promise<unknown>[] = [];
+  for (const f of folders) {
+    if (f.sync_status !== 'pending') ops.push(folderStore.save({ ...f, sync_status: 'pending' }));
+  }
+  for (const t of tags) {
+    if (t.sync_status !== 'pending') ops.push(tagStore.save({ ...t, sync_status: 'pending' }));
+  }
+  for (const s of savedSearches) {
+    if (s.sync_status !== 'pending')
+      ops.push(savedSearchStore.save({ ...s, sync_status: 'pending' }));
+  }
+  for (const n of notes) {
+    if (n.sync_status !== 'pending') ops.push(noteStore.save({ ...n, sync_status: 'pending' }));
+  }
+  await Promise.all(ops);
+  logger.info(`Marked ${ops.length} local records pending for account upload`);
+}
+
+/**
  * Push all locally-pending items (folders, tags, notes) to the server.
  * Called during manual sync to ensure local-only items reach the server.
  */

--- a/apps/reborn-notes/src/lib/services/synced-settings.service.ts
+++ b/apps/reborn-notes/src/lib/services/synced-settings.service.ts
@@ -1,14 +1,24 @@
+import { get } from 'svelte/store';
 import { API_BASE } from '$lib/utils/api-base';
 import { authFetch } from '$lib/utils/auth-fetch';
 import { createSyncedSettingsService } from '@reborn/storage';
+import { localOnly } from '$lib/stores/sync-status.store';
 
 /**
  * App-level singleton of the E2E synced settings service. Wires the shared
  * implementation to this app's `authFetch` (single-flight 401 refresh) and
  * `base` path.
+ *
+ * `isSyncEnabled` gates every server round-trip off in local-only mode: there
+ * is no account session there, so a settings PUT/GET would 401, trigger a
+ * refresh that also 401s, and trip the session-expired banner. IndexedDB stays
+ * the source of truth; sync resumes automatically after an account upgrade
+ * (localOnly flips back to false). Mirrors the isAuthenticated gate in
+ * notes-sync.service. See planning/local-only-no-account-plan.md.
  */
 export const syncedSettings = createSyncedSettingsService({
   authFetch,
   basePath: API_BASE.replace(/\/api$/, ''),
-  appName: 'reborn-notes'
+  appName: 'reborn-notes',
+  isSyncEnabled: () => !get(localOnly)
 });

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -26,7 +26,7 @@ import { API_BASE } from '$lib/utils/api-base';
 import { clearNativeRefreshToken } from '$lib/utils/native-auth-storage';
 import { clearNativeSessionId } from '$lib/utils/native-session';
 import { cryptoManager } from '@reborn/crypto';
-import { sessionExpired } from '$lib/stores/sync-status.store';
+import { sessionExpired, localOnly } from '$lib/stores/sync-status.store';
 import { createLogger } from '@reborn/utils';
 
 const logger = createLogger('Notes-AuthStore');
@@ -154,7 +154,9 @@ function createAuthStore() {
   /** Call once from the root layout to hydrate state and watch for cross-tab changes. */
   function initialize(): void {
     if (!browser) return;
-    set(readFromStorage());
+    const initial = readFromStorage();
+    set(initial);
+    localOnly.set(initial.isLocalOnly);
     // Detect login / logout in other tabs on the same origin.
     // The `storage` event fires ONLY in other tabs/windows — never in the tab
     // that changed localStorage. This means:
@@ -255,6 +257,7 @@ function createAuthStore() {
         createdAt: null,
         hasE2E: cryptoManager.isInitialized()
       });
+      localOnly.set(true);
       return true;
     } catch (err) {
       logger.error('Failed to enter local-only mode', err);
@@ -314,6 +317,7 @@ function createAuthStore() {
     if (!browser) return;
     // Reset session expired flag — this is an intentional logout, not expiry
     sessionExpired.set(false);
+    localOnly.set(false);
 
     // Notify server to deactivate session (best-effort, fire-and-forget)
     const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -34,12 +34,28 @@ const logger = createLogger('Notes-AuthStore');
 export const CREDENTIALS_KEY = 'reborn_auth_credentials';
 export const ACCESS_TOKEN_KEY = 'access_token';
 
+// Local-only mode (no account / offline-only). Shared across Notes and Task on
+// the same origin, exactly like CREDENTIALS_KEY, so entering local mode in one
+// app is visible to the other. `LOCAL_MODE_KEY` is the on/off marker;
+// `LOCAL_USER_ID_KEY` holds a device-scoped UUID used as the `user_id` of local
+// records (keeps FK-shaped fields + shadow-index repair valid before any
+// account exists). See planning/local-only-no-account-plan.md.
+export const LOCAL_MODE_KEY = 'reborn_local_mode';
+export const LOCAL_USER_ID_KEY = 'reborn_local_user_id';
+
 export interface AuthState {
-  /** `null` when unauthenticated (redirected to login). */
+  /** `null` when unauthenticated (redirected to login) or in local-only mode. */
   username: string | null;
   userId: string | null;
   accessToken: string | null;
+  /** True only with a real server account session. False in local-only mode. */
   isAuthenticated: boolean;
+  /**
+   * True in local-only / no-account mode: the app is usable and encrypted
+   * locally, but there is no server session, so sync never runs. Distinct from
+   * `isAuthenticated` precisely so the existing sync gates stay no-ops here.
+   */
+  isLocalOnly: boolean;
   /** ISO date string of account creation. */
   createdAt: string | null;
   /** True when the master key is loaded in CryptoManager (E2E unlocked). */
@@ -53,31 +69,71 @@ function readFromStorage(): AuthState {
     userId: null,
     accessToken: null,
     isAuthenticated: false,
+    isLocalOnly: false,
     createdAt: null,
     hasE2E: false
   };
   if (!browser) return empty;
   try {
     const raw = localStorage.getItem(CREDENTIALS_KEY);
-    if (!raw) return empty;
-    // Duck-type the stored AuthCredentials (avoids adding @reborn/auth dep)
-    const creds = JSON.parse(raw) as {
-      id: string;
-      user_profile: { username: string; created_at?: string };
-    };
-    if (!creds?.id || !creds.user_profile?.username) return empty;
-    return {
-      username: creds.user_profile.username,
-      userId: creds.id,
-      accessToken: localStorage.getItem(ACCESS_TOKEN_KEY),
-      isAuthenticated: true,
-      createdAt: creds.user_profile.created_at ?? null,
-      // Key may already be in memory (restored from sessionStorage by CryptoManager singleton)
-      hasE2E: cryptoManager.isInitialized()
-    };
+    if (raw) {
+      // Duck-type the stored AuthCredentials (avoids adding @reborn/auth dep)
+      const creds = JSON.parse(raw) as {
+        id: string;
+        user_profile: { username: string; created_at?: string };
+      };
+      if (creds?.id && creds.user_profile?.username) {
+        return {
+          username: creds.user_profile.username,
+          userId: creds.id,
+          accessToken: localStorage.getItem(ACCESS_TOKEN_KEY),
+          isAuthenticated: true,
+          isLocalOnly: false,
+          createdAt: creds.user_profile.created_at ?? null,
+          // Key may already be in memory (restored from sessionStorage by CryptoManager singleton)
+          hasE2E: cryptoManager.isInitialized()
+        };
+      }
+    }
+
+    // No account session: fall back to local-only mode if the marker is set.
+    // A real account always wins over the local marker, so this branch is
+    // reached only when there are no valid credentials.
+    if (localStorage.getItem(LOCAL_MODE_KEY) === '1') {
+      const localUserId = localStorage.getItem(LOCAL_USER_ID_KEY);
+      if (localUserId) {
+        return {
+          username: null,
+          userId: localUserId,
+          accessToken: null,
+          isAuthenticated: false,
+          isLocalOnly: true,
+          createdAt: null,
+          hasE2E: cryptoManager.isInitialized()
+        };
+      }
+    }
+
+    return empty;
   } catch {
     return empty;
   }
+}
+
+/** v4-shaped UUID matcher - mirrors the shape idb-cleanup's repairUserId expects. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Read or lazily create the device-scoped local user id. Used as `user_id` for
+ * records created in local-only mode so FK-shaped fields and shadow-index
+ * repair (idb-cleanup) keep working before any server account exists.
+ */
+function getOrCreateLocalUserId(): string {
+  const existing = localStorage.getItem(LOCAL_USER_ID_KEY);
+  if (existing && UUID_RE.test(existing)) return existing;
+  const id = crypto.randomUUID();
+  localStorage.setItem(LOCAL_USER_ID_KEY, id);
+  return id;
 }
 
 function createAuthStore() {
@@ -164,6 +220,46 @@ function createAuthStore() {
         set({ ...readFromStorage(), hasE2E: false });
       }
     });
+  }
+
+  /**
+   * Enter local-only mode: usable, encrypted, no account, no sync. Generates a
+   * device-scoped user id and a local master key (persisted at-rest by
+   * CryptoManager - IndexedDB on web, Keychain/Keystore vault on native) when
+   * one is not already loaded, then flips the store into local-only state.
+   *
+   * Returns false (no-op) if a real account session already exists - the
+   * account always takes precedence. Returns true once local mode is active.
+   */
+  async function enterLocalMode(): Promise<boolean> {
+    if (!browser) return false;
+    // Never shadow a real account session.
+    if (localStorage.getItem(CREDENTIALS_KEY)) return false;
+    try {
+      const localUserId = getOrCreateLocalUserId();
+      localStorage.setItem(LOCAL_MODE_KEY, '1');
+
+      // Generate + persist a local master key unless one is already loaded
+      // (e.g. restored from IndexedDB/vault on a returning local session).
+      if (!cryptoManager.isInitialized()) {
+        const key = await cryptoManager.generateMasterKey();
+        await cryptoManager.setMasterKey(key);
+      }
+
+      set({
+        username: null,
+        userId: localUserId,
+        accessToken: null,
+        isAuthenticated: false,
+        isLocalOnly: true,
+        createdAt: null,
+        hasE2E: cryptoManager.isInitialized()
+      });
+      return true;
+    } catch (err) {
+      logger.error('Failed to enter local-only mode', err);
+      return false;
+    }
   }
 
   /**
@@ -266,7 +362,7 @@ function createAuthStore() {
     window.location.href = `${base}/auth/login`;
   }
 
-  return { subscribe, initialize, unlockE2E, logout, markE2EUnlocked };
+  return { subscribe, initialize, unlockE2E, logout, markE2EUnlocked, enterLocalMode };
 }
 
 export const authStore = createAuthStore();

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -17,7 +17,8 @@ export type SyncStatusType =
   | 'error'
   | 'pending'
   | 'needs_sync'
-  | 'session_expired';
+  | 'session_expired'
+  | 'local_only';
 
 export interface SyncStatusState {
   status: SyncStatusType;
@@ -65,6 +66,10 @@ if (browser && connectivityStore) {
 export const isSyncing = writable(false);
 export const syncError = writable(false);
 export const sessionExpired = writable(false);
+// True in local-only / no-account mode. Set by the auth store (one-way, like
+// sessionExpired) to avoid an auth.store <-> sync-status.store import cycle.
+// Takes precedence over every other status: there is no server session here.
+export const localOnly = writable(false);
 export const lastSyncedAt = writable<string | null>(null);
 export const pendingCount = writable(0);
 
@@ -91,18 +96,22 @@ export async function refreshPendingCount(): Promise<number> {
 // ── Derived unified status ───────────────────────────────────────
 
 export const syncStatus = derived(
-  [isOnline, isSyncing, syncError, sessionExpired, pendingCount, lastSyncedAt],
+  [isOnline, isSyncing, syncError, sessionExpired, pendingCount, lastSyncedAt, localOnly],
   ([
     $isOnline,
     $isSyncing,
     $syncError,
     $sessionExpired,
     $pendingCount,
-    $lastSyncedAt
+    $lastSyncedAt,
+    $localOnly
   ]): SyncStatusState => {
     let status: SyncStatusType;
 
-    if ($sessionExpired) {
+    if ($localOnly) {
+      // No account, no server: sync never runs, so this overrides everything.
+      status = 'local_only';
+    } else if ($sessionExpired) {
       status = 'session_expired';
     } else if (!$isOnline) {
       status = 'offline';

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -106,11 +106,15 @@
       }
       // Pull E2E synced settings now that the master key is available.
       // Re-init appSettings so theme/locale reflect the server state.
-      try {
-        const { applied } = await syncedSettings.pullAndMerge();
-        if (applied) await appSettings.refresh();
-      } catch (err: unknown) {
-        logger.warn('Synced settings pull on E2E unlock failed', err);
+      // Local-only mode has no server account: skip the settings pull (it would
+      // just fail auth and log a warning). Local IDB stays the source of truth.
+      if (!get(authStore).isLocalOnly) {
+        try {
+          const { applied } = await syncedSettings.pullAndMerge();
+          if (applied) await appSettings.refresh();
+        } catch (err: unknown) {
+          logger.warn('Synced settings pull on E2E unlock failed', err);
+        }
       }
       // Build NoteIndex FIRST (in parallel with folders/tags), then refresh notesStore
       await Promise.all([
@@ -249,7 +253,7 @@
 
       // Pull E2E synced settings before applying theme/locale so a fresh
       // device sees the user's preferences instead of IDB defaults.
-      if (cryptoManager.isInitialized()) {
+      if (cryptoManager.isInitialized() && !$authStore.isLocalOnly) {
         try {
           await syncedSettings.pullAndMerge();
         } catch (err: unknown) {

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -67,7 +67,12 @@
     // Public read-only share view (/s/{slug}) - no account needed.
     const isPublicShareRoute = path.startsWith(`${basePath}/s/`);
 
-    if (!$authStore.isAuthenticated && !isAuthRoute && !isPublicShareRoute) {
+    if (
+      !$authStore.isAuthenticated &&
+      !$authStore.isLocalOnly &&
+      !isAuthRoute &&
+      !isPublicShareRoute
+    ) {
       untrack(() => noteIndex.clear());
       untrack(() => {
         goto('/auth/login');

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -32,6 +32,7 @@
   import { reAuthenticate, verifyTotpForReauth } from '$lib/services/notes-auth.service';
   import { SessionExpiredBanner, RequireSessionModal } from '@reborn/ui';
   import LoadingScreen from '$lib/components/LoadingScreen.svelte';
+  import LocalModeWelcome from '$lib/components/LocalModeWelcome.svelte';
   import UpdateRequiredGate from '$lib/components/layout/UpdateRequiredGate.svelte';
   import { checkNativeUpdateGate } from '$lib/utils/native-app-update';
   import { createLogger } from '@reborn/utils';
@@ -449,6 +450,7 @@
     />
     {@render children()}
     <Toaster />
+    <LocalModeWelcome />
     {#if __REBORN_NATIVE__}
       <UpdateRequiredGate />
     {/if}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -31,6 +31,8 @@
   import FolderTree from '$lib/components/sidebar/FolderTree.svelte';
   import { pendingNewFolderDraft } from '$lib/stores/new-folder-draft.store';
   import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
+  import AccountRequiredDialog from '$lib/components/shared/AccountRequiredDialog.svelte';
+  import { authStore } from '$lib/stores/auth.store';
   import NoteEditor from '$lib/components/NoteEditor.svelte';
 
   // Extracted components
@@ -238,11 +240,17 @@
   let shareDialogOpen = $state(false);
   let shareNoteId = $state<string | null>(null);
   let shareNoteTitle = $state<string>('');
+  // Local-only mode: sharing needs a server account - nudge to register instead.
+  let accountRequiredOpen = $state(false);
 
   async function handleDetailShare(noteArg?: NoteListItem) {
     detailActionSheetOpen = false;
     const target = noteArg ?? detailMenuNote;
     if (!target) return;
+    if ($authStore.isLocalOnly) {
+      accountRequiredOpen = true;
+      return;
+    }
     const ok = await requireActiveSession({
       description: $t('share.session_required.create')
     });
@@ -1286,7 +1294,7 @@
             {#if mobileView === 'folder-tree'}
               <div class="flex flex-col overflow-hidden h-full">
                 <div class="flex-1 overflow-y-auto px-2 py-2">
-                  {#if $foldersStore.length === 0}
+                  {#if $foldersStore.length === 0 && !$pendingNewFolderDraft}
                     <p class="px-2 py-1 text-xs text-muted-foreground">
                       {$t('folders.no_folders_short')}
                     </p>
@@ -1564,7 +1572,7 @@
               </div>
               <div class="mx-3 border-t"></div>
               <div class="flex-1 overflow-y-auto px-2 py-2">
-                {#if $foldersStore.length === 0}
+                {#if $foldersStore.length === 0 && !$pendingNewFolderDraft}
                   <p class="px-2 py-4 text-center text-xs text-muted-foreground">
                     {$t('folders.no_folders_short')}
                   </p>
@@ -1932,3 +1940,5 @@
 {#if shareNoteId}
   <ShareNoteDialog bind:open={shareDialogOpen} noteId={shareNoteId} noteTitle={shareNoteTitle} />
 {/if}
+
+<AccountRequiredDialog bind:open={accountRequiredOpen} />

--- a/apps/reborn-notes/src/routes/auth/login/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/login/+page.svelte
@@ -9,6 +9,8 @@
   import { sessionExpired } from '$lib/stores/sync-status.store';
   import { loginInNotes } from '$lib/services/notes-auth.service';
   import { t } from '$lib/stores/i18n.store';
+  import { get } from 'svelte/store';
+  import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
 
   let loading = $state(false);
   let error = $state<string | null>(null);
@@ -30,11 +32,26 @@
     }
   });
 
+  // Local-only mode: signing into an existing account runs clearAllUserData
+  // (notes-auth.service), which replaces the on-device notes. Confirm before
+  // that wipe so the user can export a backup instead of losing data silently.
+  let confirmReplaceOpen = $state(false);
+  let pendingLogin = $state<{ username: string; password: string } | null>(null);
+
   async function handleLogin(detail: { username: string; password: string; rememberMe: boolean }) {
+    if (get(authStore).isLocalOnly) {
+      pendingLogin = { username: detail.username, password: detail.password };
+      confirmReplaceOpen = true;
+      return;
+    }
+    await performLogin(detail.username, detail.password);
+  }
+
+  async function performLogin(username: string, password: string) {
     loading = true;
     error = null;
 
-    const result = await loginInNotes(detail.username, detail.password);
+    const result = await loginInNotes(username, password);
 
     if (result.success) {
       await goto(returnTo);
@@ -42,7 +59,7 @@
     }
 
     if (result.twoFactorRequired) {
-      sessionStorage.setItem('2fa_pending_password', detail.password);
+      sessionStorage.setItem('2fa_pending_password', password);
       // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp variable
       const params = new URLSearchParams({ userId: result.userId ?? '', returnTo });
       if (result.encryptedMasterKey) params.set('emk', result.encryptedMasterKey);
@@ -99,5 +116,18 @@
     } else {
       goto(e.url);
     }
+  }}
+/>
+
+<!-- Local-only safety: signing in replaces on-device notes - confirm first. -->
+<ConfirmDialog
+  bind:open={confirmReplaceOpen}
+  title={$t('local_mode.replace_title')}
+  description={$t('local_mode.replace_desc')}
+  confirmText={$t('local_mode.replace_confirm')}
+  cancelText={$t('common.cancel')}
+  destructive
+  onConfirm={() => {
+    if (pendingLogin) return performLogin(pendingLogin.username, pendingLogin.password);
   }}
 />

--- a/apps/reborn-notes/src/routes/auth/login/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/login/+page.svelte
@@ -54,6 +54,18 @@
     error = result.message ?? $t('auth.login.errors.invalid_credentials');
     loading = false;
   }
+
+  async function handleLocalMode() {
+    loading = true;
+    error = null;
+    const ok = await authStore.enterLocalMode();
+    if (ok) {
+      await goto('/');
+      return;
+    }
+    error = $t('auth.login.errors.server_error');
+    loading = false;
+  }
 </script>
 
 <svelte:head>
@@ -76,8 +88,10 @@
   header={logoHeader}
   showRegisterLink={true}
   registerUrl="/auth/register"
+  showLocalModeLink={true}
   themeStorageKey="reborn-notes-theme"
   onlogin={handleLogin}
+  onlocalmode={handleLocalMode}
   onnavigate={(e) => {
     if (e.url === '/auth/register' && returnTo && returnTo !== '/') {
       const params = new URLSearchParams({ returnTo });

--- a/apps/reborn-notes/src/routes/auth/register/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/register/+page.svelte
@@ -114,15 +114,17 @@
         })
       });
 
-      const data = await res.json();
+      const body = await res.json();
 
-      if (!res.ok || !data.success) {
-        error = data.error || 'Registration failed';
+      if (!res.ok || !body.success) {
+        error = body.error || 'Registration failed';
         return;
       }
 
       if (isUpgrade) {
-        await finishLocalUpgrade(data, encryptedMasterKey, masterKeySalt);
+        // The endpoint wraps the payload as { success, data } - unwrap before
+        // handing it to finishLocalUpgrade (which reads user / access_token).
+        await finishLocalUpgrade(body.data, encryptedMasterKey, masterKeySalt);
       } else {
         // 6. Auto-login after successful registration (reuses notes-auth.service)
         const loginResult = await loginInNotes(detail.username, detail.password);

--- a/apps/reborn-notes/src/routes/auth/register/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/register/+page.svelte
@@ -5,8 +5,21 @@
   import { page } from '$app/stores';
   import { RegisterPage } from '@reborn/ui';
   import { hashPassword, generateMasterKeyForUser, cryptoManager } from '@reborn/crypto';
+  import { get } from 'svelte/store';
   import { loginInNotes } from '$lib/services/notes-auth.service';
-  import { authStore } from '$lib/stores/auth.store';
+  import {
+    authStore,
+    CREDENTIALS_KEY,
+    ACCESS_TOKEN_KEY,
+    LOCAL_MODE_KEY,
+    LOCAL_USER_ID_KEY
+  } from '$lib/stores/auth.store';
+  import {
+    markAllLocalDataPending,
+    pushPendingItems,
+    pullFromServer,
+    refreshStoresAfterPull
+  } from '$lib/services/notes-sync.service';
   import { t } from '$lib/stores/i18n.store';
   import { locale } from 'svelte-i18n';
   import { API_BASE } from '$lib/utils/api-base';
@@ -40,17 +53,36 @@
     loading = true;
     error = null;
 
+    // Upgrade path: a local-only session is creating its first account. Adopt
+    // the existing local master key (wrap it with the new password) instead of
+    // generating a fresh one, so offline notes - already encrypted with that
+    // key - stay readable and just start syncing. See plan B1.
+    const isUpgrade = get(authStore).isLocalOnly && cryptoManager.isInitialized();
+
     try {
-      // 1. Hash password + generate encrypted master key (client-side, Zero Knowledge)
+      // 1. Hash password (client-side, Zero Knowledge)
       const passwordHash = await hashPassword(detail.password);
-      const { encryptedMasterKey, salt: masterKeySalt } = await generateMasterKeyForUser(
-        detail.password
-      );
 
-      // 2. Load master key into CryptoManager to encrypt default task list name
-      await cryptoManager.loadUserMasterKey(encryptedMasterKey, masterKeySalt, detail.password);
+      // 2. Wrapped master key: adopt the local one on upgrade, otherwise
+      //    generate a fresh key for a brand-new account.
+      let encryptedMasterKey: string;
+      let masterKeySalt: string;
+      if (isUpgrade) {
+        const localKey = cryptoManager.getCurrentKey();
+        if (!localKey) throw new Error('Local master key unavailable for account upgrade');
+        const wrapped = await cryptoManager.encryptMasterKey(localKey, detail.password);
+        encryptedMasterKey = wrapped.encryptedMasterKey;
+        masterKeySalt = wrapped.salt;
+      } else {
+        const generated = await generateMasterKeyForUser(detail.password);
+        encryptedMasterKey = generated.encryptedMasterKey;
+        masterKeySalt = generated.salt;
+        // Load it so the default task list below can be encrypted.
+        await cryptoManager.loadUserMasterKey(encryptedMasterKey, masterKeySalt, detail.password);
+      }
 
-      // 3. Create encrypted default task list (for re/task cross-app compatibility)
+      // 3. Create encrypted default task list (for re/task cross-app compatibility).
+      //    The master key is in memory in both paths.
       const defaultListName = $t('registration.defaultTaskListName') || 'My Tasks';
       const nameEncrypted = await cryptoManager.encryptText(defaultListName);
       const defaultTaskList = {
@@ -59,8 +91,11 @@
         is_default: true as const
       };
 
-      // 4. Clear master key — loginInNotes will re-load it after auth
-      cryptoManager.clearMasterKey();
+      // 4. Fresh account: clear the key - loginInNotes re-loads it after auth.
+      //    Upgrade: keep it loaded - it is the account's key now.
+      if (!isUpgrade) {
+        cryptoManager.clearMasterKey();
+      }
 
       // 5. Register via API with bot protection data + default task list
       const res = await fetch(`${API_BASE}/auth/register`, {
@@ -86,14 +121,17 @@
         return;
       }
 
-      // 6. Auto-login after successful registration (reuses notes-auth.service)
-      const loginResult = await loginInNotes(detail.username, detail.password);
-
-      if (loginResult.success) {
-        await goto(returnTo);
+      if (isUpgrade) {
+        await finishLocalUpgrade(data, encryptedMasterKey, masterKeySalt);
       } else {
-        // Registration succeeded but auto-login failed — redirect to login
-        await goto('/auth/login');
+        // 6. Auto-login after successful registration (reuses notes-auth.service)
+        const loginResult = await loginInNotes(detail.username, detail.password);
+        if (loginResult.success) {
+          await goto(returnTo);
+        } else {
+          // Registration succeeded but auto-login failed — redirect to login
+          await goto('/auth/login');
+        }
       }
     } catch (err: unknown) {
       error = err instanceof Error ? err.message : 'An error occurred. Please try again.';
@@ -101,6 +139,54 @@
     } finally {
       loading = false;
     }
+  }
+
+  /**
+   * Finish a local-only -> account upgrade after a successful register call.
+   * Sets the account session straight from the register response on purpose -
+   * NOT loginInNotes(), which clears IndexedDB and would wipe the very local
+   * notes we are adopting. The adopted master key is already in memory, so no
+   * unlock is needed; we just flag the offline data for upload and converge.
+   */
+  async function finishLocalUpgrade(
+    data: {
+      user: { id: string; username: string; created_at?: string };
+      access_token: string;
+      encryptedMasterKey?: string;
+      masterKeySalt?: string;
+    },
+    encryptedMasterKey: string,
+    masterKeySalt: string
+  ) {
+    const credentials = {
+      id: data.user.id,
+      encrypted_master_key: data.encryptedMasterKey ?? encryptedMasterKey,
+      master_key_salt: data.masterKeySalt ?? masterKeySalt,
+      user_profile: data.user
+    };
+    localStorage.setItem(CREDENTIALS_KEY, JSON.stringify(credentials));
+    localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
+
+    // Leave local-only mode: the account now owns this data.
+    localStorage.removeItem(LOCAL_MODE_KEY);
+    localStorage.removeItem(LOCAL_USER_ID_KEY);
+
+    // Flag every offline-created record for upload, then hydrate the account
+    // session (isAuthenticated -> true, localOnly -> false).
+    await markAllLocalDataPending();
+    authStore.initialize();
+
+    // Push the adopted data, then pull to converge user_id / sync_version.
+    // Best-effort: a failure here just defers to the next periodic sync.
+    try {
+      await pushPendingItems();
+      const synced = await pullFromServer();
+      if (synced) await refreshStoresAfterPull();
+    } catch (err: unknown) {
+      logger.warn('Initial sync after local-to-account upgrade failed:', err);
+    }
+
+    await goto(returnTo);
   }
 
   async function handleLocalMode() {

--- a/apps/reborn-notes/src/routes/auth/register/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/register/+page.svelte
@@ -6,6 +6,7 @@
   import { RegisterPage } from '@reborn/ui';
   import { hashPassword, generateMasterKeyForUser, cryptoManager } from '@reborn/crypto';
   import { loginInNotes } from '$lib/services/notes-auth.service';
+  import { authStore } from '$lib/stores/auth.store';
   import { t } from '$lib/stores/i18n.store';
   import { locale } from 'svelte-i18n';
   import { API_BASE } from '$lib/utils/api-base';
@@ -101,6 +102,18 @@
       loading = false;
     }
   }
+
+  async function handleLocalMode() {
+    loading = true;
+    error = null;
+    const ok = await authStore.enterLocalMode();
+    if (ok) {
+      await goto('/');
+      return;
+    }
+    error = $t('auth.register.errors.server_error');
+    loading = false;
+  }
 </script>
 
 <svelte:head>
@@ -123,11 +136,13 @@
   header={logoHeader}
   showLoginLink={true}
   loginUrl="/auth/login"
+  showLocalModeLink={true}
   powEndpoint={`${API_BASE}/auth/pow`}
   {termsUrl}
   {privacyUrl}
   themeStorageKey="reborn-notes-theme"
   onregister={handleRegister}
+  onlocalmode={handleLocalMode}
   onerror={(msg) => {
     error = msg;
   }}

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -176,6 +176,39 @@
         </div>
       </div>
       {/if}
+
+      <!-- Local-only: invite to create an account (adopts the local key, keeps notes).
+           Placed before Preferences so "Account" stays the first section, matching
+           the authenticated layout. -->
+      {#if $authStore.isLocalOnly}
+        <div class="space-y-1">
+          <h2 class="text-lg font-semibold mb-3">{$t('settings_page.account.title')}</h2>
+          <div class="space-y-1">
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+            <a href={resolveHref('/auth/register')} class={itemClasses}>
+              <User class="h-5 w-5 text-muted-foreground shrink-0" />
+              <div class="flex-1 min-w-0">
+                <div class="font-medium">{$t('settings_page.account.create')}</div>
+                <div class="text-sm text-muted-foreground">
+                  {$t('settings_page.account.create_desc')}
+                </div>
+              </div>
+              <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
+            </a>
+            <!-- Backup nudge: creating an account, or signing into another one, runs
+                 clearAllUserData and replaces local notes - suggest an export first. -->
+            <a href={resolve('/settings/import-export')} class={itemClasses}>
+              <FileDown class="h-5 w-5 text-muted-foreground shrink-0" />
+              <div class="flex-1 min-w-0">
+                <div class="text-sm text-muted-foreground">
+                  {$t('local_mode.backup_hint')}
+                </div>
+              </div>
+              <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
+            </a>
+          </div>
+        </div>
+      {/if}
       <!-- Preferences -->
       <div class="space-y-1">
         <h2 class="text-lg font-semibold mb-3">{$t('settings_page.preferences')}</h2>
@@ -202,26 +235,6 @@
           </a>
         </div>
       </div>
-
-      <!-- Local-only: invite to create an account (adopts the local key, keeps notes) -->
-      {#if $authStore.isLocalOnly}
-        <div class="space-y-1">
-          <h2 class="text-lg font-semibold mb-3">{$t('settings_page.account.title')}</h2>
-          <div class="space-y-1">
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-            <a href={resolveHref('/auth/register')} class={itemClasses}>
-              <User class="h-5 w-5 text-muted-foreground shrink-0" />
-              <div class="flex-1 min-w-0">
-                <div class="font-medium">{$t('settings_page.account.create')}</div>
-                <div class="text-sm text-muted-foreground">
-                  {$t('settings_page.account.create_desc')}
-                </div>
-              </div>
-              <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
-            </a>
-          </div>
-        </div>
-      {/if}
 
       <!-- Security -->
       {#if $authStore.isAuthenticated}

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -201,6 +201,26 @@
         </div>
       </div>
 
+      <!-- Local-only: invite to create an account (adopts the local key, keeps notes) -->
+      {#if $authStore.isLocalOnly}
+        <div class="space-y-1">
+          <h2 class="text-lg font-semibold mb-3">{$t('settings_page.account.title')}</h2>
+          <div class="space-y-1">
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+            <a href={resolveHref('/auth/register')} class={itemClasses}>
+              <User class="h-5 w-5 text-muted-foreground shrink-0" />
+              <div class="flex-1 min-w-0">
+                <div class="font-medium">{$t('settings_page.account.create')}</div>
+                <div class="text-sm text-muted-foreground">
+                  {$t('settings_page.account.create_desc')}
+                </div>
+              </div>
+              <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
+            </a>
+          </div>
+        </div>
+      {/if}
+
       <!-- Security -->
       {#if $authStore.isAuthenticated}
         <div class="space-y-1">

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -143,7 +143,8 @@
     <p class="text-sm text-muted-foreground mb-8">{$t('settings_page.about.desc')}</p>
 
     <div class="space-y-8">
-      <!-- Account -->
+      <!-- Account (real server account only; local-only shows the invite below) -->
+      {#if $authStore.isAuthenticated}
       <div class="space-y-1">
         <h2 class="text-lg font-semibold mb-3">{$t('settings_page.account.title')}</h2>
         <div class="space-y-1">
@@ -174,6 +175,7 @@
           </button>
         </div>
       </div>
+      {/if}
       <!-- Preferences -->
       <div class="space-y-1">
         <h2 class="text-lg font-semibold mb-3">{$t('settings_page.preferences')}</h2>

--- a/packages/crypto/src/__tests__/cryptoManager.spec.ts
+++ b/packages/crypto/src/__tests__/cryptoManager.spec.ts
@@ -112,6 +112,35 @@ describe('CryptoManager', () => {
     });
   });
 
+  describe('local-only key adoption (account upgrade)', () => {
+    it('adopts the in-memory local key so offline data stays readable after upgrade', async () => {
+      // Local-only session: a random key with no password wrapping, used to
+      // encrypt a note created entirely offline.
+      const localKey = await manager.generateMasterKey();
+      await manager.setMasterKey(localKey);
+      const offlineNote = 'note written before registering';
+      const ciphertext = await manager.encryptString(offlineNote);
+
+      // Upgrade: wrap the CURRENT key with the new account password - no fresh
+      // key is generated (this is what register/+page.svelte does on upgrade).
+      const accountPassword = 'accountPassword123!';
+      const current = manager.getCurrentKey();
+      expect(current).not.toBeNull();
+      const { encryptedMasterKey, salt } = await manager.encryptMasterKey(current!, accountPassword);
+
+      // Simulate logging in later/elsewhere: unwrap with the password, load it.
+      manager.clearMasterKey();
+      const adopted = await manager.decryptMasterKey(encryptedMasterKey, salt, accountPassword);
+      await manager.setMasterKey(adopted);
+
+      // The offline note, encrypted before the account existed, must still
+      // decrypt - proving the adopted key is the same key and no re-encryption
+      // of existing data is required.
+      const decrypted = await manager.decryptString(ciphertext);
+      expect(decrypted).toBe(offlineNote);
+    });
+  });
+
   describe('data encryption/decryption', () => {
     beforeEach(async () => {
       const masterKey = await manager.generateMasterKey();

--- a/packages/i18n/src/translations/common/de.json
+++ b/packages/i18n/src/translations/common/de.json
@@ -33,6 +33,7 @@
     }
   },
   "auth": {
+    "use_without_account": "Ohne Konto verwenden",
     "login": {
       "title": "Anmelden",
       "description": "Willkommen zurück! Geben Sie Ihre Zugangsdaten ein, um fortzufahren.",

--- a/packages/i18n/src/translations/common/en.json
+++ b/packages/i18n/src/translations/common/en.json
@@ -33,6 +33,7 @@
     }
   },
   "auth": {
+    "use_without_account": "Use without an account",
     "login": {
       "title": "Sign In",
       "description": "Welcome back! Enter your credentials to continue.",

--- a/packages/i18n/src/translations/common/es.json
+++ b/packages/i18n/src/translations/common/es.json
@@ -33,6 +33,7 @@
     }
   },
   "auth": {
+    "use_without_account": "Usar sin cuenta",
     "login": {
       "title": "Iniciar sesión",
       "description": "¡Bienvenido de nuevo! Introduzca sus credenciales para continuar.",

--- a/packages/i18n/src/translations/common/fr.json
+++ b/packages/i18n/src/translations/common/fr.json
@@ -33,6 +33,7 @@
     }
   },
   "auth": {
+    "use_without_account": "Utiliser sans compte",
     "login": {
       "title": "Connexion",
       "description": "Bon retour ! Entrez vos identifiants pour continuer.",

--- a/packages/i18n/src/translations/common/pl.json
+++ b/packages/i18n/src/translations/common/pl.json
@@ -33,6 +33,7 @@
     }
   },
   "auth": {
+    "use_without_account": "Użyj bez konta",
     "login": {
       "title": "Logowanie",
       "description": "Witaj ponownie! Wprowadź swoje dane, aby kontynuować.",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1,5 +1,17 @@
 {
   "appTitle": "reborn/notes",
+  "local_mode": {
+    "welcome": {
+      "title": "Offline-Modus, ohne Konto",
+      "subtitle": "Du verwendest re/notes ohne Konto. Das bedeutet:",
+      "point_storage": "Deine Notizen bleiben auf diesem Gerät und erreichen nie unsere Server.",
+      "point_encrypted": "Alles wird lokal verschlüsselt (AES-256).",
+      "point_no_sync": "Keine Synchronisierung zwischen Geräten und kein Cloud-Backup.",
+      "point_no_recovery": "Es gibt keine Wiederherstellung, wenn du dieses Gerät verlierst oder die App-Daten löschst - exportiere regelmäßig ein Backup.",
+      "point_upgrade": "Du kannst jederzeit ein Konto erstellen - deine Notizen bleiben erhalten und werden synchronisiert.",
+      "cta": "Verstanden"
+    }
+  },
   "nav": {
     "all_notes": "Alle Notizen",
     "starred": "Markiert",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -572,6 +572,7 @@
     "badge_tooltip": "Ende-zu-Ende-verschlüsselt — klicken zum Anzeigen"
   },
   "sync_status": {
+    "local_only": "Nur lokal",
     "synced": "Synchronisiert",
     "syncing": "Synchronisierung…",
     "offline": "Offline",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -621,6 +621,11 @@
     "keep_editing": "Weiter bearbeiten"
   },
   "settings_page": {
+    "account": {
+      "title": "Konto",
+      "create": "Konto erstellen",
+      "create_desc": "Behalte deine Notizen und synchronisiere geräteübergreifend. Deine vorhandenen Notizen bleiben erhalten."
+    },
     "title": "Einstellungen",
     "description": "Verwalten Sie Ihre App- und Kontoeinstellungen",
     "saving": "Speichern…",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -621,11 +621,6 @@
     "keep_editing": "Weiter bearbeiten"
   },
   "settings_page": {
-    "account": {
-      "title": "Konto",
-      "create": "Konto erstellen",
-      "create_desc": "Behalte deine Notizen und synchronisiere geräteübergreifend. Deine vorhandenen Notizen bleiben erhalten."
-    },
     "title": "Einstellungen",
     "description": "Verwalten Sie Ihre App- und Kontoeinstellungen",
     "saving": "Speichern…",
@@ -641,7 +636,9 @@
       "member_since": "Mitglied seit",
       "signed_in_via": "Angemeldet über re/task",
       "registered": "Registriert",
-      "log_out": "Abmelden"
+      "log_out": "Abmelden",
+      "create": "Konto erstellen",
+      "create_desc": "Behalte deine Notizen und synchronisiere geräteübergreifend. Deine vorhandenen Notizen bleiben erhalten."
     },
     "appearance": {
       "title": "Erscheinungsbild",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -10,7 +10,15 @@
       "point_no_recovery": "Es gibt keine Wiederherstellung, wenn du dieses Gerät verlierst oder die App-Daten löschst - exportiere regelmäßig ein Backup.",
       "point_upgrade": "Du kannst jederzeit ein Konto erstellen - deine Notizen bleiben erhalten und werden synchronisiert.",
       "cta": "Verstanden"
-    }
+    },
+    "register": "Konto erstellen",
+    "menu_title": "Nur lokal",
+    "menu_hint": "Kein Konto, nicht synchronisiert",
+    "share_title": "Zum Teilen ist ein Konto nötig",
+    "backup_hint": "Tipp: Exportiere ein Backup, bevor du ein Konto erstellst oder dich anderswo anmeldest.",
+    "replace_title": "Lokale Notizen ersetzen?",
+    "replace_desc": "Du nutzt re/notes ohne Konto. Beim Anmelden werden die Notizen auf diesem Gerät durch die Kontodaten ersetzt. Exportiere zuerst ein Backup, wenn du sie behalten möchtest.",
+    "replace_confirm": "Trotzdem anmelden"
   },
   "nav": {
     "all_notes": "Alle Notizen",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1,5 +1,17 @@
 {
   "appTitle": "reborn/notes",
+  "local_mode": {
+    "welcome": {
+      "title": "Working offline, no account",
+      "subtitle": "You're using re/notes without an account. Here's what that means:",
+      "point_storage": "Your notes stay on this device and never reach our servers.",
+      "point_encrypted": "Everything is encrypted (AES-256) locally.",
+      "point_no_sync": "No sync across devices and no cloud backup.",
+      "point_no_recovery": "There's no recovery if you lose this device or clear app data - export a backup regularly.",
+      "point_upgrade": "You can create an account anytime - your notes will be kept and start syncing.",
+      "cta": "Got it"
+    }
+  },
   "nav": {
     "all_notes": "All Notes",
     "starred": "Starred",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -10,7 +10,15 @@
       "point_no_recovery": "There's no recovery if you lose this device or clear app data - export a backup regularly.",
       "point_upgrade": "You can create an account anytime - your notes will be kept and start syncing.",
       "cta": "Got it"
-    }
+    },
+    "register": "Register account",
+    "menu_title": "Local only",
+    "menu_hint": "No account, not synced",
+    "share_title": "Sharing needs an account",
+    "backup_hint": "Tip: export a backup before creating an account or signing in elsewhere.",
+    "replace_title": "Replace local notes?",
+    "replace_desc": "You're using re/notes without an account. Signing in replaces the notes on this device with the account's data. Export a backup first if you want to keep them.",
+    "replace_confirm": "Sign in anyway"
   },
   "nav": {
     "all_notes": "All Notes",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -572,6 +572,7 @@
     "badge_tooltip": "Encrypted end-to-end — click to see"
   },
   "sync_status": {
+    "local_only": "Local only",
     "synced": "Synced",
     "syncing": "Syncing…",
     "offline": "Offline",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -621,11 +621,6 @@
     "keep_editing": "Keep editing"
   },
   "settings_page": {
-    "account": {
-      "title": "Account",
-      "create": "Create an account",
-      "create_desc": "Keep your notes and sync across devices. Your existing notes are kept."
-    },
     "title": "Settings",
     "description": "Manage your app and account settings",
     "saving": "Saving…",
@@ -641,7 +636,9 @@
       "member_since": "Member since",
       "signed_in_via": "Signed in via re/task",
       "registered": "Registered",
-      "log_out": "Log out"
+      "log_out": "Log out",
+      "create": "Create an account",
+      "create_desc": "Keep your notes and sync across devices. Your existing notes are kept."
     },
     "appearance": {
       "title": "Appearance",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -621,6 +621,11 @@
     "keep_editing": "Keep editing"
   },
   "settings_page": {
+    "account": {
+      "title": "Account",
+      "create": "Create an account",
+      "create_desc": "Keep your notes and sync across devices. Your existing notes are kept."
+    },
     "title": "Settings",
     "description": "Manage your app and account settings",
     "saving": "Saving…",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -572,6 +572,7 @@
     "badge_tooltip": "Cifrado de extremo a extremo — pulse para ver"
   },
   "sync_status": {
+    "local_only": "Solo local",
     "synced": "Sincronizado",
     "syncing": "Sincronizando…",
     "offline": "Sin conexión",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -10,7 +10,15 @@
       "point_no_recovery": "No hay recuperación si pierdes este dispositivo o borras los datos de la aplicación - exporta una copia de seguridad con regularidad.",
       "point_upgrade": "Puedes crear una cuenta en cualquier momento: tus notas se conservarán y comenzarán a sincronizarse.",
       "cta": "Entendido"
-    }
+    },
+    "register": "Crear una cuenta",
+    "menu_title": "Solo local",
+    "menu_hint": "Sin cuenta, sin sincronización",
+    "share_title": "Compartir requiere una cuenta",
+    "backup_hint": "Consejo: exporta una copia de seguridad antes de crear una cuenta o iniciar sesión en otra.",
+    "replace_title": "¿Reemplazar las notas locales?",
+    "replace_desc": "Estás usando re/notes sin una cuenta. Iniciar sesión reemplaza las notas de este dispositivo con los datos de la cuenta. Exporta una copia de seguridad primero si quieres conservarlas.",
+    "replace_confirm": "Iniciar sesión de todos modos"
   },
   "nav": {
     "all_notes": "Todas las notas",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -621,11 +621,6 @@
     "keep_editing": "Seguir editando"
   },
   "settings_page": {
-    "account": {
-      "title": "Cuenta",
-      "create": "Crear una cuenta",
-      "create_desc": "Conserva tus notas y sincroniza entre dispositivos. Tus notas actuales se conservan."
-    },
     "title": "Configuración",
     "description": "Administre la configuración de su aplicación y cuenta",
     "saving": "Guardando…",
@@ -641,7 +636,9 @@
       "member_since": "Miembro desde",
       "signed_in_via": "Sesión iniciada a través de re/task",
       "registered": "Registrado",
-      "log_out": "Cerrar sesión"
+      "log_out": "Cerrar sesión",
+      "create": "Crear una cuenta",
+      "create_desc": "Conserva tus notas y sincroniza entre dispositivos. Tus notas actuales se conservan."
     },
     "appearance": {
       "title": "Apariencia",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1,5 +1,17 @@
 {
   "appTitle": "reborn/notes",
+  "local_mode": {
+    "welcome": {
+      "title": "Modo sin conexión, sin cuenta",
+      "subtitle": "Estás usando re/notes sin cuenta. Esto es lo que significa:",
+      "point_storage": "Tus notas permanecen en este dispositivo y nunca llegan a nuestros servidores.",
+      "point_encrypted": "Todo se cifra (AES-256) localmente.",
+      "point_no_sync": "Sin sincronización entre dispositivos ni copia de seguridad en la nube.",
+      "point_no_recovery": "No hay recuperación si pierdes este dispositivo o borras los datos de la aplicación - exporta una copia de seguridad con regularidad.",
+      "point_upgrade": "Puedes crear una cuenta en cualquier momento: tus notas se conservarán y comenzarán a sincronizarse.",
+      "cta": "Entendido"
+    }
+  },
   "nav": {
     "all_notes": "Todas las notas",
     "starred": "Destacadas",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -621,6 +621,11 @@
     "keep_editing": "Seguir editando"
   },
   "settings_page": {
+    "account": {
+      "title": "Cuenta",
+      "create": "Crear una cuenta",
+      "create_desc": "Conserva tus notas y sincroniza entre dispositivos. Tus notas actuales se conservan."
+    },
     "title": "Configuración",
     "description": "Administre la configuración de su aplicación y cuenta",
     "saving": "Guardando…",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1,5 +1,17 @@
 {
   "appTitle": "reborn/notes",
+  "local_mode": {
+    "welcome": {
+      "title": "Mode hors ligne, sans compte",
+      "subtitle": "Vous utilisez re/notes sans compte. Voici ce que cela implique :",
+      "point_storage": "Vos notes restent sur cet appareil et n'atteignent jamais nos serveurs.",
+      "point_encrypted": "Tout est chiffré (AES-256) localement.",
+      "point_no_sync": "Pas de synchronisation entre appareils ni de sauvegarde dans le cloud.",
+      "point_no_recovery": "Aucune récupération n'est possible si vous perdez cet appareil ou effacez les données de l'application - exportez régulièrement une sauvegarde.",
+      "point_upgrade": "Vous pouvez créer un compte à tout moment - vos notes seront conservées et commenceront à se synchroniser.",
+      "cta": "J'ai compris"
+    }
+  },
   "nav": {
     "all_notes": "Toutes les notes",
     "starred": "Favorites",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -621,11 +621,6 @@
     "keep_editing": "Continuer la modification"
   },
   "settings_page": {
-    "account": {
-      "title": "Compte",
-      "create": "Créer un compte",
-      "create_desc": "Conservez vos notes et synchronisez entre appareils. Vos notes actuelles sont conservées."
-    },
     "title": "Paramètres",
     "description": "Gérez les paramètres de votre application et de votre compte",
     "saving": "Enregistrement…",
@@ -641,7 +636,9 @@
       "member_since": "Membre depuis",
       "signed_in_via": "Connecté via re/task",
       "registered": "Inscrit",
-      "log_out": "Se déconnecter"
+      "log_out": "Se déconnecter",
+      "create": "Créer un compte",
+      "create_desc": "Conservez vos notes et synchronisez entre appareils. Vos notes actuelles sont conservées."
     },
     "appearance": {
       "title": "Apparence",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -10,7 +10,15 @@
       "point_no_recovery": "Aucune récupération n'est possible si vous perdez cet appareil ou effacez les données de l'application - exportez régulièrement une sauvegarde.",
       "point_upgrade": "Vous pouvez créer un compte à tout moment - vos notes seront conservées et commenceront à se synchroniser.",
       "cta": "J'ai compris"
-    }
+    },
+    "register": "Créer un compte",
+    "menu_title": "Local uniquement",
+    "menu_hint": "Sans compte, non synchronisé",
+    "share_title": "Le partage nécessite un compte",
+    "backup_hint": "Astuce : exportez une sauvegarde avant de créer un compte ou de vous connecter ailleurs.",
+    "replace_title": "Remplacer les notes locales ?",
+    "replace_desc": "Vous utilisez re/notes sans compte. La connexion remplace les notes de cet appareil par les données du compte. Exportez d'abord une sauvegarde si vous souhaitez les conserver.",
+    "replace_confirm": "Se connecter quand même"
   },
   "nav": {
     "all_notes": "Toutes les notes",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -621,6 +621,11 @@
     "keep_editing": "Continuer la modification"
   },
   "settings_page": {
+    "account": {
+      "title": "Compte",
+      "create": "Créer un compte",
+      "create_desc": "Conservez vos notes et synchronisez entre appareils. Vos notes actuelles sont conservées."
+    },
     "title": "Paramètres",
     "description": "Gérez les paramètres de votre application et de votre compte",
     "saving": "Enregistrement…",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -572,6 +572,7 @@
     "badge_tooltip": "Chiffré de bout en bout — cliquez pour voir"
   },
   "sync_status": {
+    "local_only": "Local uniquement",
     "synced": "Synchronisé",
     "syncing": "Synchronisation…",
     "offline": "Hors ligne",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -572,6 +572,7 @@
     "badge_tooltip": "Szyfrowane end-to-end — kliknij, aby zobaczyć"
   },
   "sync_status": {
+    "local_only": "Tylko lokalnie",
     "synced": "Zsynchronizowane",
     "syncing": "Synchronizacja…",
     "offline": "Offline",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -621,6 +621,11 @@
     "keep_editing": "Kontynuuj edycję"
   },
   "settings_page": {
+    "account": {
+      "title": "Konto",
+      "create": "Załóż konto",
+      "create_desc": "Zachowaj notatki i synchronizuj między urządzeniami. Twoje obecne notatki zostaną zachowane."
+    },
     "title": "Ustawienia",
     "description": "Zarządzaj ustawieniami aplikacji i konta",
     "saving": "Zapisywanie…",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -621,11 +621,6 @@
     "keep_editing": "Kontynuuj edycję"
   },
   "settings_page": {
-    "account": {
-      "title": "Konto",
-      "create": "Załóż konto",
-      "create_desc": "Zachowaj notatki i synchronizuj między urządzeniami. Twoje obecne notatki zostaną zachowane."
-    },
     "title": "Ustawienia",
     "description": "Zarządzaj ustawieniami aplikacji i konta",
     "saving": "Zapisywanie…",
@@ -641,7 +636,9 @@
       "member_since": "Użytkownik od",
       "signed_in_via": "Zalogowano przez re/task",
       "registered": "Zarejestrowano",
-      "log_out": "Wyloguj się"
+      "log_out": "Wyloguj się",
+      "create": "Załóż konto",
+      "create_desc": "Zachowaj notatki i synchronizuj między urządzeniami. Twoje obecne notatki zostaną zachowane."
     },
     "appearance": {
       "title": "Wygląd",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1,5 +1,17 @@
 {
   "appTitle": "reborn/notes",
+  "local_mode": {
+    "welcome": {
+      "title": "Tryb offline, bez konta",
+      "subtitle": "Używasz re/notes bez konta. Oto co to oznacza:",
+      "point_storage": "Twoje notatki zostają na tym urządzeniu i nigdy nie trafiają na nasze serwery.",
+      "point_encrypted": "Wszystko jest szyfrowane (AES-256) lokalnie.",
+      "point_no_sync": "Brak synchronizacji między urządzeniami i kopii w chmurze.",
+      "point_no_recovery": "Nie ma odzyskania danych, jeśli stracisz to urządzenie lub wyczyścisz dane aplikacji - regularnie eksportuj kopię zapasową.",
+      "point_upgrade": "W każdej chwili możesz założyć konto - notatki zostaną zachowane i zaczną się synchronizować.",
+      "cta": "Rozumiem"
+    }
+  },
   "nav": {
     "all_notes": "Wszystkie notatki",
     "starred": "Ulubione",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -10,7 +10,15 @@
       "point_no_recovery": "Nie ma odzyskania danych, jeśli stracisz to urządzenie lub wyczyścisz dane aplikacji - regularnie eksportuj kopię zapasową.",
       "point_upgrade": "W każdej chwili możesz założyć konto - notatki zostaną zachowane i zaczną się synchronizować.",
       "cta": "Rozumiem"
-    }
+    },
+    "register": "Zarejestruj konto",
+    "menu_title": "Tylko lokalnie",
+    "menu_hint": "Bez konta, bez synchronizacji",
+    "share_title": "Udostępnianie wymaga konta",
+    "backup_hint": "Wskazówka: zrób kopię zapasową przed założeniem konta lub zalogowaniem na inne.",
+    "replace_title": "Zastąpić lokalne notatki?",
+    "replace_desc": "Używasz re/notes bez konta. Zalogowanie zastąpi notatki na tym urządzeniu danymi z konta. Najpierw zrób kopię zapasową, jeśli chcesz je zachować.",
+    "replace_confirm": "Zaloguj mimo to"
   },
   "nav": {
     "all_notes": "Wszystkie notatki",

--- a/packages/storage/src/services/synced-settings.service.ts
+++ b/packages/storage/src/services/synced-settings.service.ts
@@ -61,6 +61,13 @@ export interface SyncedSettingsAdapter {
   basePath: string;
   /** Which app's IDB row we are reading/writing. */
   appName: AppName;
+  /**
+   * Optional gate: when it returns false, every server round-trip (pull and
+   * push) is a no-op. Used for local-only / no-account mode, where there is no
+   * session - without this gate the GET/PUT would 401, trigger a refresh that
+   * also 401s, and trip the session-expired banner. Omitted = always enabled.
+   */
+  isSyncEnabled?: () => boolean;
 }
 
 /** How long to wait after the last `update()` before pushing to the server. */
@@ -73,6 +80,11 @@ export class SyncedSettingsService {
 
   constructor(adapter: SyncedSettingsAdapter) {
     this.adapter = adapter;
+  }
+
+  /** Server I/O is disabled (e.g. local-only mode) - every call is a no-op. */
+  private syncDisabled(): boolean {
+    return this.adapter.isSyncEnabled?.() === false;
   }
 
   // ── Public API ────────────────────────────────────────────────────
@@ -88,6 +100,7 @@ export class SyncedSettingsService {
    *   - Local is newer → push up (handled implicitly by the next push).
    */
   async pullAndMerge(): Promise<{ applied: boolean }> {
+    if (this.syncDisabled()) return { applied: false };
     if (!cryptoManager.isInitialized()) {
       logger.debug('Master key not initialized - skipping pull');
       return { applied: false };
@@ -204,6 +217,7 @@ export class SyncedSettingsService {
    * Multiple rapid `update()` calls coalesce into a single network round-trip.
    */
   schedulePush(delayMs: number = DEFAULT_DEBOUNCE_MS): void {
+    if (this.syncDisabled()) return;
     if (this.pushTimer) clearTimeout(this.pushTimer);
     this.pushTimer = setTimeout(() => {
       this.pushTimer = null;
@@ -213,6 +227,7 @@ export class SyncedSettingsService {
 
   /** Flush any pending debounced push and execute one immediately. */
   async pushNow(): Promise<void> {
+    if (this.syncDisabled()) return;
     if (this.pushTimer) {
       clearTimeout(this.pushTimer);
       this.pushTimer = null;

--- a/packages/ui/src/components/auth/LoginPage.svelte
+++ b/packages/ui/src/components/auth/LoginPage.svelte
@@ -10,20 +10,26 @@
     appName = 'Reborn Apps',
     showRegisterLink = true,
     registerUrl = '/register',
+    showLocalModeLink = false,
     themeStorageKey = 'reborn-theme',
     header,
     onlogin,
-    onnavigate
+    onnavigate,
+    onlocalmode
   } = $props<{
     loading?: boolean;
     error?: string | null;
     appName?: string;
     showRegisterLink?: boolean;
     registerUrl?: string;
+    /** Opt-in "use without an account" entry (local-only / offline mode). */
+    showLocalModeLink?: boolean;
     themeStorageKey?: string;
     header?: Snippet;
     onlogin?: (detail: { username: string; password: string; rememberMe: boolean }) => void;
     onnavigate?: (detail: { url: string }) => void;
+    /** Fired when the user chooses to use the app without an account. */
+    onlocalmode?: () => void;
   }>();
 
   function handleLogin(detail: { username: string; password: string; rememberMe: boolean }) {
@@ -47,6 +53,17 @@
       >
         {$t('auth.login.sign_up')}
       </a>
+    </p>
+  {/if}
+  {#if showLocalModeLink}
+    <p class="text-sm text-muted-foreground mt-4 border-t border-border pt-4">
+      <button
+        type="button"
+        class="font-medium text-primary underline underline-offset-4 hover:text-primary/90"
+        onclick={() => onlocalmode?.()}
+      >
+        {$t('auth.use_without_account')}
+      </button>
     </p>
   {/if}
 {/snippet}

--- a/packages/ui/src/components/auth/RegisterPage.svelte
+++ b/packages/ui/src/components/auth/RegisterPage.svelte
@@ -11,6 +11,7 @@
     appName = 'Reborn Apps',
     showLoginLink = true,
     loginUrl = '/login',
+    showLocalModeLink = false,
     powEndpoint = '',
     termsUrl = '',
     privacyUrl = '',
@@ -18,13 +19,16 @@
     header,
     onregister,
     onnavigate,
-    onerror
+    onerror,
+    onlocalmode
   } = $props<{
     loading?: boolean;
     error?: string | null;
     appName?: string;
     showLoginLink?: boolean;
     loginUrl?: string;
+    /** Opt-in "use without an account" entry (local-only / offline mode). */
+    showLocalModeLink?: boolean;
     powEndpoint?: string;
     termsUrl?: string;
     privacyUrl?: string;
@@ -40,6 +44,8 @@
     }) => void;
     onnavigate?: (detail: { url: string }) => void;
     onerror?: (message: string) => void;
+    /** Fired when the user chooses to use the app without an account. */
+    onlocalmode?: () => void;
   }>();
 
   function handleRegister(detail: {
@@ -75,6 +81,18 @@
         >
           {$t('auth.register.sign_in')}
         </a>
+      </p>
+    {/if}
+
+    {#if showLocalModeLink}
+      <p class="text-sm text-gray-600 dark:text-gray-400 text-center">
+        <button
+          type="button"
+          class="font-medium text-primary underline underline-offset-4 hover:text-primary/80"
+          onclick={() => onlocalmode?.()}
+        >
+          {$t('auth.use_without_account')}
+        </button>
       </p>
     {/if}
 


### PR DESCRIPTION
## Summary

Adds a local-only / no-account mode to reborn-notes: new users can use the app fully offline without registering, with all data encrypted locally, and can later create an account without losing their notes.

- **Entry point** (@reborn/ui): opt-in "Use without an account" link under the Login and Register forms (shared component; Task wired in a follow-up).
- **Foundation**: `isLocalOnly` auth state + `enterLocalMode()` generates and persists a device-local master key (no password wrapping; IndexedDB on web, Keychain/Keystore vault on native) and a device-scoped `user_id`. The route guard lets local-only sessions through; sync gates (keyed on `isAuthenticated`) stay no-ops.
- **First-run modal**: honest explainer (local-only, no sync, no cloud recovery, export to back up, create an account anytime), shown once per profile.
- **Sync status**: dedicated "Local only" state.
- **Upgrade to account (key adoption, plan B1)**: registering from a local-only session adopts the existing local master key (wraps it with the new password) instead of generating a fresh one, so offline notes - already encrypted with that key - stay readable and just start syncing. No re-encryption, no export/import. The session is set straight from the register response (not `loginInNotes`, which clears IndexedDB), local data is flagged pending, then push+pull converges. Normal registration is unchanged.

### Decisions (auto mode) - for review

- **At-rest key model (Zero Knowledge)**: the local master key is stored unwrapped at rest (web IndexedDB / native vault), matching the existing "stay unlocked" posture for logged-in users. Approved as the A1 baseline; an **optional local passcode** (PBKDF2-wrap) is deferred to a follow-up PR because it needs cryptoManager core changes (memory-only key + at-rest wrap).
- **Upgrade = key adoption (B1)** over key rotation (B2): no re-encryption engine, no data-loss risk from interrupted migration; rationale in the planning doc.
- **Scope**: Notes only. **reborn-task** (different auth model: SessionManager + @reborn/auth, plus user_id-filtered lists) and the **optional passcode** follow in separate PRs.

i18n: new keys across all 5 locales; parity verified. Test: cryptoManager adoption round-trip proves offline data decrypts with the adopted key.

## Test plan

- [ ] On /auth/login and /auth/register, "Use without an account" appears under the form (check a couple of locales).
- [ ] Clicking it enters the app without login; the first-run modal explains the mode; sidebar footer shows "Local only".
- [ ] Create notes: saved and encrypted locally; reload preserves them; the modal does not reappear.
- [ ] Settings shows "Create an account" while local-only.
- [ ] From local-only, register a new account: existing notes stay readable (key adopted) and sync to the server; status becomes normal.
- [ ] Normal login / registration with an account is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)