### PR TITLE
feat(notes): surface hard push rejections as per-note sync_error

### DIFF
--- a/apps/reborn-notes/src/lib/components/import/ImportResultSummary.svelte
+++ b/apps/reborn-notes/src/lib/components/import/ImportResultSummary.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { t } from '$lib/stores/i18n.store';
+  import { MAX_NOTE_CONTENT_BYTES } from '@reborn/types';
   import type {
     ImportFolderResult,
     ImportMarkdownResult
@@ -59,7 +60,10 @@
     {#if folderResult.skippedTooLarge > 0}
       <p class="text-muted-foreground">
         {$t('settings_page.export_import.folder_import_skipped_too_large', {
-          values: { count: folderResult.skippedTooLarge }
+          values: {
+            count: folderResult.skippedTooLarge,
+            max: Math.round(MAX_NOTE_CONTENT_BYTES / 1000)
+          }
         })}
       </p>
     {/if}

--- a/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
@@ -223,6 +223,13 @@
       <p class="mt-0.5 text-[13px] md:text-xs text-muted-foreground line-clamp-2">
         {formatNoteDate(displayDate, $dateFormat, $t)}
       </p>
+      <!-- Visible per-note rejection reason - not just the badge/hover tooltip,
+           so the user knows WHY a note won't sync (and it works on touch). -->
+      {#if syncErrorCode}
+        <p class="mt-0.5 text-[13px] md:text-xs font-medium text-destructive line-clamp-2">
+          {syncErrorTitle}
+        </p>
+      {/if}
     </div>
 
     <!-- Kebab menu button (hidden in selection mode — bulk actions live in the selection bar) -->

--- a/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
@@ -12,8 +12,11 @@
     Share2,
     Trash2,
     RotateCcw,
-    Trash
+    Trash,
+    AlertTriangle
   } from '@lucide/svelte';
+  import { MAX_NOTE_CONTENT_BYTES } from '@reborn/types';
+  import { syncErrorMap } from '$lib/stores/sync-status.store';
   import {
     Checkbox,
     DropdownMenu,
@@ -84,6 +87,28 @@
   // Display the date matching the active sort key so the visible value matches the sort.
   // For 'title' sort fall back to updated_at (most recent activity).
   const displayDate = $derived($sortByStore === 'created_at' ? note.created_at : note.updated_at);
+
+  // Per-note hard-rejection state (sync_status: 'sync_error'). Read from the
+  // reactive map so the badge appears/clears as soon as a push is rejected or a
+  // later edit re-syncs the note - no need to thread sync_status through the
+  // decrypted note index.
+  const syncErrorCode = $derived($syncErrorMap.get(note.id));
+  const syncErrorTitle = $derived.by(() => {
+    switch (syncErrorCode) {
+      case 'too_large':
+        return $t('sync_status.errors.too_large', {
+          values: { max: Math.round(MAX_NOTE_CONTENT_BYTES / 1000) }
+        });
+      case 'quota_exceeded':
+        return $t('sync_status.errors.quota_exceeded');
+      case 'invalid':
+        return $t('sync_status.errors.invalid');
+      case 'rejected':
+        return $t('sync_status.errors.rejected');
+      default:
+        return '';
+    }
+  });
 
   function handleItemClick(e: MouseEvent) {
     if (selectionMode) {
@@ -168,6 +193,15 @@
         <!-- Star indicator -->
         {#if note.is_starred}
           <Star class="mt-1.5 h-3.5 w-3.5 md:mt-1 md:h-3 md:w-3 shrink-0 fill-amber-400 text-amber-400" />
+        {/if}
+        <!-- Sync-error indicator: server permanently rejected this note's push. -->
+        {#if syncErrorCode}
+          <span title={syncErrorTitle} class="mt-1.5 shrink-0 md:mt-1">
+            <AlertTriangle
+              class="h-3.5 w-3.5 md:h-3 md:w-3 text-destructive"
+              aria-label={syncErrorTitle}
+            />
+          </span>
         {/if}
       </div>
       {#if breadcrumb}

--- a/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
@@ -51,6 +51,8 @@
         return WifiOff;
       case 'error':
         return AlertCircle;
+      case 'sync_error':
+        return AlertTriangle;
       case 'pending':
         return CloudUpload;
       case 'needs_sync':
@@ -71,6 +73,8 @@
       case 'offline':
         return 'text-muted-foreground';
       case 'error':
+        return 'text-destructive';
+      case 'sync_error':
         return 'text-destructive';
       case 'pending':
         return 'text-amber-500 dark:text-amber-400';
@@ -93,6 +97,8 @@
         return $t('sync_status.offline');
       case 'error':
         return $t('sync_status.error');
+      case 'sync_error':
+        return $t('sync_status.errors.count', { values: { count: $syncStatus.errorCount } });
       case 'pending':
         return $t('sync_status.pending', { values: { count: $syncStatus.pendingCount } });
       case 'needs_sync':

--- a/apps/reborn-notes/src/lib/server/api-error.spec.ts
+++ b/apps/reborn-notes/src/lib/server/api-error.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { apiErrorResponse } from './api-error';
+
+type Logger = Parameters<typeof apiErrorResponse>[1];
+const fakeLogger = () =>
+  ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) as unknown as Logger;
+
+describe('apiErrorResponse', () => {
+  it('surfaces a 413 thrown by request.json() (adapter SvelteKitError) as 413, not 500', async () => {
+    const logger = fakeLogger();
+    // Shape adapter-node throws when the body exceeds BODY_SIZE_LIMIT.
+    const err = { status: 413, text: 'Payload Too Large' };
+    const res = apiErrorResponse(err, logger, 'POST /api/notes');
+
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Request body too large');
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 400 client error as 400', async () => {
+    const res = apiErrorResponse({ status: 400 }, fakeLogger(), 'POST x');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Bad request');
+  });
+
+  it('maps an unknown 4xx to its status with a generic message', async () => {
+    const res = apiErrorResponse({ status: 418 }, fakeLogger(), 'POST x');
+    expect(res.status).toBe(418);
+    expect((await res.json()).error).toBe('Request rejected');
+  });
+
+  it('maps a generic thrown Error to 500', async () => {
+    const logger = fakeLogger();
+    const res = apiErrorResponse(new Error('db exploded'), logger, 'POST x');
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Internal server error');
+    expect(logger.error).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT treat a 5xx-carrying error as a client error', async () => {
+    const res = apiErrorResponse({ status: 503 }, fakeLogger(), 'POST x');
+    expect(res.status).toBe(500);
+  });
+
+  it('maps an error without a numeric status to 500', async () => {
+    const res = apiErrorResponse({ status: 'nope' }, fakeLogger(), 'POST x');
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/reborn-notes/src/lib/server/api-error.ts
+++ b/apps/reborn-notes/src/lib/server/api-error.ts
@@ -1,0 +1,42 @@
+import { json } from '@sveltejs/kit';
+import type { createLogger } from '@reborn/utils';
+
+type Logger = ReturnType<typeof createLogger>;
+
+/**
+ * Map a caught handler error to an HTTP JSON response.
+ *
+ * The default `catch` in our API handlers used to return 500 for *every*
+ * throw. That masked the 413 that `@sveltejs/adapter-node` raises from
+ * `request.json()` when the body exceeds `BODY_SIZE_LIMIT`: the client saw a
+ * generic 500, the note kept `sync_status: 'pending'`, and the periodic push
+ * retried the oversized payload forever (see guideline 36, rule 14). The
+ * adapter throws a `SvelteKitError` carrying a numeric `status` and a `text`
+ * (e.g. `{ status: 413, text: 'Payload Too Large' }`), so we surface client
+ * errors (4xx) with their real status and only fall back to 500 for genuine
+ * server faults.
+ *
+ * We deliberately return a generic, status-derived message rather than echoing
+ * `err.text`/`err.body` - the client classifies on the status code, not the
+ * string, and we don't want to leak internal error detail.
+ */
+export function apiErrorResponse(err: unknown, logger: Logger, context: string): Response {
+  if (typeof err === 'object' && err !== null && 'status' in err) {
+    const status = (err as { status: unknown }).status;
+    if (typeof status === 'number' && status >= 400 && status < 500) {
+      // Not a server fault - the request itself was rejected. Log at warn so it
+      // doesn't read as an outage, but stays visible for diagnosis.
+      logger.warn(`${context}: rejected request with status ${status}`);
+      const error =
+        status === 413
+          ? 'Request body too large'
+          : status === 400
+            ? 'Bad request'
+            : 'Request rejected';
+      return json({ success: false, error }, { status });
+    }
+  }
+
+  logger.error(`${context} error:`, err);
+  return json({ success: false, error: 'Internal server error' }, { status: 500 });
+}

--- a/apps/reborn-notes/src/lib/services/notes-sync.push-rejection.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.push-rejection.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Source-level invariants for permanent push rejections (guideline 36, rule 14).
+ *
+ * Like notes-sync.regression.spec.ts, these are source assertions: the sync
+ * service pulls in browser-only modules (IndexedDB, cryptoManager, $env) that
+ * are impractical to wire up in Node. The behavioural classification logic is
+ * covered separately in push-error.spec.ts. These checks pin the wiring that
+ * keeps a 4xx-rejected note from re-pushing forever.
+ */
+function readSource(relative: string): string {
+  return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+const src = () => readSource('./notes-sync.service.ts');
+
+describe('notes-sync - permanent push rejection (sync_error)', () => {
+  it('retryWithBackoff short-circuits on a permanent HttpPushError (no retry rounds)', () => {
+    const s = src();
+    const body = s.slice(
+      s.indexOf('async function retryWithBackoff'),
+      s.indexOf('async function pushSilently')
+    );
+    expect(body).toMatch(/instanceof HttpPushError/);
+    // The permanent branch throws before the maxRetries / backoff logic.
+    const throwIdx = body.indexOf('instanceof HttpPushError');
+    const backoffIdx = body.indexOf('attempt === maxRetries');
+    expect(throwIdx).toBeGreaterThan(-1);
+    expect(backoffIdx).toBeGreaterThan(throwIdx);
+  });
+
+  it('pushSilently routes permanent failures to onPermanentFailure, transient to retry log', () => {
+    const s = src();
+    const body = s.slice(s.indexOf('async function pushSilently'), s.indexOf('const entityChains'));
+    expect(body).toMatch(/onPermanentFailure/);
+    expect(body).toMatch(/instanceof HttpPushError/);
+    // Transient branch still reports network failures + logs for the periodic retry.
+    expect(body).toMatch(/reportSyncError/);
+  });
+
+  it('markNoteSyncError writes sync_status sync_error + sync_error_code', () => {
+    const s = src();
+    const start = s.indexOf('async function markNoteSyncError');
+    expect(start).toBeGreaterThan(-1);
+    const body = s.slice(start, start + 400);
+    expect(body).toMatch(/sync_status:\s*'sync_error'/);
+    expect(body).toMatch(/sync_error_code:\s*code/);
+  });
+
+  it('note POST/PATCH paths assert via ensureOk and mark sync_error on permanent failure', () => {
+    const s = src();
+    for (const sig of ['export function pushNote\\b', 'export function pushNoteUpdate\\b']) {
+      const start = s.search(new RegExp(sig));
+      expect(start, sig).toBeGreaterThan(-1);
+      const body = s.slice(start, start + 2100);
+      expect(body, `${sig} must assert via ensureOk`).toMatch(/ensureOk\(/);
+      expect(body, `${sig} must mark sync_error on permanent failure`).toMatch(/markNoteSyncError/);
+      expect(body, `${sig} must clear sync_error_code on success`).toMatch(
+        /sync_error_code:\s*undefined/
+      );
+    }
+  });
+
+  it('pushPendingItems batch tallies new sync_errors and raises one aggregated toast', () => {
+    const s = src();
+    const body = s.slice(
+      s.indexOf('Then push notes (POST for creates/updates)'),
+      s.indexOf('Retry archived-pending notes')
+    );
+    expect(body).toMatch(/ensureOk\(/);
+    expect(body).toMatch(/markNoteSyncError/);
+    expect(body).toMatch(/newNoteSyncErrors\+\+/);
+    expect(body).toMatch(/notifyBatchSyncErrors\(newNoteSyncErrors\)/);
+  });
+
+  it('pull guard keeps sync_error notes from being overwritten by a newer server version', () => {
+    const s = src();
+    expect(s).toMatch(
+      /localNote\.sync_status === 'pending' \|\| localNote\.sync_status === 'sync_error'/
+    );
+  });
+});

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -28,7 +28,8 @@ import type {
   NoteHistoryEntry,
   FolderEncrypted,
   TagEncrypted,
-  SavedSearchEncrypted
+  SavedSearchEncrypted,
+  SyncErrorCode
 } from '@reborn/types';
 import { cryptoManager } from '@reborn/crypto';
 import { extractShadowIndexes } from './shadow-index-extractor';
@@ -49,6 +50,8 @@ import { refreshQuota } from '$lib/stores/storage-quota.store';
 import { connectivityStore } from '$lib/stores/connectivity.store';
 import { buildFolderLayers } from './folder-push-order';
 import { settleInBatches } from './sync-batch';
+import { notifyNoteSyncError, notifyBatchSyncErrors } from './sync-error-notify';
+import { ensureOk, HttpPushError } from './push-error';
 
 const logger = createLogger('Notes-Sync');
 
@@ -73,6 +76,21 @@ function isNetworkError(e: unknown): boolean {
  */
 function reportSyncError(e: unknown): void {
   if (isNetworkError(e)) connectivityStore?.markFailure();
+}
+
+// Push-error classification (HttpPushError / ensureOk / isPermanentStatus) lives
+// in ./push-error so it can be unit-tested without this file's browser deps.
+
+/**
+ * Mark a note as permanently rejected: it leaves the 'pending' retry set and
+ * the UI surfaces it (red footer count + per-note badge). A later local edit
+ * re-marks it 'pending' (rule 9), which clears the error and retries the push.
+ */
+async function markNoteSyncError(id: string, code: SyncErrorCode): Promise<void> {
+  const current = (await noteStore.get(id)) as NoteStoredLocal | undefined;
+  if (current) {
+    await noteStore.save({ ...current, sync_status: 'sync_error', sync_error_code: code });
+  }
 }
 
 function isAuthenticated(): boolean {
@@ -479,10 +497,18 @@ async function pullNotes(): Promise<void> {
         sync_version?: number;
       }>
     ).map(async (n) => {
-      // Skip if local note has pending changes - don't overwrite offline edits
+      // Skip if local note has unsynced local state - don't overwrite offline
+      // edits. 'sync_error' is included on purpose: a note rejected as
+      // too-large/invalid still holds the user's local edit, so a newer server
+      // version (from another device) must not silently clobber it. The user
+      // resolves it by shrinking the note, which re-marks it 'pending' and
+      // re-pushes. See guideline 36, rule 14.
       const localNote = (await noteStore.get(n.id)) as NoteStoredLocal | undefined;
-      if (localNote && localNote.sync_status === 'pending') {
-        logger.debug(`Skipping pull for note ${n.id} - has pending local changes`);
+      if (
+        localNote &&
+        (localNote.sync_status === 'pending' || localNote.sync_status === 'sync_error')
+      ) {
+        logger.debug(`Skipping pull for note ${n.id} - has unsynced local changes`);
         return;
       }
 
@@ -763,42 +789,54 @@ export async function pushPendingItems(): Promise<void> {
     )
   );
 
-  // Then push notes (POST for creates/updates)
+  // Then push notes (POST for creates/updates). A permanent rejection (4xx)
+  // marks the note sync_error and drops it from the retry set; we tally those
+  // and raise ONE aggregated toast after the batch (a folder import can leave
+  // several oversized notes at once - per-note toasts would spam).
+  let newNoteSyncErrors = 0;
   await settleInBatches(pendingNotes, (n) =>
     serializePerEntity('note', n.id, () =>
-      pushSilently(async (idempotencyKey) => {
-        const pushedFields = {
-          title_encrypted: n.title_encrypted,
-          content_encrypted: n.content_encrypted,
-          folder_id: n.folder_id ?? null,
-          metadata_encrypted: n.metadata_encrypted ?? null
-        };
-        const payload = {
-          id: n.id,
-          ...pushedFields,
-          metadata_encrypted: n.metadata_encrypted ?? undefined,
-          created_at: n.created_at
-        };
-        validateEncryptedPayload(payload as Record<string, unknown>);
-        const res = await authFetch(`${API_BASE}/notes`, {
-          method: 'POST',
-          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-          body: JSON.stringify(payload)
-        });
-        if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
-        const { data: resData } = await res.json();
-        const current = await noteStore.get(n.id);
-        if (current) {
-          const stillDirty = pushedFieldsDiffer(current, pushedFields);
-          await noteStore.save({
-            ...current,
-            sync_status: stillDirty ? 'pending' : 'synced',
-            sync_version: resData?.sync_version ?? 1
+      pushSilently(
+        async (idempotencyKey) => {
+          const pushedFields = {
+            title_encrypted: n.title_encrypted,
+            content_encrypted: n.content_encrypted,
+            folder_id: n.folder_id ?? null,
+            metadata_encrypted: n.metadata_encrypted ?? null
+          };
+          const payload = {
+            id: n.id,
+            ...pushedFields,
+            metadata_encrypted: n.metadata_encrypted ?? undefined,
+            created_at: n.created_at
+          };
+          validateEncryptedPayload(payload as Record<string, unknown>);
+          const res = await authFetch(`${API_BASE}/notes`, {
+            method: 'POST',
+            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+            body: JSON.stringify(payload)
           });
+          await ensureOk(res, 'POST /api/notes');
+          const { data: resData } = await res.json();
+          const current = await noteStore.get(n.id);
+          if (current) {
+            const stillDirty = pushedFieldsDiffer(current, pushedFields);
+            await noteStore.save({
+              ...current,
+              sync_status: stillDirty ? 'pending' : 'synced',
+              sync_error_code: undefined,
+              sync_version: resData?.sync_version ?? 1
+            });
+          }
+        },
+        async (err) => {
+          await markNoteSyncError(n.id, err.code);
+          newNoteSyncErrors++;
         }
-      })
+      )
     )
   );
+  if (newNoteSyncErrors > 0) notifyBatchSyncErrors(newNoteSyncErrors);
 
   // Retry archived-pending notes. For notes that exist on the server
   // (sync_version > 0) we PATCH the content first, then DELETE. Without the
@@ -845,6 +883,10 @@ async function retryWithBackoff<T>(
       return await fn();
     } catch (error: unknown) {
       lastError = error;
+      // Permanent rejection (4xx that won't change on retry): short-circuit so
+      // we don't waste three backoff rounds re-sending an oversized or invalid
+      // payload. pushSilently turns this into a sync_error mark.
+      if (error instanceof HttpPushError) throw error;
       if (attempt === maxRetries) throw error;
       const delay = initialDelay * Math.pow(2, attempt);
       logger.warn(`Push attempt ${attempt + 1} failed, retrying in ${delay}ms…`);
@@ -854,15 +896,38 @@ async function retryWithBackoff<T>(
   throw lastError;
 }
 
-/** Fire-and-forget push after a local write. Retries up to 3× with exponential backoff. */
-async function pushSilently(fn: (idempotencyKey: string) => Promise<void>): Promise<void> {
+/**
+ * Fire-and-forget push after a local write. Transient failures retry up to 3×
+ * with exponential backoff and leave the entity 'pending' (retried on the next
+ * periodic/manual sync). A permanent rejection (`HttpPushError`) skips retry and
+ * invokes `onPermanentFailure` so the caller can record a per-entity sync_error
+ * instead of re-pushing the doomed payload forever.
+ */
+async function pushSilently(
+  fn: (idempotencyKey: string) => Promise<void>,
+  onPermanentFailure?: (err: HttpPushError) => Promise<void>
+): Promise<void> {
   if (!isAuthenticated()) return;
   const idempotencyKey = crypto.randomUUID();
   try {
     await retryWithBackoff(() => fn(idempotencyKey));
   } catch (err: unknown) {
-    reportSyncError(err);
-    logger.error('Push sync failed after retries (will retry on next periodic sync):', err);
+    if (err instanceof HttpPushError) {
+      logger.warn(
+        `Push permanently rejected (status ${err.status}, code ${err.code}) - dropping from retry:`,
+        err.message
+      );
+      if (onPermanentFailure) {
+        try {
+          await onPermanentFailure(err);
+        } catch (e) {
+          logger.error('onPermanentFailure handler threw', e);
+        }
+      }
+    } else {
+      reportSyncError(err);
+      logger.error('Push sync failed after retries (will retry on next periodic sync):', err);
+    }
   } finally {
     void refreshPendingCount();
   }
@@ -922,40 +987,47 @@ function pushedFieldsDiffer(current: object, pushed: Record<string, unknown>): b
 
 export function pushNote(note: NoteEncrypted | NoteStoredLocal): void {
   void serializePerEntity('note', note.id, () =>
-    pushSilently(async (idempotencyKey) => {
-      const pushedFields = {
-        title_encrypted: note.title_encrypted,
-        content_encrypted: note.content_encrypted,
-        folder_id: note.folder_id ?? null,
-        metadata_encrypted: note.metadata_encrypted ?? null
-      };
-      const payload = {
-        id: note.id,
-        ...pushedFields,
-        metadata_encrypted: note.metadata_encrypted ?? undefined,
-        created_at: note.created_at
-      };
-      validateEncryptedPayload(payload as Record<string, unknown>);
-      const res = await authFetch(`${API_BASE}/notes`, {
-        method: 'POST',
-        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-        body: JSON.stringify(payload)
-      });
-      if (!res.ok) throw new Error(`POST /api/notes: ${res.status}`);
-      const { data } = await res.json();
-      const current = await noteStore.get(note.id);
-      if (current) {
-        const stillDirty = pushedFieldsDiffer(current, pushedFields);
-        if (stillDirty) {
-          logger.debug(`Note ${note.id} changed during push - keeping sync_status=pending`);
-        }
-        await noteStore.save({
-          ...current,
-          sync_status: stillDirty ? 'pending' : 'synced',
-          sync_version: data?.sync_version ?? 1
+    pushSilently(
+      async (idempotencyKey) => {
+        const pushedFields = {
+          title_encrypted: note.title_encrypted,
+          content_encrypted: note.content_encrypted,
+          folder_id: note.folder_id ?? null,
+          metadata_encrypted: note.metadata_encrypted ?? null
+        };
+        const payload = {
+          id: note.id,
+          ...pushedFields,
+          metadata_encrypted: note.metadata_encrypted ?? undefined,
+          created_at: note.created_at
+        };
+        validateEncryptedPayload(payload as Record<string, unknown>);
+        const res = await authFetch(`${API_BASE}/notes`, {
+          method: 'POST',
+          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+          body: JSON.stringify(payload)
         });
+        await ensureOk(res, 'POST /api/notes');
+        const { data } = await res.json();
+        const current = await noteStore.get(note.id);
+        if (current) {
+          const stillDirty = pushedFieldsDiffer(current, pushedFields);
+          if (stillDirty) {
+            logger.debug(`Note ${note.id} changed during push - keeping sync_status=pending`);
+          }
+          await noteStore.save({
+            ...current,
+            sync_status: stillDirty ? 'pending' : 'synced',
+            sync_error_code: undefined,
+            sync_version: data?.sync_version ?? 1
+          });
+        }
+      },
+      async (err) => {
+        await markNoteSyncError(note.id, err.code);
+        notifyNoteSyncError(err.code);
       }
-    })
+    )
   );
 }
 
@@ -972,28 +1044,35 @@ export function pushNoteUpdate(
   }
 ): void {
   void serializePerEntity('note', id, () =>
-    pushSilently(async (idempotencyKey) => {
-      validateEncryptedPayload(fields as Record<string, unknown>);
-      const res = await authFetch(`${API_BASE}/notes/${id}`, {
-        method: 'PATCH',
-        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-        body: JSON.stringify(fields)
-      });
-      if (!res.ok) throw new Error(`PATCH /api/notes/${id}: ${res.status}`);
-      const { data } = await res.json();
-      const current = await noteStore.get(id);
-      if (current) {
-        const stillDirty = pushedFieldsDiffer(current, fields);
-        if (stillDirty) {
-          logger.debug(`Note ${id} changed during push - keeping sync_status=pending`);
-        }
-        await noteStore.save({
-          ...current,
-          sync_status: stillDirty ? 'pending' : 'synced',
-          sync_version: data?.sync_version ?? current.sync_version ?? 1
+    pushSilently(
+      async (idempotencyKey) => {
+        validateEncryptedPayload(fields as Record<string, unknown>);
+        const res = await authFetch(`${API_BASE}/notes/${id}`, {
+          method: 'PATCH',
+          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+          body: JSON.stringify(fields)
         });
+        await ensureOk(res, `PATCH /api/notes/${id}`);
+        const { data } = await res.json();
+        const current = await noteStore.get(id);
+        if (current) {
+          const stillDirty = pushedFieldsDiffer(current, fields);
+          if (stillDirty) {
+            logger.debug(`Note ${id} changed during push - keeping sync_status=pending`);
+          }
+          await noteStore.save({
+            ...current,
+            sync_status: stillDirty ? 'pending' : 'synced',
+            sync_error_code: undefined,
+            sync_version: data?.sync_version ?? current.sync_version ?? 1
+          });
+        }
+      },
+      async (err) => {
+        await markNoteSyncError(id, err.code);
+        notifyNoteSyncError(err.code);
       }
-    })
+    )
   );
 }
 

--- a/apps/reborn-notes/src/lib/services/push-error.spec.ts
+++ b/apps/reborn-notes/src/lib/services/push-error.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { ensureOk, isPermanentStatus, HttpPushError } from './push-error';
+
+describe('push-error classification', () => {
+  describe('isPermanentStatus', () => {
+    it('treats 400 / 403 / 413 as permanent (payload itself is the problem)', () => {
+      expect(isPermanentStatus(400)).toBe(true);
+      expect(isPermanentStatus(403)).toBe(true);
+      expect(isPermanentStatus(413)).toBe(true);
+    });
+
+    it('treats session / ordering / rate-limit 4xx as transient', () => {
+      // 401 = session (authFetch refresh), 404 = folder not on server yet,
+      // 408/429 = timeout/rate-limit. None should poison the note.
+      for (const s of [401, 404, 408, 409, 425, 429]) {
+        expect(isPermanentStatus(s), `status ${s}`).toBe(false);
+      }
+    });
+
+    it('treats 5xx as transient', () => {
+      for (const s of [500, 502, 503]) expect(isPermanentStatus(s), `status ${s}`).toBe(false);
+    });
+  });
+
+  describe('ensureOk', () => {
+    const jsonRes = (status: number, body?: unknown) =>
+      new Response(body === undefined ? null : JSON.stringify(body), { status });
+
+    it('resolves for a 2xx response', async () => {
+      await expect(ensureOk(jsonRes(200, { success: true }), 'POST x')).resolves.toBeUndefined();
+    });
+
+    it('throws a plain Error (retryable, NOT HttpPushError) for a transient status', async () => {
+      let caught: unknown;
+      try {
+        await ensureOk(jsonRes(500), 'POST /api/notes');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(HttpPushError);
+      expect((caught as Error).message).toBe('POST /api/notes: 500');
+    });
+
+    it('throws HttpPushError too_large for a 413 body-limit rejection', async () => {
+      let caught: unknown;
+      try {
+        await ensureOk(jsonRes(413, { error: 'Request body too large' }), 'POST /api/notes');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(HttpPushError);
+      expect((caught as HttpPushError).status).toBe(413);
+      expect((caught as HttpPushError).code).toBe('too_large');
+    });
+
+    it('throws HttpPushError quota_exceeded for a 413 QUOTA_EXCEEDED body', async () => {
+      let caught: unknown;
+      try {
+        await ensureOk(jsonRes(413, { error: 'QUOTA_EXCEEDED', used: 1, limit: 2 }), 'POST x');
+      } catch (e) {
+        caught = e;
+      }
+      expect((caught as HttpPushError).code).toBe('quota_exceeded');
+    });
+
+    it('falls back to too_large for a 413 with an empty / non-JSON body', async () => {
+      let caught: unknown;
+      try {
+        await ensureOk(new Response(null, { status: 413 }), 'POST x');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(HttpPushError);
+      expect((caught as HttpPushError).code).toBe('too_large');
+    });
+
+    it('throws HttpPushError invalid for a 400 validation rejection', async () => {
+      let caught: unknown;
+      try {
+        await ensureOk(jsonRes(400, { error: 'Bad request' }), 'PATCH x');
+      } catch (e) {
+        caught = e;
+      }
+      expect((caught as HttpPushError).code).toBe('invalid');
+    });
+
+    it('throws HttpPushError rejected for a 403 ownership rejection', async () => {
+      let caught: unknown;
+      try {
+        await ensureOk(jsonRes(403, { error: 'Forbidden' }), 'POST x');
+      } catch (e) {
+        caught = e;
+      }
+      expect((caught as HttpPushError).code).toBe('rejected');
+    });
+  });
+});

--- a/apps/reborn-notes/src/lib/services/push-error.ts
+++ b/apps/reborn-notes/src/lib/services/push-error.ts
@@ -1,0 +1,67 @@
+/**
+ * Push-error classification for notes sync.
+ *
+ * Separates a *permanent* rejection (a 4xx the client cannot fix by retrying)
+ * from a *transient* failure (server/network hiccup, retry later). Kept in its
+ * own module so it can be unit-tested without the browser-only dependencies the
+ * sync service drags in (IndexedDB, cryptoManager, $env). See guideline 36,
+ * rule 14.
+ */
+import type { SyncErrorCode } from '@reborn/types';
+
+/**
+ * Statuses where retrying the same payload can never succeed - the request
+ * itself is the problem. Deliberately an explicit allowlist, NOT "every 4xx",
+ * because several 4xx codes ARE transient for push:
+ *   - 401: session problem; authFetch handles refresh+retry then flips
+ *     sessionExpired. Treating it as permanent would falsely poison the note.
+ *   - 404: a note POST whose folder_id hasn't reached the server yet (push
+ *     ordering) - resolves once the folder lands.
+ *   - 408 / 429: timeout / rate-limit - transient by definition.
+ * 413 (too large / quota full), 400 (Zod validation) and 403 (ownership) cannot
+ * be fixed by re-sending the same bytes, so they are permanent.
+ */
+export const PERMANENT_PUSH_STATUSES = new Set([400, 403, 413]);
+
+export function isPermanentStatus(status: number): boolean {
+  return PERMANENT_PUSH_STATUSES.has(status);
+}
+
+/** Thrown by `ensureOk` for a permanent (non-retryable) HTTP rejection. */
+export class HttpPushError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: SyncErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'HttpPushError';
+  }
+}
+
+/**
+ * Assert a push response is OK, otherwise throw the right error:
+ *   - permanent status -> `HttpPushError` (skips retry; for notes, marks the
+ *     entity sync_error so it stops re-pushing forever),
+ *   - anything else -> a plain `Error`, retried with backoff and left 'pending'.
+ *
+ * For 413 we peek at the body to separate a full storage quota
+ * (`QUOTA_EXCEEDED`) from an oversized single payload, so the UI can say which.
+ */
+export async function ensureOk(res: Response, label: string): Promise<void> {
+  if (res.ok) return;
+  if (!isPermanentStatus(res.status)) {
+    throw new Error(`${label}: ${res.status}`);
+  }
+  let code: SyncErrorCode =
+    res.status === 413 ? 'too_large' : res.status === 400 ? 'invalid' : 'rejected';
+  if (res.status === 413) {
+    try {
+      const body = await res.clone().json();
+      if (body?.error === 'QUOTA_EXCEEDED') code = 'quota_exceeded';
+    } catch {
+      // Empty / non-JSON body (e.g. the adapter's plain 413) - keep 'too_large'.
+    }
+  }
+  throw new HttpPushError(res.status, code, `${label}: ${res.status}`);
+}

--- a/apps/reborn-notes/src/lib/services/sync-error-notify.ts
+++ b/apps/reborn-notes/src/lib/services/sync-error-notify.ts
@@ -39,9 +39,17 @@ export function notifyNoteSyncError(code: SyncErrorCode): void {
   });
 }
 
-/** One aggregated toast after a batch push left `count` notes rejected. */
+/**
+ * One aggregated toast after a batch push left `count` notes rejected.
+ *
+ * Intentionally a count + pointer, not a list: a batch can reject many notes,
+ * and a toast is transient. The per-note reason is shown inline on each marked
+ * row (NoteListItem), which is where the user goes to act.
+ */
 export function notifyBatchSyncErrors(count: number): void {
   if (count <= 0) return;
   const $t = get(t);
-  toastStore.error($t('sync_status.errors.toast_batch', { values: { count } }));
+  toastStore.error($t('sync_status.errors.toast_batch', { values: { count } }), {
+    description: $t('sync_status.errors.toast_marked')
+  });
 }

--- a/apps/reborn-notes/src/lib/services/sync-error-notify.ts
+++ b/apps/reborn-notes/src/lib/services/sync-error-notify.ts
@@ -1,0 +1,47 @@
+/**
+ * User-facing toasts for permanent push rejections (sync_status: 'sync_error').
+ *
+ * Kept out of `notes-sync.service.ts` so the sync engine stays free of UI
+ * imports and these helpers can be mocked in sync tests. The persistent
+ * surfaces (red footer count + per-note badge) are driven by store state; these
+ * toasts are the one-shot "it just happened" signal.
+ */
+import { get } from 'svelte/store';
+import { toastStore } from '@reborn/ui';
+import { t } from '$lib/stores/i18n.store';
+import { MAX_NOTE_CONTENT_BYTES, type SyncErrorCode } from '@reborn/types';
+
+/** Note content limit in KB, for the 'too_large' message (matches the editor indicator). */
+function limitKb(): number {
+  return Math.round(MAX_NOTE_CONTENT_BYTES / 1000);
+}
+
+/** Localised one-line reason for a given rejection code. */
+export function syncErrorMessage(code: SyncErrorCode): string {
+  const $t = get(t);
+  switch (code) {
+    case 'too_large':
+      return $t('sync_status.errors.too_large', { values: { max: limitKb() } });
+    case 'quota_exceeded':
+      return $t('sync_status.errors.quota_exceeded');
+    case 'invalid':
+      return $t('sync_status.errors.invalid');
+    case 'rejected':
+      return $t('sync_status.errors.rejected');
+  }
+}
+
+/** Toast for a single note rejected during an interactive create/edit push. */
+export function notifyNoteSyncError(code: SyncErrorCode): void {
+  const $t = get(t);
+  toastStore.error($t('sync_status.errors.toast_single'), {
+    description: syncErrorMessage(code)
+  });
+}
+
+/** One aggregated toast after a batch push left `count` notes rejected. */
+export function notifyBatchSyncErrors(count: number): void {
+  if (count <= 0) return;
+  const $t = get(t);
+  toastStore.error($t('sync_status.errors.toast_batch', { values: { count } }));
+}

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -1,4 +1,4 @@
-import { writable, derived } from 'svelte/store';
+import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import { noteStore, folderStore, tagStore } from '@reborn/storage';
 import type { SyncErrorCode } from '@reborn/types';
@@ -37,7 +37,7 @@ export interface SyncStatusState {
 // Re-export the active-probe connectivity store under the legacy `isOnline`
 // name so consumers don't need to change. `navigator.onLine` is unreliable
 // with a VPN tunnel (e.g. Proton in airplane mode), so we back this with a
-// real HTTP probe — see `connectivity.store.ts`.
+// real HTTP probe - see `connectivity.store.ts`.
 export const isOnline = connectivityIsOnline;
 
 /** Synchronous helper to check current online status (probe-backed). */
@@ -45,7 +45,7 @@ export const checkOnline = checkConnectivityOnline;
 
 // When connectivity transitions offline → online, kick off a sync just like
 // the old `window.addEventListener('online')` handler did. CRITICAL: push
-// BEFORE pull — parallel runs let pull overwrite still-pending offline edits.
+// BEFORE pull - parallel runs let pull overwrite still-pending offline edits.
 if (browser && connectivityStore) {
   let wasOnline = connectivityStore.getState().status === 'online';
   connectivity.subscribe(($c) => {
@@ -91,6 +91,18 @@ export const syncErrorMap = writable<Map<string, SyncErrorCode>>(new Map());
 
 // ── Count pending / errored items across all stores ──────────────
 
+/** Content equality for the per-note error map (sizes first, then entries). */
+function sameErrorCodes(
+  a: Map<string, SyncErrorCode>,
+  b: Map<string, SyncErrorCode>
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const [id, code] of a) {
+    if (b.get(id) !== code) return false;
+  }
+  return true;
+}
+
 export async function refreshPendingCount(): Promise<number> {
   try {
     const stores = [noteStore, folderStore, tagStore] as Array<{
@@ -107,7 +119,13 @@ export async function refreshPendingCount(): Promise<number> {
     }
     pendingCount.set(pending);
     errorCount.set(errors.size);
-    syncErrorMap.set(errors);
+    // syncErrorMap is read by a $derived in every visible NoteListItem. A
+    // writable re-emits on every object set (new ref !== old), so publishing it
+    // unconditionally would recompute every row's badge on each sync even when
+    // nothing changed - wasted work, and it widens the window for Svelte's
+    // benign `derived_inert` warning on a row that is mid-teardown. Publish only
+    // when the error set actually changed.
+    if (!sameErrorCodes(get(syncErrorMap), errors)) syncErrorMap.set(errors);
     return pending;
   } catch {
     return 0;

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -1,6 +1,7 @@
 import { writable, derived } from 'svelte/store';
 import { browser } from '$app/environment';
 import { noteStore, folderStore, tagStore } from '@reborn/storage';
+import type { SyncErrorCode } from '@reborn/types';
 import {
   connectivity,
   connectivityStore,
@@ -15,6 +16,10 @@ export type SyncStatusType =
   | 'syncing'
   | 'offline'
   | 'error'
+  // One or more records were permanently rejected by the server (a 4xx the
+  // client can't fix by retrying) and dropped from the retry set. Distinct from
+  // transient 'error': this needs user action (e.g. shrink an oversized note).
+  | 'sync_error'
   | 'pending'
   | 'needs_sync'
   | 'session_expired'
@@ -23,6 +28,7 @@ export type SyncStatusType =
 export interface SyncStatusState {
   status: SyncStatusType;
   pendingCount: number;
+  errorCount: number;
   lastSyncedAt: string | null;
 }
 
@@ -72,22 +78,37 @@ export const sessionExpired = writable(false);
 export const localOnly = writable(false);
 export const lastSyncedAt = writable<string | null>(null);
 export const pendingCount = writable(0);
+// Records permanently rejected by the server (sync_status: 'sync_error').
+// Tracked separately from pendingCount because these will NOT retry on the next
+// periodic sync - they wait for the user to edit the record (which re-marks it
+// 'pending'). Currently only notes produce this state.
+export const errorCount = writable(0);
+// Per-note rejection reason, keyed by note id. Drives the per-note badge in the
+// list without threading sync_status through the (decrypted) note index: it is
+// rebuilt from IndexedDB on every refreshPendingCount(), which already runs
+// after each push/pull.
+export const syncErrorMap = writable<Map<string, SyncErrorCode>>(new Map());
 
-// ── Count pending items across all stores ────────────────────────
+// ── Count pending / errored items across all stores ──────────────
 
 export async function refreshPendingCount(): Promise<number> {
   try {
     const stores = [noteStore, folderStore, tagStore] as Array<{
-      getAll(): Promise<Array<{ sync_status?: string }>>;
+      getAll(): Promise<Array<{ id: string; sync_status?: string; sync_error_code?: SyncErrorCode }>>;
     }>;
     const allItems = await Promise.all(stores.map((s) => s.getAll()));
-    const count = allItems.reduce(
-      (sum: number, items: Array<{ sync_status?: string }>) =>
-        sum + items.filter((i) => i.sync_status === 'pending').length,
-      0
-    );
-    pendingCount.set(count);
-    return count;
+    let pending = 0;
+    const errors = new Map<string, SyncErrorCode>();
+    for (const items of allItems) {
+      for (const i of items) {
+        if (i.sync_status === 'pending') pending++;
+        else if (i.sync_status === 'sync_error') errors.set(i.id, i.sync_error_code ?? 'rejected');
+      }
+    }
+    pendingCount.set(pending);
+    errorCount.set(errors.size);
+    syncErrorMap.set(errors);
+    return pending;
   } catch {
     return 0;
   }
@@ -96,13 +117,14 @@ export async function refreshPendingCount(): Promise<number> {
 // ── Derived unified status ───────────────────────────────────────
 
 export const syncStatus = derived(
-  [isOnline, isSyncing, syncError, sessionExpired, pendingCount, lastSyncedAt, localOnly],
+  [isOnline, isSyncing, syncError, sessionExpired, pendingCount, errorCount, lastSyncedAt, localOnly],
   ([
     $isOnline,
     $isSyncing,
     $syncError,
     $sessionExpired,
     $pendingCount,
+    $errorCount,
     $lastSyncedAt,
     $localOnly
   ]): SyncStatusState => {
@@ -117,6 +139,10 @@ export const syncStatus = derived(
       status = 'offline';
     } else if ($isSyncing) {
       status = 'syncing';
+    } else if ($errorCount > 0) {
+      // Permanent rejections need user action (shrink/fix the record), so they
+      // outrank a transient sync error and the pending count.
+      status = 'sync_error';
     } else if ($syncError) {
       status = 'error';
     } else if ($pendingCount > 0) {
@@ -127,7 +153,12 @@ export const syncStatus = derived(
       status = 'synced';
     }
 
-    return { status, pendingCount: $pendingCount, lastSyncedAt: $lastSyncedAt };
+    return {
+      status,
+      pendingCount: $pendingCount,
+      errorCount: $errorCount,
+      lastSyncedAt: $lastSyncedAt
+    };
   }
 );
 

--- a/apps/reborn-notes/src/routes/api/notes/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/+server.ts
@@ -5,6 +5,7 @@ import { createLogger } from '@reborn/utils';
 import { validateBody, schemas } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
 import { checkQuota } from '$lib/server/storage-quota';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('Notes-API-Notes');
 
@@ -51,8 +52,7 @@ export const GET: RequestHandler = async ({ request, url }) => {
 
     return json({ success: true, data });
   } catch (err: unknown) {
-    logger.error('GET /api/notes error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'GET /api/notes');
   }
 };
 
@@ -133,7 +133,6 @@ export const POST: RequestHandler = async ({ request }) => {
       }
     });
   } catch (err: unknown) {
-    logger.error('POST /api/notes error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'POST /api/notes');
   }
 };

--- a/apps/reborn-notes/src/routes/api/notes/[id]/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/[id]/+server.ts
@@ -5,6 +5,7 @@ import { createLogger } from '@reborn/utils';
 import { validateBody, schemas } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
 import { checkQuota } from '$lib/server/storage-quota';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('Notes-API-Note');
 
@@ -34,8 +35,7 @@ export const GET: RequestHandler = async ({ request, params }) => {
       }
     });
   } catch (err: unknown) {
-    logger.error('GET /api/notes/[id] error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'GET /api/notes/[id]');
   }
 };
 
@@ -105,8 +105,7 @@ export const PATCH: RequestHandler = async ({ request, params }) => {
       data: { updated_at: note.updated_at.toISOString(), sync_version: note.sync_version }
     });
   } catch (err: unknown) {
-    logger.error('PATCH /api/notes/[id] error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'PATCH /api/notes/[id]');
   }
 };
 
@@ -143,7 +142,6 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
       }
     });
   } catch (err: unknown) {
-    logger.error('DELETE /api/notes/[id] error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'DELETE /api/notes/[id]');
   }
 };

--- a/apps/reborn-notes/src/routes/api/notes/[id]/versions/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/[id]/versions/+server.ts
@@ -4,6 +4,7 @@ import { prisma } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { getUserFromToken } from '$lib/server/auth';
 import { checkQuota } from '$lib/server/storage-quota';
+import { apiErrorResponse } from '$lib/server/api-error';
 import {
   MAX_NOTE_VERSIONS,
   MAX_ENCRYPTED_CONTENT_BYTES,
@@ -49,8 +50,7 @@ export const GET: RequestHandler = async ({ request, params }) => {
       }))
     });
   } catch (err: unknown) {
-    logger.error('GET /api/notes/[id]/versions error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'GET /api/notes/[id]/versions');
   }
 };
 
@@ -138,8 +138,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
 
     return json({ success: true });
   } catch (err: unknown) {
-    logger.error('POST /api/notes/[id]/versions error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'POST /api/notes/[id]/versions');
   }
 };
 
@@ -155,7 +154,6 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
 
     return json({ success: true });
   } catch (err: unknown) {
-    logger.error('DELETE /api/notes/[id]/versions error:', err);
-    return json({ success: false, error: 'Internal server error' }, { status: 500 });
+    return apiErrorResponse(err, logger, 'DELETE /api/notes/[id]/versions');
   }
 };

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -685,6 +685,15 @@
     "initial": {
       "title": "Notizen werden synchronisiert",
       "message": "Das Herunterladen Ihrer verschlüsselten Daten vom Server kann einen Moment dauern."
+    },
+    "errors": {
+      "count": "{count} nicht synchronisiert",
+      "too_large": "Zu groß, nicht synchronisiert (Limit {max} KB)",
+      "quota_exceeded": "Speicher voll - nicht synchronisiert",
+      "invalid": "Ungültige Daten - nicht synchronisiert",
+      "rejected": "Nicht synchronisiert",
+      "toast_single": "Notiz nicht synchronisiert",
+      "toast_batch": "{count} Notizen nicht synchronisiert"
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -688,12 +688,13 @@
     },
     "errors": {
       "count": "{count} nicht synchronisiert",
-      "too_large": "Zu groß, nicht synchronisiert (Limit {max} KB)",
-      "quota_exceeded": "Speicher voll - nicht synchronisiert",
-      "invalid": "Ungültige Daten - nicht synchronisiert",
-      "rejected": "Nicht synchronisiert",
+      "too_large": "Zu groß - über {max} KB",
+      "quota_exceeded": "Speicherlimit erreicht",
+      "invalid": "Ungültige Daten",
+      "rejected": "Vom Server abgelehnt",
       "toast_single": "Notiz nicht synchronisiert",
-      "toast_batch": "{count} Notizen nicht synchronisiert"
+      "toast_batch": "{count} Notizen nicht synchronisiert",
+      "toast_marked": "Diese Notizen sind in der Liste markiert."
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -829,7 +829,7 @@
       "keep_root_destination": "Notizen werden nach „{path}“ importiert",
       "folder_import_summary": "Importiert: {imported} Notizen, {folders} neue Ordner, {tags} neue Tags",
       "folder_import_skipped_non_md": "{count} Nicht-Markdown-Datei(en) übersprungen",
-      "folder_import_skipped_too_large": "{count} Datei(en) größer als 500 KB übersprungen",
+      "folder_import_skipped_too_large": "{count} Datei(en) größer als {max} KB übersprungen",
       "folder_import_skipped_hidden": "{count} Datei(en) in versteckten Ordnern übersprungen (.obsidian, .trash usw.)",
       "dedup_files_found": "{count} Notiz(en) zum Importieren gefunden",
       "dedup_prompt_root": "Was soll passieren, wenn eine Notiz mit demselben Namen bereits in „Alle Notizen“ existiert?",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -685,6 +685,15 @@
     "initial": {
       "title": "Syncing your notes",
       "message": "Downloading your encrypted data from the server may take a moment."
+    },
+    "errors": {
+      "count": "{count} not synced",
+      "too_large": "Too large to sync (limit {max} KB)",
+      "quota_exceeded": "Storage full - not synced",
+      "invalid": "Invalid data - not synced",
+      "rejected": "Not synced",
+      "toast_single": "Note not synced",
+      "toast_batch": "{count} notes not synced"
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -829,7 +829,7 @@
       "keep_root_destination": "Notes will be imported into \"{path}\"",
       "folder_import_summary": "Imported: {imported} notes, {folders} new folders, {tags} new tags",
       "folder_import_skipped_non_md": "Skipped {count} non-markdown file(s)",
-      "folder_import_skipped_too_large": "Skipped {count} file(s) larger than 500 KB",
+      "folder_import_skipped_too_large": "Skipped {count} file(s) larger than {max} KB",
       "folder_import_skipped_hidden": "Skipped {count} file(s) in hidden folders (.obsidian, .trash, etc.)",
       "dedup_files_found": "{count} note(s) ready to import",
       "dedup_prompt_root": "What should happen when a note with the same name already exists in \"All Notes\"?",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -688,12 +688,13 @@
     },
     "errors": {
       "count": "{count} not synced",
-      "too_large": "Too large to sync (limit {max} KB)",
-      "quota_exceeded": "Storage full - not synced",
-      "invalid": "Invalid data - not synced",
-      "rejected": "Not synced",
+      "too_large": "Too large - over {max} KB",
+      "quota_exceeded": "Storage quota reached",
+      "invalid": "Invalid data",
+      "rejected": "Rejected by the server",
       "toast_single": "Note not synced",
-      "toast_batch": "{count} notes not synced"
+      "toast_batch": "{count} notes not synced",
+      "toast_marked": "These notes are marked in the list."
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -688,12 +688,13 @@
     },
     "errors": {
       "count": "{count} sin sincronizar",
-      "too_large": "Demasiado grande, sin sincronizar (límite {max} KB)",
-      "quota_exceeded": "Almacenamiento lleno - sin sincronizar",
-      "invalid": "Datos no válidos - sin sincronizar",
-      "rejected": "Sin sincronizar",
+      "too_large": "Demasiado grande - más de {max} KB",
+      "quota_exceeded": "Cuota de almacenamiento alcanzada",
+      "invalid": "Datos no válidos",
+      "rejected": "Rechazada por el servidor",
       "toast_single": "Nota sin sincronizar",
-      "toast_batch": "{count} notas sin sincronizar"
+      "toast_batch": "{count} notas sin sincronizar",
+      "toast_marked": "Estas notas están marcadas en la lista."
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -685,6 +685,15 @@
     "initial": {
       "title": "Sincronizando tus notas",
       "message": "La descarga de tus datos cifrados desde el servidor puede tardar un momento."
+    },
+    "errors": {
+      "count": "{count} sin sincronizar",
+      "too_large": "Demasiado grande, sin sincronizar (límite {max} KB)",
+      "quota_exceeded": "Almacenamiento lleno - sin sincronizar",
+      "invalid": "Datos no válidos - sin sincronizar",
+      "rejected": "Sin sincronizar",
+      "toast_single": "Nota sin sincronizar",
+      "toast_batch": "{count} notas sin sincronizar"
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -829,7 +829,7 @@
       "keep_root_destination": "Las notas se importarán en «{path}»",
       "folder_import_summary": "Importado: {imported} notas, {folders} carpetas nuevas, {tags} etiquetas nuevas",
       "folder_import_skipped_non_md": "{count} archivo(s) no Markdown omitido(s)",
-      "folder_import_skipped_too_large": "{count} archivo(s) de más de 500 KB omitido(s)",
+      "folder_import_skipped_too_large": "{count} archivo(s) de más de {max} KB omitido(s)",
       "folder_import_skipped_hidden": "{count} archivo(s) en carpetas ocultas omitido(s) (.obsidian, .trash, etc.)",
       "dedup_files_found": "{count} nota(s) listas para importar",
       "dedup_prompt_root": "¿Qué hacer cuando ya existe una nota con el mismo nombre en «Todas las notas»?",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -829,7 +829,7 @@
       "keep_root_destination": "Les notes seront importées dans « {path} »",
       "folder_import_summary": "Importé : {imported} notes, {folders} nouveaux dossiers, {tags} nouveaux tags",
       "folder_import_skipped_non_md": "{count} fichier(s) non Markdown ignoré(s)",
-      "folder_import_skipped_too_large": "{count} fichier(s) de plus de 500 Ko ignoré(s)",
+      "folder_import_skipped_too_large": "{count} fichier(s) de plus de {max} KB ignoré(s)",
       "folder_import_skipped_hidden": "{count} fichier(s) dans des dossiers cachés ignoré(s) (.obsidian, .trash, etc.)",
       "dedup_files_found": "{count} note(s) prête(s) à importer",
       "dedup_prompt_root": "Que faire lorsqu'une note du même nom existe déjà dans « Toutes les notes » ?",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -688,12 +688,13 @@
     },
     "errors": {
       "count": "{count} non synchronisé(s)",
-      "too_large": "Trop volumineuse, non synchronisée (limite {max} KB)",
-      "quota_exceeded": "Stockage plein - non synchronisée",
-      "invalid": "Données invalides - non synchronisée",
-      "rejected": "Non synchronisée",
+      "too_large": "Trop volumineuse - plus de {max} KB",
+      "quota_exceeded": "Quota de stockage atteint",
+      "invalid": "Données invalides",
+      "rejected": "Rejetée par le serveur",
       "toast_single": "Note non synchronisée",
-      "toast_batch": "{count} notes non synchronisées"
+      "toast_batch": "{count} notes non synchronisées",
+      "toast_marked": "Ces notes sont signalées dans la liste."
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -685,6 +685,15 @@
     "initial": {
       "title": "Synchronisation de vos notes",
       "message": "Le téléchargement de vos données chiffrées depuis le serveur peut prendre un instant."
+    },
+    "errors": {
+      "count": "{count} non synchronisé(s)",
+      "too_large": "Trop volumineuse, non synchronisée (limite {max} KB)",
+      "quota_exceeded": "Stockage plein - non synchronisée",
+      "invalid": "Données invalides - non synchronisée",
+      "rejected": "Non synchronisée",
+      "toast_single": "Note non synchronisée",
+      "toast_batch": "{count} notes non synchronisées"
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -688,12 +688,13 @@
     },
     "errors": {
       "count": "{count} niezsynchronizowanych",
-      "too_large": "Za duża, nie zsynchronizowano (limit {max} KB)",
-      "quota_exceeded": "Brak miejsca - nie zsynchronizowano",
-      "invalid": "Nieprawidłowe dane - nie zsynchronizowano",
-      "rejected": "Nie zsynchronizowano",
+      "too_large": "Za duża - ponad {max} KB",
+      "quota_exceeded": "Osiągnięto limit miejsca",
+      "invalid": "Nieprawidłowe dane",
+      "rejected": "Odrzucona przez serwer",
       "toast_single": "Notatka nie została zsynchronizowana",
-      "toast_batch": "{count} notatek nie zsynchronizowano"
+      "toast_batch": "{count} notatek nie zsynchronizowano",
+      "toast_marked": "Te notatki są oznaczone na liście."
     }
   },
   "view_mode": {

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -829,7 +829,7 @@
       "keep_root_destination": "Notatki trafią do „{path}”",
       "folder_import_summary": "Zaimportowano: {imported} notatek, {folders} nowych folderów, {tags} nowych tagów",
       "folder_import_skipped_non_md": "Pominięto {count} plików nie-markdown",
-      "folder_import_skipped_too_large": "Pominięto {count} plików przekraczających 500 KB",
+      "folder_import_skipped_too_large": "Pominięto {count} plików przekraczających {max} KB",
       "folder_import_skipped_hidden": "Pominięto {count} plików z ukrytych folderów (.obsidian, .trash itp.)",
       "dedup_files_found": "Znaleziono {count} notatek do importu",
       "dedup_prompt_root": "Co zrobić, gdy notatka o tej samej nazwie już istnieje w „Wszystkich notatkach”?",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -685,6 +685,15 @@
     "initial": {
       "title": "Synchronizujemy Twoje notatki",
       "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać."
+    },
+    "errors": {
+      "count": "{count} niezsynchronizowanych",
+      "too_large": "Za duża, nie zsynchronizowano (limit {max} KB)",
+      "quota_exceeded": "Brak miejsca - nie zsynchronizowano",
+      "invalid": "Nieprawidłowe dane - nie zsynchronizowano",
+      "rejected": "Nie zsynchronizowano",
+      "toast_single": "Notatka nie została zsynchronizowana",
+      "toast_batch": "{count} notatek nie zsynchronizowano"
     }
   },
   "view_mode": {

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -14,7 +14,11 @@ export interface EncryptedEntity {
  */
 export interface Syncable {
   sync_version: number;
-  sync_status: 'pending' | 'synced' | 'conflict';
+  // 'sync_error' marks an entity whose push was permanently rejected by the
+  // server (a 4xx the client cannot fix by retrying). It is dropped from the
+  // periodic-push retry set so a poisoned record stops re-sending forever.
+  // Currently produced only by reborn-notes (per-note hard rejections).
+  sync_status: 'pending' | 'synced' | 'conflict' | 'sync_error';
   last_sync_at?: string | null;
   synced_at?: string | null; // Legacy compatibility
   server_id?: string;

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -63,10 +63,27 @@ export interface NoteEncrypted extends SyncableEncryptedEntity {
 
 // ─── Local storage type (IndexedDB — shadow indexes for queries) ─────
 
+/**
+ * Reason a note's push was permanently rejected by the server (a 4xx the client
+ * cannot fix by retrying). Stored only in IndexedDB alongside
+ * `sync_status: 'sync_error'`; never sent to the server.
+ *  - `too_large`: encrypted body exceeded the request size limit (413).
+ *  - `quota_exceeded`: per-user storage quota is full (413 QUOTA_EXCEEDED).
+ *  - `invalid`: server-side Zod validation rejected the payload (400).
+ *  - `rejected`: other permanent rejection (e.g. 403 ownership).
+ */
+export type SyncErrorCode = 'too_large' | 'quota_exceeded' | 'invalid' | 'rejected';
+
 /** Extended with local-only shadow indexes extracted from decrypted metadata. */
 export interface NoteStoredLocal extends NoteEncrypted {
   is_pinned?: boolean;
   is_starred?: boolean;
+  /**
+   * Set when the last push of this note was permanently rejected (see
+   * `SyncErrorCode`). Always paired with `sync_status: 'sync_error'`. Cleared on
+   * a successful push, or whenever a local edit re-marks the note 'pending'.
+   */
+  sync_error_code?: SyncErrorCode;
 }
 
 /** Maximum number of version snapshots kept per note (client and server). */

--- a/packages/types/src/schemas/__tests__/base.spec.ts
+++ b/packages/types/src/schemas/__tests__/base.spec.ts
@@ -69,7 +69,7 @@ describe('Base Schemas', () => {
     });
 
     it('should validate all sync statuses', () => {
-      const statuses = ['pending', 'synced', 'conflict'] as const;
+      const statuses = ['pending', 'synced', 'conflict', 'sync_error'] as const;
       
       statuses.forEach(status => {
         const syncable = {

--- a/packages/types/src/schemas/base.ts
+++ b/packages/types/src/schemas/base.ts
@@ -16,7 +16,7 @@ export const EncryptedEntitySchema = z.object({
  */
 export const SyncableSchema = z.object({
   sync_version: z.number().int().min(0),
-  sync_status: z.enum(['pending', 'synced', 'conflict']),
+  sync_status: z.enum(['pending', 'synced', 'conflict', 'sync_error']),
   last_sync_at: z.string().datetime().nullable().optional(),
   device_id: z.string().optional()
 });

--- a/packages/types/src/schemas/entities/note.ts
+++ b/packages/types/src/schemas/entities/note.ts
@@ -57,7 +57,10 @@ export const NoteEncryptedSchema = SyncableEncryptedEntitySchema.extend({
  */
 export const NoteStoredLocalSchema = NoteEncryptedSchema.extend({
   is_pinned: z.boolean().optional(),
-  is_starred: z.boolean().optional()
+  is_starred: z.boolean().optional(),
+  // Local-only: reason the last push was permanently rejected (paired with
+  // sync_status: 'sync_error'). Never sent to the server. See SyncErrorCode.
+  sync_error_code: z.enum(['too_large', 'quota_exceeded', 'invalid', 'rejected']).optional()
 });
 
 // Export inferred types


### PR DESCRIPTION
## Summary

A note push the server rejects with a permanent 4xx (too large, invalid, quota full) no longer wedges as "pending" and re-pushes on every periodic sync. It becomes a per-note `sync_error` state, dropped from the retry set and surfaced in the UI so the user knows which note and why.

Two gaps closed (revealed by the `BODY_SIZE_LIMIT` bug, #286):
- **Backend:** note API handlers returned `500` for every throw, masking the `413` that `@sveltejs/adapter-node` raises from `request.json()`. `apiErrorResponse` now returns the real 4xx status (`POST/PATCH /api/notes`, `POST .../versions`).
- **Frontend:** `retryWithBackoff`/`pushSilently` retried every status forever. Permanent statuses `{400, 403, 413}` (explicit allowlist; `401`/`404`/`408`/`429`/`5xx` stay transient) now short-circuit retry and mark the note `sync_status: 'sync_error'` + `sync_error_code`.

**Decisions (agreed before coding):**
- Scope **notes only**; reborn-task has the same bug on its operation queue, tracked as a follow-up.
- UI: **red footer count + per-note badge + toast** (per-note on a single edit, one aggregated toast after a batch import).
- Permanent statuses as an explicit allowlist, not "4xx minus exceptions" (`404`/`401` have special push semantics).
- Per-note badge via a reactive `syncErrorMap` store, not threading `sync_status` through the decrypted note index.

Zero-knowledge unchanged: `sync_error_code` is local-only IndexedDB metadata, never sent in a push payload. See guideline 36, rule 14.

## Test plan

Automated (all green):
- `@reborn/types`: lint / typecheck / test (enum `sync_status` + `SyncErrorCode` + schema).
- reborn-notes: lint 0 err, svelte-check 0/0, **731 tests** (new: `push-error.spec` behavioural, `api-error.spec`, `notes-sync.push-rejection.spec` source-level), build.
- reborn-task: check + test (regression from the shared-types enum change - clean).
- i18n parity across 5 locales.

Smoke (manual):
- Account session in re/notes. Create/import a note above the server body limit (or set a low `BODY_SIZE_LIMIT`): push is rejected -> footer turns red "1 not synced", a red badge appears on the note with a tooltip, a toast shows the limit. Console shows `413` (not `500`), no 5-min retry loop.
- Shrink the note -> badge clears, note goes to "synced".
- Full storage quota -> "Storage full" message instead.