### PR TITLE
fix(notes): suppress "Load all images" on code-span image syntax

### DIFF
--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -366,9 +366,16 @@
     }
   }
 
-  // Check if there are image placeholders to show "Load all" button
+  // Show the "Load all images" button only when the rendered output actually
+  // contains per-image Load buttons. `renderer.image` emits the
+  // `image-placeholder-load` class only for ask-mode external-image tokens, and
+  // marked never calls it for image syntax inside inline code or fenced blocks.
+  // The previous check regex-matched the raw source, so documentation that
+  // mentions `![](https://example.com)` inside backticks lit the banner with no
+  // placeholder beneath it. Deriving from the rendered `html` keeps this
+  // reactive and consistent with what is actually shown.
   const hasImagePlaceholders = $derived(
-    imageLoadMode === 'ask' && content && /!\[.*?\]\(https?:\/\//.test(content)
+    imageLoadMode === 'ask' && html.includes('image-placeholder-load')
   );
 </script>
 


### PR DESCRIPTION
## Summary

The Markdown preview's "Load all images" banner was gated by a regex over the raw markdown source (`/\!\[.*?\]\(https?:\/\//`), so it lit up whenever the text contained `\![...](https://...)` anywhere, including inside inline code or fenced code blocks. A note that only *mentions* image syntax in backticks (e.g. the project's own TODO docs viewed via folder-sync) showed the banner with no image rendered and no per-image placeholder beneath it, because marked never calls `renderer.image` for image syntax inside code spans.

The fix derives the banner from the rendered `html`: it shows only when `renderer.image` actually emitted a per-image Load button (`image-placeholder-load`, produced only for ask-mode external-image tokens). The banner is now consistent with what is rendered and stays reactive on content / `imageLoadMode` changes.

No new i18n keys; no schema / crypto / server-visibility changes.

## Test plan

- `pnpm nx run reborn-notes:lint` -> 0 errors
- `pnpm nx run reborn-notes:check` -> 0 errors, 0 warnings (svelte-check)
- `pnpm nx run reborn-notes:test` -> 701 passed

Smoke (in the app, "Podgląd" / Preview tab):
1. Open a note whose body contains image syntax only inside backticks, e.g. `` `\![](https://example.com/x.png)` `` -> no "Load all images" banner appears.
2. Open a note with a real external image `\![](https://picsum.photos/200)` and image loading set to "Ask" -> banner appears, plus a per-image placeholder with a Load button.
3. Image loading "Always" -> no banner, image loads inline. "Never" -> no banner, placeholder without a Load button.