### PR TITLE
perf(notes): cap concurrency of bulk push sync

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -245,9 +245,9 @@ describe('notes-sync - regression (offline data loss)', () => {
 
   it('pushPendingItems pushes folders BFS-by-layer (parent before child)', () => {
     // Server's POST /api/folders FK-checks parent_id and 404s if the parent
-    // isn't on the server yet. Flat Promise.allSettled would 404-spam mid-batch
-    // on nested vault imports - pushPendingItems must use buildFolderLayers
-    // and await each layer before starting the next.
+    // isn't on the server yet. A flat fan-out would 404-spam mid-batch on
+    // nested vault imports - pushPendingItems must use buildFolderLayers and
+    // await each layer (via settleInBatches) before starting the next.
     const src = readSource('./notes-sync.service.ts');
     const fn = src.slice(
       src.indexOf('export async function pushPendingItems'),
@@ -258,13 +258,13 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(fn).toMatch(/buildFolderLayers\s*\(\s*pendingFolders\s*\)/);
 
     // The folder push must live inside `for (const layer of …)` with an
-    // `await Promise.allSettled` per iteration. Loose match: `for` block
-    // appears, and within the file, the `/api/folders` POST is reachable
-    // only through that loop.
+    // awaited per-layer sweep. Loose match: `for` block appears, and within
+    // the file, the `/api/folders` POST is reachable only through that loop.
     expect(fn).toMatch(/for\s*\(\s*const\s+layer\s+of\s+buildFolderLayers/);
 
-    // Sanity: the old flat folder-and-tag combined Promise.allSettled is gone.
-    // (If both were in one settle, layering wouldn't matter.)
+    // Sanity: folders and tags push in SEPARATE sweeps (if they shared one,
+    // layering wouldn't matter). Between the folders POST and the tags POST
+    // there must be a fresh `await settleInBatches(pendingTags, …)`.
     const foldersPostIdx = fn.indexOf("'/api/folders'") >= 0
       ? fn.indexOf("'/api/folders'")
       : fn.indexOf('/api/folders');
@@ -273,10 +273,8 @@ describe('notes-sync - regression (offline data loss)', () => {
       : fn.indexOf('/api/tags');
     expect(foldersPostIdx).toBeGreaterThan(-1);
     expect(tagsPostIdx).toBeGreaterThan(-1);
-    // Between folders POST and tags POST there must be a `})` closing the
-    // folder for-loop, then a fresh `await Promise.allSettled` for tags.
     const between = fn.slice(foldersPostIdx, tagsPostIdx);
-    expect(between).toMatch(/await\s+Promise\.allSettled/);
+    expect(between).toMatch(/await\s+settleInBatches\(\s*pendingTags\b/);
   });
 
   it('pushPendingItems sends PATCH before DELETE for archived notes with server-side history', () => {
@@ -294,10 +292,13 @@ describe('notes-sync - regression (offline data loss)', () => {
       src.indexOf('/** Retry a function with exponential backoff')
     );
 
-    // Locate the archived-pending loop and assert it gates on sync_version.
-    const loopIdx = fn.search(/for\s*\(\s*const\s+n\s+of\s+pendingArchivedNotes\s*\)/);
-    expect(loopIdx).toBeGreaterThan(-1);
-    const loopBody = fn.slice(loopIdx);
+    // Locate the archived-pending retry sweep and assert it gates on
+    // sync_version (notes that never reached the server are skipped).
+    const anchorIdx = fn.search(
+      /const\s+retriableArchivedNotes\s*=\s*pendingArchivedNotes\.filter/
+    );
+    expect(anchorIdx).toBeGreaterThan(-1);
+    const loopBody = fn.slice(anchorIdx);
     expect(loopBody).toMatch(/n\.sync_version\s*\?\?\s*0\)?\s*>\s*0/);
 
     // PATCH (pushNoteUpdate) must appear before DELETE (pushNoteDelete).
@@ -306,6 +307,63 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(patchIdx).toBeGreaterThan(-1);
     expect(deleteIdx).toBeGreaterThan(-1);
     expect(patchIdx).toBeLessThan(deleteIdx);
+  });
+
+  it('pushPendingItems caps every fan-out via settleInBatches (no flat Promise.allSettled)', () => {
+    // Regression for the mass-push burst (Michał's ~195-note folder import,
+    // 2026-06-14): a flat Promise.allSettled over every pending item fired the
+    // whole burst at once, saturating the server's shared pg pool (node-pg
+    // default max 10, connectionTimeoutMillis 0 → queries queue forever instead
+    // of erroring). Every sweep must route through settleInBatches (cap
+    // SYNC_BATCH_SIZE), never a bare allSettled. See sync-batch.ts.
+    const src = readSource('./notes-sync.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function pushPendingItems'),
+      src.indexOf('/** Retry a function with exponential backoff')
+    );
+
+    // Each in-function sweep goes through the helper.
+    expect(fn).toMatch(/settleInBatches\(\s*layer\b/); // folders, per BFS layer
+    expect(fn).toMatch(/settleInBatches\(\s*pendingTags\b/);
+    expect(fn).toMatch(/settleInBatches\(\s*pendingSavedSearches\b/);
+    expect(fn).toMatch(/settleInBatches\(\s*pendingNotes\b/);
+    expect(fn).toMatch(/settleInBatches\(\s*retriableArchivedNotes\b/);
+
+    // No bare Promise.allSettled CALL left in the function body - those WERE
+    // the unbounded bursts. The bounded one now lives inside settleInBatches.
+    // (Matches a call `Promise.allSettled(`, not the word in a comment.)
+    expect(fn).not.toMatch(/Promise\.allSettled\s*\(/);
+
+    // The tail version push and the pull-side version fetch share the cap too.
+    const versionsFn = src.slice(src.indexOf('async function pushPendingVersions'));
+    expect(versionsFn.slice(0, 900)).toMatch(/settleInBatches\(\s*pending\b/);
+    const pullVersions = src.slice(src.indexOf('async function pullNoteVersions'));
+    expect(pullVersions.slice(0, 400)).toMatch(/settleInBatches\(\s*noteIds\b/);
+    // The bespoke pull-versions batch constant is gone (unified onto the helper).
+    expect(src).not.toMatch(/PULL_VERSIONS_BATCH_SIZE/);
+  });
+
+  it('archived-pending retry joins the per-entity chain so the cap is real', () => {
+    // pushNoteUpdate/pushNoteDelete are fire-and-forget (void). If the sweep
+    // didn't await something, settleInBatches would enqueue every archived note
+    // at once and the cap would be a no-op. The task must await a trailing
+    // serializePerEntity('note', …) so it only settles after the queued
+    // PATCH+DELETE run - that's what gives the batch real backpressure.
+    const src = readSource('./notes-sync.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function pushPendingItems'),
+      src.indexOf('/** Retry a function with exponential backoff')
+    );
+    const anchorIdx = fn.search(
+      /const\s+retriableArchivedNotes\s*=\s*pendingArchivedNotes\.filter/
+    );
+    expect(anchorIdx).toBeGreaterThan(-1);
+    const sweep = fn.slice(anchorIdx);
+    expect(sweep).toMatch(/await\s+settleInBatches\(\s*retriableArchivedNotes\b/);
+    // The trailing join: a no-op chained on the same note entity, awaited.
+    expect(sweep).toMatch(
+      /await\s+serializePerEntity\(\s*'note',\s*n\.id,\s*\(\)\s*=>\s*Promise\.resolve\(\)\s*\)/
+    );
   });
 
   it('importJsonBackup defers all pushes to pushPendingItems (ordering)', () => {

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -48,6 +48,7 @@ import { validateEncryptedPayload } from '@reborn/crypto';
 import { refreshQuota } from '$lib/stores/storage-quota.store';
 import { connectivityStore } from '$lib/stores/connectivity.store';
 import { buildFolderLayers } from './folder-push-order';
+import { settleInBatches } from './sync-batch';
 
 const logger = createLogger('Notes-Sync');
 
@@ -640,6 +641,11 @@ export async function markAllLocalDataPending(): Promise<void> {
 /**
  * Push all locally-pending items (folders, tags, notes) to the server.
  * Called during manual sync to ensure local-only items reach the server.
+ *
+ * Every fan-out below goes through `settleInBatches` (cap `SYNC_BATCH_SIZE`)
+ * rather than a flat `Promise.allSettled`, so a mass push (a folder import can
+ * leave ~200 notes pending at once) never fires the whole burst concurrently
+ * and saturates the server's shared pg pool. See `sync-batch.ts`.
  */
 export async function pushPendingItems(): Promise<void> {
   if (!isAuthenticated()) return;
@@ -682,39 +688,37 @@ export async function pushPendingItems(): Promise<void> {
 
   // Push folders BFS-by-layer so parents land before children. Server's
   // POST /api/folders rejects with 404 "Parent folder not found" when
-  // parent_id references a folder not yet on the server - flat
-  // Promise.allSettled would 404-spam mid-batch on vault imports with
-  // nested hierarchies. Siblings within a layer push in parallel.
+  // parent_id references a folder not yet on the server - a flat fan-out
+  // would 404-spam mid-batch on vault imports with nested hierarchies.
+  // Siblings within a layer push in parallel, capped by settleInBatches.
   for (const layer of buildFolderLayers(pendingFolders)) {
-    await Promise.allSettled(
-      layer.map((f) =>
-        serializePerEntity('folder', f.id, () =>
-          pushSilently(async (idempotencyKey) => {
-            const pushedFields = {
-              name_encrypted: f.name_encrypted,
-              parent_id: f.parent_id ?? null,
-              order_index: f.order_index
-            };
-            const payload = { id: f.id, ...pushedFields, created_at: f.created_at };
-            validateEncryptedPayload(payload as Record<string, unknown>);
-            const res = await authFetch(`${API_BASE}/folders`, {
-              method: 'POST',
-              headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-              body: JSON.stringify(payload)
+    await settleInBatches(layer, (f) =>
+      serializePerEntity('folder', f.id, () =>
+        pushSilently(async (idempotencyKey) => {
+          const pushedFields = {
+            name_encrypted: f.name_encrypted,
+            parent_id: f.parent_id ?? null,
+            order_index: f.order_index
+          };
+          const payload = { id: f.id, ...pushedFields, created_at: f.created_at };
+          validateEncryptedPayload(payload as Record<string, unknown>);
+          const res = await authFetch(`${API_BASE}/folders`, {
+            method: 'POST',
+            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+            body: JSON.stringify(payload)
+          });
+          if (!res.ok) throw new Error(`POST /api/folders: ${res.status}`);
+          const { data: resData } = await res.json();
+          const current = await folderStore.get(f.id);
+          if (current) {
+            const stillDirty = pushedFieldsDiffer(current, pushedFields);
+            await folderStore.save({
+              ...current,
+              sync_status: stillDirty ? 'pending' : 'synced',
+              sync_version: resData?.sync_version ?? 1
             });
-            if (!res.ok) throw new Error(`POST /api/folders: ${res.status}`);
-            const { data: resData } = await res.json();
-            const current = await folderStore.get(f.id);
-            if (current) {
-              const stillDirty = pushedFieldsDiffer(current, pushedFields);
-              await folderStore.save({
-                ...current,
-                sync_status: stillDirty ? 'pending' : 'synced',
-                sync_version: resData?.sync_version ?? 1
-              });
-            }
-          })
-        )
+          }
+        })
       )
     );
   }
@@ -722,83 +726,77 @@ export async function pushPendingItems(): Promise<void> {
   // Tags don't reference folders - push in parallel after folders are
   // settled. Notes' metadata_encrypted may embed tag ids, so tags must
   // land before the notes layer below.
-  await Promise.allSettled(
-    pendingTags.map((t) =>
-      serializePerEntity('tag', t.id, () =>
-        pushSilently(async (idempotencyKey) => {
-          const pushedFields = {
-            name_encrypted: t.name_encrypted,
-            color_encrypted: t.color_encrypted ?? null
-          };
-          const payload = { id: t.id, ...pushedFields, created_at: t.created_at };
-          validateEncryptedPayload(payload as Record<string, unknown>);
-          const res = await authFetch(`${API_BASE}/tags`, {
-            method: 'POST',
-            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-            body: JSON.stringify(payload)
+  await settleInBatches(pendingTags, (t) =>
+    serializePerEntity('tag', t.id, () =>
+      pushSilently(async (idempotencyKey) => {
+        const pushedFields = {
+          name_encrypted: t.name_encrypted,
+          color_encrypted: t.color_encrypted ?? null
+        };
+        const payload = { id: t.id, ...pushedFields, created_at: t.created_at };
+        validateEncryptedPayload(payload as Record<string, unknown>);
+        const res = await authFetch(`${API_BASE}/tags`, {
+          method: 'POST',
+          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) throw new Error(`POST /api/tags: ${res.status}`);
+        const { data: resData } = await res.json();
+        const current = await tagStore.get(t.id);
+        if (current) {
+          const stillDirty = pushedFieldsDiffer(current, pushedFields);
+          await tagStore.save({
+            ...current,
+            sync_status: stillDirty ? 'pending' : 'synced',
+            sync_version: resData?.sync_version ?? 1
           });
-          if (!res.ok) throw new Error(`POST /api/tags: ${res.status}`);
-          const { data: resData } = await res.json();
-          const current = await tagStore.get(t.id);
-          if (current) {
-            const stillDirty = pushedFieldsDiffer(current, pushedFields);
-            await tagStore.save({
-              ...current,
-              sync_status: stillDirty ? 'pending' : 'synced',
-              sync_version: resData?.sync_version ?? 1
-            });
-          }
-        })
-      )
+        }
+      })
     )
   );
 
   // Saved searches reference folders (parking FK), so they go after the
   // folder layers, like notes. No other entity depends on them.
-  await Promise.allSettled(
-    pendingSavedSearches.map((s) =>
-      serializePerEntity('savedSearch', s.id, () =>
-        pushSilently((idempotencyKey) => pushSavedSearchPayload(s, idempotencyKey))
-      )
+  await settleInBatches(pendingSavedSearches, (s) =>
+    serializePerEntity('savedSearch', s.id, () =>
+      pushSilently((idempotencyKey) => pushSavedSearchPayload(s, idempotencyKey))
     )
   );
 
   // Then push notes (POST for creates/updates)
-  await Promise.allSettled(
-    pendingNotes.map((n) =>
-      serializePerEntity('note', n.id, () =>
-        pushSilently(async (idempotencyKey) => {
-          const pushedFields = {
-            title_encrypted: n.title_encrypted,
-            content_encrypted: n.content_encrypted,
-            folder_id: n.folder_id ?? null,
-            metadata_encrypted: n.metadata_encrypted ?? null
-          };
-          const payload = {
-            id: n.id,
-            ...pushedFields,
-            metadata_encrypted: n.metadata_encrypted ?? undefined,
-            created_at: n.created_at
-          };
-          validateEncryptedPayload(payload as Record<string, unknown>);
-          const res = await authFetch(`${API_BASE}/notes`, {
-            method: 'POST',
-            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-            body: JSON.stringify(payload)
+  await settleInBatches(pendingNotes, (n) =>
+    serializePerEntity('note', n.id, () =>
+      pushSilently(async (idempotencyKey) => {
+        const pushedFields = {
+          title_encrypted: n.title_encrypted,
+          content_encrypted: n.content_encrypted,
+          folder_id: n.folder_id ?? null,
+          metadata_encrypted: n.metadata_encrypted ?? null
+        };
+        const payload = {
+          id: n.id,
+          ...pushedFields,
+          metadata_encrypted: n.metadata_encrypted ?? undefined,
+          created_at: n.created_at
+        };
+        validateEncryptedPayload(payload as Record<string, unknown>);
+        const res = await authFetch(`${API_BASE}/notes`, {
+          method: 'POST',
+          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
+        const { data: resData } = await res.json();
+        const current = await noteStore.get(n.id);
+        if (current) {
+          const stillDirty = pushedFieldsDiffer(current, pushedFields);
+          await noteStore.save({
+            ...current,
+            sync_status: stillDirty ? 'pending' : 'synced',
+            sync_version: resData?.sync_version ?? 1
           });
-          if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
-          const { data: resData } = await res.json();
-          const current = await noteStore.get(n.id);
-          if (current) {
-            const stillDirty = pushedFieldsDiffer(current, pushedFields);
-            await noteStore.save({
-              ...current,
-              sync_status: stillDirty ? 'pending' : 'synced',
-              sync_version: resData?.sync_version ?? 1
-            });
-          }
-        })
-      )
+        }
+      })
     )
   );
 
@@ -811,17 +809,23 @@ export async function pushPendingItems(): Promise<void> {
   // pushNoteUpdate + pushNoteDelete are serialized per-entity, so DELETE waits
   // for PATCH to land. Notes with sync_version === 0 never reached the server,
   // so there is nothing to update or delete remotely - skip both.
-  for (const n of pendingArchivedNotes) {
-    if ((n.sync_version ?? 0) > 0) {
-      pushNoteUpdate(n.id, {
-        title_encrypted: n.title_encrypted,
-        content_encrypted: n.content_encrypted,
-        folder_id: n.folder_id ?? null,
-        metadata_encrypted: n.metadata_encrypted ?? undefined
-      });
-      pushNoteDelete(n.id);
-    }
-  }
+  const retriableArchivedNotes = pendingArchivedNotes.filter((n) => (n.sync_version ?? 0) > 0);
+  await settleInBatches(retriableArchivedNotes, async (n) => {
+    pushNoteUpdate(n.id, {
+      title_encrypted: n.title_encrypted,
+      content_encrypted: n.content_encrypted,
+      folder_id: n.folder_id ?? null,
+      metadata_encrypted: n.metadata_encrypted ?? undefined
+    });
+    pushNoteDelete(n.id);
+    // pushNoteUpdate/pushNoteDelete are fire-and-forget (void), so without a
+    // join the loop would enqueue every archived note at once and the cap would
+    // be a no-op. Await a trailing no-op on the same per-entity chain: it runs
+    // FIFO after the queued PATCH+DELETE, so this task only settles once they
+    // have - giving settleInBatches real backpressure (<= SYNC_BATCH_SIZE notes
+    // mid-PATCH/DELETE at a time).
+    await serializePerEntity('note', n.id, () => Promise.resolve());
+  });
 
   // Push pending note versions
   await pushPendingVersions();
@@ -1449,38 +1453,31 @@ export function pushNoteVersion(entry: NoteHistoryEntry): void {
   });
 }
 
-const PULL_VERSIONS_BATCH_SIZE = 10;
-
-/** Pull versions for all notes from server and upsert locally (batched, max 10 concurrent). */
+/** Pull versions for all notes from server and upsert locally (batched, max SYNC_BATCH_SIZE concurrent). */
 async function pullNoteVersions(noteIds: string[]): Promise<void> {
-  for (let i = 0; i < noteIds.length; i += PULL_VERSIONS_BATCH_SIZE) {
-    const batch = noteIds.slice(i, i + PULL_VERSIONS_BATCH_SIZE);
-    await Promise.allSettled(
-      batch.map(async (noteId) => {
-        const res = await authFetch(`${API_BASE}/notes/${noteId}/versions`);
-        if (!res.ok) return;
-        const { data } = await res.json();
-        if (!Array.isArray(data)) return;
+  await settleInBatches(noteIds, async (noteId) => {
+    const res = await authFetch(`${API_BASE}/notes/${noteId}/versions`);
+    if (!res.ok) return;
+    const { data } = await res.json();
+    if (!Array.isArray(data)) return;
 
-        for (const v of data as Array<{
-          id: string;
-          note_id: string;
-          title_encrypted: string;
-          content_encrypted: string;
-          created_at: string;
-        }>) {
-          await noteHistoryStore.save({
-            id: v.id,
-            note_id: v.note_id,
-            title_encrypted: v.title_encrypted,
-            content_encrypted: v.content_encrypted,
-            sync_status: 'synced',
-            created_at: v.created_at
-          });
-        }
-      })
-    );
-  }
+    for (const v of data as Array<{
+      id: string;
+      note_id: string;
+      title_encrypted: string;
+      content_encrypted: string;
+      created_at: string;
+    }>) {
+      await noteHistoryStore.save({
+        id: v.id,
+        note_id: v.note_id,
+        title_encrypted: v.title_encrypted,
+        content_encrypted: v.content_encrypted,
+        sync_status: 'synced',
+        created_at: v.created_at
+      });
+    }
+  });
 }
 
 /** Push all pending (unsynced) note versions to server. */
@@ -1490,25 +1487,23 @@ async function pushPendingVersions(): Promise<void> {
   if (pending.length === 0) return;
 
   logger.info(`Pushing ${pending.length} pending note versions`);
-  await Promise.allSettled(
-    pending.map((entry) =>
-      pushSilently(async (idempotencyKey) => {
-        const res = await authFetch(`${API_BASE}/notes/${entry.note_id}/versions`, {
-          method: 'POST',
-          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-          body: JSON.stringify({
-            id: entry.id,
-            title_encrypted: entry.title_encrypted,
-            content_encrypted: entry.content_encrypted,
-            created_at: entry.created_at
-          })
-        });
-        if (!res.ok) throw new Error(`POST versions: ${res.status}`);
-        const current = await noteHistoryStore.get(entry.id);
-        if (current) {
-          await noteHistoryStore.save({ ...current, sync_status: 'synced' });
-        }
-      })
-    )
+  await settleInBatches(pending, (entry) =>
+    pushSilently(async (idempotencyKey) => {
+      const res = await authFetch(`${API_BASE}/notes/${entry.note_id}/versions`, {
+        method: 'POST',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify({
+          id: entry.id,
+          title_encrypted: entry.title_encrypted,
+          content_encrypted: entry.content_encrypted,
+          created_at: entry.created_at
+        })
+      });
+      if (!res.ok) throw new Error(`POST versions: ${res.status}`);
+      const current = await noteHistoryStore.get(entry.id);
+      if (current) {
+        await noteHistoryStore.save({ ...current, sync_status: 'synced' });
+      }
+    })
   );
 }

--- a/apps/reborn-notes/src/lib/services/saved-searches-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/saved-searches-sync.regression.spec.ts
@@ -57,7 +57,9 @@ describe('saved searches - push sync', () => {
     );
     expect(fn).toMatch(/pendingSavedSearches\s*=\s*allSavedSearches\.filter/);
     const folderLayersIdx = fn.indexOf('buildFolderLayers');
-    const savedSearchPushIdx = fn.search(/pendingSavedSearches\.map/);
+    // The push sweep (distinct from the partition filter above) must come after
+    // the folder layers - a parked saved search FK-references its folder.
+    const savedSearchPushIdx = fn.search(/settleInBatches\(\s*pendingSavedSearches\b/);
     expect(folderLayersIdx).toBeGreaterThan(-1);
     expect(savedSearchPushIdx).toBeGreaterThan(folderLayersIdx);
   });

--- a/apps/reborn-notes/src/lib/services/sync-batch.spec.ts
+++ b/apps/reborn-notes/src/lib/services/sync-batch.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { settleInBatches, SYNC_BATCH_SIZE } from './sync-batch';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe('settleInBatches', () => {
+  it('processes every item', async () => {
+    const seen: number[] = [];
+    await settleInBatches([1, 2, 3, 4, 5], async (n) => {
+      seen.push(n);
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('is a no-op on an empty list', async () => {
+    let called = 0;
+    await settleInBatches([], async () => {
+      called++;
+    });
+    expect(called).toBe(0);
+  });
+
+  it('never runs more than `limit` tasks at once', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 25 }, (_, i) => i);
+    await settleInBatches(
+      items,
+      async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await tick();
+        inFlight--;
+      },
+      4
+    );
+    expect(peak).toBe(4);
+  });
+
+  it('defaults the cap to SYNC_BATCH_SIZE', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    // More items than the default cap so the cap is the binding constraint.
+    const items = Array.from({ length: SYNC_BATCH_SIZE * 2 + 3 }, (_, i) => i);
+    await settleInBatches(items, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await tick();
+      inFlight--;
+    });
+    expect(peak).toBe(SYNC_BATCH_SIZE);
+  });
+
+  it('waits for a chunk to fully settle before starting the next (batch barrier)', async () => {
+    const items = [0, 1, 2, 3];
+    const gates = items.map(() => deferred());
+    const started: number[] = [];
+
+    const done = settleInBatches(
+      items,
+      async (i) => {
+        started.push(i);
+        await gates[i].promise;
+      },
+      2
+    );
+
+    // First chunk (2 items) started; the second chunk must NOT have started yet.
+    await tick();
+    expect(started).toEqual([0, 1]);
+
+    // Release the first chunk - only now may the second start.
+    gates[0].resolve();
+    gates[1].resolve();
+    await tick();
+    expect(started).toEqual([0, 1, 2, 3]);
+
+    gates[2].resolve();
+    gates[3].resolve();
+    await done;
+  });
+
+  it('a rejected task neither aborts its siblings nor rejects the call', async () => {
+    const seen: number[] = [];
+    await expect(
+      settleInBatches(
+        [1, 2, 3, 4, 5],
+        async (n) => {
+          if (n === 3) throw new Error('boom');
+          seen.push(n);
+        },
+        2
+      )
+    ).resolves.toBeUndefined();
+    // Every non-throwing item still ran, including those batched alongside the
+    // thrower and in later chunks.
+    expect(seen.sort((a, b) => a - b)).toEqual([1, 2, 4, 5]);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/sync-batch.ts
+++ b/apps/reborn-notes/src/lib/services/sync-batch.ts
@@ -1,0 +1,41 @@
+/**
+ * Concurrency cap for batched sync sweeps.
+ *
+ * The server's Prisma connection pool (`PrismaPg` in `packages/database`) takes
+ * the node-postgres defaults - `max: 10` connections, `connectionTimeoutMillis:
+ * 0` - and that pool is shared by every user of the container. With timeout 0 a
+ * saturated pool queues new queries indefinitely instead of erroring, so a flat
+ * `Promise.allSettled` over every pending item (a folder import can leave ~200
+ * notes pending in a single run) fires the whole burst at once and, as the user
+ * count grows, multiplies the peak. Capping in-flight work per sweep keeps one
+ * client from monopolising the pool.
+ *
+ * Note: each `POST /api/notes` also runs `getUserStorageBreakdown` (a
+ * `SUM(OCTET_LENGTH(...))` across the user's whole notes table), so a wide burst
+ * is doubly expensive server-side. Making that quota count cheaper is tracked
+ * separately (TODO P2) - this cap is the cheap, client-only first line.
+ */
+export const SYNC_BATCH_SIZE = 10;
+
+/**
+ * Run `task` over `items` in chunks of at most `limit`, awaiting each chunk
+ * before starting the next. Like `Promise.allSettled`, a rejected task never
+ * aborts its siblings - callers rely on that (one failed push must not strand
+ * the rest of the sweep).
+ *
+ * This is a batch-barrier, not a rolling pool: the slowest item in a chunk gates
+ * only that chunk. That keeps the helper trivial and matches the pull-side idiom
+ * it replaced; the simplicity is worth more than squeezing the last bit of
+ * throughput out of an error-path sweep. Production always uses the default
+ * `limit` (`SYNC_BATCH_SIZE`); the parameter exists so tests can pin a small cap.
+ */
+export async function settleInBatches<T>(
+  items: T[],
+  task: (item: T) => Promise<unknown>,
+  limit: number = SYNC_BATCH_SIZE
+): Promise<void> {
+  const size = Math.max(1, limit);
+  for (let i = 0; i < items.length; i += size) {
+    await Promise.allSettled(items.slice(i, i + size).map(task));
+  }
+}


### PR DESCRIPTION
## Summary

`pushPendingItems` fired every pending item at once via a flat `Promise.allSettled`. A folder import (~195 notes in a 2026-06-14 test) burst ~195 parallel `POST /api/notes`. The server's Prisma pool uses the node-postgres defaults (`max: 10`, `connectionTimeoutMillis: 0`) and is **shared across all users** of the container, so a saturated pool queues queries indefinitely instead of erroring. As the user count grows this multiplies the peak, and each `POST /api/notes` also runs `getUserStorageBreakdown` (a `SUM(OCTET_LENGTH)` over the user's whole notes table). Defense-in-depth before user growth - nothing breaks today.

This was the false lead in the `BODY_SIZE_LIMIT` wedge (#286): the burst was suspected first, but the root cause turned out to be a 413. The burst is still real debt and is closed here.

### What changed
- New `sync-batch.ts`: `SYNC_BATCH_SIZE = 10` + `settleInBatches(items, task, limit?)` - chunk-and-await (batch-barrier), `Promise.allSettled` semantics (a rejected task never aborts its siblings).
- Every fan-out in `pushPendingItems` (folders per BFS layer, tags, saved searches, notes, archived-retry, versions) routes through it; `pullNoteVersions` unified onto the same helper (bespoke `PULL_VERSIONS_BATCH_SIZE` removed).
- The cap is **per single run**, not time-spreading - periodic sync still re-pushes everything pending every 5 min; this only bounds how many requests run in parallel within one sweep.

### Decisions made autonomously (please confirm at review)
- **Helper in its own module** (vs inline) - enables a real behavioral concurrency test; mirrors `folder-push-order.ts`. Rejected inline batch loops (5x duplication, no behavioral test).
- **Batch-barrier, not a rolling pool** - follows the pre-agreed `pullNoteVersions` pattern and keeps one idiom in the file. A rolling pool would win throughput on the error path; simplicity wins here.
- **Extended beyond the literal task** to the archived-pending retry loop: its `void` fire-and-forget `pushNoteUpdate`/`pushNoteDelete` are joined via a trailing `serializePerEntity` no-op so the cap is real, not a no-op. Side effect: `pushPendingItems` now awaits the archived retry before returning (was fire-and-forget) - stronger push-first, less race with the next pull.
- **Left out of scope** (kept as "consider" in TODO): cheaper storage quota (incremental vs `SUM`-all per write) and a larger pg pool `max` - both server-side/infra, separate architectural calls.

No ZK / schema / API / dependency changes.

## Test plan
- `pnpm nx run-many -t lint check test -p reborn-notes` - lint 0 err, svelte-check 0/0, **709 tests** green.
- New `sync-batch.spec.ts` (6 behavioral tests): cap == limit, default == `SYNC_BATCH_SIZE`, chunk-barrier ordering, throwing-task isolation, empty-list no-op; deterministic 5/5 across repeats.
- 3 regression specs updated to the new structure (anchors moved from `Promise.allSettled` / `for…pendingArchivedNotes` / `pendingSavedSearches.map` to `settleInBatches`); invariants preserved. New assertions: every sweep routes through the helper, no bare `Promise.allSettled(` left in the function body, archived-retry joins the entity chain.
- `pnpm nx build reborn-notes` OK.
- Smoke (manual): re/notes with two attached folders (or a large import) -> "Sync now" -> all notes go from "pending" to "synced" (as before, just in batches of <=10 parallel rather than all at once); pending counter -> 0. Cascade-delete a large folder -> notes land in trash and clear pending.