### PR TITLE
feat(task): surface hard push rejections as per-task sync_error

### DIFF
--- a/apps/reborn-task/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-task/src/lib/components/sync/SyncStatusFooter.svelte
@@ -9,6 +9,7 @@
 		Check,
 		WifiOff,
 		AlertCircle,
+		AlertTriangle,
 		CloudUpload,
 		ShieldAlert,
 		HardDrive
@@ -80,6 +81,8 @@
 				return WifiOff;
 			case 'error':
 				return AlertCircle;
+			case 'sync_error':
+				return AlertTriangle;
 			case 'pending':
 				return CloudUpload;
 			case 'auth-error':
@@ -98,6 +101,8 @@
 			case 'offline':
 				return 'text-muted-foreground';
 			case 'error':
+				return 'text-destructive';
+			case 'sync_error':
 				return 'text-destructive';
 			case 'pending':
 				return 'text-amber-500 dark:text-amber-400';
@@ -118,6 +123,8 @@
 				return $t('sync.indicator.offline');
 			case 'error':
 				return $t('sync.indicator.error');
+			case 'sync_error':
+				return $t('sync.errors.count', { values: { count: $syncStatus.errorCount } });
 			case 'pending':
 				return $t('sync.indicator.pending', { values: { count: $syncStatus.pendingCount } });
 			case 'auth-error':

--- a/apps/reborn-task/src/lib/components/sync/SyncStatusIndicator.svelte
+++ b/apps/reborn-task/src/lib/components/sync/SyncStatusIndicator.svelte
@@ -12,6 +12,7 @@
 		Check,
 		WifiOff,
 		AlertCircle,
+		AlertTriangle,
 		CloudUpload,
 		ShieldAlert,
 		HardDrive
@@ -90,6 +91,8 @@
 				return WifiOff;
 			case 'error':
 				return AlertCircle;
+			case 'sync_error':
+				return AlertTriangle;
 			case 'pending':
 				return CloudUpload;
 			case 'auth-error':
@@ -108,6 +111,8 @@
 			case 'offline':
 				return 'text-muted-foreground';
 			case 'error':
+				return 'text-destructive';
+			case 'sync_error':
 				return 'text-destructive';
 			case 'pending':
 				return 'text-amber-500';
@@ -132,6 +137,12 @@
 					($syncStatus.failedCount > 0 ? ` (${$syncStatus.failedCount})` : '') +
 					' - ' +
 					$t('sync.indicator.tap_to_retry')
+				);
+			case 'sync_error':
+				return (
+					$t('sync.errors.count', { values: { count: $syncStatus.errorCount } }) +
+					' - ' +
+					$t('sync.indicator.tap_to_sync')
 				);
 			case 'pending':
 				return $t('sync.indicator.pending', { values: { count: $syncStatus.pendingCount } });
@@ -182,6 +193,13 @@
 							class="absolute -top-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-destructive text-[9px] font-bold text-white"
 						>
 							{$syncStatus.failedCount > 9 ? '9+' : $syncStatus.failedCount}
+						</span>
+					{/if}
+					{#if $syncStatus.status === 'sync_error' && $syncStatus.errorCount > 0}
+						<span
+							class="absolute -top-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-destructive text-[9px] font-bold text-white"
+						>
+							{$syncStatus.errorCount > 9 ? '9+' : $syncStatus.errorCount}
 						</span>
 					{/if}
 				</button>

--- a/apps/reborn-task/src/lib/components/tasks/TaskItem.svelte
+++ b/apps/reborn-task/src/lib/components/tasks/TaskItem.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { Checkbox, cn } from '@reborn/ui';
-	import { Star, Calendar, RotateCw, Clock, AlertCircle, Folder } from '@lucide/svelte';
+	import { Star, Calendar, RotateCw, Clock, AlertCircle, AlertTriangle, Folder } from '@lucide/svelte';
 	import type { TaskListItem } from '$lib/services/task-title-index.svelte';
 	import { createLogger } from '@reborn/utils';
 	import { t, locale } from '$lib/stores/i18n.store';
 	import { dateFormat } from '$lib/stores/app-settings.store';
 	import { formatDueDate, truncateListName } from '$lib/services/task-formatting.service';
+	import { syncErrorMap } from '$lib/stores/sync-errors.store';
 
 	const logger = createLogger('TaskItem');
 
@@ -60,6 +61,26 @@
 	const dueDate = $derived(
 		formatDueDate(task.due_date, task.has_time, $locale || 'en', $t, $dateFormat)
 	);
+
+	// Per-task hard-rejection state (sync_status: 'sync_error'). Read from the
+	// reactive map so the marker appears/clears as soon as a push is rejected or a
+	// later edit re-syncs the task - no need to thread sync_status through the
+	// decrypted title index. See guideline 36, rule 14.
+	const syncErrorCode = $derived($syncErrorMap.get(task.id));
+	const syncErrorTitle = $derived.by(() => {
+		switch (syncErrorCode) {
+			case 'too_large':
+				return $t('sync.errors.too_large');
+			case 'quota_exceeded':
+				return $t('sync.errors.quota_exceeded');
+			case 'invalid':
+				return $t('sync.errors.invalid');
+			case 'rejected':
+				return $t('sync.errors.rejected');
+			default:
+				return '';
+		}
+	});
 
 	const hasMetadata = $derived(
 		(!!dueDate && !task.is_completed) ||
@@ -118,6 +139,19 @@
 		>
 			{task.title}
 		</h3>
+
+		<!-- Sync-error reason: the server permanently rejected this task's push.
+		     Rendered as a visible red line (not just a hover tooltip), so the user
+		     knows WHY it won't sync and it works on touch. -->
+		{#if syncErrorCode}
+			<p
+				class="mt-0.5 flex items-center gap-1 text-sm md:text-xs font-medium text-destructive"
+				aria-label={syncErrorTitle}
+			>
+				<AlertTriangle class="h-3.5 w-3.5 md:h-3 md:w-3 shrink-0" aria-hidden="true" />
+				<span class="line-clamp-2">{syncErrorTitle}</span>
+			</p>
+		{/if}
 
 		<!-- Metadata -->
 		{#if hasMetadata}

--- a/apps/reborn-task/src/lib/server/api-error.spec.ts
+++ b/apps/reborn-task/src/lib/server/api-error.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { apiErrorResponse } from './api-error';
+
+type Logger = Parameters<typeof apiErrorResponse>[1];
+const fakeLogger = () =>
+	({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) as unknown as Logger;
+
+describe('apiErrorResponse', () => {
+	it('surfaces a 413 thrown by request.json() (adapter SvelteKitError) as 413, not 500', async () => {
+		const logger = fakeLogger();
+		// Shape adapter-node throws when the body exceeds BODY_SIZE_LIMIT.
+		const err = { status: 413, text: 'Payload Too Large' };
+		const res = apiErrorResponse(err, logger, 'POST /api/tasks');
+
+		expect(res.status).toBe(413);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+		expect(body.error).toBe('Request body too large');
+		expect(logger.warn).toHaveBeenCalledOnce();
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it('surfaces a 400 client error as 400', async () => {
+		const res = apiErrorResponse({ status: 400 }, fakeLogger(), 'POST x');
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toBe('Bad request');
+	});
+
+	it('maps an unknown 4xx to its status with a generic message', async () => {
+		const res = apiErrorResponse({ status: 418 }, fakeLogger(), 'POST x');
+		expect(res.status).toBe(418);
+		expect((await res.json()).error).toBe('Request rejected');
+	});
+
+	it('maps a generic thrown Error to 500', async () => {
+		const logger = fakeLogger();
+		const res = apiErrorResponse(new Error('db exploded'), logger, 'POST x');
+		expect(res.status).toBe(500);
+		expect((await res.json()).error).toBe('Internal server error');
+		expect(logger.error).toHaveBeenCalledOnce();
+	});
+
+	it('does NOT treat a 5xx-carrying error as a client error', async () => {
+		const res = apiErrorResponse({ status: 503 }, fakeLogger(), 'POST x');
+		expect(res.status).toBe(500);
+	});
+
+	it('maps an error without a numeric status to 500', async () => {
+		const res = apiErrorResponse({ status: 'nope' }, fakeLogger(), 'POST x');
+		expect(res.status).toBe(500);
+	});
+});

--- a/apps/reborn-task/src/lib/server/api-error.ts
+++ b/apps/reborn-task/src/lib/server/api-error.ts
@@ -1,0 +1,42 @@
+import { json } from '@sveltejs/kit';
+import type { createLogger } from '@reborn/utils';
+
+type Logger = ReturnType<typeof createLogger>;
+
+/**
+ * Map a caught handler error to an HTTP JSON response.
+ *
+ * The default `catch` in our API handlers used to return 500 for *every*
+ * throw. That masked the 413 that `@sveltejs/adapter-node` raises from
+ * `request.json()` when the body exceeds `BODY_SIZE_LIMIT`: the client saw a
+ * generic 500, the offline operation stayed queued, and the periodic push
+ * retried the oversized payload forever (see guideline 36, rule 14). The
+ * adapter throws a `SvelteKitError` carrying a numeric `status` and a `text`
+ * (e.g. `{ status: 413, text: 'Payload Too Large' }`), so we surface client
+ * errors (4xx) with their real status and only fall back to 500 for genuine
+ * server faults.
+ *
+ * We deliberately return a generic, status-derived message rather than echoing
+ * `err.text`/`err.body` - the client classifies on the status code, not the
+ * string, and we don't want to leak internal error detail.
+ */
+export function apiErrorResponse(err: unknown, logger: Logger, context: string): Response {
+	if (typeof err === 'object' && err !== null && 'status' in err) {
+		const status = (err as { status: unknown }).status;
+		if (typeof status === 'number' && status >= 400 && status < 500) {
+			// Not a server fault - the request itself was rejected. Log at warn so it
+			// doesn't read as an outage, but stays visible for diagnosis.
+			logger.warn(`${context}: rejected request with status ${status}`);
+			const error =
+				status === 413
+					? 'Request body too large'
+					: status === 400
+						? 'Bad request'
+						: 'Request rejected';
+			return json({ success: false, error }, { status });
+		}
+	}
+
+	logger.error(`${context} error:`, err);
+	return json({ success: false, error: 'Internal server error' }, { status: 500 });
+}

--- a/apps/reborn-task/src/lib/services/sync-error-notify.ts
+++ b/apps/reborn-task/src/lib/services/sync-error-notify.ts
@@ -1,0 +1,42 @@
+/**
+ * User-facing toast for permanent push rejections (sync_status: 'sync_error').
+ *
+ * Kept out of the sync engine so it stays free of UI imports and can be mocked
+ * in sync tests. The persistent surfaces (red footer count + per-task badge +
+ * inline reason) are driven by store state; this toast is the one-shot "it just
+ * happened" signal after a batch push. Mirrors notes' `sync-error-notify.ts`.
+ */
+import { get } from 'svelte/store';
+import { toastStore } from '@reborn/ui';
+import { t } from '$lib/stores/i18n.store';
+import type { SyncErrorCode } from '@reborn/types';
+
+/** Localised one-line reason for a given rejection code (used inline + in toasts). */
+export function syncErrorMessage(code: SyncErrorCode): string {
+	const $t = get(t);
+	switch (code) {
+		case 'too_large':
+			return $t('sync.errors.too_large');
+		case 'quota_exceeded':
+			return $t('sync.errors.quota_exceeded');
+		case 'invalid':
+			return $t('sync.errors.invalid');
+		case 'rejected':
+			return $t('sync.errors.rejected');
+	}
+}
+
+/**
+ * One aggregated toast after a sync left `count` items permanently rejected.
+ *
+ * Intentionally a count + pointer, not a list: a batch can reject several
+ * items, and a toast is transient. The per-item reason is shown inline on each
+ * marked task row (TaskItem), which is where the user goes to act.
+ */
+export function notifyTaskSyncErrors(count: number): void {
+	if (count <= 0) return;
+	const $t = get(t);
+	toastStore.error($t('sync.errors.toast_batch', { values: { count } }), {
+		description: $t('sync.errors.toast_marked')
+	});
+}

--- a/apps/reborn-task/src/lib/services/sync/operation-error.spec.ts
+++ b/apps/reborn-task/src/lib/services/sync/operation-error.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+	ensureOperationOk,
+	isPermanentStatus,
+	PermanentOperationError
+} from './operation-error';
+
+describe('operation-error classification', () => {
+	describe('isPermanentStatus', () => {
+		it('treats 400 / 403 / 413 as permanent (payload itself is the problem)', () => {
+			expect(isPermanentStatus(400)).toBe(true);
+			expect(isPermanentStatus(403)).toBe(true);
+			expect(isPermanentStatus(413)).toBe(true);
+		});
+
+		it('treats session / ordering / rate-limit 4xx as transient', () => {
+			// 401 = session (ApiClient refresh), 404 = parent not on server yet,
+			// 408/429 = timeout/rate-limit. None should poison the operation.
+			for (const s of [401, 404, 408, 409, 425, 429]) {
+				expect(isPermanentStatus(s), `status ${s}`).toBe(false);
+			}
+		});
+
+		it('treats 5xx as transient', () => {
+			for (const s of [500, 502, 503]) expect(isPermanentStatus(s), `status ${s}`).toBe(false);
+		});
+	});
+
+	describe('ensureOperationOk', () => {
+		it('returns for a successful response', () => {
+			expect(() => ensureOperationOk({ success: true, status: 200 }, 'POST x')).not.toThrow();
+		});
+
+		it('throws a plain Error (retryable, NOT PermanentOperationError) for a transient status', () => {
+			let caught: unknown;
+			try {
+				ensureOperationOk({ success: false, status: 500, error: 'boom' }, 'POST /api/tasks');
+			} catch (e) {
+				caught = e;
+			}
+			expect(caught).toBeInstanceOf(Error);
+			expect(caught).not.toBeInstanceOf(PermanentOperationError);
+			expect((caught as Error).message).toBe('boom');
+		});
+
+		it('throws a plain Error when status is missing/unknown (treated as transient)', () => {
+			let caught: unknown;
+			try {
+				ensureOperationOk({ success: false }, 'PUT /api/tasks/1');
+			} catch (e) {
+				caught = e;
+			}
+			expect(caught).toBeInstanceOf(Error);
+			expect(caught).not.toBeInstanceOf(PermanentOperationError);
+		});
+
+		it('throws PermanentOperationError too_large for a 413 body-limit rejection', () => {
+			let caught: unknown;
+			try {
+				ensureOperationOk(
+					{ success: false, status: 413, error: 'Request body too large' },
+					'POST /api/tasks'
+				);
+			} catch (e) {
+				caught = e;
+			}
+			expect(caught).toBeInstanceOf(PermanentOperationError);
+			expect((caught as PermanentOperationError).status).toBe(413);
+			expect((caught as PermanentOperationError).code).toBe('too_large');
+		});
+
+		it('throws PermanentOperationError quota_exceeded for a 413 QUOTA_EXCEEDED body', () => {
+			let caught: unknown;
+			try {
+				ensureOperationOk({ success: false, status: 413, error: 'QUOTA_EXCEEDED' }, 'POST x');
+			} catch (e) {
+				caught = e;
+			}
+			expect((caught as PermanentOperationError).code).toBe('quota_exceeded');
+		});
+
+		it('throws PermanentOperationError invalid for a 400 validation rejection', () => {
+			let caught: unknown;
+			try {
+				ensureOperationOk({ success: false, status: 400, error: 'Bad request' }, 'PUT x');
+			} catch (e) {
+				caught = e;
+			}
+			expect(caught).toBeInstanceOf(PermanentOperationError);
+			expect((caught as PermanentOperationError).code).toBe('invalid');
+		});
+
+		it('throws PermanentOperationError rejected for a 403 ownership rejection', () => {
+			let caught: unknown;
+			try {
+				ensureOperationOk({ success: false, status: 403, error: 'Forbidden' }, 'POST x');
+			} catch (e) {
+				caught = e;
+			}
+			expect((caught as PermanentOperationError).code).toBe('rejected');
+		});
+	});
+});

--- a/apps/reborn-task/src/lib/services/sync/operation-error.ts
+++ b/apps/reborn-task/src/lib/services/sync/operation-error.ts
@@ -1,0 +1,82 @@
+/**
+ * Push-error classification for the task offline-operation queue.
+ *
+ * Separates a *permanent* rejection (a 4xx the client cannot fix by retrying)
+ * from a *transient* failure (server/network hiccup, retry later). The notes
+ * app has the same logic in `push-error.ts`; here it is adapted to the
+ * `ApiClient` response shape ({ success, status, error }) the sync services
+ * already receive, and kept in its own module so it can be unit-tested without
+ * the browser-only dependencies the sync engine drags in. See guideline 36,
+ * rule 14.
+ */
+import type { SyncErrorCode } from '@reborn/types';
+
+/**
+ * Statuses where retrying the same payload can never succeed - the request
+ * itself is the problem. Deliberately an explicit allowlist, NOT "every 4xx",
+ * because several 4xx codes ARE transient for a push:
+ *   - 401: session problem; ApiClient.onUnauthorized handles refresh+retry then
+ *     flips sessionExpired. Treating it as permanent would falsely poison the op.
+ *   - 404: a create whose parent (list/task) hasn't reached the server yet
+ *     (push ordering) - resolves once the parent lands.
+ *   - 408 / 429: timeout / rate-limit - transient by definition.
+ * 413 (too large), 400 (Zod validation) and 403 (ownership) cannot be fixed by
+ * re-sending the same bytes, so they are permanent.
+ */
+export const PERMANENT_PUSH_STATUSES = new Set([400, 403, 413]);
+
+export function isPermanentStatus(status: number): boolean {
+	return PERMANENT_PUSH_STATUSES.has(status);
+}
+
+/** Thrown by `ensureOperationOk` for a permanent (non-retryable) HTTP rejection. */
+export class PermanentOperationError extends Error {
+	constructor(
+		readonly status: number,
+		readonly code: SyncErrorCode,
+		message: string
+	) {
+		super(message);
+		this.name = 'PermanentOperationError';
+	}
+}
+
+/** Minimal shape of an ApiClient response that this module reasons about. */
+export interface ClassifiableResponse {
+	success: boolean;
+	status?: number;
+	error?: string;
+	message?: string;
+}
+
+/**
+ * Map a permanent status (+ body) to a SyncErrorCode. For 413 we look at the
+ * body to separate a full storage quota (`QUOTA_EXCEEDED`) from an oversized
+ * single payload, so the UI can say which (parity with notes; task has no quota
+ * endpoint today, so 413 is effectively always `too_large`).
+ */
+function codeForStatus(status: number, errorBody?: string): SyncErrorCode {
+	if (status === 413) return errorBody === 'QUOTA_EXCEEDED' ? 'quota_exceeded' : 'too_large';
+	if (status === 400) return 'invalid';
+	return 'rejected'; // 403 and any other permanent status
+}
+
+/**
+ * Assert an ApiClient response is OK, otherwise throw the right error:
+ *   - permanent status -> `PermanentOperationError` (skips retry; the queue
+ *     dead-letters the op and marks the entity sync_error so it stops
+ *     re-pushing forever),
+ *   - anything else -> a plain `Error`, left in the queue as today.
+ */
+export function ensureOperationOk(response: ClassifiableResponse, label: string): void {
+	if (response.success) return;
+	const status = response.status ?? 0;
+	if (isPermanentStatus(status)) {
+		throw new PermanentOperationError(
+			status,
+			codeForStatus(status, response.error),
+			`${label}: ${status}`
+		);
+	}
+	throw new Error(response.error || response.message || `${label}: ${status || 'failed'}`);
+}

--- a/apps/reborn-task/src/lib/services/sync/sync-lists.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-lists.service.ts
@@ -1,4 +1,5 @@
 import { SyncBaseService } from './sync-base.service';
+import { ensureOperationOk } from './operation-error';
 import { listStore } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
 import type { ListEncrypted, StorageOfflineOperation } from '@reborn/types';
@@ -55,8 +56,10 @@ export class SyncListsService extends SyncBaseService {
 			for (const list of lists) {
 				try {
 					const localList = await listStore.get(list.id);
-					if (localList?.sync_status === 'pending') {
-						this.logger.debug(`Skipping list ${list.id} — pending local changes exist`);
+					// 'sync_error' = a permanently-rejected (dead-lettered) local edit;
+					// keep it for the same reason as 'pending' - don't clobber it.
+					if (localList?.sync_status === 'pending' || localList?.sync_status === 'sync_error') {
+						this.logger.debug(`Skipping list ${list.id} — unsynced local changes exist`);
 						continue;
 					}
 					// Detect server-side updates (existing local entity overwritten by newer server data)
@@ -156,9 +159,7 @@ export class SyncListsService extends SyncBaseService {
 			case 'create': {
 				// Create list on server
 				const createResponse = await this.apiClient.post<ListEncrypted>('tasklists', listData);
-				if (!createResponse.success) {
-					throw new Error(createResponse.error || 'Failed to create list');
-				}
+				ensureOperationOk(createResponse, 'POST /api/tasklists');
 
 				// Update local list with server response (might have different ID or timestamps)
 				if (createResponse.data) {
@@ -173,9 +174,7 @@ export class SyncListsService extends SyncBaseService {
 					`tasklists/${listData.id}`,
 					listData
 				);
-				if (!updateResponse.success) {
-					throw new Error(updateResponse.error || 'Failed to update list');
-				}
+				ensureOperationOk(updateResponse, `PUT /api/tasklists/${listData.id}`);
 				// Mark local entity as synced so the next pull doesn't skip it
 				await listStore.save({ ...listData, sync_status: 'synced' });
 				break;
@@ -201,9 +200,7 @@ export class SyncListsService extends SyncBaseService {
 					? await this.apiClient.delete(`tasklists/${listData.id}`, deleteBody)
 					: await this.apiClient.delete(`tasklists/${listData.id}`);
 
-				if (!deleteResponse.success) {
-					throw new Error(deleteResponse.error || 'Failed to delete list');
-				}
+				ensureOperationOk(deleteResponse, `DELETE /api/tasklists/${listData.id}`);
 				break;
 			}
 		}

--- a/apps/reborn-task/src/lib/services/sync/sync-subtasks.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-subtasks.service.ts
@@ -1,4 +1,5 @@
 import { SyncBaseService } from './sync-base.service';
+import { ensureOperationOk } from './operation-error';
 import { subtaskStore } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
 import type {
@@ -50,9 +51,14 @@ export class SyncSubtasksService extends SyncBaseService {
 				try {
 					// Check if local subtask has pending changes — don't overwrite
 					const localSubtask = await subtaskStore.get(subtask.id);
-					if (localSubtask && localSubtask.sync_status === 'pending') {
+					// 'sync_error' = a permanently-rejected (dead-lettered) local edit;
+					// keep it for the same reason as 'pending' - don't clobber it.
+					if (
+						localSubtask &&
+						(localSubtask.sync_status === 'pending' || localSubtask.sync_status === 'sync_error')
+					) {
 						this.logger.debug(
-							`Skipping pull for subtask ${subtask.id} — has pending local changes`
+							`Skipping pull for subtask ${subtask.id} — has unsynced local changes`
 						);
 						continue;
 					}
@@ -118,9 +124,7 @@ export class SyncSubtasksService extends SyncBaseService {
 			case 'create': {
 				// Create subtask on server
 				const createResponse = await this.apiClient.post<SubtaskEncrypted>('subtasks', subtaskData);
-				if (!createResponse.success) {
-					throw new Error(createResponse.error || 'Failed to create subtask');
-				}
+				ensureOperationOk(createResponse, 'POST /api/subtasks');
 
 				// Update local subtask with server response
 				if (createResponse.data) {
@@ -140,9 +144,7 @@ export class SyncSubtasksService extends SyncBaseService {
 					`subtasks/${subtaskData.id}`,
 					subtaskData
 				);
-				if (!updateResponse.success) {
-					throw new Error(updateResponse.error || 'Failed to update subtask');
-				}
+				ensureOperationOk(updateResponse, `PUT /api/subtasks/${subtaskData.id}`);
 
 				// Update local subtask with server's sync_version
 				if (updateResponse.data) {
@@ -159,9 +161,7 @@ export class SyncSubtasksService extends SyncBaseService {
 			case 'delete': {
 				// Delete subtask on server
 				const deleteResponse = await this.apiClient.delete(`subtasks/${subtaskData.id}`);
-				if (!deleteResponse.success) {
-					throw new Error(deleteResponse.error || 'Failed to delete subtask');
-				}
+				ensureOperationOk(deleteResponse, `DELETE /api/subtasks/${subtaskData.id}`);
 				break;
 			}
 		}

--- a/apps/reborn-task/src/lib/services/sync/sync-tasks.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync-tasks.service.ts
@@ -1,5 +1,6 @@
 import { SyncBaseService } from './sync-base.service';
 import { rebuildShadowIndexes } from './shadow-indexes';
+import { ensureOperationOk } from './operation-error';
 import { taskStore } from '@reborn/storage';
 import type {
 	TaskEncrypted,
@@ -85,6 +86,17 @@ export class SyncTasksService extends SyncBaseService {
 					// If task has pending operations in the queue, don't overwrite with server data
 					if (localTask && pendingTaskOps.has(task.id)) {
 						this.logger.debug(`Skipping sync for task ${task.id} - has pending operations in queue`);
+						continue;
+					}
+
+					// A task whose push was permanently rejected (sync_error) was
+					// dead-lettered out of the queue, so pendingTaskOps no longer guards
+					// it. Skip it anyway: it still holds the user's local edit (e.g. a
+					// too-large description), so a newer server version must not silently
+					// clobber it. The user resolves it by shrinking the task, which
+					// re-queues a push. See guideline 36, rule 14.
+					if (localTask && localTask.sync_status === 'sync_error') {
+						this.logger.debug(`Skipping sync for task ${task.id} - has unsynced sync_error edit`);
 						continue;
 					}
 
@@ -382,6 +394,14 @@ export class SyncTasksService extends SyncBaseService {
 						continue;
 					}
 
+					// Permanently-rejected (dead-lettered) task: keep the local edit.
+					if (localTask && localTask.sync_status === 'sync_error') {
+						this.logger.debug(
+							`Skipping sync for deleted task ${task.id} - has unsynced sync_error edit`
+						);
+						continue;
+					}
+
 					// CRITICAL: Check if this is an instance of a locally deleted template
 					// This ensures all instances stay in trash if template is in trash
 					if (task.parent_task_id && deletedTemplateIds.has(task.parent_task_id)) {
@@ -475,9 +495,10 @@ export class SyncTasksService extends SyncBaseService {
 			case 'create': {
 				// Create task on server
 				const createResponse = await this.apiClient.post<TaskEncrypted>('tasks', taskData);
-				if (!createResponse.success) {
-					throw new Error(createResponse.error || 'Failed to create task');
-				}
+				// Permanent 4xx (413/400/403) -> PermanentOperationError; the queue
+				// dead-letters the op and marks the task sync_error. Transient -> plain
+				// Error, left in the queue as today.
+				ensureOperationOk(createResponse, 'POST /api/tasks');
 
 				// Update local task with server response
 				if (createResponse.data) {
@@ -494,9 +515,7 @@ export class SyncTasksService extends SyncBaseService {
 					`tasks/${taskData.id}`,
 					taskData
 				);
-				if (!updateResponse.success) {
-					throw new Error(updateResponse.error || 'Failed to update task');
-				}
+				ensureOperationOk(updateResponse, `PUT /api/tasks/${taskData.id}`);
 
 				// Save server response to IndexedDB (resets sync_status, updates sync_version)
 				if (updateResponse.data) {
@@ -552,18 +571,14 @@ export class SyncTasksService extends SyncBaseService {
 						return;
 					}
 
-					// For other errors, throw
-					if (!deleteResponse.success) {
-						throw new Error(deleteResponse.error || 'Failed to permanently delete task');
-					}
+					// For other errors, throw (404 already handled as success above).
+					ensureOperationOk(deleteResponse, `DELETE /api/tasks/${taskData.id}/permanent`);
 				} else {
 					// This shouldn't happen anymore as soft deletes are handled as updates
 					// But keep it for backward compatibility with old operations
 					this.logger.warn('Unexpected delete operation without permanent flag', { taskData });
 					const deleteResponse = await this.apiClient.delete(`tasks/${taskData.id}`);
-					if (!deleteResponse.success) {
-						throw new Error(deleteResponse.error || 'Failed to delete task');
-					}
+					ensureOperationOk(deleteResponse, `DELETE /api/tasks/${taskData.id}`);
 				}
 				break;
 			}

--- a/apps/reborn-task/src/lib/services/sync/sync.push-rejection.spec.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync.push-rejection.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Source-level invariants for permanent push rejections on the task operation
+ * queue (guideline 36, rule 14). The sync engine pulls in browser-only modules
+ * (IndexedDB, cryptoManager, $env, $app) that are impractical to wire up in
+ * Node, so these are source assertions that pin the wiring; the classification
+ * logic itself is covered behaviourally in operation-error.spec.ts.
+ */
+function readSource(relative: string): string {
+	return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+describe('task sync - permanent push rejection (sync_error)', () => {
+	it('syncOfflineOperations dead-letters a PermanentOperationError: mark entity + drop op + tally', () => {
+		const s = readSource('./sync.service.ts');
+		const body = s.slice(
+			s.indexOf('async syncOfflineOperations'),
+			s.indexOf('private async processOperation')
+		);
+		expect(body).toMatch(/instanceof PermanentOperationError/);
+		expect(body).toMatch(/markEntitySyncError/);
+		expect(body).toMatch(/removeOperation\(operation\.id\)/);
+		expect(body).toMatch(/newSyncErrors\+\+/);
+		// Transient path still leaves the op queued as 'failed' (unchanged behaviour).
+		expect(body).toMatch(/updateOperationStatus\(\s*[\n\t ]*operation\.id,\s*[\n\t ]*'failed'/);
+		// One aggregated toast + a rescan after the batch.
+		expect(body).toMatch(/notifyTaskSyncErrors\(newSyncErrors\)/);
+		expect(body).toMatch(/refreshSyncErrors\(\)/);
+	});
+
+	it('markEntitySyncError writes sync_status sync_error (+ code for tasks)', () => {
+		const s = readSource('./sync.service.ts');
+		const start = s.indexOf('private async markEntitySyncError');
+		expect(start).toBeGreaterThan(-1);
+		const body = s.slice(start, start + 1000);
+		expect(body).toMatch(/sync_status:\s*'sync_error'/);
+		expect(body).toMatch(/sync_error_code:\s*code/);
+	});
+
+	it('per-entity sync services assert pushes via ensureOperationOk, not a bare throw', () => {
+		for (const f of [
+			'./sync-tasks.service.ts',
+			'./sync-lists.service.ts',
+			'./sync-subtasks.service.ts'
+		]) {
+			const s = readSource(f);
+			expect(s, f).toMatch(/ensureOperationOk\(/);
+			// No raw "throw new Error(<x>Response.error ...)" left on the push paths -
+			// those discard the status the classifier needs.
+			expect(s, f).not.toMatch(/throw new Error\([a-zA-Z]+Response\.error/);
+		}
+	});
+
+	it('pull guards keep sync_error entities from being overwritten by newer server data', () => {
+		expect(readSource('./sync-tasks.service.ts')).toMatch(/sync_status === 'sync_error'/);
+		expect(readSource('./sync-lists.service.ts')).toMatch(/sync_status === 'sync_error'/);
+		expect(readSource('./sync-subtasks.service.ts')).toMatch(/sync_status === 'sync_error'/);
+	});
+});

--- a/apps/reborn-task/src/lib/services/sync/sync.service.ts
+++ b/apps/reborn-task/src/lib/services/sync/sync.service.ts
@@ -1,16 +1,19 @@
 import { get } from 'svelte/store';
 import { createLogger } from '@reborn/utils';
 import { taskCounts } from '$lib/stores/task-counts.store';
-import { taskStore } from '@reborn/storage';
+import { taskStore, listStore, subtaskStore } from '@reborn/storage';
 import { localOnly } from '$lib/stores/local-mode.store';
 import { taskTitleIndex } from '$lib/services/task-title-index.svelte';
 import { SyncListsService } from './sync-lists.service';
 import { SyncTasksService } from './sync-tasks.service';
 import { SyncSubtasksService } from './sync-subtasks.service';
 import { SyncOfflineService } from './sync-offline.service';
+import { PermanentOperationError } from './operation-error';
 import { connectivityStore, checkOnline } from '$lib/stores/connectivity.store';
 import { isNetworkError } from '$lib/stores/network.store';
-import type { StorageOfflineOperation, TaskEncryptedBooleans } from '@reborn/types';
+import { refreshSyncErrors } from '$lib/stores/sync-errors.store';
+import { notifyTaskSyncErrors } from '$lib/services/sync-error-notify';
+import type { StorageOfflineOperation, TaskEncryptedBooleans, SyncErrorCode } from '@reborn/types';
 
 const logger = createLogger('SyncService');
 
@@ -429,6 +432,10 @@ class SyncService {
 	}> {
 		const processedOps: StorageOfflineOperation[] = [];
 		let failedCount = 0;
+		// Operations the server permanently rejected this run (4xx the client can't
+		// fix). Dead-lettered out of the queue + entity marked sync_error; tallied
+		// so we raise ONE aggregated toast after the batch instead of per-op spam.
+		let newSyncErrors = 0;
 
 		if (get(localOnly)) return { processedOps, failedCount };
 
@@ -492,10 +499,38 @@ class SyncService {
 					processedOps.push(operation);
 				} catch (error: unknown) {
 					reportIfNetwork(error);
+
+					if (error instanceof PermanentOperationError) {
+						// Permanent 4xx (e.g. server Zod rejection or a 413 body-limit):
+						// this op can never succeed. Dead-letter it - drop it from the
+						// queue so it stops shielding the entity from pulls and re-failing
+						// forever - and mark the entity sync_error so the user sees which
+						// one and why. A later local edit re-queues a push, clearing it.
+						logger.warn(
+							`Operation ${operation.id} permanently rejected (status ${error.status}, code ${error.code}) - dead-lettering:`,
+							error.message
+						);
+						try {
+							await this.markEntitySyncError(
+								operation.entityType,
+								operation.entityId,
+								error.code
+							);
+						} catch (markErr: unknown) {
+							logger.error(
+								`Failed to mark ${operation.entityType} ${operation.entityId} sync_error:`,
+								markErr
+							);
+						}
+						await this.offlineService.removeOperation(operation.id);
+						newSyncErrors++;
+						continue;
+					}
+
 					logger.error(`Failed to sync operation ${operation.id}:`, error);
 					failedCount++;
 
-					// Update operation status with error
+					// Transient failure: leave the op queued (status 'failed') as before.
 					await this.offlineService.updateOperationStatus(
 						operation.id,
 						'failed',
@@ -515,6 +550,13 @@ class SyncService {
 			reportIfNetwork(error);
 			logger.error('Failed to sync offline operations:', error);
 		}
+
+		// Surface permanent rejections: one aggregated toast for this run, and
+		// rescan IndexedDB so the footer count + per-task badges reflect the new
+		// (or cleared) sync_error entities. Runs even on the happy path so a
+		// previously-errored task that just synced clears its badge.
+		if (newSyncErrors > 0) notifyTaskSyncErrors(newSyncErrors);
+		void refreshSyncErrors();
 
 		return { processedOps, failedCount };
 	}
@@ -551,6 +593,43 @@ class SyncService {
 				break;
 			default:
 				logger.warn(`Unknown entity type: ${operation.entityType}`);
+		}
+	}
+
+	/**
+	 * Mark an entity as permanently rejected after its operation was dead-lettered.
+	 * The entity keeps the user's local edit but leaves the push retry loop; the UI
+	 * surfaces it (footer count + per-task badge). A later local edit re-marks it
+	 * 'pending' and re-queues a push, which clears the error on success.
+	 *
+	 * Only tasks store a `sync_error_code` (the only entity with a list badge and
+	 * the only realistic 413/400 case). Lists/subtasks are marked sync_error so the
+	 * footer count is complete; their reason defaults to 'rejected'.
+	 */
+	private async markEntitySyncError(
+		entityType: string,
+		entityId: string,
+		code: SyncErrorCode
+	): Promise<void> {
+		if (entityType === 'task') {
+			const current = await taskStore.get(entityId);
+			if (current) {
+				await taskStore.save({
+					...current,
+					sync_status: 'sync_error',
+					sync_error_code: code
+				} as unknown as TaskEncryptedBooleans);
+			}
+		} else if (entityType === 'task_list') {
+			const current = await listStore.get(entityId);
+			if (current) {
+				await listStore.save({ ...current, sync_status: 'sync_error' });
+			}
+		} else if (entityType === 'sub_task') {
+			const current = await subtaskStore.get(entityId);
+			if (current) {
+				await subtaskStore.save({ ...current, sync_status: 'sync_error' });
+			}
 		}
 	}
 }

--- a/apps/reborn-task/src/lib/stores/sync-errors.store.ts
+++ b/apps/reborn-task/src/lib/stores/sync-errors.store.ts
@@ -1,0 +1,66 @@
+/**
+ * Sync-error state for the task offline-operation queue.
+ *
+ * An operation the server permanently rejects (a 4xx the client can't fix by
+ * retrying) is dead-lettered out of the queue and its target entity marked
+ * `sync_status: 'sync_error'`. Because the poison op is removed, the signal
+ * lives on the entity, not the queue - so this store rescans IndexedDB for such
+ * entities and exposes the count + per-entity reason.
+ *
+ * Kept as a standalone leaf module (not in sync-status.store) so the sync engine
+ * can import `refreshSyncErrors` without the sync.service <-> sync-status.store
+ * import cycle (sync-status.store reads syncProgress from the service). Mirrors
+ * the role of notes' refreshPendingCount(). See guideline 36, rule 14.
+ */
+import { writable, get } from 'svelte/store';
+import { taskStore, listStore, subtaskStore } from '@reborn/storage';
+import type { SyncErrorCode } from '@reborn/types';
+
+// Count of entities permanently rejected by the server (sync_status: 'sync_error').
+export const errorCount = writable(0);
+// Per-entity rejection reason, keyed by entity id. Drives the per-task badge in
+// the list without threading sync_status through the decrypted title index.
+export const syncErrorMap = writable<Map<string, SyncErrorCode>>(new Map());
+
+/** Content equality for the per-entity error map (sizes first, then entries). */
+function sameErrorCodes(a: Map<string, SyncErrorCode>, b: Map<string, SyncErrorCode>): boolean {
+	if (a.size !== b.size) return false;
+	for (const [id, code] of a) {
+		if (b.get(id) !== code) return false;
+	}
+	return true;
+}
+
+/**
+ * Rescan IndexedDB for entities marked `sync_status: 'sync_error'` and publish
+ * the count + per-entity reason map. Called after each sync (a push marks them,
+ * a later successful push clears them). Cheap: three getAll() scans.
+ *
+ * Only tasks carry a `sync_error_code`; lists/subtasks (which realistically
+ * never hit a permanent rejection) fall back to 'rejected' so the footer count
+ * still reflects them.
+ */
+export async function refreshSyncErrors(): Promise<void> {
+	try {
+		const stores = [taskStore, listStore, subtaskStore] as Array<{
+			getAll(): Promise<
+				Array<{ id: string; sync_status?: string; sync_error_code?: SyncErrorCode }>
+			>;
+		}>;
+		const all = await Promise.all(stores.map((s) => s.getAll()));
+		const errors = new Map<string, SyncErrorCode>();
+		for (const items of all) {
+			for (const i of items) {
+				if (i.sync_status === 'sync_error') errors.set(i.id, i.sync_error_code ?? 'rejected');
+			}
+		}
+		errorCount.set(errors.size);
+		// syncErrorMap is read by a $derived in every visible TaskItem. A writable
+		// re-emits on every set (new ref !== old), so publishing it unconditionally
+		// would recompute every row's badge on each sync even when nothing changed.
+		// Publish only when the error set actually changed.
+		if (!sameErrorCodes(get(syncErrorMap), errors)) syncErrorMap.set(errors);
+	} catch {
+		// Best-effort: a failed rescan just leaves the previous counts in place.
+	}
+}

--- a/apps/reborn-task/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-task/src/lib/stores/sync-status.store.ts
@@ -4,6 +4,7 @@ import { syncProgress, lastSyncedAt } from '$lib/services/sync.service';
 import { pendingOperations, failedOperations } from './offline-operations.store';
 import { sessionExpired } from './session-expired.store';
 import { localOnly } from './local-mode.store';
+import { errorCount } from './sync-errors.store';
 
 export { lastSyncedAt };
 
@@ -12,6 +13,11 @@ export type SyncStatusType =
 	| 'syncing'
 	| 'offline'
 	| 'error'
+	// One or more entities were permanently rejected by the server (a 4xx the
+	// client can't fix by retrying); their operation was dead-lettered out of the
+	// queue. Distinct from transient 'error': this needs user action (e.g. fix an
+	// invalid/oversized task).
+	| 'sync_error'
 	| 'pending'
 	| 'auth-error'
 	| 'local_only';
@@ -20,6 +26,7 @@ export interface SyncStatusState {
 	status: SyncStatusType;
 	pendingCount: number;
 	failedCount: number;
+	errorCount: number;
 	message: string;
 	progress: number;
 	lastSyncedAt: string | null;
@@ -27,7 +34,7 @@ export interface SyncStatusState {
 
 /**
  * Unified sync status derived from multiple stores.
- * Priority: local_only > auth-error > offline > syncing > error > pending > synced
+ * Priority: local_only > auth-error > offline > syncing > sync_error > error > pending > synced
  */
 export const syncStatus = derived(
 	[
@@ -35,6 +42,7 @@ export const syncStatus = derived(
 		syncProgress,
 		pendingOperations,
 		failedOperations,
+		errorCount,
 		sessionExpired,
 		lastSyncedAt,
 		localOnly
@@ -44,88 +52,59 @@ export const syncStatus = derived(
 		$syncProgress,
 		$pendingOps,
 		$failedOps,
+		$errorCount,
 		$sessionExpired,
 		$lastSyncedAt,
 		$localOnly
 	]): SyncStatusState => {
 		const pendingCount = $pendingOps.length;
 		const failedCount = $failedOps.length;
-
-		if ($localOnly) {
-			// No account, no server: sync never runs, so this overrides everything.
-			return {
-				status: 'local_only',
-				pendingCount,
-				failedCount,
-				message: '',
-				progress: 0,
-				lastSyncedAt: $lastSyncedAt
-			};
-		}
-
-		if ($sessionExpired && $isOnline) {
-			return {
-				status: 'auth-error',
-				pendingCount,
-				failedCount,
-				message: '',
-				progress: 0,
-				lastSyncedAt: $lastSyncedAt
-			};
-		}
-
-		if (!$isOnline) {
-			return {
-				status: 'offline',
-				pendingCount,
-				failedCount,
-				message: '',
-				progress: 0,
-				lastSyncedAt: $lastSyncedAt
-			};
-		}
-
-		if ($syncProgress.isInProgress) {
-			return {
-				status: 'syncing',
-				pendingCount,
-				failedCount,
-				message: $syncProgress.message,
-				progress: $syncProgress.progress,
-				lastSyncedAt: $lastSyncedAt
-			};
-		}
-
-		if (failedCount > 0) {
-			return {
-				status: 'error',
-				pendingCount,
-				failedCount,
-				message: '',
-				progress: 0,
-				lastSyncedAt: $lastSyncedAt
-			};
-		}
-
-		if (pendingCount > 0) {
-			return {
-				status: 'pending',
-				pendingCount,
-				failedCount,
-				message: '',
-				progress: 0,
-				lastSyncedAt: $lastSyncedAt
-			};
-		}
-
-		return {
-			status: 'synced',
-			pendingCount: 0,
-			failedCount: 0,
+		const base = {
+			pendingCount,
+			failedCount,
+			errorCount: $errorCount,
 			message: '',
 			progress: 0,
 			lastSyncedAt: $lastSyncedAt
 		};
+
+		if ($localOnly) {
+			// No account, no server: sync never runs, so this overrides everything.
+			return { ...base, status: 'local_only' };
+		}
+
+		if ($sessionExpired && $isOnline) {
+			return { ...base, status: 'auth-error' };
+		}
+
+		if (!$isOnline) {
+			return { ...base, status: 'offline' };
+		}
+
+		if ($syncProgress.isInProgress) {
+			return {
+				...base,
+				status: 'syncing',
+				message: $syncProgress.message,
+				progress: $syncProgress.progress
+			};
+		}
+
+		if ($errorCount > 0) {
+			// Permanent rejections need user action (fix the invalid/oversized item),
+			// so they outrank a transient sync error and the pending count.
+			return { ...base, status: 'sync_error' };
+		}
+
+		if (failedCount > 0) {
+			return { ...base, status: 'error' };
+		}
+
+		if (pendingCount > 0) {
+			return { ...base, status: 'pending' };
+		}
+
+		return { ...base, status: 'synced', pendingCount: 0, failedCount: 0 };
 	}
 );
 

--- a/apps/reborn-task/src/routes/api/subtasks/+server.ts
+++ b/apps/reborn-task/src/routes/api/subtasks/+server.ts
@@ -4,6 +4,7 @@ import { prisma } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { validateBody, schemas, type SubtaskEncrypted } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('SubtasksAPI');
 
@@ -118,14 +119,7 @@ export const GET: RequestHandler = async ({ request, url }) => {
 			data: subtasksResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Get subtasks error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'GET /api/subtasks');
 	}
 };
 
@@ -217,13 +211,6 @@ export const POST: RequestHandler = async ({ request }) => {
 			{ status: 201 }
 		);
 	} catch (error: unknown) {
-		logger.error('Create subtask error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'POST /api/subtasks');
 	}
 };

--- a/apps/reborn-task/src/routes/api/subtasks/[id]/+server.ts
+++ b/apps/reborn-task/src/routes/api/subtasks/[id]/+server.ts
@@ -4,6 +4,7 @@ import { prisma, type Prisma } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { validateBody, schemas, type SubtaskEncrypted } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('SubtaskAPI');
 
@@ -114,14 +115,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
 			data: subtaskResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Update subtask error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'PUT /api/subtasks/[id]');
 	}
 };
 
@@ -193,14 +187,7 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
 			message: 'Subtask deleted successfully'
 		});
 	} catch (error: unknown) {
-		logger.error('Delete subtask error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'DELETE /api/subtasks/[id]');
 	}
 };
 
@@ -278,13 +265,6 @@ export const GET: RequestHandler = async ({ request, params }) => {
 			data: subtaskResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Get subtask error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'GET /api/subtasks/[id]');
 	}
 };

--- a/apps/reborn-task/src/routes/api/tasklists/+server.ts
+++ b/apps/reborn-task/src/routes/api/tasklists/+server.ts
@@ -4,6 +4,7 @@ import { prisma, type TaskList } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { validateBody, schemas } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('TaskListsAPI');
 
@@ -54,14 +55,7 @@ export const GET: RequestHandler = async ({ request }) => {
 			data: listsResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Get task lists error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'GET /api/tasklists');
 	}
 };
 
@@ -163,13 +157,6 @@ export const POST: RequestHandler = async ({ request }) => {
 			{ status: 201 }
 		);
 	} catch (error: unknown) {
-		logger.error('Create task list error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'POST /api/tasklists');
 	}
 };

--- a/apps/reborn-task/src/routes/api/tasklists/[id]/+server.ts
+++ b/apps/reborn-task/src/routes/api/tasklists/[id]/+server.ts
@@ -4,6 +4,7 @@ import { prisma } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { validateBody, schemas } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('TaskListAPI');
 
@@ -109,14 +110,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
 			data: listResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Update task list error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'PUT /api/tasklists/[id]');
 	}
 };
 
@@ -274,13 +268,6 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
 			message: 'List deleted successfully'
 		});
 	} catch (error: unknown) {
-		logger.error('Delete task list error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'DELETE /api/tasklists/[id]');
 	}
 };

--- a/apps/reborn-task/src/routes/api/tasks/+server.ts
+++ b/apps/reborn-task/src/routes/api/tasks/+server.ts
@@ -4,6 +4,7 @@ import { prisma, type Task } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { validateBody, schemas } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('TasksAPI');
 
@@ -161,14 +162,7 @@ export const GET: RequestHandler = async ({ request, url }) => {
 			data: tasksResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Get tasks error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'GET /api/tasks');
 	}
 };
 
@@ -271,13 +265,6 @@ export const POST: RequestHandler = async ({ request }) => {
 			{ status: 201 }
 		);
 	} catch (error: unknown) {
-		logger.error('Create task error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'POST /api/tasks');
 	}
 };

--- a/apps/reborn-task/src/routes/api/tasks/[id]/+server.ts
+++ b/apps/reborn-task/src/routes/api/tasks/[id]/+server.ts
@@ -4,6 +4,7 @@ import { prisma, type Prisma } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { validateBody, schemas } from '@reborn/types';
 import { getUserFromToken } from '$lib/server/auth';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('TaskAPI');
 
@@ -150,14 +151,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
 			data: taskResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Update task error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'PUT /api/tasks/[id]');
 	}
 };
 
@@ -237,14 +231,7 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
 			message: 'Task deleted successfully'
 		});
 	} catch (error: unknown) {
-		logger.error('Delete task error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'DELETE /api/tasks/[id]');
 	}
 };
 
@@ -319,13 +306,6 @@ export const GET: RequestHandler = async ({ request, params }) => {
 			data: taskResponse
 		});
 	} catch (error: unknown) {
-		logger.error('Get task error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'GET /api/tasks/[id]');
 	}
 };

--- a/apps/reborn-task/src/routes/api/tasks/[id]/permanent/+server.ts
+++ b/apps/reborn-task/src/routes/api/tasks/[id]/permanent/+server.ts
@@ -3,6 +3,7 @@ import { json } from '@sveltejs/kit';
 import { prisma } from '@reborn/database';
 import { createLogger } from '@reborn/utils';
 import { getUserFromToken } from '$lib/server/auth';
+import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('TaskPermanentDeleteAPI');
 
@@ -166,13 +167,6 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
 			message: 'Task permanently deleted'
 		});
 	} catch (error: unknown) {
-		logger.error('Permanent delete task error:', error);
-		return json(
-			{
-				success: false,
-				error: 'Internal server error'
-			},
-			{ status: 500 }
-		);
+		return apiErrorResponse(error, logger, 'DELETE /api/tasks/[id]/permanent');
 	}
 };

--- a/packages/i18n/src/translations/tasks/de/sync.json
+++ b/packages/i18n/src/translations/tasks/de/sync.json
@@ -60,6 +60,15 @@
     "session_expired": "Sitzung abgelaufen",
     "local_only": "Nur lokal"
   },
+  "errors": {
+    "count": "{count} nicht synchronisiert",
+    "too_large": "Zu groß zum Synchronisieren",
+    "quota_exceeded": "Speicherlimit erreicht",
+    "invalid": "Ungültige Daten - vom Server abgelehnt",
+    "rejected": "Vom Server abgelehnt",
+    "toast_batch": "{count} nicht synchronisiert",
+    "toast_marked": "Diese Einträge sind in der Liste markiert."
+  },
   "initial": {
     "title": "Aufgaben werden synchronisiert",
     "message": "Das Herunterladen Ihrer verschlüsselten Daten vom Server kann einen Moment dauern."

--- a/packages/i18n/src/translations/tasks/en/sync.json
+++ b/packages/i18n/src/translations/tasks/en/sync.json
@@ -60,6 +60,15 @@
     "session_expired": "Session expired",
     "local_only": "Local only"
   },
+  "errors": {
+    "count": "{count} not synced",
+    "too_large": "Too large to sync",
+    "quota_exceeded": "Storage limit reached",
+    "invalid": "Invalid data - rejected by the server",
+    "rejected": "Rejected by the server",
+    "toast_batch": "{count} not synced",
+    "toast_marked": "These items are marked in the list."
+  },
   "initial": {
     "title": "Syncing your tasks",
     "message": "Downloading your encrypted data from the server may take a moment."

--- a/packages/i18n/src/translations/tasks/es/sync.json
+++ b/packages/i18n/src/translations/tasks/es/sync.json
@@ -60,6 +60,15 @@
     "session_expired": "Sesión expirada",
     "local_only": "Solo local"
   },
+  "errors": {
+    "count": "{count} sin sincronizar",
+    "too_large": "Demasiado grande para sincronizar",
+    "quota_exceeded": "Cuota de almacenamiento alcanzada",
+    "invalid": "Datos no válidos - rechazados por el servidor",
+    "rejected": "Rechazado por el servidor",
+    "toast_batch": "{count} sin sincronizar",
+    "toast_marked": "Estos elementos están marcados en la lista."
+  },
   "initial": {
     "title": "Sincronizando tus tareas",
     "message": "La descarga de tus datos cifrados desde el servidor puede tardar un momento."

--- a/packages/i18n/src/translations/tasks/fr/sync.json
+++ b/packages/i18n/src/translations/tasks/fr/sync.json
@@ -60,6 +60,15 @@
     "session_expired": "Session expir\u00e9e",
     "local_only": "Local uniquement"
   },
+  "errors": {
+    "count": "{count} non synchronis\u00e9(s)",
+    "too_large": "Trop volumineux pour la synchronisation",
+    "quota_exceeded": "Quota de stockage atteint",
+    "invalid": "Donn\u00e9es invalides - rejet\u00e9es par le serveur",
+    "rejected": "Rejet\u00e9 par le serveur",
+    "toast_batch": "{count} non synchronis\u00e9(s)",
+    "toast_marked": "Ces \u00e9l\u00e9ments sont signal\u00e9s dans la liste."
+  },
   "initial": {
     "title": "Synchronisation de vos t\u00e2ches",
     "message": "Le t\u00e9l\u00e9chargement de vos donn\u00e9es chiffr\u00e9es depuis le serveur peut prendre un instant."

--- a/packages/i18n/src/translations/tasks/pl/sync.json
+++ b/packages/i18n/src/translations/tasks/pl/sync.json
@@ -60,6 +60,15 @@
     "session_expired": "Sesja wygasła",
     "local_only": "Tylko lokalnie"
   },
+  "errors": {
+    "count": "{count} niezsynchronizowanych",
+    "too_large": "Za duże, aby zsynchronizować",
+    "quota_exceeded": "Osiągnięto limit miejsca",
+    "invalid": "Nieprawidłowe dane - odrzucone przez serwer",
+    "rejected": "Odrzucone przez serwer",
+    "toast_batch": "{count} niezsynchronizowanych",
+    "toast_marked": "Te elementy są oznaczone na liście."
+  },
   "initial": {
     "title": "Synchronizujemy Twoje zadania",
     "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać."

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -17,13 +17,28 @@ export interface Syncable {
   // 'sync_error' marks an entity whose push was permanently rejected by the
   // server (a 4xx the client cannot fix by retrying). It is dropped from the
   // periodic-push retry set so a poisoned record stops re-sending forever.
-  // Currently produced only by reborn-notes (per-note hard rejections).
+  // Produced by reborn-notes (per-note hard rejections) and reborn-task (a
+  // permanently-rejected operation is dead-lettered and its entity marked).
   sync_status: 'pending' | 'synced' | 'conflict' | 'sync_error';
   last_sync_at?: string | null;
   synced_at?: string | null; // Legacy compatibility
   server_id?: string;
   device_id?: string;
 }
+
+/**
+ * Reason an entity's push was permanently rejected by the server (a 4xx the
+ * client cannot fix by retrying). Stored only locally (IndexedDB) alongside
+ * `sync_status: 'sync_error'`; never sent to the server.
+ *  - `too_large`: encrypted body exceeded the request size limit (413).
+ *  - `quota_exceeded`: per-user storage quota is full (413 QUOTA_EXCEEDED).
+ *  - `invalid`: server-side Zod validation rejected the payload (400).
+ *  - `rejected`: other permanent rejection (e.g. 403 ownership).
+ *
+ * Lives in `base` rather than a single entity module because both apps now
+ * produce it (notes per-note, task per-operation).
+ */
+export type SyncErrorCode = 'too_large' | 'quota_exceeded' | 'invalid' | 'rejected';
 
 /**
  * Combined interface for encrypted and syncable entities

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -1,4 +1,4 @@
-import type { SyncableEncryptedEntity } from '../base';
+import type { SyncableEncryptedEntity, SyncErrorCode } from '../base';
 
 // ─── Sensitive metadata bundle (encrypted, never sent as plaintext) ──
 
@@ -63,16 +63,8 @@ export interface NoteEncrypted extends SyncableEncryptedEntity {
 
 // ─── Local storage type (IndexedDB — shadow indexes for queries) ─────
 
-/**
- * Reason a note's push was permanently rejected by the server (a 4xx the client
- * cannot fix by retrying). Stored only in IndexedDB alongside
- * `sync_status: 'sync_error'`; never sent to the server.
- *  - `too_large`: encrypted body exceeded the request size limit (413).
- *  - `quota_exceeded`: per-user storage quota is full (413 QUOTA_EXCEEDED).
- *  - `invalid`: server-side Zod validation rejected the payload (400).
- *  - `rejected`: other permanent rejection (e.g. 403 ownership).
- */
-export type SyncErrorCode = 'too_large' | 'quota_exceeded' | 'invalid' | 'rejected';
+// `SyncErrorCode` moved to `../base` (both apps produce it now); re-exported
+// there. NoteStoredLocal still pairs it with `sync_status: 'sync_error'`.
 
 /** Extended with local-only shadow indexes extracted from decrypted metadata. */
 export interface NoteStoredLocal extends NoteEncrypted {

--- a/packages/types/src/entities/task.ts
+++ b/packages/types/src/entities/task.ts
@@ -1,4 +1,4 @@
-import type { SyncableEncryptedEntity } from '../base';
+import type { SyncableEncryptedEntity, SyncErrorCode } from '../base';
 import type { BooleanInt } from '../common';
 
 // ─── Size limits ────────────────────────────────────────────────────
@@ -116,6 +116,13 @@ export interface TaskStoredLocal extends TaskEncrypted {
   is_starred: BooleanInt;
   is_recurring?: BooleanInt;
   due_date?: string | null;
+  /**
+   * Set when the last push of this task's operation was permanently rejected
+   * (see `SyncErrorCode`). Always paired with `sync_status: 'sync_error'`.
+   * Local-only, never sent to the server. Cleared on a successful push, or
+   * whenever a local edit re-marks the task 'pending'.
+   */
+  sync_error_code?: SyncErrorCode;
 }
 
 /** Extended with local-only shadow index for subtask completion. */

--- a/packages/types/src/schemas/entities/task.ts
+++ b/packages/types/src/schemas/entities/task.ts
@@ -91,7 +91,10 @@ export const TaskStoredLocalSchema = TaskEncryptedSchema.extend({
   is_completed: BooleanIntSchema,
   is_starred: BooleanIntSchema,
   is_recurring: BooleanIntSchema.optional(),
-  due_date: z.string().nullable().optional()
+  due_date: z.string().nullable().optional(),
+  // Local-only: reason the last push was permanently rejected (paired with
+  // sync_status: 'sync_error'). Never sent to the server. See SyncErrorCode.
+  sync_error_code: z.enum(['too_large', 'quota_exceeded', 'invalid', 'rejected']).optional()
 });
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to the notes treatment (#288): reborn-task had the same bug on its **operation queue**. A push the server permanently rejects (a 4xx the client can't fix by retrying) was mishandled at three layers, and - unlike notes - it failed *silently while corrupting sync*:

1. **Server** - the task API handlers (`POST /api/tasks`, `PUT /api/tasks/[id]`, lists/subtasks) caught every throw and returned **500**, masking the real 413/400 (e.g. the `SvelteKitError(413)` adapter-node raises from `request.json()`).
2. **Client** - `syncTaskOperation` threw `new Error(response.error)` and **discarded `response.status`**.
3. **Queue** - the operation was marked `failed` and left in the queue with no 4xx/5xx distinction. Because `getPendingTaskOperations()`/`getPendingDeleteOperations()` count `failed` ops, the poisoned operation **shielded its task from server pulls forever** (it could never receive newer data from another device), and the only escape was the footer's blunt "clear failed ops" - which deletes the change (silent local divergence). No per-task signal.

### What changed
- **Server:** `lib/server/api-error.ts` (`apiErrorResponse`, identical to notes) wired into every tasks/tasklists/subtasks write handler -> real 4xx instead of 500.
- **Classifier:** `sync/operation-error.ts` (`PermanentOperationError`, `ensureOperationOk`, `isPermanentStatus`) - same `{400,403,413}` allowlist, adapted to the `ApiClient` response shape. Replaces the status-discarding throws in the three per-entity sync services.
- **Dead-letter:** on a permanent rejection, `syncOfflineOperations` marks the **entity** `sync_status: 'sync_error'` (+ `sync_error_code` for tasks) and **removes the operation** from the queue, so it stops shielding the entity from pulls. Transient failures stay `failed`/queued, unchanged.
- **Pull guards** (`syncTasks`/`syncDeletedTasks`/`syncLists`/`syncSubtasks`) skip overwriting a local `sync_error` entity. A later edit re-queues a push, clearing it.
- **UI (full notes parity):** `sync_error` footer + header state with a count badge; `TaskItem` shows an `⚠` plus a **visible red reason line** under the title (not hover-only, works on touch); one aggregated toast after a batch (count + pointer, never a list). `sync.errors.*` i18n across all 5 locales.

### Decisions made autonomously (for review)
- **Dead-letter (remove the op) instead of a terminal op status** - it immediately lifts the pull shield and needs no change to every queue-scanning site; the durable record lives on the entity (`sync_status` in IndexedDB), so nothing is lost.
- **State on the entity (`sync_status: 'sync_error'`) rather than the operation** - parity with notes, the `Syncable` type already supports it (#288), natural per-task badge.
- **`SyncErrorCode` moved from `entities/note.ts` to `base.ts`** in `@reborn/types` (both apps produce it now); removed from note.ts to avoid a duplicate barrel export.
- **`sync_error_code` only for tasks** - lists/subtasks have a negligible permanent-reject chance and no list row; they get `sync_error` (reason defaults to `rejected`) so the footer count stays complete.
- **Scoped out:** transient `failed` ops still aren't auto-retried by periodic sync (they wait for a re-edit or the manual footer "clear") - a broader, pre-existing queue debt left untouched to keep this surgical.

`SyncErrorCode`/`sync_error_code` is local-only IndexedDB metadata, never in a push payload - **no change to the Zero-Knowledge model or server visibility**.

## Test plan
Gates green: `@reborn/types` build+test, reborn-task **test (64; +operation-error, +api-error, +sync.push-rejection)**, `check` 0/0 (it caught a missing `sync_error` case in `SyncStatusIndicator` - fixed), lint 0 errors, build OK; reborn-notes check 0/0 + 731 tests (regression from the shared-type move - clean); i18n parity tasks ×5.

Smoke (re/task with an account):
- Force a permanent rejection: set a low `BODY_SIZE_LIMIT` (Dockerfile/localprod) **or** a task description at the `MAX_ENCRYPTED_TASK_DESCRIPTION_BYTES` boundary (400). Push is rejected -> footer red "1 not synced", `⚠` + red reason line on the task, toast. Console: a 4xx (not 500), a `dead-lettering` WARN, no retry loop, and the operation gone from the queue.
- Edit the task to fix it -> badge clears, returns to "synced".
- Confirm a pull from another device does not clobber the local rejected edit.