### PR TITLE
fix(notes): keep whitespace outside emphasis markers on format

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -146,18 +146,35 @@
     let head: number;
 
     if (selected) {
-      if (
-        selected.startsWith(marker) &&
-        selected.endsWith(marker) &&
-        selected.length > marker.length * 2
+      // Markdown emphasis delimiters must hug non-whitespace: per CommonMark's
+      // flanking rule `** x **` renders literally, only `**x**` is bold. So any
+      // leading/trailing whitespace caught in the selection has to stay OUTSIDE
+      // the markers. Split it off and wrap only the trimmed core; this also
+      // makes toggle-off work when the selection includes surrounding spaces.
+      const leadingWs = (selected.match(/^\s*/) ?? [''])[0];
+      const rest = selected.slice(leadingWs.length);
+      const trailingWs = (rest.match(/\s*$/) ?? [''])[0];
+      const core = rest.slice(0, rest.length - trailingWs.length);
+
+      if (!core) {
+        // Whitespace-only selection: nothing to emphasize. Keep the spaces,
+        // drop empty markers in place, leave the cursor between them to type.
+        insert = `${leadingWs}${marker}${marker}${trailingWs}`;
+        anchor = sel.from + leadingWs.length + marker.length;
+        head = anchor;
+      } else if (
+        core.startsWith(marker) &&
+        core.endsWith(marker) &&
+        core.length > marker.length * 2
       ) {
-        insert = selected.slice(marker.length, -marker.length);
-        anchor = sel.from;
-        head = sel.from + insert.length;
+        const unwrapped = core.slice(marker.length, -marker.length);
+        insert = `${leadingWs}${unwrapped}${trailingWs}`;
+        anchor = sel.from + leadingWs.length;
+        head = anchor + unwrapped.length;
       } else {
-        insert = `${marker}${selected}${marker}`;
-        anchor = sel.from;
-        head = sel.from + insert.length;
+        insert = `${leadingWs}${marker}${core}${marker}${trailingWs}`;
+        anchor = sel.from + leadingWs.length;
+        head = anchor + marker.length * 2 + core.length;
       }
     } else {
       insert = `${marker}${marker}`;


### PR DESCRIPTION
## Summary

Selecting text with a leading or trailing space and clicking the bold ("B") toolbar button - or any inline format (italic, strikethrough, inline code, all sharing `wrapSelection`) - wrapped the selection verbatim, producing `** word **`. Per CommonMark's flanking-delimiter rule, `** x **` renders literally (visible asterisks) rather than as emphasis, so to the user bold simply "didn't work" whenever the selection edge touched a space.

`wrapSelection` now peels any leading/trailing whitespace (including newlines) off the selection and wraps only the trimmed core: `" word "` becomes `" **word** "`. The same trimming makes toggle-off whitespace-robust (`" **x** "` -> `" x "`), and a whitespace-only selection keeps its spaces with the cursor left between empty markers. This matches Obsidian / Typora / VS Code behaviour.

No schema, i18n or Zero-Knowledge surface touched.

## Test plan

In Reborn Notes, Live Preview (or Markdown) editor:

- [ ] Select `word` (no spaces) and click **B** -> `**word**`, renders bold. (baseline unchanged)
- [ ] Select ` word ` (a space each side) and click **B** -> ` **word** `, renders bold; spaces stay outside the markers.
- [ ] Select ` word` (leading space) and `word ` (trailing space) -> space stays outside, renders bold.
- [ ] Repeat with Ctrl/Cmd+B, and with italic (`_`), strikethrough (`~~`), inline code (`` ` ``).
- [ ] Toggle off: select ` **word** ` (with surrounding spaces) and click **B** -> ` word `.
- [ ] Select only spaces and click **B** -> spaces preserved, cursor left between the empty `**` `**`.