### PR TITLE
fix(notes): match folder-sync files to notes by path manifest

### DIFF
--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -55,7 +55,7 @@ import {
 } from './markdown-import-utils';
 import {
   computeRenamedTitle,
-  findExisting,
+  pickOverwriteTarget,
   isImportUnchanged,
   mergeTagIds,
   tagSetsEqual,
@@ -1438,10 +1438,33 @@ async function applyDuplicateStrategy(args: {
   modifiedAt: string | undefined;
   lookup: TitleLookup;
   strategy: DuplicateStrategy;
+  /**
+   * Live folder sync only: the note id this file's path mapped to on the
+   * previous run (from the persisted `path_note_ids` manifest). When it still
+   * resolves to a live note it overrides the title lookup, so a file already
+   * linked to a note updates THAT note even if this tab's in-memory title index
+   * is stale - see {@link pickOverwriteTarget}. Undefined for manual / flat .md
+   * imports, which stay on pure title matching.
+   */
+  manifestNoteId?: string;
 }): Promise<DuplicateOutcomeResult> {
   const { baseTitle, content, folderId, tagIds, createdAt, modifiedAt, lookup, strategy } = args;
   const tagMode = args.tagMode ?? 'replace';
-  const existingId = findExisting(lookup, folderId, baseTitle);
+
+  // Resolve the note to overwrite. The path→note manifest (folder sync) wins
+  // over the title lookup when it points at a still-live note: the lookup comes
+  // from the per-tab in-memory note index, which can be stale, and trusting it
+  // alone minted duplicate notes on re-sync. getNote() returns null for
+  // missing/trashed notes, so a stale manifest link falls through to title
+  // matching below (which re-creates the note - the mirror's "disk wins" rule).
+  const manifestNote =
+    args.manifestNoteId !== undefined ? await NoteService.getNote(args.manifestNoteId) : null;
+  const existingId = pickOverwriteTarget(
+    { noteId: args.manifestNoteId, live: manifestNote !== null },
+    lookup,
+    folderId,
+    baseTitle
+  );
 
   if (!existingId) {
     const newId = await NoteService.createNote(baseTitle, content, folderId, {
@@ -1456,6 +1479,14 @@ async function applyDuplicateStrategy(args: {
     return { outcome: 'created', noteId: newId };
   }
 
+  // A manifest match can resolve a note whose title was NOT in the lookup (the
+  // stale-index case). Claim the (folder, title) slot now so a later same-
+  // titled file in this same batch dedupes against it instead of minting yet
+  // another copy. A title-lookup match already occupies the slot - no-op.
+  if (manifestNote !== null) {
+    rememberTitle(lookup, folderId, baseTitle, existingId);
+  }
+
   if (strategy === 'skip') {
     return { outcome: 'skipped', noteId: undefined };
   }
@@ -1464,9 +1495,12 @@ async function applyDuplicateStrategy(args: {
     // Skip the write entirely when the stored note already matches the file -
     // repeated "re-import to refresh" runs stay cheap (no re-encrypt, no sync
     // push) and don't shuffle every note to the top of `updated_at` ordering.
-    // getNote() returns null for trashed notes, but those never reach this
-    // point: the title lookup is built from non-archived index entries only.
-    const existingNote = await NoteService.getNote(existingId);
+    // Reuse the note already fetched for the manifest check (same id) to avoid
+    // a second decrypt; a title-lookup match re-fetches here. getNote() returns
+    // null for trashed notes - a title match never points at one (the lookup is
+    // built from non-archived entries) and a trashed manifest link already fell
+    // through to title matching above.
+    const existingNote = manifestNote ?? (await NoteService.getNote(existingId));
     const existingTagIds =
       tagIds === undefined ? [] : await noteTagQueries.getTagsForNote(existingId);
     if (existingNote) {
@@ -1634,6 +1668,15 @@ export type ImportFolderOptions = {
    * truth. See {@link TagOverwriteMode}.
    */
   tagsOnOverwrite?: TagOverwriteMode;
+  /**
+   * Live folder sync only: the previous run's durable `relativePath → note id`
+   * manifest (persisted as `path_note_ids`). Lets the importer overwrite the
+   * note a file is already linked to even when this tab's in-memory title index
+   * is stale - the fix for duplicate notes on re-sync (see
+   * {@link pickOverwriteTarget}). Absent for manual folder imports, which stay
+   * on pure title-based dedup.
+   */
+  pathManifest?: Record<string, string>;
 };
 
 /**
@@ -1696,6 +1739,7 @@ export async function importFolder(
   const keepRootFolder = opts?.keepRootFolder ?? false;
   const targetFolderId = opts?.targetFolderId;
   const tagsOnOverwrite = opts?.tagsOnOverwrite ?? 'replace';
+  const pathManifest = opts?.pathManifest;
 
   // 0. Normalize inputs to { file, relativePath } pairs. Plain Files carry
   //    their path in webkitRelativePath ('' when absent → name only, lands
@@ -1832,7 +1876,10 @@ export async function importFolder(
         createdAt,
         modifiedAt,
         lookup: titleLookup,
-        strategy: duplicateStrategy
+        strategy: duplicateStrategy,
+        // Authoritative for folder sync: a file already linked to a live note
+        // overwrites it regardless of the (possibly stale) title lookup.
+        manifestNoteId: pathManifest?.[relativePath]
       });
 
       // Record the file↔note link for every outcome that resolved to a note

--- a/apps/reborn-notes/src/lib/services/folder-sync.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/folder-sync.service.spec.ts
@@ -89,7 +89,11 @@ vi.mock('$lib/stores/folders.store', async () => {
 // Concurrency tracker: the runner must never overlap two imports.
 let activeImports = 0;
 let maxActiveImports = 0;
-type ImportCall = { paths: string[]; targetFolderId?: string };
+type ImportCall = {
+  paths: string[];
+  targetFolderId?: string;
+  pathManifest?: Record<string, string>;
+};
 const importCalls: ImportCall[] = [];
 
 vi.mock('./export-import.service', () => ({
@@ -98,13 +102,14 @@ vi.mock('./export-import.service', () => ({
       entries: Array<{ file: File; relativePath: string }>,
       _strategy?: unknown,
       _onProgress?: unknown,
-      opts?: { targetFolderId?: string }
+      opts?: { targetFolderId?: string; pathManifest?: Record<string, string> }
     ) => {
       activeImports++;
       maxActiveImports = Math.max(maxActiveImports, activeImports);
       importCalls.push({
         paths: entries.map((e) => e.relativePath),
-        targetFolderId: opts?.targetFolderId
+        targetFolderId: opts?.targetFolderId,
+        pathManifest: opts?.pathManifest
       });
       // Yield twice so an accidentally-parallel runner would overlap here.
       await Promise.resolve();
@@ -436,6 +441,32 @@ describe('runFolderSync (in-app deletion)', () => {
     expect(rows.find((r) => r.id === 'a')?.path_note_ids).toEqual({
       'Docs/a.md': 'note:Docs/a.md'
     });
+  });
+
+  it('passes the prior path-to-note manifest to importFolder so a stale title index cannot duplicate', async () => {
+    // a.md is known and already linked to note-a. Its mtime (fakeDir stamps
+    // 1000ms) is past the watermark, so it re-enters the incremental set and
+    // reaches importFolder - which must receive the manifest to overwrite
+    // note-a in place rather than trust the volatile in-memory title index.
+    seedConfig({
+      id: 'a',
+      root_name: 'Docs',
+      target_folder_id: 'f1',
+      handle: fakeDir('Docs', ['a.md']),
+      last_sync_at: '1970-01-01T00:00:00.000Z',
+      known_paths: ['Docs/a.md'],
+      path_note_ids: { 'Docs/a.md': 'note-a' }
+    });
+    folderRows.push({ id: 'f1', name: 'Docs', parent_id: null });
+    noteRows.push({ id: 'note-a' });
+    const svc = await loadService();
+    await svc.refreshFolderSyncStatus();
+
+    await svc.runFolderSync('manual', 'a');
+
+    expect(importCalls).toHaveLength(1);
+    expect(importCalls[0].paths).toEqual(['Docs/a.md']);
+    expect(importCalls[0].pathManifest).toEqual({ 'Docs/a.md': 'note-a' });
   });
 });
 

--- a/apps/reborn-notes/src/lib/services/folder-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder-sync.service.ts
@@ -848,7 +848,14 @@ async function scanAndImport(
       changed,
       'overwrite',
       (p) => patchStatus(cfg.id, { progress: p }),
-      { targetFolderId, tagsOnOverwrite: 'merge' }
+      // Pass the previous run's path↔note manifest so a file already linked to a
+      // live note overwrites THAT note even when this tab's in-memory title
+      // index is stale (e.g. the note was imported in another tab/window this
+      // context hasn't pulled yet) - the index-miss that minted duplicate notes.
+      // New paths and stale links (note hard-deleted) fall back to title
+      // matching inside the importer. `prevManifest` is undefined on the first
+      // manifest-populating run; the importer then uses title matching alone.
+      { targetFolderId, tagsOnOverwrite: 'merge', pathManifest: prevManifest }
     );
   }
 

--- a/apps/reborn-notes/src/lib/services/import-dedup-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/import-dedup-utils.spec.ts
@@ -3,6 +3,7 @@ import {
   folderKey,
   rememberTitle,
   findExisting,
+  pickOverwriteTarget,
   computeRenamedTitle,
   isImportUnchanged,
   mergeTagIds,
@@ -56,6 +57,56 @@ describe('rememberTitle / findExisting', () => {
     rememberTitle(lookup, 'folder-1', 'Notes', 'note-1');
     rememberTitle(lookup, 'folder-1', 'Notes', 'note-2');
     expect(findExisting(lookup, 'folder-1', 'notes')).toBe('note-2');
+  });
+});
+
+describe('pickOverwriteTarget', () => {
+  // A title lookup where "Title A" in folder f1 resolves to note-by-title.
+  const lookup: TitleLookup = new Map();
+  rememberTitle(lookup, 'f1', 'Title A', 'note-by-title');
+
+  it('prefers a live manifest match over the title lookup (path link is authoritative)', () => {
+    expect(
+      pickOverwriteTarget({ noteId: 'note-by-manifest', live: true }, lookup, 'f1', 'Title A')
+    ).toBe('note-by-manifest');
+  });
+
+  it('uses the manifest id even when the title is absent from the lookup (stale index)', () => {
+    // This is the duplicate-note bug: the index lacks the note, so a title-only
+    // match would miss and create a copy. The manifest still links the file.
+    expect(pickOverwriteTarget({ noteId: 'note-x', live: true }, lookup, 'f1', 'Not Indexed')).toBe(
+      'note-x'
+    );
+  });
+
+  it('falls back to the title lookup when the manifest id is no longer live (deleted/trashed)', () => {
+    expect(pickOverwriteTarget({ noteId: 'gone', live: false }, lookup, 'f1', 'Title A')).toBe(
+      'note-by-title'
+    );
+  });
+
+  it('falls back to the title lookup when there is no manifest entry (manual import / new path)', () => {
+    expect(pickOverwriteTarget({ noteId: undefined, live: false }, lookup, 'f1', 'Title A')).toBe(
+      'note-by-title'
+    );
+  });
+
+  it('returns undefined (→ create) when neither a live manifest nor the title matches', () => {
+    expect(
+      pickOverwriteTarget({ noteId: undefined, live: false }, lookup, 'f1', 'Brand New')
+    ).toBeUndefined();
+    // A dead manifest id with no title match is also a create.
+    expect(
+      pickOverwriteTarget({ noteId: 'dead', live: false }, lookup, 'f1', 'Brand New')
+    ).toBeUndefined();
+  });
+
+  it('ignores a manifest id flagged not-live even if it would otherwise match the title slot', () => {
+    // live=false means the caller could not confirm the note exists; never
+    // trust the id, regardless of what the title lookup holds.
+    expect(
+      pickOverwriteTarget({ noteId: 'note-by-title', live: false }, lookup, 'f1', 'Title A')
+    ).toBe('note-by-title');
   });
 });
 

--- a/apps/reborn-notes/src/lib/services/import-dedup-utils.ts
+++ b/apps/reborn-notes/src/lib/services/import-dedup-utils.ts
@@ -76,6 +76,35 @@ export function findExisting(
 }
 
 /**
+ * Pick the existing note an imported file should overwrite, preferring the
+ * durable path→note manifest over the volatile in-memory title index.
+ *
+ * Live folder sync persists a `relativePath → note id` manifest in IndexedDB
+ * (`path_note_ids`). When a file is already linked to a still-live note that
+ * link is AUTHORITATIVE: the file overwrites THAT note regardless of the title
+ * lookup. The lookup is built from the per-tab, RAM-only `noteIndex`, which can
+ * be stale (e.g. a note imported in another tab the current context hasn't
+ * pulled yet) - trusting it alone minted a duplicate note on the next sync
+ * (`findExisting` missed → a second copy was created). Falling back to the
+ * title lookup only when the manifest has no usable entry keeps manual imports
+ * (no manifest) and brand-new files on the original case-insensitive matching.
+ *
+ * `manifest.live` is the caller's confirmation that `manifest.noteId` still
+ * exists AND is active (`NoteService.getNote` returns null for missing/trashed
+ * notes); a stale id pointing at a deleted note therefore falls through to the
+ * title lookup, which re-creates it - the one-way mirror's "disk wins" intent.
+ */
+export function pickOverwriteTarget(
+  manifest: { noteId: string | undefined; live: boolean },
+  lookup: TitleLookup,
+  folderId: string | undefined,
+  title: string
+): string | undefined {
+  if (manifest.noteId !== undefined && manifest.live) return manifest.noteId;
+  return findExisting(lookup, folderId, title);
+}
+
+/**
  * Decide whether an `overwrite`-strategy import can skip the write entirely
  * because the incoming file is identical to the already-stored note.
  *


### PR DESCRIPTION
## Summary

Live folder sync duplicated notes for the most-recently-edited files (reported: the two newest `reapps-docs/guidelines` notes were copied after a sync).

Root cause: the overwrite-vs-create decision matched only by `(folder, lowercase title)` read from `noteIndex` - a per-tab, RAM-only cache with no cross-tab invalidation. With the same directory synced from two tabs/windows, one context's index lacked a note the other had just imported, so `findExisting` missed and a second copy was created (only recently-edited files reach the importer, hence the symptom). The note title equals the filename here (no frontmatter `title:`), so the match key was stable - this was a stale-index miss, not a title change. The durable `path_note_ids` manifest already mapped the file to the right note id but was used only for in-app deletion detection.

Fix: `scanAndImport` passes `path_note_ids` to `importFolder` as `pathManifest`. The pure helper `pickOverwriteTarget` prefers the manifest's note over the title lookup when it still resolves to a live note (`getNote` returns null for missing/trashed, so a dead link falls back to title matching = re-create, the one-way mirror's "disk wins" rule). Matching now reads off shared IndexedDB, independent of the volatile per-tab index, and is robust to on-disk title changes. Manual imports (no manifest) are unchanged.

Architectural decision (the sync match key) was approved before implementation.

## Test plan

- `pnpm nx test reborn-notes` - 701 pass, incl. new `pickOverwriteTarget` unit tests (manifest wins / stale-index miss / dead-link & no-entry fallback) and a folder-sync test asserting the manifest reaches `importFolder`.
- `pnpm nx lint reborn-notes` - 0 errors; `pnpm nx check reborn-notes` - 0/0; `pnpm nx build reborn-notes` - OK.
- Manual smoke: link a folder, sync, edit a file, re-sync -> the existing note updates in place (no duplicate). Open the app in two tabs, sync from one, then edit + sync from the other -> still updates in place. Existing dupes: delete the older copy of each pair (the manifest now points at the newer one).