### PR TITLE
fix(task): trash-aware detail view + bigger mobile search toggle

### DIFF
--- a/apps/reborn-task/src/lib/components/layout/sidebar/SidebarSearchBar.svelte
+++ b/apps/reborn-task/src/lib/components/layout/sidebar/SidebarSearchBar.svelte
@@ -60,27 +60,32 @@
 		{/if}
 	</div>
 	{#if searchInput}
-		<button
-			type="button"
-			onclick={toggleSearchInDescription}
-			class={cn(
-				'mt-1.5 md:mt-1 flex items-center gap-1.5 md:gap-1 text-xs md:text-[11px] transition-colors',
-				searchInDescription
-					? 'font-medium text-primary'
-					: 'text-muted-foreground hover:text-foreground'
-			)}
-		>
-			<span
+		<!-- Mobile: 44px-tall tap target (HIG minimum) with breathing room from the
+		     input; desktop keeps the compact text-row look via md:. Mirrors the Notes
+		     app's NoteListSearchBar. -->
+		<div class="mt-0.5 md:mt-1 flex items-center justify-between gap-2">
+			<button
+				type="button"
+				onclick={toggleSearchInDescription}
 				class={cn(
-					'inline-flex h-4 w-4 md:h-3 md:w-3 items-center justify-center rounded border',
+					'flex min-h-[44px] md:min-h-0 items-center gap-2 md:gap-1 px-1 -mx-1 md:px-0 md:mx-0 text-left text-sm md:text-[11px] transition-colors',
 					searchInDescription
-						? 'border-primary bg-primary text-primary-foreground'
-						: 'border-muted-foreground'
+						? 'font-medium text-primary'
+						: 'text-muted-foreground hover:text-foreground'
 				)}
 			>
-				{#if searchInDescription}✓{/if}
-			</span>
-			{$t('search.search_in_descriptions')}
-		</button>
+				<span
+					class={cn(
+						'inline-flex h-5 w-5 md:h-3 md:w-3 items-center justify-center rounded border',
+						searchInDescription
+							? 'border-primary bg-primary text-primary-foreground'
+							: 'border-muted-foreground'
+					)}
+				>
+					{#if searchInDescription}✓{/if}
+				</span>
+				{$t('search.search_in_descriptions')}
+			</button>
+		</div>
 	{/if}
 </div>

--- a/apps/reborn-task/src/lib/utils/task-detail-nav.ts
+++ b/apps/reborn-task/src/lib/utils/task-detail-nav.ts
@@ -1,0 +1,53 @@
+import { get } from 'svelte/store';
+import { goto } from '$lib/utils/navigation';
+import { layoutStore } from '$lib/stores/layout.store';
+import type { Section } from '$lib/components/layout/IconNav.svelte';
+
+/**
+ * Icon-rail sections that own a full-page list/filter view. The "lists" section
+ * is handled separately in taskDetailReturnRoute() because it returns to the
+ * specific list that was open, not a generic route.
+ */
+const SECTION_ROUTE: Partial<Record<Section, string>> = {
+	all: '/all',
+	starred: '/starred',
+	overdue: '/overdue',
+	today: '/today',
+	upcoming: '/upcoming',
+	no_date: '/no-date',
+	trash: '/trash'
+};
+
+/**
+ * The route to return to when a task detail view closes: the section the user
+ * was in before opening the task. `activeSection` is persisted in layoutStore
+ * and left untouched by the `/tasks/[id]` route, so it still reflects the
+ * list/filter the user was looking at. For the "lists" section we go back to
+ * the specific list (identified by the task's own list id). Returns null when
+ * nothing maps - the caller should fall back to history.back().
+ */
+export function taskDetailReturnRoute(listId?: string | null): string | null {
+	const section = get(layoutStore).activeSection;
+	const mapped = SECTION_ROUTE[section];
+	if (mapped) return mapped;
+	if (section === 'lists' && listId && !['starred', 'completed', 'trash'].includes(listId)) {
+		return `/lists/${listId}`;
+	}
+	return null;
+}
+
+/**
+ * Navigate back to the view the user came from before opening a task detail.
+ * Mirrors the icon-rail "back" convention so closing a task - via the mobile
+ * back button, or because the open task was trashed elsewhere - lands on the
+ * same list/filter the user was already looking at, instead of jumping to an
+ * unrelated list view.
+ */
+export function goBackFromTaskDetail(listId?: string | null, opts?: { replace?: boolean }): void {
+	const route = taskDetailReturnRoute(listId);
+	if (route) {
+		void goto(route, { replaceState: opts?.replace ?? false });
+	} else {
+		history.back();
+	}
+}

--- a/apps/reborn-task/src/routes/(app)/+layout.svelte
+++ b/apps/reborn-task/src/routes/(app)/+layout.svelte
@@ -42,6 +42,7 @@
 	import { TaskSelectPlaceholder, FilterViewPlaceholder } from '$lib/components/tasks';
 	import { page } from '$app/stores';
 	import { goto } from '$lib/utils/navigation';
+	import { goBackFromTaskDetail } from '$lib/utils/task-detail-nav';
 	import { requireActiveSession } from '$lib/utils/require-active-session';
 	import { session } from '$lib/stores/auth.store';
 	import { t } from '$lib/stores/i18n.store';
@@ -555,29 +556,11 @@
 	function handleMobileBack() {
 		const routeId = $page.route.id ?? '';
 
-		// For task detail, navigate based on current section
+		// Task detail: return to the section/list the user came from. Section
+		// changes use replaceState, so a plain history.back() might skip sections -
+		// goBackFromTaskDetail() resolves the target from the persisted section.
 		if (routeId.includes('/tasks/')) {
-			const sectionRouteMap: Partial<Record<Section, string>> = {
-				all: '/all',
-				starred: '/starred',
-				overdue: '/overdue',
-				today: '/today',
-				upcoming: '/upcoming',
-				no_date: '/no-date',
-				trash: '/trash'
-			};
-			const target = sectionRouteMap[activeSection];
-			if (target) {
-				goto(target, { replaceState: true });
-			} else if (
-				activeSection === 'lists' &&
-				selectedListId &&
-				!['starred', 'completed', 'trash'].includes(selectedListId)
-			) {
-				goto(`/lists/${selectedListId}`, { replaceState: true });
-			} else {
-				history.back();
-			}
+			goBackFromTaskDetail(selectedListId, { replace: true });
 		} else {
 			// For search, settings — history.back() works fine
 			history.back();

--- a/apps/reborn-task/src/routes/(app)/tasks/[taskId]/+page.svelte
+++ b/apps/reborn-task/src/routes/(app)/tasks/[taskId]/+page.svelte
@@ -29,6 +29,7 @@
 	import { taskDetailService } from '$lib/services/task-detail.service';
 	import { trashManagementService } from '$lib/services/trash-management.service';
 	import { taskIndex } from '$lib/services/task-title-index.svelte';
+	import { goBackFromTaskDetail } from '$lib/utils/task-detail-nav';
 	import { decryptedLists } from '$lib/stores/decrypted-lists.store';
 	import { session } from '$lib/stores/auth.store';
 	import { createLogger } from '@reborn/utils';
@@ -207,11 +208,10 @@
 	// Leave the detail view when the currently-open ACTIVE task gets soft-deleted
 	// elsewhere - e.g. "empty completed" while this task is open. The task then
 	// lives in trash and is only reachable (read-only) from the trash view, so the
-	// stale, still-interactive detail must not linger. Mirrors single-delete, which
-	// already navigates to the task's list. A task opened directly from trash
-	// (isTrashed at load) is exempt: we gate on `task` being loaded so the freshly
-	// mounted trash view - where isTrashed only flips true once loadTask resolves -
-	// is never mistaken for an active task that just got trashed.
+	// stale, still-interactive detail must not linger. A task opened directly from
+	// trash (isTrashed at load) is exempt: we gate on `task` being loaded so the
+	// freshly mounted trash view - where isTrashed only flips true once loadTask
+	// resolves - is never mistaken for an active task that just got trashed.
 	let hasLeftTrashedTask = false;
 	$effect(() => {
 		if (!browser) return;
@@ -220,10 +220,9 @@
 		void taskIndex.version; // subscribe to in-memory index mutations
 		if (taskIndex.get(id)?.isDeleted) {
 			hasLeftTrashedTask = true;
-			const listId = task.task_list_id;
-			goto(listId ? `/lists/${listId}` : '/').catch((err) =>
-				logger.error('Failed to navigate after open task was trashed:', err)
-			);
+			// Return to the view the user came from (e.g. /all), NOT the task's
+			// own list - jumping to an unrelated list panel is disorienting.
+			goBackFromTaskDetail(task.task_list_id, { replace: true });
 		}
 	});
 

--- a/apps/reborn-task/src/routes/(app)/tasks/[taskId]/+page.svelte
+++ b/apps/reborn-task/src/routes/(app)/tasks/[taskId]/+page.svelte
@@ -28,6 +28,7 @@
 	import { SubtaskList } from '$lib/components/subtasks';
 	import { taskDetailService } from '$lib/services/task-detail.service';
 	import { trashManagementService } from '$lib/services/trash-management.service';
+	import { taskIndex } from '$lib/services/task-title-index.svelte';
 	import { decryptedLists } from '$lib/stores/decrypted-lists.store';
 	import { session } from '$lib/stores/auth.store';
 	import { createLogger } from '@reborn/utils';
@@ -201,6 +202,29 @@
 		return () => {
 			cancelled = true;
 		};
+	});
+
+	// Leave the detail view when the currently-open ACTIVE task gets soft-deleted
+	// elsewhere - e.g. "empty completed" while this task is open. The task then
+	// lives in trash and is only reachable (read-only) from the trash view, so the
+	// stale, still-interactive detail must not linger. Mirrors single-delete, which
+	// already navigates to the task's list. A task opened directly from trash
+	// (isTrashed at load) is exempt: we gate on `task` being loaded so the freshly
+	// mounted trash view - where isTrashed only flips true once loadTask resolves -
+	// is never mistaken for an active task that just got trashed.
+	let hasLeftTrashedTask = false;
+	$effect(() => {
+		if (!browser) return;
+		const id = taskId;
+		if (!id || !task || isTrashed || hasLeftTrashedTask) return;
+		void taskIndex.version; // subscribe to in-memory index mutations
+		if (taskIndex.get(id)?.isDeleted) {
+			hasLeftTrashedTask = true;
+			const listId = task.task_list_id;
+			goto(listId ? `/lists/${listId}` : '/').catch((err) =>
+				logger.error('Failed to navigate after open task was trashed:', err)
+			);
+		}
 	});
 
 	// Handle title change


### PR DESCRIPTION
## Summary

Two small UI bugs in **Reborn Task**, reported together.

### 1. Open task stayed interactive after being moved to trash
Opening a task, marking it completed, then "move completed to trash" left the task **open and fully interactive** in the detail panel (title, star, move-to-list, menu) even though it was already soft-deleted and gone from every list. `task-detail.service` loads a task once and only sets `isTrashed` at load time, so the in-memory `taskIndex` flip to `isDeleted` never reached the detail body or the layout toolbar (both derive from the service).

Fix: a reactive `$effect` in `tasks/[taskId]/+page.svelte` subscribes to `taskIndex.version` and, once the open **active** task becomes `isDeleted` externally, navigates to the task's list - the same thing single-delete from the detail already does. The route change also clears the route-gated toolbar. A task opened **directly from trash** keeps its read-only view (gated on the task being loaded and `\!isTrashed`). The task remains reachable only from the trash view.

### 2. Mobile "search in descriptions" toggle too small / glued to the input
`SidebarSearchBar.svelte` rendered a cramped `text-xs` label with a tiny `h-4` checkbox and no tap target, flush against the search input. Adopted the Notes app's `NoteListSearchBar` mobile pattern the component already documents it mirrors: a 44px tap target (HIG minimum), larger checkbox/gap/font, and breathing room from the input. Desktop is unchanged (`md:` collapses back to the compact row).

No Zero-Knowledge / schema / i18n changes (reuses the existing `search.search_in_descriptions` key).

## Test plan

Reborn Task, two-pane (desktop) and mobile width:

**Bug 1**
- [ ] Open a task in the detail panel, mark it completed, then trigger "move completed to trash" (sidebar or `completed` view). The detail leaves and lands on the task's list; toolbar (star/complete/move/menu) is gone.
- [ ] Open a trashed task from the **trash** view: it still shows read-only with the trash banner and restore / permanently-delete actions (no bounce).
- [ ] Single-delete from the detail still navigates to the list as before.

**Bug 2**
- [ ] On mobile width, type a query in the sidebar search: the "search in descriptions" toggle has a comfortable tap target and clear spacing from the input, matching Notes.
- [ ] On desktop the toggle is unchanged (compact row).

Local gates green: lint 0, check (svelte-check) 0/0, test 64, build OK.