### PR TITLE
chore(native): biometric App Lock for the Capacitor shell

### DIFF
--- a/apps/reborn-notes/android/app/capacitor.build.gradle
+++ b/apps/reborn-notes/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':aparajita-capacitor-biometric-auth')
     implementation project(':aparajita-capacitor-secure-storage')
     implementation project(':capacitor-app')
     implementation project(':capacitor-clipboard')

--- a/apps/reborn-notes/android/capacitor.settings.gradle
+++ b/apps/reborn-notes/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../../../node_modules/.pnpm/@capacitor+android@8.4.0_@capacitor+core@8.4.0/node_modules/@capacitor/android/capacitor')
 
+include ':aparajita-capacitor-biometric-auth'
+project(':aparajita-capacitor-biometric-auth').projectDir = new File('../../../node_modules/.pnpm/@aparajita+capacitor-biometric-auth@10.0.0/node_modules/@aparajita/capacitor-biometric-auth/android')
+
 include ':aparajita-capacitor-secure-storage'
 project(':aparajita-capacitor-secure-storage').projectDir = new File('../../../node_modules/.pnpm/@aparajita+capacitor-secure-storage@8.0.0/node_modules/@aparajita/capacitor-secure-storage/android')
 

--- a/apps/reborn-notes/ios/App/App/Info.plist
+++ b/apps/reborn-notes/ios/App/App/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>re/notes uses Face ID to unlock the app when App Lock is enabled. Your notes stay encrypted on this device either way.</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/reborn-notes/ios/App/CapApp-SPM/Package.swift
+++ b/apps/reborn-notes/ios/App/CapApp-SPM/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.0"),
+        .package(name: "AparajitaCapacitorBiometricAuth", path: "../../../../../node_modules/.pnpm/@aparajita+capacitor-biometric-auth@10.0.0/node_modules/@aparajita/capacitor-biometric-auth"),
         .package(name: "AparajitaCapacitorSecureStorage", path: "../../../../../node_modules/.pnpm/@aparajita+capacitor-secure-storage@8.0.0/node_modules/@aparajita/capacitor-secure-storage"),
         .package(name: "CapacitorApp", path: "../../../../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.4.0/node_modules/@capacitor/app"),
         .package(name: "CapacitorClipboard", path: "../../../../../node_modules/.pnpm/@capacitor+clipboard@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/clipboard"),
@@ -25,6 +26,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "AparajitaCapacitorBiometricAuth", package: "AparajitaCapacitorBiometricAuth"),
                 .product(name: "AparajitaCapacitorSecureStorage", package: "AparajitaCapacitorSecureStorage"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorClipboard", package: "CapacitorClipboard"),

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -36,6 +36,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@aparajita/capacitor-biometric-auth": "10.0.0",
     "@aparajita/capacitor-secure-storage": "8.0.0",
     "@capacitor/android": "8.4.0",
     "@capacitor/app": "8.1.0",

--- a/apps/reborn-notes/src/lib/services/app-lock.service.ts
+++ b/apps/reborn-notes/src/lib/services/app-lock.service.ts
@@ -1,0 +1,172 @@
+/**
+ * App Lock (native biometric gate) service.
+ *
+ * Coordinates the opt-in "require Face ID / fingerprint to open the app"
+ * feature for the Capacitor shell. It is a UX access gate (option B): the
+ * master key stays Keystore/Keychain-wrapped in the vault; the biometric prompt
+ * only gates *reading* it back into memory, on cold start and on resume after
+ * an idle timeout. It is NOT a cryptographic lock - see
+ * planning/native-app-lock-biometric-plan.md (and `@reborn/crypto`
+ * cryptoManager App Lock section) for the honest framing and the future
+ * crypto-bound option C.
+ *
+ * Scope: account-mode native sessions, where the key lives in the vault.
+ * Local-only mode keeps its passcode lock (a real at-rest crypto lock); this
+ * service stays out of its way (the crypto gate is mutually exclusive with the
+ * passcode wrap).
+ *
+ * Layering:
+ *  - enabled flag       → owned by `@reborn/crypto` (its restore gate reads it)
+ *  - idle timeout       → owned here (localStorage, device-local, not synced)
+ *  - biometric prompt   → `native-biometric-auth.ts` (raw bridge)
+ *  - reactive hasE2E    → `auth.store.ts` (markE2EUnlocked / lockAppNow)
+ *
+ * Everything is gated on `__REBORN_NATIVE__` so the web build drops the module.
+ */
+
+import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
+import { platform } from '$lib/platform';
+import { authStore } from '$lib/stores/auth.store';
+import {
+  getBiometryStatus,
+  promptBiometric,
+  type BiometricAuthResult,
+  type BiometricPromptOptions,
+  type BiometryStatus
+} from '$lib/utils/native-biometric-auth';
+
+const logger = createLogger('AppLock');
+
+/** localStorage key for the idle timeout (ms). Device-local, never synced. */
+const TIMEOUT_KEY = 'reborn_app_lock_timeout_ms';
+
+/** Default idle timeout before resume re-locks: 1 minute (decision, 2026-06-14). */
+export const DEFAULT_TIMEOUT_MS = 60_000;
+
+/** Timeout presets surfaced in settings (ms). `0` = lock immediately on leave. */
+export const TIMEOUT_PRESETS_MS = [0, 60_000, 300_000, 900_000] as const;
+
+/** Wall-clock of the last background transition; 0 until the app first pauses. */
+let pausedAt = 0;
+let lifecycleWired = false;
+
+/** Whether the device offers App Lock (native + biometry or device credential). */
+export async function getAppLockAvailability(): Promise<BiometryStatus> {
+  return getBiometryStatus();
+}
+
+/** Whether App Lock is currently enabled (synchronous). */
+export function isAppLockEnabled(): boolean {
+  return cryptoManager.isAppLockEnabled();
+}
+
+/** Read the idle timeout (ms), clamped to a known preset, default 1 min. */
+export function getTimeoutMs(): number {
+  if (typeof window === 'undefined' || !window.localStorage) return DEFAULT_TIMEOUT_MS;
+  const raw = window.localStorage.getItem(TIMEOUT_KEY);
+  if (raw === null) return DEFAULT_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_TIMEOUT_MS;
+  // Accept only known presets so a hand-edited value can't disable the lock.
+  return (TIMEOUT_PRESETS_MS as readonly number[]).includes(parsed)
+    ? parsed
+    : DEFAULT_TIMEOUT_MS;
+}
+
+/** Persist the idle timeout (ms). */
+export function setTimeoutMs(ms: number): void {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  window.localStorage.setItem(TIMEOUT_KEY, String(ms));
+}
+
+/**
+ * Wire the background-timestamp tracker once. Called from hooks.client.ts on
+ * native boot. The resume-side decision lives in the layout's onResume handler
+ * (it owns navigation + the auth store), which calls `shouldLockOnResume()`.
+ */
+export function initAppLock(): void {
+  if (!__REBORN_NATIVE__ || lifecycleWired) return;
+  lifecycleWired = true;
+  platform.lifecycle.onPause(() => {
+    pausedAt = Date.now();
+  });
+}
+
+/**
+ * Whether a resume should re-lock the app: enabled, currently unlocked, and the
+ * app spent at least the idle timeout in the background. `pausedAt === 0`
+ * (never backgrounded) never locks.
+ */
+export function shouldLockOnResume(): boolean {
+  if (!__REBORN_NATIVE__) return false;
+  if (!cryptoManager.isAppLockEnabled()) return false;
+  if (!cryptoManager.isInitialized()) return false; // already locked
+  if (pausedAt === 0) return false;
+  return Date.now() - pausedAt >= getTimeoutMs();
+}
+
+/**
+ * Enable App Lock. Requires biometry (or a device credential) to be available,
+ * then confirms with a prompt so the user proves they can unlock later. On
+ * success the crypto gate flag is set; the key stays in the vault (no re-wrap).
+ * `prompts` carries the localized dialog strings from the caller.
+ */
+export async function enableAppLock(
+  prompts: BiometricPromptOptions
+): Promise<BiometricAuthResult> {
+  if (!__REBORN_NATIVE__) return { ok: false, code: 'biometryNotAvailable' };
+  const status = await getBiometryStatus();
+  if (!status.isAvailable && !status.deviceIsSecure) {
+    return { ok: false, code: 'biometryNotEnrolled' };
+  }
+  const result = await promptBiometric({ allowDeviceCredential: true, ...prompts });
+  if (!result.ok) return result;
+  cryptoManager.setAppLockEnabled(true);
+  if (getTimeoutMs() === DEFAULT_TIMEOUT_MS) setTimeoutMs(DEFAULT_TIMEOUT_MS);
+  logger.info('App Lock enabled');
+  return { ok: true };
+}
+
+/**
+ * Disable App Lock. No prompt: the caller is in an unlocked session (settings).
+ * Clears the gate flag; the key remains in the vault and auto-restores normally
+ * on the next cold start.
+ */
+export function disableAppLock(): void {
+  cryptoManager.setAppLockEnabled(false);
+  logger.info('App Lock disabled');
+}
+
+/** Lock the app now (manual "Lock now" / settings). Shows the lock screen. */
+export function lockNow(): void {
+  authStore.lockAppNow();
+}
+
+/**
+ * Drive an unlock attempt from the lock screen: biometric prompt, then read the
+ * key back from the vault and flip the auth store. Returns `{ ok: false, code }`
+ * on a failed/cancelled prompt or a vault read that yielded no key. `prompts`
+ * carries the localized dialog strings.
+ */
+export async function unlock(prompts: BiometricPromptOptions): Promise<BiometricAuthResult> {
+  if (!__REBORN_NATIVE__) return { ok: false, code: 'biometryNotAvailable' };
+  const result = await promptBiometric({ allowDeviceCredential: true, ...prompts });
+  if (!result.ok) return result;
+  try {
+    const restored = await cryptoManager.unlockFromVault();
+    if (!restored) {
+      // Prompt passed but the vault held no usable key (cleared/corrupt). The
+      // lock screen offers the account-password fallback for this case.
+      return { ok: false, code: 'vaultEmpty' };
+    }
+    authStore.markE2EUnlocked();
+    // Reset the timer so a unlock immediately followed by a background→resume
+    // doesn't re-lock before the user does anything.
+    pausedAt = 0;
+    return { ok: true };
+  } catch (error: unknown) {
+    logger.error('Vault read after biometric unlock failed:', error);
+    return { ok: false, code: 'vaultEmpty' };
+  }
+}

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -345,6 +345,19 @@ function createAuthStore() {
   }
 
   /**
+   * Lock the native App Lock now: drop the in-memory key but KEEP the vault
+   * entry (unlike logout), so a biometric unlock can re-read it. Flips hasE2E
+   * so the guard routes to the biometric lock screen. Used by resume-after-
+   * timeout and the manual "Lock now" action; unlock goes through the App Lock
+   * service + markE2EUnlocked().
+   */
+  function lockAppNow(): void {
+    if (!browser) return;
+    cryptoManager.lockToVault();
+    set({ ...readFromStorage(), hasE2E: false });
+  }
+
+  /**
    * Clear all shared auth tokens and redirect to login.
    * Also clears the master key from memory (logs out of E2E too).
    * Because the tokens are shared, this also effectively logs the user out
@@ -379,6 +392,10 @@ function createAuthStore() {
     }
 
     cryptoManager.clearMasterKey();
+    // Drop the App Lock opt-in on logout: the vault is now empty, so leaving the
+    // gate armed would strand the next account on a biometric lock screen with
+    // no key to unlock. Re-enable is a one-tap opt-in after the next login.
+    cryptoManager.setAppLockEnabled(false);
     localStorage.removeItem(CREDENTIALS_KEY);
     localStorage.removeItem(ACCESS_TOKEN_KEY);
 
@@ -412,6 +429,7 @@ function createAuthStore() {
     unlockE2E,
     unlockLocalPasscode,
     lockLocalNow,
+    lockAppNow,
     logout,
     markE2EUnlocked,
     enterLocalMode

--- a/apps/reborn-notes/src/lib/utils/native-biometric-auth.ts
+++ b/apps/reborn-notes/src/lib/utils/native-biometric-auth.ts
@@ -1,0 +1,163 @@
+/**
+ * Raw-bridge access to the native biometric-auth plugin
+ * (`@aparajita/capacitor-biometric-auth`), used by the App Lock feature.
+ *
+ * Talks DIRECTLY to the natively-registered plugin via Capacitor's
+ * `registerPlugin('BiometricAuthNative')` proxy, exactly like
+ * `native-secure-storage.ts`. The package's own entry point is deliberately
+ * NOT imported: it builds its proxy with a lazy platform factory
+ * (`registerPlugin('BiometricAuthNative', { ios: async () => import('./native.js'), ... })`),
+ * i.e. a nested dynamic import resolved on first call. That is the exact
+ * boot-storm wedge pattern that hung iOS cold start twice in Faza 4 (see
+ * native-secure-storage.ts header + guideline 61 "boot-time wedge"). The App
+ * Lock screen shows at cold start, so its first biometric call is close to that
+ * window - the raw proxy (synchronous `registerPlugin`, no factory, no nested
+ * import) keeps it off the wedge path entirely.
+ *
+ * `@capacitor/core` is imported STATICALLY (same reason as
+ * native-secure-storage.ts): on native it is already in the boot bundle, and on
+ * web `registerPlugin` is only referenced inside the compile-time-false
+ * `__REBORN_NATIVE__` branch, so the whole module - plugin included - is
+ * tree-shaken from the web bundle.
+ *
+ * The native method surface is `checkBiometry` + `internalAuthenticate` (the
+ * `internal*` name is the plugin's native method; the package's public
+ * `authenticate()` just re-wraps its rejection as a typed `BiometryError`,
+ * which we replicate here by reading the `.code` string off the rejection).
+ */
+
+import { registerPlugin } from '@capacitor/core';
+
+/**
+ * Biometry type, mirroring the plugin's `BiometryType` enum (duplicated as
+ * literals so the wedging package module stays unimported). Locked by
+ * `native-biometric-auth.spec.ts` against the package.
+ */
+const BIOMETRY_TYPE = {
+  none: 0,
+  touchId: 1,
+  faceId: 2,
+  fingerprint: 3,
+  face: 4,
+  iris: 5
+} as const;
+
+/** A stable, platform-neutral biometry label the UI maps to an i18n string. */
+export type BiometryKind = 'faceId' | 'touchId' | 'fingerprint' | 'face' | 'iris' | 'none';
+
+/** Result of a biometric prompt attempt. `code` is a `BiometryErrorType` string. */
+export type BiometricAuthResult = { ok: true } | { ok: false; code: string };
+
+/** Subset of the plugin's `CheckBiometryResult` we consume. */
+interface RawCheckBiometryResult {
+  isAvailable: boolean;
+  strongBiometryIsAvailable: boolean;
+  biometryType: number;
+  biometryTypes: number[];
+  deviceIsSecure: boolean;
+  reason: string;
+  code: string;
+}
+
+/** Subset of the plugin's `AuthenticateOptions` we pass through. */
+export interface BiometricPromptOptions {
+  reason?: string;
+  cancelTitle?: string;
+  allowDeviceCredential?: boolean;
+  iosFallbackTitle?: string;
+  androidTitle?: string;
+  androidSubtitle?: string;
+  androidConfirmationRequired?: boolean;
+}
+
+/** The plugin's native method surface (see its ios/android sources). */
+interface RawBiometricPlugin {
+  checkBiometry(): Promise<RawCheckBiometryResult>;
+  internalAuthenticate(options: BiometricPromptOptions): Promise<void>;
+}
+
+/** Device biometry status, normalized for the App Lock UI. */
+export interface BiometryStatus {
+  /** Weak-or-better biometry is available AND enrolled. */
+  isAvailable: boolean;
+  /** Device has a PIN/pattern/passcode (iOS: passcode set). */
+  deviceIsSecure: boolean;
+  /** Primary biometry kind, for labelling ("Face ID", "Fingerprint", …). */
+  kind: BiometryKind;
+}
+
+let rawPlugin: RawBiometricPlugin | null = null;
+
+/** Lazily build the raw plugin proxy. Native-only. */
+function getPlugin(): RawBiometricPlugin {
+  // registerPlugin is synchronous (a proxy over the already-injected native
+  // bridge) - no async init step a boot race could wedge.
+  rawPlugin ??= registerPlugin<RawBiometricPlugin>('BiometricAuthNative');
+  return rawPlugin;
+}
+
+function toKind(type: number): BiometryKind {
+  switch (type) {
+    case BIOMETRY_TYPE.touchId:
+      return 'touchId';
+    case BIOMETRY_TYPE.faceId:
+      return 'faceId';
+    case BIOMETRY_TYPE.fingerprint:
+      return 'fingerprint';
+    case BIOMETRY_TYPE.face:
+      return 'face';
+    case BIOMETRY_TYPE.iris:
+      return 'iris';
+    default:
+      return 'none';
+  }
+}
+
+/**
+ * Query whether biometry is available and enrolled on this device. Returns a
+ * "nothing available" status on web or any plugin error, so callers can treat
+ * the absence of biometry uniformly.
+ */
+export async function getBiometryStatus(): Promise<BiometryStatus> {
+  if (!__REBORN_NATIVE__) {
+    return { isAvailable: false, deviceIsSecure: false, kind: 'none' };
+  }
+  try {
+    const result = await getPlugin().checkBiometry();
+    return {
+      isAvailable: result.isAvailable,
+      deviceIsSecure: result.deviceIsSecure,
+      kind: toKind(result.biometryType)
+    };
+  } catch {
+    return { isAvailable: false, deviceIsSecure: false, kind: 'none' };
+  }
+}
+
+/**
+ * Prompt the user for biometric (or, when `allowDeviceCredential` is set,
+ * device-credential) authentication. Resolves `{ ok: true }` on success or
+ * `{ ok: false, code }` on any failure/cancel, where `code` is one of the
+ * plugin's `BiometryErrorType` strings (e.g. `userCancel`, `biometryLockout`,
+ * `biometryNotEnrolled`). Never rejects.
+ */
+export async function promptBiometric(
+  options: BiometricPromptOptions = {}
+): Promise<BiometricAuthResult> {
+  if (!__REBORN_NATIVE__) {
+    return { ok: false, code: 'biometryNotAvailable' };
+  }
+  try {
+    await getPlugin().internalAuthenticate(options);
+    return { ok: true };
+  } catch (error: unknown) {
+    // Capacitor surfaces `call.reject(message, code)` as an error carrying a
+    // `.code` string (the BiometryErrorType). Fall back to a generic code when
+    // the shape is unexpected.
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code: unknown }).code)
+        : 'authenticationFailed';
+    return { ok: false, code: code || 'authenticationFailed' };
+  }
+}

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
   import LocalModeWelcome from '$lib/components/LocalModeWelcome.svelte';
   import UpdateRequiredGate from '$lib/components/layout/UpdateRequiredGate.svelte';
   import { checkNativeUpdateGate } from '$lib/utils/native-app-update';
+  import { initAppLock, shouldLockOnResume } from '$lib/services/app-lock.service';
   import { createLogger } from '@reborn/utils';
 
   const logger = createLogger('notes:layout');
@@ -64,6 +65,7 @@
       path.startsWith(`${basePath}/auth/register`) ||
       path.startsWith(`${basePath}/auth/unlock`) ||
       path.startsWith(`${basePath}/auth/lock`) ||
+      path.startsWith(`${basePath}/auth/applock`) ||
       path.startsWith(`${basePath}/auth/2fa`);
 
     // Public read-only share view (/s/{slug}) - no account needed.
@@ -92,6 +94,19 @@
       untrack(() => noteIndex.clear());
       untrack(() => {
         goto('/auth/login');
+      });
+      return;
+    }
+
+    // Native App Lock: key is in the vault but gated behind a biometric prompt
+    // (cold start, or resume after the idle timeout). Route to the biometric
+    // lock screen before the password-unlock check below, so an account user
+    // gets Face ID / fingerprint, not the password form. Inert on web (no
+    // vault) and when App Lock is off. See guideline 66.
+    if (cryptoManager.isAppLockLocked() && !isAuthRoute && !isPublicShareRoute) {
+      untrack(() => noteIndex.clear());
+      untrack(() => {
+        goto('/auth/applock');
       });
       return;
     }
@@ -340,7 +355,19 @@
     let offDeepLink: (() => void) | undefined;
     let updateGateTimer: ReturnType<typeof setTimeout> | undefined;
     if (__REBORN_NATIVE__) {
+      // App Lock: start tracking background time so a resume after the idle
+      // timeout re-locks (wires platform.lifecycle.onPause once).
+      initAppLock();
+
       offResume = platform.lifecycle.onResume(() => {
+        // App Lock first: if the app was backgrounded past the idle timeout,
+        // re-lock and show the biometric screen instead of syncing while
+        // unlocked. No-op when App Lock is off.
+        if (shouldLockOnResume()) {
+          authStore.lockAppNow();
+          void goto('/auth/applock');
+          return;
+        }
         // Min-version gate re-check (throttled internally, fail-open).
         void checkNativeUpdateGate();
         if ($authStore.isAuthenticated && $authStore.hasE2E) {

--- a/apps/reborn-notes/src/routes/auth/applock/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/applock/+page.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import { onMount } from 'svelte';
+  import { goto } from '$lib/utils/navigation';
+  import { page } from '$app/stores';
+  import { AuthLayout, Button, Alert, AlertDescription } from '@reborn/ui';
+  import { Fingerprint, ScanFace, Lock } from '@lucide/svelte';
+  import { t } from '$lib/stores/i18n.store';
+  import { cryptoManager } from '@reborn/crypto';
+  import { authStore } from '$lib/stores/auth.store';
+  import { unlock as appLockUnlock, getAppLockAvailability } from '$lib/services/app-lock.service';
+  import type { BiometryKind } from '$lib/utils/native-biometric-auth';
+  import { createLogger } from '@reborn/utils';
+
+  const logger = createLogger('AppLockRoute');
+
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let biometryKind = $state<BiometryKind>('none');
+  let isRedirecting = false;
+
+  const returnTo = $derived.by(() => $page.url.searchParams.get('returnTo') || '/');
+
+  // A human label for the device's biometry, used in the prompt + description.
+  const biometryLabel = $derived(
+    biometryKind === 'none'
+      ? $t('app_lock.biometry.generic')
+      : $t(`app_lock.biometry.${biometryKind}`)
+  );
+
+  // Account users always have the password escape hatch (decrypts the key from
+  // the server-stored wrap). Local-only sessions are out of App Lock's scope.
+  const canUsePassword = $derived($authStore.isAuthenticated);
+
+  onMount(() => {
+    // Nothing to unlock (not locked / already unlocked) → leave.
+    if (!cryptoManager.isAppLockLocked()) {
+      isRedirecting = true;
+      void goto(returnTo);
+      return;
+    }
+    void getAppLockAvailability().then((status) => (biometryKind = status.kind));
+    // Auto-prompt on first paint - this runs after boot (the raw-bridge plugin
+    // has no nested dynamic import, so it is safe from the cold-start wedge).
+    void runUnlock();
+  });
+
+  function messageForCode(code: string): string | null {
+    switch (code) {
+      case 'userCancel':
+      case 'systemCancel':
+      case 'appCancel':
+        // User-initiated cancel - no error noise, just let them retry.
+        return null;
+      case 'biometryLockout':
+        return $t('app_lock.error.lockout');
+      case 'biometryNotAvailable':
+      case 'biometryNotEnrolled':
+      case 'passcodeNotSet':
+      case 'noDeviceCredential':
+        return $t('app_lock.error.unavailable');
+      case 'vaultEmpty':
+        return $t('app_lock.error.vault');
+      default:
+        return $t('app_lock.error.failed');
+    }
+  }
+
+  async function runUnlock() {
+    if (loading || isRedirecting) return;
+    loading = true;
+    error = null;
+    try {
+      const result = await appLockUnlock({
+        reason: $t('app_lock.prompt.reason'),
+        cancelTitle: $t('app_lock.prompt.cancel'),
+        androidTitle: $t('app_lock.prompt.android_title'),
+        androidSubtitle: $t('app_lock.prompt.android_subtitle'),
+        iosFallbackTitle: ''
+      });
+      if (result.ok) {
+        isRedirecting = true;
+        await goto(returnTo);
+        return;
+      }
+      error = messageForCode(result.code);
+    } catch (err: unknown) {
+      logger.error('App Lock unlock failed:', err);
+      error = $t('app_lock.error.failed');
+    } finally {
+      loading = false;
+    }
+  }
+
+  function usePassword() {
+    isRedirecting = true;
+    void goto('/auth/unlock');
+  }
+</script>
+
+{#snippet logoHeader()}
+  <img src="{base}/logo-black.svg" alt="re/notes" class="h-6 w-auto block dark:hidden" />
+  <img
+    src="{base}/logo-white.svg"
+    alt="re/notes"
+    class="h-6 w-auto hidden dark:block dark:opacity-80"
+  />
+{/snippet}
+
+<AuthLayout header={logoHeader}>
+  <div class="space-y-6">
+    <div class="text-center">
+      <div
+        class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10"
+      >
+        {#if biometryKind === 'faceId' || biometryKind === 'face'}
+          <ScanFace class="h-6 w-6 text-primary" />
+        {:else if biometryKind === 'touchId' || biometryKind === 'fingerprint'}
+          <Fingerprint class="h-6 w-6 text-primary" />
+        {:else}
+          <Lock class="h-6 w-6 text-primary" />
+        {/if}
+      </div>
+      <h2 class="text-lg font-semibold text-foreground">{$t('app_lock.locked_title')}</h2>
+      <p class="mt-1 text-sm text-muted-foreground">
+        {$t('app_lock.locked_desc', { values: { biometry: biometryLabel } })}
+      </p>
+    </div>
+
+    {#if error}
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    {/if}
+
+    <div class="space-y-3">
+      <Button onclick={runUnlock} disabled={loading} class="w-full">
+        {loading ? $t('app_lock.unlocking') : $t('app_lock.unlock_cta')}
+      </Button>
+
+      {#if canUsePassword}
+        <Button variant="ghost" onclick={usePassword} disabled={loading} class="w-full">
+          {$t('app_lock.use_password')}
+        </Button>
+      {/if}
+    </div>
+  </div>
+</AuthLayout>

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -13,6 +13,7 @@
     Trash2,
     LayoutList,
     Share2,
+    Fingerprint,
     ChevronLeft,
     ChevronRight,
     ChevronDown,
@@ -320,6 +321,23 @@
                 <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
               </a>
             {/each}
+
+            {#if __REBORN_NATIVE__}
+              <!-- App Lock (biometric) - native only. The master key must live
+                   in the device vault for the biometric gate to read it back,
+                   which is the account-mode posture on native. -->
+              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+              <a href={resolveHref('/settings/security/app-lock')} class={itemClasses}>
+                <Fingerprint class="h-5 w-5 text-muted-foreground shrink-0" />
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium">{$t('app_lock.settings_item_title')}</div>
+                  <div class="text-sm text-muted-foreground">
+                    {$t('app_lock.settings_item_desc')}
+                  </div>
+                </div>
+                <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
+              </a>
+            {/if}
 
             <!-- Delete account -->
             <a

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -122,6 +122,22 @@
   // management-only items (password change, sessions, delete account) are
   // meaningless without an account and stay hidden.
   const lockedAccountSecurityItems = [
+    // App Lock (biometric) is native-only. Surfaced first so a local-mode user
+    // on a device with biometrics sees it as an account perk: the gate needs
+    // the master key in the device vault (the account-mode posture), whereas
+    // local mode locks with the passcode - a real at-rest crypto wrap that
+    // purges the vault. So biometric unlock and the local passcode stay
+    // separate, and biometrics belong here under "available with an account".
+    // Reuses the App Lock copy; the compile-time guard drops it from web.
+    ...(__REBORN_NATIVE__
+      ? [
+          {
+            icon: Fingerprint,
+            title: $t('app_lock.settings_item_title'),
+            description: $t('app_lock.settings_item_desc')
+          }
+        ]
+      : []),
     {
       icon: Shield,
       title: $t('settings_page.security.two_factor'),

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -310,22 +310,11 @@
         <div class="space-y-1">
           <h2 class="text-lg font-semibold mb-3">{$t('settings_page.security.title')}</h2>
           <div class="space-y-1">
-            {#each securityItems as item}
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-            <a href={resolveHref(item.href)} class={itemClasses}>
-                <item.icon class="h-5 w-5 text-muted-foreground shrink-0" />
-                <div class="flex-1 min-w-0">
-                  <div class="font-medium">{item.title}</div>
-                  <div class="text-sm text-muted-foreground">{item.description}</div>
-                </div>
-                <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
-              </a>
-            {/each}
-
             {#if __REBORN_NATIVE__}
-              <!-- App Lock (biometric) - native only. The master key must live
-                   in the device vault for the biometric gate to read it back,
-                   which is the account-mode posture on native. -->
+              <!-- App Lock (biometric) - native only, surfaced first in the
+                   section (UX). The master key must live in the device vault for
+                   the biometric gate to read it back, the account-mode posture
+                   on native. -->
               <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
               <a href={resolveHref('/settings/security/app-lock')} class={itemClasses}>
                 <Fingerprint class="h-5 w-5 text-muted-foreground shrink-0" />
@@ -338,6 +327,18 @@
                 <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
               </a>
             {/if}
+
+            {#each securityItems as item}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+            <a href={resolveHref(item.href)} class={itemClasses}>
+                <item.icon class="h-5 w-5 text-muted-foreground shrink-0" />
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium">{item.title}</div>
+                  <div class="text-sm text-muted-foreground">{item.description}</div>
+                </div>
+                <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
+              </a>
+            {/each}
 
             <!-- Delete account -->
             <a

--- a/apps/reborn-notes/src/routes/settings/security/app-lock/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/app-lock/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    SettingsLayout,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    CardDescription,
+    Button,
+    Alert,
+    AlertDescription,
+    toast
+  } from '@reborn/ui';
+  import { Fingerprint, ScanFace, Lock, ShieldAlert } from '@lucide/svelte';
+  import { t } from '$lib/stores/i18n.store';
+  import { goto } from '$lib/utils/navigation';
+  import { authStore } from '$lib/stores/auth.store';
+  import { createLogger } from '@reborn/utils';
+  import { get } from 'svelte/store';
+  import {
+    enableAppLock,
+    disableAppLock,
+    isAppLockEnabled,
+    lockNow,
+    getAppLockAvailability,
+    getTimeoutMs,
+    setTimeoutMs,
+    TIMEOUT_PRESETS_MS
+  } from '$lib/services/app-lock.service';
+  import type { BiometryKind } from '$lib/utils/native-biometric-auth';
+
+  const logger = createLogger('AppLockSettingsPage');
+
+  let enabled = $state(false);
+  let available = $state(false);
+  let biometryKind = $state<BiometryKind>('none');
+  let timeoutMs = $state(getTimeoutMs());
+  let busy = $state(false);
+
+  const biometryLabel = $derived(
+    biometryKind === 'none'
+      ? $t('app_lock.biometry.generic')
+      : $t(`app_lock.biometry.${biometryKind}`)
+  );
+
+  const timeoutLabels: Record<number, string> = {
+    0: 'app_lock.timeout.immediate',
+    60000: 'app_lock.timeout.min1',
+    300000: 'app_lock.timeout.min5',
+    900000: 'app_lock.timeout.min15'
+  };
+
+  onMount(() => {
+    // App Lock is a native, account-mode feature: the master key has to live in
+    // the device vault for the biometric gate to read it back. Local-only mode
+    // uses its passcode lock instead.
+    if (!__REBORN_NATIVE__ || !get(authStore).isAuthenticated) {
+      goto('/settings');
+      return;
+    }
+    enabled = isAppLockEnabled();
+    void getAppLockAvailability().then((status) => {
+      available = status.isAvailable || status.deviceIsSecure;
+      biometryKind = status.kind;
+    });
+  });
+
+  async function handleEnable() {
+    busy = true;
+    try {
+      const result = await enableAppLock({
+        reason: $t('app_lock.prompt.reason'),
+        cancelTitle: $t('app_lock.prompt.cancel'),
+        androidTitle: $t('app_lock.prompt.android_title'),
+        androidSubtitle: $t('app_lock.prompt.android_subtitle'),
+        iosFallbackTitle: ''
+      });
+      if (result.ok) {
+        enabled = true;
+        timeoutMs = getTimeoutMs();
+        toast.success($t('app_lock.success_enabled'));
+      } else if (
+        result.code !== 'userCancel' &&
+        result.code !== 'systemCancel' &&
+        result.code !== 'appCancel'
+      ) {
+        toast.error($t('app_lock.enable_failed'));
+      }
+    } catch (err: unknown) {
+      logger.error('Failed to enable App Lock:', err);
+      toast.error($t('app_lock.enable_failed'));
+    } finally {
+      busy = false;
+    }
+  }
+
+  function handleDisable() {
+    disableAppLock();
+    enabled = false;
+    toast.success($t('app_lock.success_disabled'));
+  }
+
+  function selectTimeout(ms: number) {
+    setTimeoutMs(ms);
+    timeoutMs = ms;
+  }
+
+  function handleLockNow() {
+    lockNow();
+    goto('/auth/applock');
+  }
+</script>
+
+<SettingsLayout title={$t('app_lock.settings_item_title')} backHref="/settings">
+  <div class="space-y-6">
+    <Alert>
+      <Lock class="h-4 w-4" />
+      <AlertDescription>{$t('app_lock.settings_intro')}</AlertDescription>
+    </Alert>
+
+    {#if !available}
+      <Card>
+        <CardHeader>
+          <CardTitle class="text-base flex items-center gap-2">
+            <ShieldAlert class="h-4 w-4 text-muted-foreground" />
+            {$t('app_lock.unavailable_title')}
+          </CardTitle>
+          <CardDescription>{$t('app_lock.unavailable_desc')}</CardDescription>
+        </CardHeader>
+      </Card>
+    {:else}
+      <Card>
+        <CardHeader>
+          <CardTitle class="text-base flex items-center gap-2">
+            {#if biometryKind === 'faceId' || biometryKind === 'face'}
+              <ScanFace class="h-4 w-4 text-muted-foreground" />
+            {:else}
+              <Fingerprint class="h-4 w-4 text-muted-foreground" />
+            {/if}
+            {$t('app_lock.enable_title')}
+          </CardTitle>
+          <CardDescription>
+            {$t('app_lock.enable_desc', { values: { biometry: biometryLabel } })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {#if enabled}
+            <Button variant="outline" onclick={handleDisable} disabled={busy}>
+              {$t('app_lock.disable_cta')}
+            </Button>
+          {:else}
+            <Button onclick={handleEnable} disabled={busy} class="w-full sm:w-auto">
+              {$t('app_lock.enable_cta')}
+            </Button>
+          {/if}
+        </CardContent>
+      </Card>
+
+      {#if enabled}
+        <Card>
+          <CardHeader>
+            <CardTitle class="text-base">{$t('app_lock.timeout_title')}</CardTitle>
+            <CardDescription>{$t('app_lock.timeout_desc')}</CardDescription>
+          </CardHeader>
+          <CardContent class="space-y-2">
+            {#each TIMEOUT_PRESETS_MS as ms (ms)}
+              <button
+                type="button"
+                class="flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left text-sm transition-colors hover:bg-muted/50 {timeoutMs ===
+                ms
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border'}"
+                onclick={() => selectTimeout(ms)}
+              >
+                <span class="font-medium">{$t(timeoutLabels[ms])}</span>
+                {#if timeoutMs === ms}
+                  <span class="text-primary text-xs font-semibold">✓</span>
+                {/if}
+              </button>
+            {/each}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle class="text-base">{$t('app_lock.lock_now_title')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div class="flex items-center justify-between gap-4">
+              <div class="text-sm text-muted-foreground">{$t('app_lock.lock_now_desc')}</div>
+              <Button variant="outline" onclick={handleLockNow}>
+                {$t('app_lock.lock_now_cta')}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      {/if}
+    {/if}
+  </div>
+</SettingsLayout>

--- a/packages/crypto/src/__tests__/cryptoManager.appLock.spec.ts
+++ b/packages/crypto/src/__tests__/cryptoManager.appLock.spec.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CryptoManager, type MasterKeyVault } from '../cryptoManager';
+
+/**
+ * Native App Lock: an opt-in biometric gate on reading the vault-backed master
+ * key (planning/native-app-lock-biometric-plan.md, guideline 65).
+ *
+ * Model:
+ *  - The key stays in the injected vault (Keystore/Keychain-wrapped on device);
+ *    a localStorage flag (`reborn_app_lock_enabled`) tells restore NOT to load
+ *    it at cold start. The app shows the biometric lock screen and calls
+ *    `unlockFromVault()` after the prompt passes.
+ *  - It is a UX gate, not a re-wrap: the at-rest ciphertext is unchanged.
+ *
+ * These tests inject a fake in-memory vault (the biometric prompt itself lives
+ * in the app layer and is out of scope here - crypto only owns the key read).
+ * A fresh `new CryptoManager()` simulates a cold start; the flag lives in the
+ * shared mocked localStorage and the vault object is shared between instances,
+ * exactly like the device key store across app launches.
+ */
+const APP_LOCK_KEY = 'reborn_app_lock_enabled';
+const TEMP_KEY = 'TEMP_MASTER_KEY_EXPORT';
+
+const freshManager = () => new (CryptoManager as unknown as { new (): CryptoManager })();
+const ls = () => (global as unknown as { window: { localStorage: Storage } }).window.localStorage;
+const ss = () => (global as unknown as { window: { sessionStorage: Storage } }).window.sessionStorage;
+
+/** A shared in-memory stand-in for the device secure-storage vault. */
+function makeFakeVault(): MasterKeyVault & { peek: () => string | null } {
+  let stored: string | null = null;
+  return {
+    save: async (raw: string) => {
+      stored = raw;
+    },
+    load: async () => stored,
+    clear: async () => {
+      stored = null;
+    },
+    peek: () => stored
+  };
+}
+
+describe('CryptoManager - App Lock (native biometric gate)', () => {
+  beforeEach(() => {
+    ls().clear();
+    ss().clear();
+  });
+
+  describe('enable flag', () => {
+    it('toggles isAppLockEnabled via the localStorage marker', () => {
+      const m = freshManager();
+      expect(m.isAppLockEnabled()).toBe(false);
+
+      m.setAppLockEnabled(true);
+      expect(m.isAppLockEnabled()).toBe(true);
+      expect(ls().getItem(APP_LOCK_KEY)).toBe('1');
+
+      m.setAppLockEnabled(false);
+      expect(m.isAppLockEnabled()).toBe(false);
+      expect(ls().getItem(APP_LOCK_KEY)).toBeNull();
+    });
+
+    it('isAppLockLocked needs a vault (inert on web)', async () => {
+      const m = freshManager(); // no vault injected (web)
+      m.setAppLockEnabled(true);
+      expect(m.isAppLockEnabled()).toBe(true);
+      // No vault -> not "App Lock locked", and restore is not gated by the flag.
+      expect(m.isAppLockLocked()).toBe(false);
+    });
+  });
+
+  describe('restore gate (cold start)', () => {
+    it('does NOT auto-read the vault when App Lock is enabled', async () => {
+      const vault = makeFakeVault();
+      const setup = freshManager();
+      setup.setMasterKeyVault(vault);
+      await setup.setMasterKey(await setup.generateMasterKey());
+      expect(vault.peek()).not.toBeNull(); // key saved to the vault
+      setup.setAppLockEnabled(true);
+
+      const cold = freshManager();
+      cold.setMasterKeyVault(vault); // same device vault
+      const restored = await cold.waitForRestore();
+
+      expect(restored).toBe(false);
+      expect(cold.isInitialized()).toBe(false);
+      expect(cold.isAppLockLocked()).toBe(true);
+      // The key is still in the vault, just not read into memory yet.
+      expect(vault.peek()).not.toBeNull();
+      // App Lock is a vault gate, not a passcode wrap: no sessionStorage export.
+      expect(ss().getItem(TEMP_KEY)).toBeNull();
+    });
+
+    it('auto-restores normally when App Lock is disabled', async () => {
+      const vault = makeFakeVault();
+      const setup = freshManager();
+      setup.setMasterKeyVault(vault);
+      await setup.setMasterKey(await setup.generateMasterKey());
+
+      const cold = freshManager();
+      cold.setMasterKeyVault(vault);
+      const restored = await cold.waitForRestore();
+
+      expect(restored).toBe(true);
+      expect(cold.isInitialized()).toBe(true);
+      expect(cold.isAppLockLocked()).toBe(false);
+    });
+  });
+
+  describe('unlockFromVault', () => {
+    it('reads the key back after the gate and decrypts pre-lock data', async () => {
+      const vault = makeFakeVault();
+      const setup = freshManager();
+      setup.setMasterKeyVault(vault);
+      await setup.setMasterKey(await setup.generateMasterKey());
+      const ciphertext = await setup.encryptString('note before lock');
+      setup.setAppLockEnabled(true);
+
+      const cold = freshManager();
+      cold.setMasterKeyVault(vault);
+      await cold.waitForRestore();
+      expect(cold.isInitialized()).toBe(false);
+
+      const ok = await cold.unlockFromVault();
+
+      expect(ok).toBe(true);
+      expect(cold.isInitialized()).toBe(true);
+      expect(cold.isAppLockLocked()).toBe(false);
+      expect(await cold.decryptString(ciphertext)).toBe('note before lock');
+    });
+
+    it('returns false when the vault holds no key', async () => {
+      const vault = makeFakeVault(); // empty
+      const m = freshManager();
+      m.setMasterKeyVault(vault);
+      m.setAppLockEnabled(true);
+
+      expect(await m.unlockFromVault()).toBe(false);
+      expect(m.isInitialized()).toBe(false);
+    });
+
+    it('is a no-op without a vault (web)', async () => {
+      const m = freshManager();
+      expect(await m.unlockFromVault()).toBe(false);
+    });
+  });
+
+  describe('lockToVault', () => {
+    it('drops the in-memory key but keeps the vault entry; re-unlock works', async () => {
+      const vault = makeFakeVault();
+      const m = freshManager();
+      m.setMasterKeyVault(vault);
+      await m.setMasterKey(await m.generateMasterKey());
+      const ciphertext = await m.encryptString('locked data');
+      m.setAppLockEnabled(true);
+
+      m.lockToVault();
+
+      expect(m.isInitialized()).toBe(false);
+      expect(m.isAppLockLocked()).toBe(true);
+      expect(vault.peek()).not.toBeNull(); // vault preserved (unlike logout)
+
+      expect(await m.unlockFromVault()).toBe(true);
+      expect(await m.decryptString(ciphertext)).toBe('locked data');
+    });
+  });
+
+  describe('precedence', () => {
+    it('a local passcode wrap gates before App Lock (mutually exclusive)', async () => {
+      const vault = makeFakeVault();
+      const setup = freshManager();
+      setup.setMasterKeyVault(vault);
+      await setup.setMasterKey(await setup.generateMasterKey());
+      // enableLocalPasscode purges the vault and writes the wrap.
+      await setup.enableLocalPasscode('correct horse');
+      expect(vault.peek()).toBeNull();
+      // Even if the App Lock flag is somehow also set, the passcode path wins.
+      setup.setAppLockEnabled(true);
+
+      const cold = freshManager();
+      cold.setMasterKeyVault(vault);
+      const restored = await cold.waitForRestore();
+
+      expect(restored).toBe(false);
+      expect(cold.isLocalPasscodeLocked()).toBe(true);
+    });
+  });
+
+  describe('logout-style clear', () => {
+    it('clearMasterKey empties the vault so a stale gate cannot strand the user', async () => {
+      const vault = makeFakeVault();
+      const m = freshManager();
+      m.setMasterKeyVault(vault);
+      await m.setMasterKey(await m.generateMasterKey());
+      m.setAppLockEnabled(true);
+
+      m.clearMasterKey();
+      // The auth store also clears the flag on logout; here we assert the vault
+      // is emptied so unlockFromVault would yield no key (the lock screen then
+      // falls back to the account password).
+      await new Promise((r) => setTimeout(r, 0)); // clearMasterKey's vault clear is async
+      expect(vault.peek()).toBeNull();
+    });
+  });
+});

--- a/packages/crypto/src/cryptoManager.ts
+++ b/packages/crypto/src/cryptoManager.ts
@@ -84,6 +84,19 @@ export class CryptoManager {
    */
   private readonly LOCAL_PASSCODE_WRAP_KEY = 'reborn_local_passcode_wrap';
   private readonly WRAP_FORMAT_VERSION = 1;
+  /**
+   * localStorage flag for the native App Lock (biometric gate). When set on a
+   * native build, the master key is NOT auto-read from the vault at cold start:
+   * the app shows the biometric lock screen and calls `unlockFromVault()` after
+   * a successful prompt. A plain on/off marker (no secret), read synchronously
+   * so the auth guard can branch without awaiting restore - same rationale as
+   * the passcode wrap above. Native-only in practice: the web build never sets
+   * it and has no vault, so the gate in restoreKeyOnStartup stays inert. App
+   * Lock is a UX gate on *reading* the vault, not a re-wrap of the key - the
+   * cryptographic at-rest posture is unchanged (Keystore/Keychain-wrapped). See
+   * planning/native-app-lock-biometric-plan.md.
+   */
+  private readonly APP_LOCK_ENABLED_KEY = 'reborn_app_lock_enabled';
   private restoreKeyAttempted = false;
   private restorePromise: Promise<boolean> | null = null;
   private vault: MasterKeyVault | null = null;
@@ -147,6 +160,19 @@ export class CryptoManager {
       if (this.hasLocalPasscodeWrap()) {
         this.restoreKeyAttempted = true;
         logger.info('Local passcode set - key locked, awaiting passcode unlock');
+        return false;
+      }
+
+      // App Lock (native): the key lives in the vault, but the user opted into a
+      // biometric gate on app open. Do NOT auto-read the vault at cold start -
+      // stay locked and let the biometric lock screen drive unlockFromVault()
+      // after the prompt passes. Mirrors the passcode gate above; the two are
+      // mutually exclusive (a local passcode purges the vault, so an enabled
+      // flag + a populated vault only coexist for an account session). Requires
+      // a vault, so this is inert on web (this.vault === null).
+      if (this.vault && this.hasAppLockEnabled()) {
+        this.restoreKeyAttempted = true;
+        logger.info('App Lock enabled - key locked, awaiting biometric unlock');
         return false;
       }
 
@@ -366,6 +392,81 @@ export class CryptoManager {
     await this.persistKeyToVault();
     await this.clearKeyFromIDB();
     logger.info('Master key migrated from IndexedDB to vault');
+  }
+
+  // ── App Lock (native biometric gate) ─────────────────────────
+  //
+  // Opt-in lock for native shells: require a device biometric (or device
+  // credential) before the vault-backed master key is read, on cold start and
+  // on resume after a configurable idle timeout. This is a UX access gate -
+  // it defends against someone opening the app on an unlocked device - not a
+  // cryptographic upgrade: the key stays Keystore/Keychain-wrapped in the vault
+  // exactly as before, and code running in the app sandbox could still read it.
+  // The cryptographic option (Keystore setUserAuthenticationRequired) is a
+  // documented future hardening; see planning/native-app-lock-biometric-plan.md.
+
+  /** Whether the native App Lock biometric gate is enabled (localStorage flag). */
+  private hasAppLockEnabled(): boolean {
+    if (typeof window === 'undefined' || !window.localStorage) return false;
+    return window.localStorage.getItem(this.APP_LOCK_ENABLED_KEY) === '1';
+  }
+
+  /** Public reader for settings UI / auth guards (synchronous, no restore wait). */
+  public isAppLockEnabled(): boolean {
+    return this.hasAppLockEnabled();
+  }
+
+  /**
+   * Turn the native App Lock on or off. Only writes the flag; the key itself
+   * stays in the vault either way (App Lock gates *reading* the vault, it does
+   * not re-wrap the key). The caller must verify biometry availability before
+   * enabling.
+   */
+  public setAppLockEnabled(enabled: boolean): void {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    if (enabled) window.localStorage.setItem(this.APP_LOCK_ENABLED_KEY, '1');
+    else window.localStorage.removeItem(this.APP_LOCK_ENABLED_KEY);
+  }
+
+  /**
+   * App Lock is engaged: enabled, a vault is present (native), and the key is
+   * not in memory. The auth guard routes to the biometric lock screen on this -
+   * a check distinct from the password-unlock state so an account user gets the
+   * biometric prompt, not the password form.
+   */
+  public isAppLockLocked(): boolean {
+    return !!this.vault && this.hasAppLockEnabled() && !this.isInitialized();
+  }
+
+  /**
+   * Read the master key from the vault after the App Lock biometric prompt has
+   * passed. Mirrors the cold-start vault path (load → verify, with the one-time
+   * legacy-IndexedDB migration as a fallback). Returns true once the key is in
+   * memory. No-op without an injected vault (web). The biometric prompt itself
+   * lives in the native app layer; crypto only owns the key read.
+   */
+  public async unlockFromVault(): Promise<boolean> {
+    if (!this.vault) return false;
+    const restored = await this.restoreKeyFromVault();
+    if (!restored) {
+      await this.migrateLegacyKeyToVault();
+    }
+    return this.isInitialized();
+  }
+
+  /**
+   * Re-lock for App Lock: drop the in-memory key but KEEP the vault entry, so a
+   * later biometric unlock can re-read it. Unlike clearMasterKey() (logout), the
+   * vault and account credentials are preserved. Used on resume-after-timeout
+   * and the manual "Lock now" action.
+   */
+  public lockToVault(): void {
+    this.masterKey = null;
+    this.initialized = false;
+    if (typeof window !== 'undefined' && window.sessionStorage) {
+      window.sessionStorage.removeItem(this.CRYPTO_VERIFIED_KEY);
+    }
+    logger.debug('Master key locked to vault (App Lock)');
   }
 
   /**

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1,5 +1,55 @@
 {
   "appTitle": "reborn/notes",
+  "app_lock": {
+    "settings_item_title": "App-Sperre",
+    "settings_item_desc": "Biometrie zum Öffnen der App verlangen",
+    "settings_intro": "Die App-Sperre verlangt bei jedem Öffnen von re/notes und nach längerer Zeit im Hintergrund eine biometrische Bestätigung. Deine Notizen bleiben auf diesem Gerät ohnehin verschlüsselt - das ist ein Schnellzugriffsschutz, keine zusätzliche Verschlüsselung.",
+    "unavailable_title": "Biometrie nicht eingerichtet",
+    "unavailable_desc": "Richte in den Geräteeinstellungen einen Fingerabdruck oder eine Gesichtsentsperrung ein, um die App-Sperre zu nutzen.",
+    "enable_title": "App-Sperre",
+    "enable_desc": "Erfordert {biometry}, um die App zu öffnen.",
+    "enable_cta": "App-Sperre aktivieren",
+    "disable_cta": "Deaktivieren",
+    "timeout_title": "Erneut sperren nach",
+    "timeout_desc": "Wie lange die App im Hintergrund sein darf, bevor erneut gefragt wird.",
+    "timeout": {
+      "immediate": "Sofort",
+      "min1": "Nach 1 Minute",
+      "min5": "Nach 5 Minuten",
+      "min15": "Nach 15 Minuten"
+    },
+    "lock_now_title": "Jetzt sperren",
+    "lock_now_desc": "Die App sofort sperren.",
+    "lock_now_cta": "Jetzt sperren",
+    "success_enabled": "App-Sperre aktiviert",
+    "success_disabled": "App-Sperre deaktiviert",
+    "enable_failed": "App-Sperre konnte nicht aktiviert werden. Bitte erneut versuchen.",
+    "locked_title": "App gesperrt",
+    "locked_desc": "Zum Fortfahren mit {biometry} entsperren.",
+    "unlock_cta": "Entsperren",
+    "unlocking": "Wird entsperrt...",
+    "use_password": "Stattdessen Passwort verwenden",
+    "prompt": {
+      "reason": "re/notes entsperren",
+      "cancel": "Abbrechen",
+      "android_title": "re/notes entsperren",
+      "android_subtitle": "Bestätige, dass du es bist, um fortzufahren"
+    },
+    "error": {
+      "lockout": "Zu viele Versuche. Warte einen Moment oder verwende dein Passwort.",
+      "unavailable": "Biometrie ist gerade nicht verfügbar. Verwende dein Passwort.",
+      "vault": "Entsperren auf diesem Gerät nicht möglich. Verwende dein Passwort, um fortzufahren.",
+      "failed": "Entsperren fehlgeschlagen. Bitte erneut versuchen."
+    },
+    "biometry": {
+      "faceId": "Face ID",
+      "touchId": "Touch ID",
+      "fingerprint": "Fingerabdruck",
+      "face": "Gesichtserkennung",
+      "iris": "Iris",
+      "generic": "Biometrie"
+    }
+  },
   "local_mode": {
     "account_features_title": "Mit einem Konto verfügbar",
     "welcome": {

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1,5 +1,55 @@
 {
   "appTitle": "reborn/notes",
+  "app_lock": {
+    "settings_item_title": "App Lock",
+    "settings_item_desc": "Require biometrics to open the app",
+    "settings_intro": "App Lock asks for biometric confirmation each time you open re/notes and after it has been in the background for a while. Your notes stay encrypted on this device either way - this is a quick-access guard, not extra encryption.",
+    "unavailable_title": "Biometrics not set up",
+    "unavailable_desc": "Add a fingerprint or face unlock in your device settings to use App Lock.",
+    "enable_title": "App Lock",
+    "enable_desc": "Require {biometry} to open the app.",
+    "enable_cta": "Enable App Lock",
+    "disable_cta": "Turn off",
+    "timeout_title": "Re-lock after",
+    "timeout_desc": "How long the app can stay in the background before asking again.",
+    "timeout": {
+      "immediate": "Immediately",
+      "min1": "After 1 minute",
+      "min5": "After 5 minutes",
+      "min15": "After 15 minutes"
+    },
+    "lock_now_title": "Lock now",
+    "lock_now_desc": "Lock the app immediately.",
+    "lock_now_cta": "Lock now",
+    "success_enabled": "App Lock enabled",
+    "success_disabled": "App Lock turned off",
+    "enable_failed": "Couldn't enable App Lock. Please try again.",
+    "locked_title": "App locked",
+    "locked_desc": "Unlock with {biometry} to continue.",
+    "unlock_cta": "Unlock",
+    "unlocking": "Unlocking...",
+    "use_password": "Use password instead",
+    "prompt": {
+      "reason": "Unlock re/notes",
+      "cancel": "Cancel",
+      "android_title": "Unlock re/notes",
+      "android_subtitle": "Confirm it's you to continue"
+    },
+    "error": {
+      "lockout": "Too many attempts. Wait a moment, or use your password.",
+      "unavailable": "Biometrics aren't available right now. Use your password.",
+      "vault": "Couldn't unlock on this device. Use your password to continue.",
+      "failed": "Couldn't unlock. Try again."
+    },
+    "biometry": {
+      "faceId": "Face ID",
+      "touchId": "Touch ID",
+      "fingerprint": "fingerprint",
+      "face": "face unlock",
+      "iris": "iris",
+      "generic": "biometrics"
+    }
+  },
   "local_mode": {
     "account_features_title": "Available with an account",
     "welcome": {

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1,5 +1,55 @@
 {
   "appTitle": "reborn/notes",
+  "app_lock": {
+    "settings_item_title": "Bloqueo de la app",
+    "settings_item_desc": "Requerir biometría para abrir la aplicación",
+    "settings_intro": "El bloqueo de la app pide confirmación biométrica cada vez que abres re/notes y después de un rato en segundo plano. Tus notas permanecen cifradas en este dispositivo de todos modos - es una protección de acceso rápido, no un cifrado adicional.",
+    "unavailable_title": "Biometría no configurada",
+    "unavailable_desc": "Añade una huella dactilar o el desbloqueo facial en los ajustes del dispositivo para usar el bloqueo de la app.",
+    "enable_title": "Bloqueo de la app",
+    "enable_desc": "Requiere {biometry} para abrir la aplicación.",
+    "enable_cta": "Activar el bloqueo",
+    "disable_cta": "Desactivar",
+    "timeout_title": "Volver a bloquear tras",
+    "timeout_desc": "Cuánto tiempo puede estar la app en segundo plano antes de volver a preguntar.",
+    "timeout": {
+      "immediate": "Inmediatamente",
+      "min1": "Tras 1 minuto",
+      "min5": "Tras 5 minutos",
+      "min15": "Tras 15 minutos"
+    },
+    "lock_now_title": "Bloquear ahora",
+    "lock_now_desc": "Bloquear la aplicación inmediatamente.",
+    "lock_now_cta": "Bloquear ahora",
+    "success_enabled": "Bloqueo de la app activado",
+    "success_disabled": "Bloqueo de la app desactivado",
+    "enable_failed": "No se pudo activar el bloqueo. Inténtalo de nuevo.",
+    "locked_title": "Aplicación bloqueada",
+    "locked_desc": "Desbloquea con {biometry} para continuar.",
+    "unlock_cta": "Desbloquear",
+    "unlocking": "Desbloqueando...",
+    "use_password": "Usar la contraseña en su lugar",
+    "prompt": {
+      "reason": "Desbloquear re/notes",
+      "cancel": "Cancelar",
+      "android_title": "Desbloquear re/notes",
+      "android_subtitle": "Confirma que eres tú para continuar"
+    },
+    "error": {
+      "lockout": "Demasiados intentos. Espera un momento o usa tu contraseña.",
+      "unavailable": "La biometría no está disponible ahora mismo. Usa tu contraseña.",
+      "vault": "No se pudo desbloquear en este dispositivo. Usa tu contraseña para continuar.",
+      "failed": "No se pudo desbloquear. Inténtalo de nuevo."
+    },
+    "biometry": {
+      "faceId": "Face ID",
+      "touchId": "Touch ID",
+      "fingerprint": "la huella dactilar",
+      "face": "el reconocimiento facial",
+      "iris": "el iris",
+      "generic": "la biometría"
+    }
+  },
   "local_mode": {
     "account_features_title": "Disponible con una cuenta",
     "welcome": {

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1,5 +1,55 @@
 {
   "appTitle": "reborn/notes",
+  "app_lock": {
+    "settings_item_title": "Verrouillage de l'app",
+    "settings_item_desc": "Exiger la biométrie pour ouvrir l'application",
+    "settings_intro": "Le verrouillage de l'app demande une confirmation biométrique à chaque ouverture de re/notes et après un certain temps en arrière-plan. Vos notes restent chiffrées sur cet appareil dans tous les cas - c'est une protection d'accès rapide, pas un chiffrement supplémentaire.",
+    "unavailable_title": "Biométrie non configurée",
+    "unavailable_desc": "Ajoutez une empreinte digitale ou un déverrouillage facial dans les réglages de l'appareil pour utiliser le verrouillage de l'app.",
+    "enable_title": "Verrouillage de l'app",
+    "enable_desc": "Exiger {biometry} pour ouvrir l'application.",
+    "enable_cta": "Activer le verrouillage",
+    "disable_cta": "Désactiver",
+    "timeout_title": "Reverrouiller après",
+    "timeout_desc": "Combien de temps l'app peut rester en arrière-plan avant de redemander.",
+    "timeout": {
+      "immediate": "Immédiatement",
+      "min1": "Après 1 minute",
+      "min5": "Après 5 minutes",
+      "min15": "Après 15 minutes"
+    },
+    "lock_now_title": "Verrouiller maintenant",
+    "lock_now_desc": "Verrouiller l'application immédiatement.",
+    "lock_now_cta": "Verrouiller maintenant",
+    "success_enabled": "Verrouillage de l'app activé",
+    "success_disabled": "Verrouillage de l'app désactivé",
+    "enable_failed": "Impossible d'activer le verrouillage. Veuillez réessayer.",
+    "locked_title": "Application verrouillée",
+    "locked_desc": "Déverrouillez avec {biometry} pour continuer.",
+    "unlock_cta": "Déverrouiller",
+    "unlocking": "Déverrouillage...",
+    "use_password": "Utiliser le mot de passe à la place",
+    "prompt": {
+      "reason": "Déverrouiller re/notes",
+      "cancel": "Annuler",
+      "android_title": "Déverrouiller re/notes",
+      "android_subtitle": "Confirmez votre identité pour continuer"
+    },
+    "error": {
+      "lockout": "Trop de tentatives. Patientez un instant ou utilisez votre mot de passe.",
+      "unavailable": "La biométrie n'est pas disponible pour le moment. Utilisez votre mot de passe.",
+      "vault": "Impossible de déverrouiller sur cet appareil. Utilisez votre mot de passe pour continuer.",
+      "failed": "Échec du déverrouillage. Réessayez."
+    },
+    "biometry": {
+      "faceId": "Face ID",
+      "touchId": "Touch ID",
+      "fingerprint": "l'empreinte digitale",
+      "face": "la reconnaissance faciale",
+      "iris": "l'iris",
+      "generic": "la biométrie"
+    }
+  },
   "local_mode": {
     "account_features_title": "Disponible avec un compte",
     "welcome": {

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1,5 +1,55 @@
 {
   "appTitle": "reborn/notes",
+  "app_lock": {
+    "settings_item_title": "Blokada aplikacji",
+    "settings_item_desc": "Wymagaj biometrii do otwarcia aplikacji",
+    "settings_intro": "Blokada aplikacji prosi o potwierdzenie biometryczne przy każdym otwarciu re/notes oraz po dłuższym pobycie w tle. Twoje notatki i tak pozostają zaszyfrowane na tym urządzeniu - to zabezpieczenie szybkiego dostępu, nie dodatkowe szyfrowanie.",
+    "unavailable_title": "Biometria nie jest skonfigurowana",
+    "unavailable_desc": "Dodaj odcisk palca lub rozpoznawanie twarzy w ustawieniach urządzenia, aby korzystać z blokady aplikacji.",
+    "enable_title": "Blokada aplikacji",
+    "enable_desc": "Wymagaj {biometry} do otwarcia aplikacji.",
+    "enable_cta": "Włącz blokadę aplikacji",
+    "disable_cta": "Wyłącz",
+    "timeout_title": "Ponowna blokada po",
+    "timeout_desc": "Jak długo aplikacja może pozostać w tle, zanim zapyta ponownie.",
+    "timeout": {
+      "immediate": "Natychmiast",
+      "min1": "Po 1 minucie",
+      "min5": "Po 5 minutach",
+      "min15": "Po 15 minutach"
+    },
+    "lock_now_title": "Zablokuj teraz",
+    "lock_now_desc": "Natychmiast zablokuj aplikację.",
+    "lock_now_cta": "Zablokuj teraz",
+    "success_enabled": "Blokada aplikacji włączona",
+    "success_disabled": "Blokada aplikacji wyłączona",
+    "enable_failed": "Nie udało się włączyć blokady aplikacji. Spróbuj ponownie.",
+    "locked_title": "Aplikacja zablokowana",
+    "locked_desc": "Odblokuj za pomocą {biometry}, aby kontynuować.",
+    "unlock_cta": "Odblokuj",
+    "unlocking": "Odblokowywanie...",
+    "use_password": "Użyj zamiast tego hasła",
+    "prompt": {
+      "reason": "Odblokuj re/notes",
+      "cancel": "Anuluj",
+      "android_title": "Odblokuj re/notes",
+      "android_subtitle": "Potwierdź swoją tożsamość, aby kontynuować"
+    },
+    "error": {
+      "lockout": "Zbyt wiele prób. Poczekaj chwilę lub użyj hasła.",
+      "unavailable": "Biometria jest teraz niedostępna. Użyj hasła.",
+      "vault": "Nie udało się odblokować na tym urządzeniu. Użyj hasła, aby kontynuować.",
+      "failed": "Nie udało się odblokować. Spróbuj ponownie."
+    },
+    "biometry": {
+      "faceId": "Face ID",
+      "touchId": "Touch ID",
+      "fingerprint": "odcisku palca",
+      "face": "rozpoznawania twarzy",
+      "iris": "tęczówki",
+      "generic": "biometrii"
+    }
+  },
   "local_mode": {
     "account_features_title": "Dostępne z kontem",
     "welcome": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
 
   apps/reborn-notes:
     dependencies:
+      '@aparajita/capacitor-biometric-auth':
+        specifier: 10.0.0
+        version: 10.0.0
       '@aparajita/capacitor-secure-storage':
         specifier: 8.0.0
         version: 8.0.0
@@ -789,28 +792,28 @@ importers:
         version: link:../types
       '@storybook/addon-essentials':
         specifier: 8.6.14
-        version: 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-interactions':
         specifier: 8.6.14
-        version: 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-links':
         specifier: 10.4.2
-        version: 10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-svelte-csf':
         specifier: 5.1.2
-        version: 5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/blocks':
         specifier: 8.6.14
-        version: 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/svelte':
         specifier: 10.4.2
-        version: 10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
+        version: 10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       '@storybook/svelte-vite':
         specifier: 10.4.2
-        version: 10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/test':
         specifier: 8.6.15
-        version: 8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.1.2
         version: 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -831,7 +834,7 @@ importers:
         version: 8.5.15
       storybook:
         specifier: 10.4.2
-        version: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte:
         specifier: 5.56.3
         version: 5.56.3(@typescript-eslint/types@8.59.3)
@@ -884,6 +887,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aparajita/capacitor-biometric-auth@10.0.0':
+    resolution: {integrity: sha512-azjWaRucB8x1/gSzSTp/NxelaOZyg+m765gSzjwUkSQgg30RrZPmPq6pyLeeXVSZNDY3Rxf5Hj8obgZaXirCFQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aparajita/capacitor-secure-storage@8.0.0':
     resolution: {integrity: sha512-oYnwSjdIh23aRNgz8982+TmFvQH/2yZkEdw1iIg+H2ziFJoOVELPTc7u6Ez2HwOuDIW5AGqBX75GvrzQ+D70Qg==}
@@ -1995,105 +2002,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2298,25 +2289,21 @@ packages:
     resolution: {integrity: sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.5':
     resolution: {integrity: sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.5':
     resolution: {integrity: sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.5':
     resolution: {integrity: sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.5':
     resolution: {integrity: sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==}
@@ -2463,112 +2450,96 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-gnu@0.130.0':
     resolution: {integrity: sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-arm64-musl@0.130.0':
     resolution: {integrity: sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.130.0':
     resolution: {integrity: sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.130.0':
     resolution: {integrity: sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.130.0':
     resolution: {integrity: sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.130.0':
     resolution: {integrity: sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.130.0':
     resolution: {integrity: sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-musl@0.130.0':
     resolution: {integrity: sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -2676,49 +2647,41 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -2943,42 +2906,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -3076,79 +3033,66 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -3446,42 +3390,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.40':
     resolution: {integrity: sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.40':
     resolution: {integrity: sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.40':
     resolution: {integrity: sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.40':
     resolution: {integrity: sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.40':
     resolution: {integrity: sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.40':
     resolution: {integrity: sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==}
@@ -3560,28 +3498,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -5261,28 +5195,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6971,6 +6901,13 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@aparajita/capacitor-biometric-auth@10.0.0':
+    dependencies:
+      '@capacitor/android': 8.4.0(@capacitor/core@8.4.0)
+      '@capacitor/app': 8.1.0(@capacitor/core@8.4.0)
+      '@capacitor/core': 8.4.0
+      '@capacitor/ios': 8.4.0(@capacitor/core@8.4.0)
 
   '@aparajita/capacitor-secure-storage@8.0.0':
     dependencies:
@@ -8947,6 +8884,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
     optional: true
 
@@ -9298,102 +9243,102 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-actions@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-actions@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-backgrounds@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-controls@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-docs@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@storybook/blocks': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/csf-plugin': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/blocks': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/csf-plugin': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-essentials@8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@storybook/addon-actions': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-backgrounds': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-controls': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-docs': 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-highlight': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-measure': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-outline': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-toolbars': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/addon-viewport': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/addon-actions': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-backgrounds': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-controls': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-docs': 8.6.14(@types/react@19.2.14)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-highlight': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-measure': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-outline': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-toolbars': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/addon-viewport': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-highlight@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/addon-interactions@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-interactions@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/test': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/test': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       polished: 4.3.1
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-links@10.4.2(@types/react@19.2.14)(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.6
 
-  '@storybook/addon-measure@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-measure@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-outline@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-outline@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@storybook/csf': 0.1.13
-      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
+      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
       es-toolkit: 1.46.1
       esrap: 1.4.9
       magic-string: 0.30.21
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
       svelte-ast-print: 0.4.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -9401,28 +9346,28 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@storybook/addon-toolbars@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-toolbars@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/addon-viewport@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/addon-viewport@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/blocks@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/blocks@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/icons': 1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@storybook/builder-vite@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/builder-vite@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -9430,18 +9375,18 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/csf-plugin@10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.0
       rollup: 4.60.3
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@storybook/csf-plugin@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/csf-plugin@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       unplugin: 1.16.1
 
   '@storybook/csf@0.1.13':
@@ -9460,31 +9405,31 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@storybook/instrumenter@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/instrumenter@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/instrumenter@8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/instrumenter@8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/svelte-vite@10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/svelte-vite@10.4.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/builder-vite': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
+      '@storybook/builder-vite': 10.4.2(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/svelte': 10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       magic-string: 0.30.21
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
       svelte2tsx: 0.7.55(svelte@5.56.3(@typescript-eslint/types@8.59.3))(typescript@5.9.3)
       typescript: 5.9.3
@@ -9494,34 +9439,34 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))':
+  '@storybook/svelte@10.4.2(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(svelte@5.56.3(@typescript-eslint/types@8.59.3))':
     dependencies:
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
       ts-dedent: 2.2.0
       type-fest: 5.7.0
 
-  '@storybook/test@8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/test@8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/instrumenter': 8.6.14(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/test@8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/test@8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.15(storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@storybook/instrumenter': 8.6.15(storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
     dependencies:
@@ -12005,6 +11950,32 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
+      '@oxc-resolver/binding-android-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-x64': 11.19.1
+      '@oxc-resolver/binding-freebsd-x64': 11.19.1
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -12632,7 +12603,7 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  storybook@10.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  storybook@10.4.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -12644,7 +12615,7 @@ snapshots:
       esbuild: 0.28.0
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       recast: 0.23.11
       semver: 7.8.0
       use-sync-external-store: 1.6.0(react@19.2.6)


### PR DESCRIPTION
## Summary

Opt-in biometric **App Lock** for the native (Capacitor) shell: require Face ID / Touch ID / fingerprint (or a device PIN/pattern) to open the app, on cold start **and** on resume after a configurable idle timeout (default 1 min). Account-mode, native only. Closes the P2 item deferred at the Faza 3c gate.

**Decision (approved before implementation): option B - a UX access gate, not a cryptographic lock.** The master key stays Keystore/Keychain-wrapped in the vault; biometry only gates *reading* it into memory. This matches Signal / Standard Notes / Proton and our own analysis (biometry is an access deterrent; the cryptographic at-rest lock is the local passcode / account). The crypto-bound **option C** (`setUserAuthenticationRequired`) is documented as a future hardening with its injection point ready (`MasterKeyVault` / `unlockFromVault`). Re-lock default: **1 min**, configurable (immediately / 1 / 5 / 15 min).

**The ZK model and server visibility are unchanged** - this is a client-side UX gate, so `docs/architecture/zero-knowledge-architecture.md` is untouched.

### What changed
- **`@reborn/crypto`**: `reborn_app_lock_enabled` flag + a restore gate in `restoreKeyOnStartup` (twin of the passcode gate, mutually exclusive), `isAppLockLocked()` / `unlockFromVault()` / `lockToVault()` (keeps the vault, unlike logout).
- **`native-biometric-auth.ts`**: raw `registerPlugin('BiometricAuthNative')` bridge - deliberately **not** the package entry point, whose lazy nested dynamic import is the same iOS boot wedge fixed in Faza 4 (the lock screen auto-prompts at cold start).
- **`app-lock.service.ts`**: timeout (device-local, not synced), lifecycle wiring, unlock orchestration. `auth.store` gets `lockAppNow()` + clears the flag on logout so an empty vault can't strand the next account.
- **`/auth/applock`** lock screen (auto-prompt + retry + account-password fallback), **`/settings/security/app-lock`** (toggle + timeout + lock now), guard routes App Lock before the password-unlock step.
- iOS `NSFaceIDUsageDescription`; Android `USE_BIOMETRIC` comes via `androidx.biometric` (manifest merge).
- 10 crypto tests (fake vault); i18n x5 (biometry labels declined to fit the sentence templates).

### Web safety
Every path is `__REBORN_NATIVE__`-gated and dead-code-eliminated. Verified by grep on the client bundle: `BiometricAuthNative` / `internalAuthenticate` are absent from the web build.

## Test plan

**Green here (CI mirror):**
- `@reborn/crypto` tests (10 new App Lock + existing) ✓
- i18n parity x5 (1098 keys) ✓
- `reborn-notes` svelte-check 0/0 ✓, lint 0 errors ✓, 701 tests ✓
- web build ✓ + DCE verified by grep

**⚠️ Follow-up needed (cannot run in the sandbox):**
1. `pnpm install` (sandbox-off) to add `@aparajita/capacitor-biometric-auth@10.0.0` and **commit the regenerated `pnpm-lock.yaml` to this branch** - CI `--frozen-lockfile` is red until then. The TS code uses the raw bridge and does not import the package, so check/build already pass without it.
2. `cap sync android && cap sync ios` to pull the native plugin.

**Native smoke (after the above):**
- Enroll biometry on the emulator/simulator (Android: `adb -e emu finger touch 1`; iOS: Features -> Face ID -> Enrolled).
- Enable App Lock in settings (confirming prompt) -> kill/reopen -> lock screen -> biometric -> decrypted notes + "Synced".
- Background > 1 min -> resume -> lock screen. Background < 1 min -> no lock.
- "Lock now" -> lock screen. Cancel the prompt -> retry. "Use password" -> `/auth/unlock` -> unlocks.
- Disable App Lock -> kill/reopen -> no lock (auto-restore). Logout -> log in with another account -> not stranded.
- 🔴 Boot-wedge regression: kill/reopen on iOS with App Lock on - the lock screen must not hang (raw bridge).