### PR TITLE
chore(android): tolerate an empty keystore.properties placeholder

### DIFF
--- a/apps/reborn-notes/android/app/build.gradle
+++ b/apps/reborn-notes/android/app/build.gradle
@@ -7,14 +7,21 @@ apply plugin: 'com.android.application'
 //   storePassword=...
 //   keyAlias=upload
 //   keyPassword=...
-// Without the file the release build is simply unsigned (safe for CI/dev).
-// Play App Signing holds the actual app signing key; this upload key only
-// authenticates uploads and is recoverable through Play support if lost.
+// Without the file - or while it is still an empty placeholder with no
+// storeFile entry yet - the release build is simply unsigned, and the gradle
+// sync/config of every variant (debug included) still succeeds. Play App
+// Signing holds the actual app signing key; this upload key only authenticates
+// uploads and is recoverable through Play support if lost.
 def keystorePropertiesFile = rootProject.file('keystore.properties')
 def keystoreProperties = new Properties()
 if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.withInputStream { keystoreProperties.load(it) }
 }
+// Guard release signing on the storeFile actually being set, not just on the
+// file existing: a partial/empty keystore.properties used to make `file(null)`
+// throw "Cannot convert 'null' to File" during configuration, failing the whole
+// project evaluation (so even a debug run broke).
+def hasReleaseSigning = keystorePropertiesFile.exists() && keystoreProperties['storeFile']
 
 android {
     namespace = "eu.reapps.notes"
@@ -37,7 +44,7 @@ android {
     }
     signingConfigs {
         release {
-            if (keystorePropertiesFile.exists()) {
+            if (hasReleaseSigning) {
                 storeFile file(keystoreProperties['storeFile'])
                 storePassword keystoreProperties['storePassword']
                 keyAlias keystoreProperties['keyAlias']
@@ -49,7 +56,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : null
+            signingConfig hasReleaseSigning ? signingConfigs.release : null
         }
     }
 }


### PR DESCRIPTION
## Summary

The Faza 5 release-signing scaffold (`apps/reborn-notes/android/app/build.gradle`) guarded signing on `keystore.properties` **existing**, but read `storeFile` unconditionally inside that block:

```groovy
if (keystorePropertiesFile.exists()) {
    storeFile file(keystoreProperties['storeFile'])   // file(null) if storeFile unset
    ...
}
```

An **empty / partial placeholder** `keystore.properties` (created ahead of the real upload keystore) makes `file(null)` throw `Cannot convert 'null' to File` at gradle **configuration** time, which fails the whole project evaluation - so even a debug build/sync breaks. This surfaced when smoke-testing on a device with a placeholder file in place.

**Fix:** guard on the `storeFile` value being set, not just on the file existing:

```groovy
def hasReleaseSigning = keystorePropertiesFile.exists() && keystoreProperties['storeFile']
```

- Missing or empty placeholder -> release unsigned, **debug builds/sync work**.
- Complete `keystore.properties` -> release signed, behaviour unchanged.

Independent of the App Lock PR (#282) - this is a pre-existing scaffold robustness gap that would fail identically on `main` with a placeholder file present. Split out so it can merge on its own.

## Test plan

- Build config only (no app/runtime code) - the existing CI gates (lint/check/test/build) are unaffected.
- On-device: with an empty `keystore.properties` present, gradle sync + a debug Run now succeed (previously failed with `Cannot convert 'null' to File`).
- Sanity: a complete `keystore.properties` still produces a signed release (`hasReleaseSigning` truthy).