### PR TITLE
feat(task): local-only / no-account mode + upgrade to account

### DIFF
--- a/apps/reborn-task/src/lib/components/LocalModeWelcome.svelte
+++ b/apps/reborn-task/src/lib/components/LocalModeWelcome.svelte
@@ -1,0 +1,75 @@
+<!--
+  First-run explainer for local-only / no-account mode. Shown exactly once per
+  browser profile: the marker is written the moment the dialog opens, so any way
+  of dismissing it (button, Esc, overlay) still counts as "seen". The copy is
+  deliberately honest about the trade-off (no server, no cloud recovery) - this
+  is the privacy pitch, not fine print. See planning/local-only-no-account-plan.md.
+-->
+<script lang="ts">
+	import {
+		Dialog,
+		DialogContent,
+		DialogHeader,
+		DialogTitle,
+		DialogDescription,
+		DialogFooter,
+		Button
+	} from '@reborn/ui';
+	import { browser } from '$app/environment';
+	import { isLocalOnly } from '$lib/stores/auth.store';
+	import { t } from '$lib/stores/i18n.store';
+
+	const WELCOMED_KEY = 'reborn_local_mode_welcomed';
+	let open = $state(false);
+
+	$effect(() => {
+		if (!browser) return;
+		if ($isLocalOnly && localStorage.getItem(WELCOMED_KEY) !== '1') {
+			open = true;
+			// Mark as seen on open so it shows exactly once regardless of how it's closed.
+			try {
+				localStorage.setItem(WELCOMED_KEY, '1');
+			} catch {
+				/* private mode / storage disabled - worst case it shows again, harmless */
+			}
+		}
+	});
+</script>
+
+<Dialog bind:open>
+	<DialogContent>
+		<DialogHeader>
+			<DialogTitle>{$t('local_mode.welcome.title')}</DialogTitle>
+			<DialogDescription>{$t('local_mode.welcome.subtitle')}</DialogDescription>
+		</DialogHeader>
+
+		<ul class="space-y-3 py-2 text-sm text-muted-foreground">
+			<li class="flex gap-2">
+				<span aria-hidden="true">•</span>
+				<span>{$t('local_mode.welcome.point_storage')}</span>
+			</li>
+			<li class="flex gap-2">
+				<span aria-hidden="true">•</span>
+				<span>{$t('local_mode.welcome.point_encrypted')}</span>
+			</li>
+			<li class="flex gap-2">
+				<span aria-hidden="true">•</span>
+				<span>{$t('local_mode.welcome.point_no_sync')}</span>
+			</li>
+			<li class="flex gap-2 font-medium text-foreground">
+				<span aria-hidden="true">•</span>
+				<span>{$t('local_mode.welcome.point_no_recovery')}</span>
+			</li>
+			<li class="flex gap-2">
+				<span aria-hidden="true">•</span>
+				<span>{$t('local_mode.welcome.point_upgrade')}</span>
+			</li>
+		</ul>
+
+		<DialogFooter>
+			<Button onclick={() => (open = false)}>
+				{$t('local_mode.welcome.cta')}
+			</Button>
+		</DialogFooter>
+	</DialogContent>
+</Dialog>

--- a/apps/reborn-task/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-task/src/lib/components/layout/IconNav.svelte
@@ -24,7 +24,8 @@
 		Settings,
 		LogOut,
 		Share2,
-		Heart
+		Heart,
+		UserPlus
 	} from '@lucide/svelte';
 	import {
 		overdueTasks,
@@ -43,6 +44,7 @@
 	import { activeSharesCount } from '$lib/stores/shares.store';
 	import { requireActiveSession } from '$lib/utils/require-active-session';
 	import ManageSharesDialog from '$lib/components/tasks/ManageSharesDialog.svelte';
+	import AccountRequiredDialog from '$lib/components/shared/AccountRequiredDialog.svelte';
 
 	let {
 		activeSection = $bindable<Section>('lists'),
@@ -70,8 +72,14 @@
 		(import.meta.env.PUBLIC_SITE_URL as string | undefined) ?? 'https://reapps.eu';
 	const supportUrl = $derived(`${SITE_URL}${$i18nLocale === 'pl' ? '/pl' : ''}/support`);
 	let sharesDialogOpen = $state(false);
+	let accountRequiredOpen = $state(false);
 
 	async function handleOpenShares() {
+		// Sharing is account-only: in local-only mode, invite to create an account.
+		if ($session.isLocalOnly) {
+			accountRequiredOpen = true;
+			return;
+		}
 		const ok = await requireActiveSession({
 			description: $t('share.session_required.view')
 		});
@@ -503,9 +511,15 @@
 									{getUserInitial($session.user?.username ?? null)}
 								</span>
 								<div class="grid flex-1 text-start text-sm leading-tight">
-									<span class="truncate font-medium">{$session.user?.username ?? '—'}</span>
+									<span class="truncate font-medium"
+										>{$session.isLocalOnly
+											? $t('local_mode.menu_title')
+											: ($session.user?.username ?? '—')}</span
+									>
 									<span class="truncate text-xs text-muted-foreground"
-										>{$t('common.e2ee_account', { default: 'Konto E2EE' })}</span
+										>{$session.isLocalOnly
+											? $t('local_mode.menu_subtitle')
+											: $t('common.e2ee_account', { default: 'Konto E2EE' })}</span
 									>
 								</div>
 							</div>
@@ -517,6 +531,13 @@
 								{$t('settings.app_settings')}
 							</DropdownMenu.Item>
 						</DropdownMenu.Group>
+						{#if $session.isLocalOnly}
+							<DropdownMenu.Separator />
+							<DropdownMenu.Item onclick={() => goto('/auth/register')}>
+								<UserPlus class="h-4 w-4" />
+								{$t('local_mode.create_account')}
+							</DropdownMenu.Item>
+						{/if}
 						{#if $session.isAuthenticated}
 							<DropdownMenu.Separator />
 							<DropdownMenu.Item
@@ -537,6 +558,9 @@
 <!-- Shares manage dialog (mounted once, used by both nav modes) -->
 <ManageSharesDialog bind:open={sharesDialogOpen} sourceId={null} />
 
+<!-- Account-required prompt (shares opened in local-only mode) -->
+<AccountRequiredDialog bind:open={accountRequiredOpen} />
+
 <!-- Mobile: User menu Sheet -->
 <Sheet bind:open={userSheetOpen}>
 	<SheetContent side="bottom" class="h-auto">
@@ -550,9 +574,15 @@
 						{getUserInitial($session.user?.username ?? null)}
 					</span>
 					<div class="grid flex-1 text-start text-sm leading-tight">
-						<span class="truncate font-medium">{$session.user?.username ?? '—'}</span>
+						<span class="truncate font-medium"
+							>{$session.isLocalOnly
+								? $t('local_mode.menu_title')
+								: ($session.user?.username ?? '—')}</span
+						>
 						<span class="truncate text-xs font-normal text-muted-foreground"
-							>{$t('common.e2ee_account', { default: 'Konto E2EE' })}</span
+							>{$session.isLocalOnly
+								? $t('local_mode.menu_subtitle')
+								: $t('common.e2ee_account', { default: 'Konto E2EE' })}</span
 						>
 					</div>
 				</div>
@@ -570,6 +600,19 @@
 				<Settings class="mr-2 h-4 w-4" />
 				{$t('settings.app_settings')}
 			</Button>
+			{#if $session.isLocalOnly}
+				<Button
+					variant="ghost"
+					class="w-full justify-start"
+					onclick={() => {
+						userSheetOpen = false;
+						goto('/auth/register');
+					}}
+				>
+					<UserPlus class="mr-2 h-4 w-4" />
+					{$t('local_mode.create_account')}
+				</Button>
+			{/if}
 			{#if $session.isAuthenticated}
 				<Button
 					variant="ghost"

--- a/apps/reborn-task/src/lib/components/shared/AccountRequiredDialog.svelte
+++ b/apps/reborn-task/src/lib/components/shared/AccountRequiredDialog.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import ConfirmDialog from './dialogs/ConfirmDialog.svelte';
+	import { goto } from '$lib/utils/navigation';
+	import { t } from '$lib/stores/i18n.store';
+
+	// Shown when an account-only action (e.g. sharing) is attempted in local-only
+	// mode. Confirm routes to registration - which adopts the local master key and
+	// keeps existing tasks (see register/+page.svelte upgrade path); cancel just
+	// dismisses.
+	let { open = $bindable(false) }: { open?: boolean } = $props();
+</script>
+
+<ConfirmDialog
+	bind:open
+	title={$t('local_mode.share_title')}
+	description={$t('local_mode.account_required_desc')}
+	confirmText={$t('local_mode.create_account')}
+	cancelText={$t('common.cancel')}
+	onConfirm={() => goto('/auth/register')}
+/>

--- a/apps/reborn-task/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-task/src/lib/components/sync/SyncStatusFooter.svelte
@@ -4,7 +4,15 @@
   Shows last sync state, click to trigger manual sync.
 -->
 <script lang="ts">
-	import { RefreshCw, Check, WifiOff, AlertCircle, CloudUpload, ShieldAlert } from '@lucide/svelte';
+	import {
+		RefreshCw,
+		Check,
+		WifiOff,
+		AlertCircle,
+		CloudUpload,
+		ShieldAlert,
+		HardDrive
+	} from '@lucide/svelte';
 	import { syncStatus, type SyncStatusType } from '$lib/stores/sync-status.store';
 	import { syncService } from '$lib/services/sync.service';
 	import { failedOperations, offlineOperationsStore } from '$lib/stores/offline-operations.store';
@@ -18,7 +26,8 @@
 			isSyncing ||
 			$syncStatus.status === 'syncing' ||
 			$syncStatus.status === 'offline' ||
-			$syncStatus.status === 'auth-error'
+			$syncStatus.status === 'auth-error' ||
+			$syncStatus.status === 'local_only'
 		)
 			return;
 
@@ -75,6 +84,8 @@
 				return CloudUpload;
 			case 'auth-error':
 				return ShieldAlert;
+			case 'local_only':
+				return HardDrive;
 		}
 	}
 
@@ -92,6 +103,8 @@
 				return 'text-amber-500 dark:text-amber-400';
 			case 'auth-error':
 				return 'text-destructive';
+			case 'local_only':
+				return 'text-muted-foreground';
 		}
 	}
 
@@ -109,6 +122,8 @@
 				return $t('sync.indicator.pending', { values: { count: $syncStatus.pendingCount } });
 			case 'auth-error':
 				return $t('sync.indicator.session_expired');
+			case 'local_only':
+				return $t('sync.indicator.local_only');
 		}
 	}
 
@@ -118,6 +133,7 @@
 		$syncStatus.status !== 'offline' &&
 			$syncStatus.status !== 'syncing' &&
 			$syncStatus.status !== 'auth-error' &&
+			$syncStatus.status !== 'local_only' &&
 			!isSyncing
 	);
 </script>

--- a/apps/reborn-task/src/lib/components/sync/SyncStatusIndicator.svelte
+++ b/apps/reborn-task/src/lib/components/sync/SyncStatusIndicator.svelte
@@ -7,7 +7,15 @@
 <script lang="ts">
 	import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@reborn/ui';
 	import { toastStore } from '@reborn/ui';
-	import { RefreshCw, Check, WifiOff, AlertCircle, CloudUpload, ShieldAlert } from '@lucide/svelte';
+	import {
+		RefreshCw,
+		Check,
+		WifiOff,
+		AlertCircle,
+		CloudUpload,
+		ShieldAlert,
+		HardDrive
+	} from '@lucide/svelte';
 	import { syncStatus, type SyncStatusType } from '$lib/stores/sync-status.store';
 	import { failedOperations } from '$lib/stores/offline-operations.store';
 	import { offlineOperationsStore } from '$lib/stores/offline-operations.store';
@@ -86,6 +94,8 @@
 				return CloudUpload;
 			case 'auth-error':
 				return ShieldAlert;
+			case 'local_only':
+				return HardDrive;
 		}
 	}
 
@@ -103,6 +113,8 @@
 				return 'text-amber-500';
 			case 'auth-error':
 				return 'text-destructive';
+			case 'local_only':
+				return 'text-muted-foreground';
 		}
 	}
 
@@ -118,13 +130,15 @@
 				return (
 					$t('sync.indicator.error') +
 					($syncStatus.failedCount > 0 ? ` (${$syncStatus.failedCount})` : '') +
-					' — ' +
+					' - ' +
 					$t('sync.indicator.tap_to_retry')
 				);
 			case 'pending':
 				return $t('sync.indicator.pending', { values: { count: $syncStatus.pendingCount } });
 			case 'auth-error':
 				return $t('sync.indicator.session_expired');
+			case 'local_only':
+				return $t('sync.indicator.local_only');
 		}
 	}
 
@@ -134,6 +148,7 @@
 		$syncStatus.status !== 'offline' &&
 			$syncStatus.status !== 'syncing' &&
 			$syncStatus.status !== 'auth-error' &&
+			$syncStatus.status !== 'local_only' &&
 			!isSyncing
 	);
 </script>

--- a/apps/reborn-task/src/lib/guards/auth.ts
+++ b/apps/reborn-task/src/lib/guards/auth.ts
@@ -61,6 +61,14 @@ export async function authGuard(options: AuthGuardOptions = {}): Promise<boolean
 	// Check if we're already on the target page to prevent redirect loops
 	const currentPath = window.location.pathname;
 
+	// Local-only / no-account mode is a valid, usable state: the app is encrypted
+	// and functional without a server session, so it must pass the guard. The E2E
+	// check below still applies (hasE2E is true once the local key is loaded).
+	if (currentSession.isLocalOnly) {
+		redirectCount = 0;
+		return true;
+	}
+
 	// Check if user is authenticated
 	if (!currentSession.isAuthenticated) {
 		// Don't redirect if already on login page

--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -11,6 +11,7 @@ import {
 import { AuthStorageAdapter } from '$lib/auth/adapters/authStorage';
 import { createLogger } from '@reborn/utils';
 import { SUPPORTED_LOCALES, type SupportedLocale } from '@reborn/i18n';
+import type { AuthUser } from '@reborn/auth';
 import type { CryptoManager } from '@reborn/crypto';
 import type { ReAuthResult } from '@reborn/ui';
 import { syncService } from './sync.service';
@@ -319,6 +320,160 @@ export class AuthOperationsService {
 			logger.error('Login failed:', error);
 			throw error;
 		}
+	}
+
+	/**
+	 * Enter local-only / no-account mode: usable, encrypted, no server session,
+	 * no sync. Generates a device-scoped user id and a local master key
+	 * (persisted at-rest by CryptoManager - IndexedDB on web, Keychain/Keystore
+	 * vault on native) when one is not already loaded, sets a synthetic local
+	 * session, and bootstraps a default list.
+	 *
+	 * The session's `user.id` is the device id on purpose: every existing
+	 * `session.user.id`-based list/task operation then works unchanged in local
+	 * mode (the username is empty - the UI shows a local-mode label instead).
+	 *
+	 * Returns false (no-op) if a real account session already exists - the
+	 * account always wins. See planning/local-only-no-account-plan.md.
+	 */
+	async enterLocalMode(): Promise<boolean> {
+		if (!browser) return false;
+		// Never shadow a real account session.
+		if (localStorage.getItem('reborn_auth_credentials')) return false;
+
+		this.ensureAuthServiceInitialized();
+
+		try {
+			const { getOrCreateLocalUserId, LOCAL_MODE_KEY, localOnly } = await import(
+				'$lib/stores/local-mode.store'
+			);
+			const { cryptoManager } = await import('@reborn/crypto');
+
+			const localUserId = getOrCreateLocalUserId();
+			localStorage.setItem(LOCAL_MODE_KEY, '1');
+
+			// Generate + persist a local master key unless one is already loaded
+			// (e.g. restored from IndexedDB/vault on a returning local session).
+			if (!cryptoManager.isInitialized()) {
+				const key = await cryptoManager.generateMasterKey();
+				await cryptoManager.setMasterKey(key);
+			}
+
+			// Storage is normally initialized in hooks.client.ts; be defensive on
+			// the entry-page path where it may not be ready yet.
+			const { isDatabaseInitialized, initializeStorage } = await import('@reborn/storage');
+			if (!isDatabaseInitialized()) await initializeStorage('task');
+
+			// Mark local mode BEFORE any list bootstrap so the immediate
+			// scheduleSyncSoon() from ensureDefaultList() no-ops (no server here).
+			localOnly.set(true);
+
+			const now = new Date().toISOString();
+			const sessionManager = this.getSessionManager();
+			sessionManager.setSession({
+				isAuthenticated: false,
+				isLocalOnly: true,
+				isInitialized: true,
+				isLoading: false,
+				hasE2E: cryptoManager.isInitialized(),
+				user: { id: localUserId, username: '', created_at: now, updated_at: now },
+				error: null
+			});
+
+			// Bootstrap a default list so the app has somewhere to put tasks.
+			const { listOperationsService } = await import('./list-operations.service');
+			await listOperationsService.ensureDefaultList(localUserId);
+
+			// Refresh decrypted stores so the default list shows immediately.
+			const { refreshDecryptedLists } = await import('$lib/stores/decrypted-lists.store');
+			await taskListStore.loadLists();
+			await refreshDecryptedLists();
+
+			logger.info('Entered local-only (no-account) mode');
+			return true;
+		} catch (err: unknown) {
+			logger.error('Failed to enter local-only mode:', err);
+			return false;
+		}
+	}
+
+	/**
+	 * Finish a local-only -> account upgrade after a successful register call.
+	 * Promotes the session straight from the register response WITHOUT going
+	 * through login() (whose onStorageInit clears IndexedDB on context='login'
+	 * and would wipe the very local data we are adopting). The adopted master key
+	 * is already in memory, so no unlock is needed: we re-stamp local data with
+	 * the account id + flag it pending, set the session, then push + pull to
+	 * converge. See planning/local-only-no-account-plan.md (decision B1).
+	 */
+	async completeLocalUpgrade(params: {
+		user: AuthUser;
+		accessToken: string;
+		encryptedMasterKey: string;
+		masterKeySalt: string;
+	}): Promise<void> {
+		if (!browser) return;
+		this.ensureAuthServiceInitialized();
+
+		const { user, accessToken, encryptedMasterKey, masterKeySalt } = params;
+
+		// Persist account credentials in the same shape the normal login flow uses
+		// (AuthService.saveAuthCredentials) so the next cold start restores cleanly.
+		const storage = new AuthStorageAdapter();
+		await storage.saveCredentials({
+			id: 'currentUser',
+			encrypted_master_key: encryptedMasterKey,
+			master_key_salt: masterKeySalt,
+			user_profile: user
+		});
+		localStorage.setItem('access_token', accessToken);
+
+		// Leave local-only mode: the account now owns this data.
+		const { clearLocalModeMarkers, localOnly } = await import('$lib/stores/local-mode.store');
+		clearLocalModeMarkers();
+		localOnly.set(false);
+
+		// Re-stamp local data with the account user id + flag pending so it uploads
+		// and is visible under the account immediately (lists query by user_id).
+		const { markAllLocalDataForUpload } = await import('./local-mode.service');
+		await markAllLocalDataForUpload(user.id);
+
+		// Promote the session directly (NOT login() - that clears IndexedDB).
+		syncService.setAuthToken(accessToken);
+		const sessionManager = this.getSessionManager();
+		sessionManager.setSession({
+			isAuthenticated: true,
+			isLocalOnly: false,
+			isInitialized: true,
+			isLoading: false,
+			hasE2E: true,
+			user,
+			error: null
+		});
+		this.clearSessionExpired();
+		this.startBackgroundTokenRefresh();
+
+		// Push the adopted data, then pull to converge user_id / sync_version.
+		// initialSync() flushes the offline-op queue (push) before pulling, so the
+		// adopted local lists/tasks reach the server and come back owned by the
+		// account. Best-effort: a failure just defers to the next periodic sync.
+		try {
+			await syncService.initialSync();
+			const { refreshDecryptedLists } = await import('$lib/stores/decrypted-lists.store');
+			const { refreshDecryptedSubtasks } = await import('$lib/stores/decrypted-subtasks.store');
+			await taskListStore.loadLists();
+			await Promise.all([refreshDecryptedLists(), refreshDecryptedSubtasks()]);
+			await taskTitleIndex.rebuild();
+			const { taskCounts } = await import('$lib/stores/task-counts.store');
+			taskCounts.refresh();
+		} catch (err: unknown) {
+			logger.warn('Initial sync after local-to-account upgrade failed:', err);
+		}
+
+		// Send encrypted device info (non-blocking, non-critical).
+		import('$lib/services/device-info.service').then(({ sendEncryptedDeviceInfo }) =>
+			sendEncryptedDeviceInfo().catch(() => {})
+		);
 	}
 
 	/**
@@ -680,6 +835,28 @@ export class AuthOperationsService {
 			} else if (hasTokens) {
 				// Legacy fallback — access token without a credentials record.
 				sessionManager.setSession({ isAuthenticated: true });
+			} else {
+				// No account session: restore local-only mode if its marker is set.
+				// A real account always wins over the marker, so this branch is
+				// reached only when there are no valid credentials/tokens. The local
+				// master key is restored from IndexedDB by checkE2EStatus() below,
+				// which flips hasE2E once waitForRestore() resolves.
+				const { readLocalModeFromStorage, localOnly } = await import(
+					'$lib/stores/local-mode.store'
+				);
+				const local = readLocalModeFromStorage();
+				if (local.active && local.userId) {
+					logger.info('Restoring local-only (no-account) session');
+					const epoch = new Date(0).toISOString();
+					sessionManager.setSession({
+						isAuthenticated: false,
+						isLocalOnly: true,
+						isInitialized: true,
+						user: { id: local.userId, username: '', created_at: epoch, updated_at: epoch },
+						error: null
+					});
+					localOnly.set(true);
+				}
 			}
 
 			// Restore E2E status from IndexedDB (master key may survive PWA restart).

--- a/apps/reborn-task/src/lib/services/local-mode.service.spec.ts
+++ b/apps/reborn-task/src/lib/services/local-mode.service.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * The local-only -> account upgrade re-stamps every local entity with the new
+ * account's user id and flags it pending, so the offline-op queue uploads it and
+ * Task's user_id-keyed list queries find it under the new account. These tests
+ * pin down that invariant for lists, tasks and subtasks.
+ */
+
+vi.mock('@reborn/storage', () => ({
+	listStore: { getAll: vi.fn(), save: vi.fn() },
+	taskStore: { getAll: vi.fn(), save: vi.fn() },
+	subtaskStore: { getAll: vi.fn(), save: vi.fn() }
+}));
+
+vi.mock('@reborn/utils', () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	})
+}));
+
+import { listStore, taskStore, subtaskStore } from '@reborn/storage';
+import { markAllLocalDataForUpload } from './local-mode.service';
+
+const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
+const ACCOUNT_ID = '22222222-2222-4222-8222-222222222222';
+
+function row(id: string, extra: Record<string, unknown> = {}) {
+	return {
+		id,
+		user_id: DEVICE_ID,
+		created_at: '2026-01-01T00:00:00.000Z',
+		updated_at: '2026-01-01T00:00:00.000Z',
+		sync_version: 1,
+		sync_status: 'synced' as const,
+		...extra
+	};
+}
+
+describe('markAllLocalDataForUpload', () => {
+	const listGetAll = vi.mocked(listStore.getAll);
+	const listSave = vi.mocked(listStore.save);
+	const taskGetAll = vi.mocked(taskStore.getAll);
+	const taskSave = vi.mocked(taskStore.save);
+	const subtaskGetAll = vi.mocked(subtaskStore.getAll);
+	const subtaskSave = vi.mocked(subtaskStore.save);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		listSave.mockResolvedValue(undefined as never);
+		taskSave.mockResolvedValue(undefined as never);
+		subtaskSave.mockResolvedValue(undefined as never);
+	});
+
+	it('rewrites user_id to the account id and flags every entity pending', async () => {
+		listGetAll.mockResolvedValue([row('list-1', { name_encrypted: 'x', is_default: true })] as never);
+		taskGetAll.mockResolvedValue([row('task-1', { task_list_id: 'list-1', title_encrypted: 'y' })] as never);
+		subtaskGetAll.mockResolvedValue([row('sub-1', { task_id: 'task-1', name_encrypted: 'z' })] as never);
+
+		await markAllLocalDataForUpload(ACCOUNT_ID);
+
+		expect(listSave).toHaveBeenCalledTimes(1);
+		expect(taskSave).toHaveBeenCalledTimes(1);
+		expect(subtaskSave).toHaveBeenCalledTimes(1);
+
+		for (const save of [listSave, taskSave, subtaskSave]) {
+			const saved = save.mock.calls[0][0] as { user_id: string; sync_status: string };
+			expect(saved.user_id).toBe(ACCOUNT_ID);
+			expect(saved.sync_status).toBe('pending');
+		}
+	});
+
+	it('preserves all other fields (id, task_list_id, is_default) while re-stamping', async () => {
+		listGetAll.mockResolvedValue([
+			row('list-1', { name_encrypted: 'enc', is_default: true, order_index: 3 })
+		] as never);
+		taskGetAll.mockResolvedValue([] as never);
+		subtaskGetAll.mockResolvedValue([] as never);
+
+		await markAllLocalDataForUpload(ACCOUNT_ID);
+
+		const saved = listSave.mock.calls[0][0] as unknown as Record<string, unknown>;
+		expect(saved.id).toBe('list-1');
+		expect(saved.name_encrypted).toBe('enc');
+		expect(saved.is_default).toBe(true);
+		expect(saved.order_index).toBe(3);
+	});
+
+	it('is a no-op (no saves) when there is no local data', async () => {
+		listGetAll.mockResolvedValue([] as never);
+		taskGetAll.mockResolvedValue([] as never);
+		subtaskGetAll.mockResolvedValue([] as never);
+
+		await markAllLocalDataForUpload(ACCOUNT_ID);
+
+		expect(listSave).not.toHaveBeenCalled();
+		expect(taskSave).not.toHaveBeenCalled();
+		expect(subtaskSave).not.toHaveBeenCalled();
+	});
+});

--- a/apps/reborn-task/src/lib/services/local-mode.service.ts
+++ b/apps/reborn-task/src/lib/services/local-mode.service.ts
@@ -1,0 +1,61 @@
+import { listStore, taskStore, subtaskStore } from '@reborn/storage';
+import { createLogger } from '@reborn/utils';
+
+const logger = createLogger('LocalModeService');
+
+/**
+ * Re-stamp every local entity with the new account's user id and flag it pending
+ * so a local-only (no-account) session can upgrade to a real account without
+ * losing data. See planning/local-only-no-account-plan.md (decision B1).
+ *
+ * Why this is enough (and why it differs from reborn-notes' equivalent):
+ *
+ *  - **Ownership / visibility.** Task lists are queried locally by `user_id`
+ *    (`listStore.query('user_id', ...)`), so the device-scoped UUID used while
+ *    offline must be rewritten to the account id or the lists vanish under the
+ *    new account. Tasks/subtasks are not queried by `user_id` locally (they hang
+ *    off `task_list_id` / `task_id`), but we rewrite them too for consistency
+ *    and clean push snapshots. The server assigns ownership from the JWT, so the
+ *    body `user_id` is irrelevant to the server - this is purely for the local
+ *    view; the next pull converges everything to the account id anyway.
+ *
+ *  - **Push.** Unlike Notes (whose push reads `sync_status === 'pending'` rows
+ *    directly), Task uploads via the offline-operation queue. In local-only mode
+ *    sync never runs, so that queue is a *complete, naturally-ordered* log of
+ *    every create/update/delete (a list is always created before its tasks, so
+ *    timestamps already order parent-before-child). The upgrade simply lets that
+ *    queue replay - no re-enqueue needed, which also avoids the bulk-timestamp
+ *    collision that re-enqueueing dozens of ops at once would risk.
+ *
+ *  - **Pull safety.** Flagging rows `pending` makes the post-upgrade pull skip
+ *    them (`syncLists` skips `sync_status === 'pending'`), so a pull that races
+ *    the push cannot clobber a not-yet-uploaded row.
+ *
+ * Idempotent and cheap: a no-op queue replay + a save per row. Failures bubble
+ * up so the caller can fall back to the next periodic sync.
+ */
+export async function markAllLocalDataForUpload(newUserId: string): Promise<void> {
+	const [lists, tasks, subtasks] = await Promise.all([
+		listStore.getAll(),
+		taskStore.getAll(),
+		subtaskStore.getAll()
+	]);
+
+	const pending = 'pending' as const;
+	const ops: Promise<unknown>[] = [];
+	for (const l of lists) {
+		ops.push(listStore.save({ ...l, user_id: newUserId, sync_status: pending }));
+	}
+	for (const t of tasks) {
+		ops.push(taskStore.save({ ...t, user_id: newUserId, sync_status: pending }));
+	}
+	for (const s of subtasks) {
+		ops.push(subtaskStore.save({ ...s, user_id: newUserId, sync_status: pending }));
+	}
+
+	await Promise.all(ops);
+	logger.info(
+		`Re-stamped ${lists.length} lists, ${tasks.length} tasks, ${subtasks.length} subtasks for account upload`,
+		{ newUserId }
+	);
+}

--- a/apps/reborn-task/src/lib/services/sync/sync.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync.service.ts
@@ -1,6 +1,8 @@
+import { get } from 'svelte/store';
 import { createLogger } from '@reborn/utils';
 import { taskCounts } from '$lib/stores/task-counts.store';
 import { taskStore } from '@reborn/storage';
+import { localOnly } from '$lib/stores/local-mode.store';
 import { taskTitleIndex } from '$lib/services/task-title-index.svelte';
 import { SyncListsService } from './sync-lists.service';
 import { SyncTasksService } from './sync-tasks.service';
@@ -142,6 +144,10 @@ class SyncService {
 	 * post-sync logic (ensureDefaultList) only runs after a real sync.
 	 */
 	async initialSync(): Promise<void> {
+		// Local-only / no-account mode: there is no server session, so every sync
+		// is a no-op. Without this gate the hasE2E effect in +layout would push to
+		// the server with no token, 401, and mark ops failed (which then never retry).
+		if (get(localOnly)) return;
 		if (this._initialSyncPromise) {
 			logger.debug('Sync already in progress, waiting for existing sync');
 			return this._initialSyncPromise;
@@ -298,6 +304,7 @@ class SyncService {
 	 * Multiple calls within the delay window are collapsed into one sync.
 	 */
 	scheduleSyncSoon(): void {
+		if (get(localOnly)) return;
 		if (!checkOnline()) return;
 
 		if (this.syncSoonTimer) {
@@ -318,6 +325,7 @@ class SyncService {
 	 * Unlike initialSync(), no progress callbacks and no soft-delete wait.
 	 */
 	async periodicSync(): Promise<void> {
+		if (get(localOnly)) return;
 		if (!checkOnline()) {
 			logger.debug('Offline - skipping periodic sync');
 			return;
@@ -376,6 +384,7 @@ class SyncService {
 	 * This should be called periodically or after changes
 	 */
 	async syncToServer(): Promise<{ failedCount: number }> {
+		if (get(localOnly)) return { failedCount: 0 };
 		if (!checkOnline()) {
 			logger.info('Offline - skipping sync to server');
 			return { failedCount: 0 };
@@ -420,6 +429,8 @@ class SyncService {
 	}> {
 		const processedOps: StorageOfflineOperation[] = [];
 		let failedCount = 0;
+
+		if (get(localOnly)) return { processedOps, failedCount };
 
 		if (!checkOnline()) {
 			logger.info('Offline - skipping offline operations sync');

--- a/apps/reborn-task/src/lib/services/synced-settings.service.ts
+++ b/apps/reborn-task/src/lib/services/synced-settings.service.ts
@@ -1,14 +1,22 @@
+import { get } from 'svelte/store';
 import { base } from '$app/paths';
 import { authFetch } from '$lib/utils/auth-fetch';
 import { createSyncedSettingsService } from '@reborn/storage';
+import { localOnly } from '$lib/stores/local-mode.store';
 
 /**
  * App-level singleton of the E2E synced settings service. Wires the shared
  * implementation to this app's `authFetch` (single-flight 401 refresh) and
  * `base` path.
+ *
+ * `isSyncEnabled` gates out local-only / no-account mode: without it, a settings
+ * mutation would PUT /api/settings → 401 → refresh (also 401) → session-expired
+ * banner, even though there is no account. Disabled while local-only; re-enabled
+ * automatically once the user upgrades (localOnly flips back to false).
  */
 export const syncedSettings = createSyncedSettingsService({
 	authFetch,
 	basePath: base,
-	appName: 'reborn-task'
+	appName: 'reborn-task',
+	isSyncEnabled: () => !get(localOnly)
 });

--- a/apps/reborn-task/src/lib/stores/auth.store.ts
+++ b/apps/reborn-task/src/lib/stores/auth.store.ts
@@ -167,6 +167,12 @@ export const session: Readable<AuthSession> = getOrCreateSessionStore();
 
 // Derived stores for convenience
 export const isAuthenticated = derived(session, ($s) => $s?.isAuthenticated ?? false);
+// Local-only / no-account mode. Guarded `&& !isAuthenticated` so a real account
+// session is never treated as local-only even if the flag were left stale.
+export const isLocalOnly = derived(
+	session,
+	($s) => (($s?.isLocalOnly ?? false) && !$s?.isAuthenticated)
+);
 export const hasE2E = derived(session, ($s) => $s?.hasE2E ?? false);
 export const user = derived(session, ($s) => $s?.user ?? null);
 export const isLoading = derived(session, ($s) => $s?.isLoading ?? false);

--- a/apps/reborn-task/src/lib/stores/local-mode.store.ts
+++ b/apps/reborn-task/src/lib/stores/local-mode.store.ts
@@ -1,0 +1,60 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+/**
+ * Local-only / no-account mode primitives for Reborn Task.
+ *
+ * The on/off marker and the device-scoped user id live in localStorage under
+ * the SAME keys as reborn-notes, so entering local mode in one app is visible
+ * to the other on the same origin (cross-app SSO), exactly like
+ * `reborn_auth_credentials`. See planning/local-only-no-account-plan.md.
+ *
+ * `localOnly` is a one-way writable set by `authOperationsService`
+ * (enterLocalMode / boot restore / upgrade / login) so the sync layer can gate
+ * itself without importing the auth store - mirrors reborn-notes' `localOnly`
+ * and avoids an auth <-> sync import cycle.
+ */
+
+export const LOCAL_MODE_KEY = 'reborn_local_mode';
+export const LOCAL_USER_ID_KEY = 'reborn_local_user_id';
+
+/**
+ * True in local-only / no-account mode. Read synchronously by the sync service
+ * (`get(localOnly)`) to no-op every server round-trip - there is no session.
+ */
+export const localOnly = writable(false);
+
+/** v4-shaped UUID matcher - mirrors the shape idb-cleanup's repairUserId expects. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Read or lazily create the device-scoped local user id. Used as `user_id` for
+ * records created in local-only mode so FK-shaped fields and shadow-index
+ * repair keep working before any server account exists.
+ */
+export function getOrCreateLocalUserId(): string {
+	const existing = localStorage.getItem(LOCAL_USER_ID_KEY);
+	if (existing && UUID_RE.test(existing)) return existing;
+	const id = crypto.randomUUID();
+	localStorage.setItem(LOCAL_USER_ID_KEY, id);
+	return id;
+}
+
+/**
+ * Synchronous snapshot of the persisted local-mode markers. A real account
+ * session always wins over the marker, so callers must check for credentials
+ * first (the boot path in `initializeAuth` does exactly that).
+ */
+export function readLocalModeFromStorage(): { active: boolean; userId: string | null } {
+	if (!browser) return { active: false, userId: null };
+	const active = localStorage.getItem(LOCAL_MODE_KEY) === '1';
+	const userId = localStorage.getItem(LOCAL_USER_ID_KEY);
+	return { active: active && !!userId && UUID_RE.test(userId), userId };
+}
+
+/** Clear the local-mode markers (called when upgrading to / logging into an account). */
+export function clearLocalModeMarkers(): void {
+	if (!browser) return;
+	localStorage.removeItem(LOCAL_MODE_KEY);
+	localStorage.removeItem(LOCAL_USER_ID_KEY);
+}

--- a/apps/reborn-task/src/lib/stores/shares.store.ts
+++ b/apps/reborn-task/src/lib/stores/shares.store.ts
@@ -4,6 +4,7 @@ import { base } from '$app/paths';
 import { authFetch } from '$lib/utils/auth-fetch';
 import { connectivityStore } from '$lib/stores/connectivity.store';
 import { sessionExpired } from '$lib/stores/session-expired.store';
+import { localOnly } from '$lib/stores/local-mode.store';
 import {
 	cryptoManager,
 	buildShareUrl,
@@ -96,6 +97,14 @@ function createSharesStore() {
 
 	async function refresh(): Promise<void> {
 		if (!browser) return;
+		// Local-only / no-account mode: sharing is account-only and there is no
+		// token, so hitting /api/shares would 401 and trip the session-expired
+		// banner. The crypto key IS loaded locally, so the isInitialized() guard
+		// below is not enough on its own.
+		if (get(localOnly)) {
+			state.update((s) => ({ ...s, loading: false }));
+			return;
+		}
 		if (!cryptoManager.isInitialized()) {
 			state.update((s) => ({ ...s, loading: false }));
 			return;

--- a/apps/reborn-task/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-task/src/lib/stores/sync-status.store.ts
@@ -3,10 +3,18 @@ import { isOnline } from './network.store';
 import { syncProgress, lastSyncedAt } from '$lib/services/sync.service';
 import { pendingOperations, failedOperations } from './offline-operations.store';
 import { sessionExpired } from './session-expired.store';
+import { localOnly } from './local-mode.store';
 
 export { lastSyncedAt };
 
-export type SyncStatusType = 'synced' | 'syncing' | 'offline' | 'error' | 'pending' | 'auth-error';
+export type SyncStatusType =
+	| 'synced'
+	| 'syncing'
+	| 'offline'
+	| 'error'
+	| 'pending'
+	| 'auth-error'
+	| 'local_only';
 
 export interface SyncStatusState {
 	status: SyncStatusType;
@@ -19,20 +27,41 @@ export interface SyncStatusState {
 
 /**
  * Unified sync status derived from multiple stores.
- * Priority: auth-error > offline > syncing > error > pending > synced
+ * Priority: local_only > auth-error > offline > syncing > error > pending > synced
  */
 export const syncStatus = derived(
-	[isOnline, syncProgress, pendingOperations, failedOperations, sessionExpired, lastSyncedAt],
+	[
+		isOnline,
+		syncProgress,
+		pendingOperations,
+		failedOperations,
+		sessionExpired,
+		lastSyncedAt,
+		localOnly
+	],
 	([
 		$isOnline,
 		$syncProgress,
 		$pendingOps,
 		$failedOps,
 		$sessionExpired,
-		$lastSyncedAt
+		$lastSyncedAt,
+		$localOnly
 	]): SyncStatusState => {
 		const pendingCount = $pendingOps.length;
 		const failedCount = $failedOps.length;
+
+		if ($localOnly) {
+			// No account, no server: sync never runs, so this overrides everything.
+			return {
+				status: 'local_only',
+				pendingCount,
+				failedCount,
+				message: '',
+				progress: 0,
+				lastSyncedAt: $lastSyncedAt
+			};
+		}
 
 		if ($sessionExpired && $isOnline) {
 			return {

--- a/apps/reborn-task/src/routes/(app)/+layout.svelte
+++ b/apps/reborn-task/src/routes/(app)/+layout.svelte
@@ -38,6 +38,7 @@
 	import { CreateListSheet, DeleteListDialog, EditListNameModal, TaskListSheet } from '$lib/components/task-list';
 	import { DeleteTaskDialog, TaskList, TaskFilterBar } from '$lib/components/tasks';
 	import ShareTaskDialog from '$lib/components/tasks/ShareTaskDialog.svelte';
+	import AccountRequiredDialog from '$lib/components/shared/AccountRequiredDialog.svelte';
 	import { TaskSelectPlaceholder, FilterViewPlaceholder } from '$lib/components/tasks';
 	import { page } from '$app/stores';
 	import { goto } from '$lib/utils/navigation';
@@ -278,9 +279,17 @@
 	// Share dialog state (read-only public snapshot)
 	let shareDialogOpen = $state(false);
 	let shareDialogTask = $state<TaskDecrypted | null>(null);
+	// Shown when sharing is attempted in local-only mode (account required).
+	let accountRequiredOpen = $state(false);
 
 	async function openShareDialogForCurrentTask() {
 		if (!currentTask) return;
+		// Sharing is account-only: in local-only mode, invite to create an account
+		// instead of opening the (server-backed) share flow.
+		if ($session.isLocalOnly) {
+			accountRequiredOpen = true;
+			return;
+		}
 		const ok = await requireActiveSession({
 			description: $t('share.session_required.create')
 		});
@@ -341,7 +350,9 @@
 			taskListStore
 				.loadLists()
 				.then(async () => {
-					if ($activeLists.length === 0 && $session.user?.id) {
+					// Skip the online-setup gate in local-only mode: there is no server
+					// to sync from, and enterLocalMode() already created a default list.
+					if ($activeLists.length === 0 && $session.user?.id && !$session.isLocalOnly) {
 						if (!navigator.onLine) {
 							// First run offline — cannot sync, show blocking UI
 							needsOnlineSetup = true;
@@ -867,8 +878,12 @@
 	// Layout children
 	let { children } = $props<{ children?: Snippet }>();
 
-	// Only render content if user has E2E access
-	let showContent = $derived(browser && $session.isAuthenticated && $session.hasE2E);
+	// Render the app when the master key is loaded and either a real account
+	// session OR local-only / no-account mode is active. Local-only is a fully
+	// usable state (encrypted locally, no server), so it gets the same UI.
+	let showContent = $derived(
+		browser && ($session.isAuthenticated || $session.isLocalOnly === true) && $session.hasE2E
+	);
 
 	// Auth guard — redirect when session check is done and user is not authenticated
 	let isAuthRedirecting = $state(false);
@@ -876,6 +891,8 @@
 	$effect(() => {
 		if (!browser || !$session.isInitialized || $session.isLoading) return;
 		if (isAuthRedirecting) return;
+		// Local-only / no-account mode is a valid state - never bounce it to login/unlock.
+		if ($session.isLocalOnly) return;
 
 		if (!$session.isAuthenticated) {
 			const path = $page.url.pathname;
@@ -1377,6 +1394,9 @@
 
 	<!-- Share read-only snapshot dialog -->
 	<ShareTaskDialog bind:open={shareDialogOpen} task={shareDialogTask} />
+
+	<!-- Account-required prompt (sharing attempted in local-only mode) -->
+	<AccountRequiredDialog bind:open={accountRequiredOpen} />
 {:else}
 	<div class="flex items-center justify-center h-screen bg-background">
 		<div class="flex flex-col items-center gap-3">

--- a/apps/reborn-task/src/routes/(app)/tasks/[taskId]/+page.svelte
+++ b/apps/reborn-task/src/routes/(app)/tasks/[taskId]/+page.svelte
@@ -315,8 +315,8 @@
 		<div class="flex items-center justify-center py-12">
 			<p class="text-lg text-muted-foreground">{$t('common.loading')}</p>
 		</div>
-	{:else if !$session.isAuthenticated}
-		<!-- Not authenticated -->
+	{:else if !$session.isAuthenticated && !$session.isLocalOnly}
+		<!-- Not authenticated (local-only mode is a valid, accountless state and must pass) -->
 		<div class="flex items-center justify-center py-12">
 			<p class="text-lg text-muted-foreground">{$t('auth.login_required')}</p>
 		</div>

--- a/apps/reborn-task/src/routes/+layout.svelte
+++ b/apps/reborn-task/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 	import { authOperationsService } from '$lib/services/auth-operations.service';
 	import { SessionExpiredBanner, RequireSessionModal } from '@reborn/ui';
 	import LoadingScreen from '$lib/components/LoadingScreen.svelte';
+	import LocalModeWelcome from '$lib/components/LocalModeWelcome.svelte';
 	import { Toaster } from '@reborn/ui';
 	import type { Snippet } from 'svelte';
 	import { initializeStorage, isDatabaseInitialized } from '@reborn/storage';
@@ -312,6 +313,7 @@
 			{@render children()}
 		{/if}
 	</div>
+	<LocalModeWelcome />
 	<Toaster />
 {:else}
 	<LoadingScreen />

--- a/apps/reborn-task/src/routes/+page.ts
+++ b/apps/reborn-task/src/routes/+page.ts
@@ -3,6 +3,7 @@ import { redirect } from '@sveltejs/kit';
 import { browser } from '$app/environment';
 import { base } from '$app/paths';
 import { authOperationsService } from '$lib/services/auth-operations.service';
+import { LOCAL_MODE_KEY } from '$lib/stores/local-mode.store';
 
 async function waitForSessionReady(timeoutMs = 1500) {
 	const sessionManager = authOperationsService.getSessionManager();
@@ -37,14 +38,21 @@ export const load: PageLoad = async ({ parent }) => {
 		// "/ → /auth/login" even though valid credentials are on disk.
 		if (!navigator.onLine) {
 			const hasCredentials = !!localStorage.getItem('reborn_auth_credentials');
-			if (!hasCredentials) {
+			const isLocalOnly = localStorage.getItem(LOCAL_MODE_KEY) === '1';
+			if (!hasCredentials && !isLocalOnly) {
 				redirect(303, `${base}/auth/login`);
 			}
 			const { cryptoManager } = await import('@reborn/crypto');
 			await cryptoManager.waitForRestore();
+			// Local-only mode has no unlock page: the key lives at-rest in IndexedDB,
+			// so a restored key means straight to the app.
 			redirect(
 				303,
-				cryptoManager.isInitialized() ? `${base}/all` : `${base}/auth/unlock`
+				cryptoManager.isInitialized()
+					? `${base}/all`
+					: isLocalOnly
+						? `${base}/auth/login`
+						: `${base}/auth/unlock`
 			);
 		}
 
@@ -58,6 +66,11 @@ export const load: PageLoad = async ({ parent }) => {
 
 		if (currentSession.isAuthenticated) {
 			redirect(303, currentSession.hasE2E ? `${base}/all` : `${base}/auth/unlock`);
+		}
+
+		// Local-only / no-account mode is a usable state - send it into the app.
+		if (currentSession.isLocalOnly) {
+			redirect(303, `${base}/all`);
 		}
 
 		redirect(303, `${base}/auth/login`);

--- a/apps/reborn-task/src/routes/auth/login/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/login/+page.svelte
@@ -3,10 +3,13 @@
 	import { base } from '$app/paths';
 	import { goto } from '$lib/utils/navigation';
 	import { page } from '$app/stores';
+	import { get } from 'svelte/store';
 	import { t } from '$lib/stores/i18n.store';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
 	import { sessionExpired } from '$lib/stores/session-expired.store';
+	import { isLocalOnly } from '$lib/stores/auth.store';
 	import { LoginPage } from '@reborn/ui';
+	import ConfirmDialog from '$lib/components/shared/dialogs/ConfirmDialog.svelte';
 	import { createLogger } from '@reborn/utils';
 
 	const logger = createLogger('LoginRoute');
@@ -14,6 +17,12 @@
 	let returnTo = $state('');
 	let loading = $state(false);
 	let error = $state<string | null>(null);
+
+	// Local-only mode: signing into an existing account runs clearAllUserData
+	// (onStorageInit context='login'), replacing on-device tasks. Confirm before
+	// that wipe so the user can export a backup instead of losing data silently.
+	let confirmReplaceOpen = $state(false);
+	let pendingLogin = $state<{ username: string; password: string } | null>(null);
 
 	$effect(() => {
 		if (browser) {
@@ -28,14 +37,23 @@
 	});
 
 	async function handleLogin(detail: { username: string; password: string; rememberMe: boolean }) {
+		if (get(isLocalOnly)) {
+			pendingLogin = { username: detail.username, password: detail.password };
+			confirmReplaceOpen = true;
+			return;
+		}
+		await performLogin(detail.username, detail.password);
+	}
+
+	async function performLogin(username: string, password: string) {
 		loading = true;
 		error = null;
 
 		try {
-			logger.debug('Starting login process for:', detail.username);
+			logger.debug('Starting login process for:', username);
 
 			// Use the auth operations service
-			const result = await authOperationsService.login(detail.username, detail.password);
+			const result = await authOperationsService.login(username, password);
 
 			if (!result || !result.success) {
 				loading = false;
@@ -48,7 +66,7 @@
 				logger.info('2FA required, redirecting...');
 				loading = false;
 				// Save password temporarily for E2E decryption after 2FA verification
-				sessionStorage.setItem('2fa_pending_password', detail.password);
+				sessionStorage.setItem('2fa_pending_password', password);
 				// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp variable
 				const params = new URLSearchParams({
 					userId: result.userId || '',
@@ -75,6 +93,18 @@
 			loading = false;
 		}
 	}
+
+	async function handleLocalMode() {
+		loading = true;
+		error = null;
+		const ok = await authOperationsService.enterLocalMode();
+		if (ok) {
+			await goto('/all');
+			return;
+		}
+		error = $t('local_mode.enter_failed');
+		loading = false;
+	}
 </script>
 
 {#snippet logoHeader()}
@@ -93,8 +123,10 @@
 	header={logoHeader}
 	showRegisterLink={true}
 	registerUrl="/auth/register"
+	showLocalModeLink={true}
 	themeStorageKey="reborn-task-theme"
 	onlogin={handleLogin}
+	onlocalmode={handleLocalMode}
 	onnavigate={(e) => {
 		if (e.url === '/auth/register' && returnTo && returnTo !== '/all') {
 			// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp variable
@@ -105,5 +137,18 @@
 		} else {
 			goto(e.url);
 		}
+	}}
+/>
+
+<!-- Local-only safety: signing in replaces on-device tasks - confirm first. -->
+<ConfirmDialog
+	bind:open={confirmReplaceOpen}
+	title={$t('local_mode.replace_title')}
+	description={$t('local_mode.replace_desc')}
+	confirmText={$t('local_mode.replace_confirm')}
+	cancelText={$t('common.cancel')}
+	variant="destructive"
+	onConfirm={() => {
+		if (pendingLogin) return performLogin(pendingLogin.username, pendingLogin.password);
 	}}
 />

--- a/apps/reborn-task/src/routes/auth/register/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/register/+page.svelte
@@ -7,7 +7,9 @@
 	import { page } from '$app/stores';
 	import { t } from '$lib/stores/i18n.store';
 	import { locale } from 'svelte-i18n';
+	import { get } from 'svelte/store';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
+	import { isLocalOnly } from '$lib/stores/auth.store';
 	import { RegisterPage } from '@reborn/ui';
 	import { hashPassword, generateMasterKeyForUser, cryptoManager } from '@reborn/crypto';
 	import { createLogger } from '@reborn/utils';
@@ -85,26 +87,55 @@
 		loading = true;
 		error = null;
 
-		try {
-			// 1. Prepare registration data client-side (hash password, generate keys, encrypt default list)
-			const registrationData = await prepareRegistrationData(detail.username, detail.password);
+		// Upgrade path: a local-only session is creating its first account. Adopt
+		// the existing local master key (wrap it with the new password) instead of
+		// generating a fresh one, so offline tasks - already encrypted with that
+		// key - stay readable and just start syncing. See plan B1.
+		const isUpgrade = get(isLocalOnly) && cryptoManager.isInitialized();
 
-			// 2. Call register API — user + default task list created atomically on server
+		try {
+			// 1. Build the registration payload (client-side, Zero Knowledge).
+			const passwordHash = await hashPassword(detail.password);
+			let encryptedMasterKey: string;
+			let masterKeySalt: string;
+			let defaultTaskList:
+				| { id: string; name_encrypted: string; is_default: true }
+				| undefined;
+
+			if (isUpgrade) {
+				const localKey = cryptoManager.getCurrentKey();
+				if (!localKey) throw new Error('Local master key unavailable for account upgrade');
+				const wrapped = await cryptoManager.encryptMasterKey(localKey, detail.password);
+				encryptedMasterKey = wrapped.encryptedMasterKey;
+				masterKeySalt = wrapped.salt;
+				// No defaultTaskList on upgrade: the user already has local lists that
+				// adopt into the account (the local default list becomes the account
+				// default on push). Sending one would create a duplicate default.
+				defaultTaskList = undefined;
+			} else {
+				const prepared = await prepareRegistrationData(detail.username, detail.password);
+				encryptedMasterKey = prepared.encryptedMasterKey;
+				masterKeySalt = prepared.masterKeySalt;
+				defaultTaskList = prepared.defaultTaskList;
+			}
+
+			// 2. Call register API — user (+ default task list for fresh accounts)
+			//    created atomically on server.
 			const response = await fetch(`${PUBLIC_BASE_PATH}/api/auth/register`, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({
-					username: registrationData.username,
-					passwordHash: registrationData.passwordHash,
-					encryptedMasterKey: registrationData.encryptedMasterKey,
-					masterKeySalt: registrationData.masterKeySalt,
+					username: detail.username,
+					passwordHash,
+					encryptedMasterKey,
+					masterKeySalt,
 					website: detail.website,
 					_t: detail._t,
 					powChallenge: detail.powChallenge,
 					powSolution: detail.powSolution,
-					defaultTaskList: registrationData.defaultTaskList
+					defaultTaskList
 				})
 			});
 
@@ -115,8 +146,19 @@
 				return;
 			}
 
-			// 3. Log the user in automatically
-			if (data.data?.access_token) {
+			if (isUpgrade) {
+				// 3a. Promote the local session to the new account WITHOUT the login
+				//     path (whose onStorageInit clears IndexedDB and would wipe the
+				//     very local tasks we are adopting).
+				await authOperationsService.completeLocalUpgrade({
+					user: data.data.user,
+					accessToken: data.data.access_token,
+					encryptedMasterKey,
+					masterKeySalt
+				});
+				await goto(returnTo);
+			} else if (data.data?.access_token) {
+				// 3b. Fresh account: auto-login (re-loads the key after auth).
 				await authOperationsService.login(detail.username, detail.password);
 				await goto(returnTo);
 			}
@@ -126,6 +168,18 @@
 		} finally {
 			loading = false;
 		}
+	}
+
+	async function handleLocalMode() {
+		loading = true;
+		error = null;
+		const ok = await authOperationsService.enterLocalMode();
+		if (ok) {
+			await goto('/all');
+			return;
+		}
+		error = $t('local_mode.enter_failed');
+		loading = false;
 	}
 </script>
 
@@ -145,11 +199,13 @@
 	header={logoHeader}
 	showLoginLink={true}
 	loginUrl="/auth/login"
+	showLocalModeLink={true}
 	powEndpoint="{PUBLIC_BASE_PATH}/api/auth/pow"
 	{termsUrl}
 	{privacyUrl}
 	themeStorageKey="reborn-task-theme"
 	onregister={handleRegister}
+	onlocalmode={handleLocalMode}
 	onerror={(msg) => {
 		error = msg;
 	}}

--- a/apps/reborn-task/src/routes/settings/+layout.svelte
+++ b/apps/reborn-task/src/routes/settings/+layout.svelte
@@ -14,6 +14,8 @@
 	$effect(() => {
 		if (!browser || !$session.isInitialized || $session.isLoading) return;
 		if (isAuthRedirecting) return;
+		// Local-only / no-account mode is a valid state - never bounce it to login/unlock.
+		if ($session.isLocalOnly) return;
 
 		if (!$session.isAuthenticated) {
 			const path = $page.url.pathname;

--- a/apps/reborn-task/src/routes/settings/+page.svelte
+++ b/apps/reborn-task/src/routes/settings/+page.svelte
@@ -22,12 +22,13 @@
 		LogOut,
 		StickyNote,
 		ShieldAlert,
-		Share2
+		Share2,
+		UserPlus
 	} from '@lucide/svelte';
 	import { t } from '$lib/stores/i18n.store';
 	import { locale } from '$lib/stores/i18n.store';
 	import { cn, SettingsLayout, GithubMark } from '@reborn/ui';
-	import { user } from '$lib/stores/auth.store';
+	import { user, isAuthenticated, isLocalOnly } from '$lib/stores/auth.store';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
 	import { resolve } from '$app/paths';
 	import { createLogger } from '@reborn/utils';
@@ -172,8 +173,13 @@
 	let loadingSessions = $state(true);
 
 	async function loadSessionsCount() {
+		const accessToken = localStorage.getItem('access_token');
+		// Local-only mode has no account/token - the sessions UI is hidden anyway.
+		if (!accessToken) {
+			loadingSessions = false;
+			return;
+		}
 		try {
-			const accessToken = localStorage.getItem('access_token');
 			const response = await fetch(`${PUBLIC_BASE_PATH}/api/auth/sessions`, {
 				headers: { Authorization: `Bearer ${accessToken}` }
 			});
@@ -201,37 +207,56 @@
 	<p class="text-sm text-muted-foreground mb-8">{$t('settings.about.description')}</p>
 
 	<div class="space-y-8">
-		<!-- Account -->
-		<div class="space-y-1">
-			<h2 class="text-lg font-semibold mb-3">{$t('settings.account.title')}</h2>
+		<!-- Account (real account session) -->
+		{#if $isAuthenticated}
 			<div class="space-y-1">
-				<div class={itemClasses}>
-					<User class="h-5 w-5 text-muted-foreground shrink-0" />
-					<div class="flex-1 min-w-0">
-						<div class="font-medium">{$user?.username ?? 'User'}</div>
-						<div class="text-sm text-muted-foreground">
-							{#if $user?.created_at}
-								{$t('profile.member_since')}
-								{new Date($user.created_at).toLocaleDateString(
-									$locale ?? undefined,
-									{ year: 'numeric', month: 'long', day: 'numeric' }
-								)}
-							{/if}
+				<h2 class="text-lg font-semibold mb-3">{$t('settings.account.title')}</h2>
+				<div class="space-y-1">
+					<div class={itemClasses}>
+						<User class="h-5 w-5 text-muted-foreground shrink-0" />
+						<div class="flex-1 min-w-0">
+							<div class="font-medium">{$user?.username ?? 'User'}</div>
+							<div class="text-sm text-muted-foreground">
+								{#if $user?.created_at}
+									{$t('profile.member_since')}
+									{new Date($user.created_at).toLocaleDateString(
+										$locale ?? undefined,
+										{ year: 'numeric', month: 'long', day: 'numeric' }
+									)}
+								{/if}
+							</div>
 						</div>
 					</div>
+					<button
+						type="button"
+						onclick={handleLogout}
+						class={cn(itemClasses, 'w-full text-destructive hover:bg-destructive/5')}
+					>
+						<LogOut class="h-5 w-5 shrink-0" />
+						<div class="flex-1 min-w-0 text-left">
+							<div class="font-medium">{$t('settings.account.log_out')}</div>
+						</div>
+					</button>
 				</div>
-				<button
-					type="button"
-					onclick={handleLogout}
-					class={cn(itemClasses, 'w-full text-destructive hover:bg-destructive/5')}
-				>
-					<LogOut class="h-5 w-5 shrink-0" />
-					<div class="flex-1 min-w-0 text-left">
-						<div class="font-medium">{$t('settings.account.log_out')}</div>
-					</div>
-				</button>
 			</div>
-		</div>
+		{:else if $isLocalOnly}
+			<!-- Local-only mode: invite to create an account (keeps existing tasks) -->
+			<div class="space-y-1">
+				<h2 class="text-lg font-semibold mb-3">{$t('settings.account.title')}</h2>
+				<a href={resolve('/auth/register')} class={itemClasses}>
+					<UserPlus class="h-5 w-5 text-primary shrink-0" />
+					<div class="flex-1 min-w-0">
+						<div class="font-medium">{$t('local_mode.create_account')}</div>
+						<div class="text-sm text-muted-foreground">
+							{$t('local_mode.account_invite_desc')}
+						</div>
+					</div>
+				</a>
+				<div class="px-4 pt-1">
+					<p class="text-xs text-muted-foreground">{$t('local_mode.backup_reminder')}</p>
+				</div>
+			</div>
+		{/if}
 		<!-- Preferences sections -->
 		{#each preferencesSections as section}
 			<div class="space-y-1">
@@ -253,7 +278,8 @@
 			</div>
 		{/each}
 
-		<!-- Security section -->
+		<!-- Security section (account-only - hidden in local-only mode) -->
+		{#if $isAuthenticated}
 		<div class="space-y-1">
 			<h2 class="text-lg font-semibold mb-3">{$t('settings.security.title')}</h2>
 
@@ -320,6 +346,7 @@
 				</a>
 			</div>
 		</div>
+		{/if}
 
 		<!-- Data & Info sections -->
 		{#each dataSections as section}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -20,6 +20,13 @@ export interface AuthSession {
   error: string | null;
   isLoading: boolean;
   isLoggingOut: boolean;
+  /**
+   * Local-only / no-account mode: the app is usable and encrypted locally, but
+   * there is no server session, so sync never runs. Optional + defaults to
+   * undefined/false, so a real account session stays byte-identical. Distinct
+   * from `isAuthenticated` precisely so the existing sync gates stay no-ops here.
+   */
+  isLocalOnly?: boolean;
 }
 
 export interface LoginResult {

--- a/packages/i18n/src/setup.ts
+++ b/packages/i18n/src/setup.ts
@@ -59,6 +59,7 @@ const TASKS_MODULE_FILES = [
   'e2e',
   'error',
   'home',
+  'local_mode',
   'menu',
   'nav',
   'network',

--- a/packages/i18n/src/translations/tasks/de/local_mode.json
+++ b/packages/i18n/src/translations/tasks/de/local_mode.json
@@ -1,0 +1,23 @@
+{
+  "enter_failed": "Der lokale Modus konnte nicht gestartet werden. Bitte versuche es erneut.",
+  "replace_title": "Lokale Aufgaben ersetzen?",
+  "replace_desc": "Die Anmeldung bei einem bestehenden Konto ersetzt die Aufgaben, die sich derzeit auf diesem Gerät befinden. Exportiere zuerst eine Sicherung, wenn du sie behalten möchtest.",
+  "replace_confirm": "Trotzdem anmelden",
+  "share_title": "Konto erforderlich",
+  "account_required_desc": "Zum Teilen ist ein Konto nötig. Erstelle eins - deine Aufgaben bleiben erhalten und werden synchronisiert.",
+  "create_account": "Konto erstellen",
+  "account_invite_desc": "Behalte deine Aufgaben, synchronisiere sie geräteübergreifend und aktiviere das Teilen. Deine aktuellen Aufgaben bleiben erhalten.",
+  "backup_reminder": "Tipp: Exportiere regelmäßig eine Sicherung - lokale Daten lassen sich nach Verlust des Geräts nicht wiederherstellen.",
+  "menu_title": "Nur lokal",
+  "menu_subtitle": "Kein Konto, keine Synchronisierung",
+  "welcome": {
+    "title": "Offline arbeiten - ohne Konto",
+    "subtitle": "Deine Aufgaben befinden sich nur auf diesem Gerät.",
+    "point_storage": "Deine Daten bleiben auf diesem Gerät und erreichen niemals unsere Server.",
+    "point_encrypted": "Alles wird lokal verschlüsselt (AES-256).",
+    "point_no_sync": "Keine Synchronisierung zwischen Geräten und keine Cloud-Sicherung.",
+    "point_no_recovery": "Keine Wiederherstellung, wenn du dieses Gerät verlierst oder die App-Daten löschst - exportiere regelmäßig eine Sicherung.",
+    "point_upgrade": "Du kannst jederzeit ein Konto erstellen - deine Aufgaben bleiben erhalten und werden synchronisiert.",
+    "cta": "Verstanden"
+  }
+}

--- a/packages/i18n/src/translations/tasks/de/sync.json
+++ b/packages/i18n/src/translations/tasks/de/sync.json
@@ -57,7 +57,8 @@
     "conflict_title": "Daten auf einem anderen Ger\u00e4t ge\u00e4ndert",
     "conflict_message": "Neuere Daten wurden auf dem Server erkannt. Aktualisierte Daten wurden heruntergeladen.",
     "conflict_action": "Aktualisieren",
-    "session_expired": "Sitzung abgelaufen"
+    "session_expired": "Sitzung abgelaufen",
+    "local_only": "Nur lokal"
   },
   "initial": {
     "title": "Aufgaben werden synchronisiert",

--- a/packages/i18n/src/translations/tasks/en/local_mode.json
+++ b/packages/i18n/src/translations/tasks/en/local_mode.json
@@ -1,0 +1,23 @@
+{
+  "enter_failed": "Couldn't start local mode. Please try again.",
+  "replace_title": "Replace local tasks?",
+  "replace_desc": "Signing in to an existing account replaces the tasks currently on this device. Export a backup first if you want to keep them.",
+  "replace_confirm": "Sign in anyway",
+  "share_title": "Account required",
+  "account_required_desc": "Sharing needs an account. Create one - your tasks are kept and start syncing.",
+  "create_account": "Create account",
+  "account_invite_desc": "Keep your tasks, sync them across devices, and enable sharing. Your current tasks are kept.",
+  "backup_reminder": "Tip: export a backup regularly - local data can't be recovered if you lose this device.",
+  "menu_title": "Local only",
+  "menu_subtitle": "No account, no sync",
+  "welcome": {
+    "title": "Working offline - no account",
+    "subtitle": "Your tasks live only on this device.",
+    "point_storage": "Your data stays on this device and never reaches our servers.",
+    "point_encrypted": "Everything is encrypted (AES-256) locally.",
+    "point_no_sync": "No sync between devices and no cloud backup.",
+    "point_no_recovery": "No recovery if you lose this device or clear app data - export a backup regularly.",
+    "point_upgrade": "You can create an account at any time - your tasks are kept and start syncing.",
+    "cta": "Got it"
+  }
+}

--- a/packages/i18n/src/translations/tasks/en/sync.json
+++ b/packages/i18n/src/translations/tasks/en/sync.json
@@ -57,7 +57,8 @@
     "conflict_title": "Data changed on another device",
     "conflict_message": "Newer data was detected on the server. Updated data has been downloaded.",
     "conflict_action": "Refresh",
-    "session_expired": "Session expired"
+    "session_expired": "Session expired",
+    "local_only": "Local only"
   },
   "initial": {
     "title": "Syncing your tasks",

--- a/packages/i18n/src/translations/tasks/es/local_mode.json
+++ b/packages/i18n/src/translations/tasks/es/local_mode.json
@@ -1,0 +1,23 @@
+{
+  "enter_failed": "No se pudo iniciar el modo local. Inténtalo de nuevo.",
+  "replace_title": "¿Reemplazar las tareas locales?",
+  "replace_desc": "Iniciar sesión en una cuenta existente reemplaza las tareas que hay actualmente en este dispositivo. Exporta una copia de seguridad antes si quieres conservarlas.",
+  "replace_confirm": "Iniciar sesión de todos modos",
+  "share_title": "Cuenta necesaria",
+  "account_required_desc": "Compartir requiere una cuenta. Crea una - tus tareas se conservan y empiezan a sincronizarse.",
+  "create_account": "Crear cuenta",
+  "account_invite_desc": "Conserva tus tareas, sincronízalas entre dispositivos y activa el uso compartido. Tus tareas actuales se conservan.",
+  "backup_reminder": "Consejo: exporta una copia de seguridad con regularidad - los datos locales no se pueden recuperar si pierdes este dispositivo.",
+  "menu_title": "Solo local",
+  "menu_subtitle": "Sin cuenta, sin sincronización",
+  "welcome": {
+    "title": "Trabajar sin conexión - sin cuenta",
+    "subtitle": "Tus tareas solo están en este dispositivo.",
+    "point_storage": "Tus datos permanecen en este dispositivo y nunca llegan a nuestros servidores.",
+    "point_encrypted": "Todo se cifra (AES-256) localmente.",
+    "point_no_sync": "Sin sincronización entre dispositivos ni copia en la nube.",
+    "point_no_recovery": "Sin recuperación si pierdes este dispositivo o borras los datos de la aplicación - exporta una copia de seguridad con regularidad.",
+    "point_upgrade": "Puedes crear una cuenta en cualquier momento - tus tareas se conservan y empiezan a sincronizarse.",
+    "cta": "Entendido"
+  }
+}

--- a/packages/i18n/src/translations/tasks/es/sync.json
+++ b/packages/i18n/src/translations/tasks/es/sync.json
@@ -57,7 +57,8 @@
     "conflict_title": "Datos modificados en otro dispositivo",
     "conflict_message": "Se detectaron datos más recientes en el servidor. Los datos actualizados han sido descargados.",
     "conflict_action": "Actualizar",
-    "session_expired": "Sesión expirada"
+    "session_expired": "Sesión expirada",
+    "local_only": "Solo local"
   },
   "initial": {
     "title": "Sincronizando tus tareas",

--- a/packages/i18n/src/translations/tasks/fr/local_mode.json
+++ b/packages/i18n/src/translations/tasks/fr/local_mode.json
@@ -1,0 +1,23 @@
+{
+  "enter_failed": "Impossible de démarrer le mode local. Veuillez réessayer.",
+  "replace_title": "Remplacer les tâches locales ?",
+  "replace_desc": "Se connecter à un compte existant remplace les tâches actuellement présentes sur cet appareil. Exportez d'abord une sauvegarde si vous souhaitez les conserver.",
+  "replace_confirm": "Se connecter quand même",
+  "share_title": "Compte requis",
+  "account_required_desc": "Le partage nécessite un compte. Créez-en un - vos tâches sont conservées et commencent à se synchroniser.",
+  "create_account": "Créer un compte",
+  "account_invite_desc": "Conservez vos tâches, synchronisez-les entre vos appareils et activez le partage. Vos tâches actuelles sont conservées.",
+  "backup_reminder": "Astuce : exportez régulièrement une sauvegarde - les données locales sont irrécupérables en cas de perte de l'appareil.",
+  "menu_title": "Local uniquement",
+  "menu_subtitle": "Sans compte, sans synchronisation",
+  "welcome": {
+    "title": "Travailler hors ligne - sans compte",
+    "subtitle": "Vos tâches restent uniquement sur cet appareil.",
+    "point_storage": "Vos données restent sur cet appareil et n'atteignent jamais nos serveurs.",
+    "point_encrypted": "Tout est chiffré (AES-256) localement.",
+    "point_no_sync": "Aucune synchronisation entre appareils ni sauvegarde dans le cloud.",
+    "point_no_recovery": "Aucune récupération si vous perdez cet appareil ou effacez les données de l'application - exportez régulièrement une sauvegarde.",
+    "point_upgrade": "Vous pouvez créer un compte à tout moment - vos tâches sont conservées et commencent à se synchroniser.",
+    "cta": "J'ai compris"
+  }
+}

--- a/packages/i18n/src/translations/tasks/fr/sync.json
+++ b/packages/i18n/src/translations/tasks/fr/sync.json
@@ -57,7 +57,8 @@
     "conflict_title": "Donn\u00e9es modifi\u00e9es sur un autre appareil",
     "conflict_message": "Des donn\u00e9es plus r\u00e9centes ont \u00e9t\u00e9 d\u00e9tect\u00e9es sur le serveur. Les donn\u00e9es mises \u00e0 jour ont \u00e9t\u00e9 t\u00e9l\u00e9charg\u00e9es.",
     "conflict_action": "Actualiser",
-    "session_expired": "Session expir\u00e9e"
+    "session_expired": "Session expir\u00e9e",
+    "local_only": "Local uniquement"
   },
   "initial": {
     "title": "Synchronisation de vos t\u00e2ches",

--- a/packages/i18n/src/translations/tasks/pl/local_mode.json
+++ b/packages/i18n/src/translations/tasks/pl/local_mode.json
@@ -1,0 +1,23 @@
+{
+  "enter_failed": "Nie udało się uruchomić trybu lokalnego. Spróbuj ponownie.",
+  "replace_title": "Zastąpić lokalne zadania?",
+  "replace_desc": "Zalogowanie się na istniejące konto zastąpi zadania znajdujące się obecnie na tym urządzeniu. Jeśli chcesz je zachować, najpierw wyeksportuj kopię zapasową.",
+  "replace_confirm": "Zaloguj mimo to",
+  "share_title": "Wymagane konto",
+  "account_required_desc": "Udostępnianie wymaga konta. Załóż je - Twoje zadania zostaną zachowane i zaczną się synchronizować.",
+  "create_account": "Załóż konto",
+  "account_invite_desc": "Zachowaj zadania, synchronizuj je między urządzeniami i włącz udostępnianie. Obecne zadania zostaną zachowane.",
+  "backup_reminder": "Wskazówka: regularnie eksportuj kopię zapasową - danych lokalnych nie da się odzyskać po utracie urządzenia.",
+  "menu_title": "Tylko lokalnie",
+  "menu_subtitle": "Bez konta, bez synchronizacji",
+  "welcome": {
+    "title": "Praca offline - bez konta",
+    "subtitle": "Twoje zadania są tylko na tym urządzeniu.",
+    "point_storage": "Twoje dane zostają na tym urządzeniu i nigdy nie trafiają na nasze serwery.",
+    "point_encrypted": "Wszystko jest szyfrowane (AES-256) lokalnie.",
+    "point_no_sync": "Brak synchronizacji między urządzeniami i brak kopii w chmurze.",
+    "point_no_recovery": "Brak odzyskania, jeśli stracisz to urządzenie lub wyczyścisz dane aplikacji - regularnie eksportuj kopię zapasową.",
+    "point_upgrade": "W każdej chwili możesz założyć konto - zadania zostaną zachowane i zaczną się synchronizować.",
+    "cta": "Rozumiem"
+  }
+}

--- a/packages/i18n/src/translations/tasks/pl/sync.json
+++ b/packages/i18n/src/translations/tasks/pl/sync.json
@@ -57,7 +57,8 @@
     "conflict_title": "Dane zmienione na innym urządzeniu",
     "conflict_message": "Wykryto nowsze dane na serwerze. Pobrano zaktualizowane dane.",
     "conflict_action": "Odśwież",
-    "session_expired": "Sesja wygasła"
+    "session_expired": "Sesja wygasła",
+    "local_only": "Tylko lokalnie"
   },
   "initial": {
     "title": "Synchronizujemy Twoje zadania",


### PR DESCRIPTION
## Summary

Replicates the local-only / no-account mode from reborn-notes (#276) into reborn-task, adapted to Task's different auth model (SessionManager + `@reborn/auth`, offline-operation queue, lists filtered by `user_id`). A new user can use the app fully offline without registering ("Use without an account" under login/register), with locally-encrypted data, and upgrade to an account at any time keeping their tasks (key adoption, B1).

**Auto-mode decisions (need review approval):**
- **`isLocalOnly` as an optional `AuthSession` field** (not a separate app-local store): the whole app reads auth from the session store, so the field gives `hasE2E` reactivity for free; additive, so the logged-in flow is byte-identical. Notes uses its own `AuthState`, so it is untouched.
- **Synthetic local user `{ id: device-UUID, username: '' }`** (not `user: null`): the many `session.user.id` call sites work unchanged with the device id.
- **Upgrade replays the existing op queue** (rewrite `user_id` + flag pending) rather than clearing and re-enqueuing - the local-mode queue is a complete, naturally-ordered log, and re-enqueuing would risk timestamp collisions (a task pushed before its list -> 404 -> failed op, which is not retried). The server assigns ownership from the JWT, so the body `user_id` only matters for the local view and converges on the next pull.
- **At-rest key model (ZK):** the local master key is bare at-rest (web IndexedDB / native vault) = baseline A1, matching #276 and Standard Notes' default. An optional passcode layer is deferred to a follow-up PR.
- **Upgrade = key adoption (B1)** over rotation: no re-encryption engine, no data-loss risk from an interrupted migration.

No change to the ZK model or server visibility (the server still assigns `user_id` from the JWT; the `reborn_local_*` markers and device UUID are client-only).

## Test plan

Smoke (web; local mode shares its localStorage markers with Notes on the same origin):
- **Enter local mode:** from `/auth/login` (and `/auth/register`) click "Use without an account" -> lands in the app, first-run `LocalModeWelcome` shows once. Footer shows "Local only" (disk icon, not clickable).
- **Use offline:** create lists + tasks + subtasks, star/complete, trash. No session-expired banner and no failed-sync indicator. Changing settings (theme / notifications) does not trip the banner.
- **Reload:** returning to the app stays in local mode with data intact (master key restored from IndexedDB).
- **Share gating:** the Shares nav button and a task's share action open an "account required" dialog (-> register), not the share flow.
- **Settings:** the account section shows a "create account" invite + backup reminder; the security section (password / 2FA / recovery codes / sessions / delete account) is hidden. Export / import still work.
- **Upgrade to account:** from the avatar menu / settings "Create account" -> register. After registering you stay logged in, all local tasks are present and start syncing (no data wipe). Verify there is exactly one default list (no duplicate). Open the same account in a second browser -> tasks sync down.
- **Login replaces local data:** while in local mode, going to `/auth/login` and signing in to an EXISTING account prompts a destructive confirm first (sign-in wipes local tasks).
- **No regression for accounts:** a normal register / login / unlock flow is unchanged.

Green gate: `affected -t lint check test typecheck`, i18n parity (tasks, new `local_mode` namespace + `sync.indicator.local_only`), build (both apps). New unit test: `local-mode.service.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)