### PR TITLE
fix(notes): sync large notes blocked by 512K server body limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,17 +50,25 @@ RUN pnpm nx build reborn-notes
 
 # ─── Runtime: reborn-task ──────────────────────────────────────
 FROM base AS reborn-task
-ENV NODE_ENV=production
+# Lift adapter-node's 512K body-size cap to 1 MiB so it matches the app's own
+# request-body ceiling (MAX_BODY_BYTES in hooks.server.ts). The 512K default
+# rejected legitimate large payloads (the client allows up to ~680 KB ciphertext
+# bodies) with a 413 that API routes catch and surface as a 500, wedging sync.
+ENV NODE_ENV=production \
+    BODY_SIZE_LIMIT=1M
 COPY --from=build-task --chown=node:node /app /app
 USER node
 EXPOSE 4200
-# Prisma migrations run on boot (idempotent). Only reborn-task runs them —
+# Prisma migrations run on boot (idempotent). Only reborn-task runs them -
 # reborn-notes shares the same DB schema.
 CMD ["sh", "-c", "pnpm --filter @reborn/database exec prisma migrate deploy && exec node apps/reborn-task/build"]
 
 # ─── Runtime: reborn-notes ─────────────────────────────────────
 FROM base AS reborn-notes
-ENV NODE_ENV=production
+# See reborn-task above: 1 MiB body limit to match MAX_BODY_BYTES and admit large
+# notes (the 512K adapter-node default 413'd them, surfaced as 500, wedging sync).
+ENV NODE_ENV=production \
+    BODY_SIZE_LIMIT=1M
 COPY --from=build-notes --chown=node:node /app /app
 USER node
 EXPOSE 4201


### PR DESCRIPTION
## Summary

`@sveltejs/adapter-node`'s `BODY_SIZE_LIMIT` defaults to **512K** - lower than every other request-size limit in the app:

| Limit | Where | Value |
|---|---|---|
| client note cap | `MAX_NOTE_CONTENT_BYTES` | 500 KB plaintext (~680 KB ciphertext body) |
| content-length gate | `MAX_BODY_BYTES` (hooks.server.ts) | 1 MiB |
| Zod content | `MAX_ENCRYPTED_CONTENT_BYTES` | 750 KB |
| **adapter body read** | **`BODY_SIZE_LIMIT`** | **512K  <- bottleneck** |

A note whose encrypted body exceeds 512K (e.g. a 400 KB markdown doc -> ~540 KB ciphertext, easily hit by folder-syncing a docs directory) makes `request.json()` throw `SvelteKitError(413, 'Payload Too Large')`, which `POST /api/notes` catches and returns as a **500**. The client retries it on every periodic sync, so the note wedges at `pending` forever. Confirmed from the server log:

```
[Notes-API-Notes] POST /api/notes error: { status: 413, text: "Payload Too Large" }
```

Prod-only - the dev stack runs Vite dev-host, which has no such limit.

**Fix:** set `BODY_SIZE_LIMIT=1M` on both runtime stages in the Dockerfile so the adapter matches the app's own 1 MiB ceiling. The content-length hook (`MAX_BODY_BYTES`, also 1 MiB) stays the single authoritative size gate. `parse_as_bytes('1M')` = exactly `1*1024*1024`, identical to `MAX_BODY_BYTES`.

### Decisions (auto mode - for review)
- **1 MiB, matching the existing hook** (not higher): the largest body the app accepts (Zod 750 KB content + title/metadata) is ~744 KB, so 1 MiB covers every legitimate note with headroom.
- **Raise the server limit, don't block large notes**: the client already allows notes up to 500 KB plaintext, so they are legitimate and must sync.
- **No Zero Knowledge / schema impact**: request bodies are ciphertext; only a size cap changes.

Also fixes an em-dash in the touched Dockerfile comment (repo convention). The gitignored `docker-compose.prod.yml` carries the same env so prod can be fixed by a container recreate without an image rebuild.

A follow-up (API handlers return 413/400 instead of swallowing to 500; push treats 4xx as permanent instead of retrying forever) is logged in the internal backlog.

## Test plan

- [ ] Deploy: recreate `app`+`notes` with `BODY_SIZE_LIMIT=1M`, then in re/notes hit "Sync now" - a >512 KB note (the docs folder's largest file) leaves `pending` and reaches `synced`.
- [ ] `docker logs reborn-apps-notes-1` shows no further `413 Payload Too Large` for `POST /api/notes`.
- [ ] A normal small note still syncs (no regression).
- [ ] (Optional) a note above 1 MiB body is rejected cleanly by the content-length hook (413), not swallowed as 500.