### PR TITLE
chore(deps): pin tmp and form-data to clear high CVEs (nx-transitive)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,8 @@ overrides:
   esbuild: 0.28.1
   '@hono/node-server': 1.19.14
   devalue: 5.8.1
-  tmp@<0.2.6: 0.2.7
+  tmp@<0.2.7: 0.2.7
+  form-data@<4.0.6: 4.0.6
   joi: 18.2.1
   ws: 8.21.0
   qs: 6.15.2
@@ -4750,8 +4751,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formatly@0.3.0:
@@ -4873,6 +4874,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -6383,8 +6388,8 @@ packages:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
-  tmp@0.2.6:
-    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   toposort@2.0.2:
@@ -10120,7 +10125,7 @@ snapshots:
   axios@1.16.1(supports-color@7.2.0):
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -10938,12 +10943,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formatly@0.3.0:
@@ -11053,6 +11058,10 @@ snapshots:
       function-bind: 1.1.2
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -11686,7 +11695,7 @@ snapshots:
       figures: 3.2.0
       flat: 5.0.2
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-constants: 1.0.0
       function-bind: 1.1.2
       get-caller-file: 2.0.5
@@ -11737,7 +11746,7 @@ snapshots:
       strip-bom: 3.0.0
       supports-color: 7.2.0
       tar-stream: 2.2.0
-      tmp: 0.2.6
+      tmp: 0.2.7
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
@@ -12821,7 +12830,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.30
 
-  tmp@0.2.6: {}
+  tmp@0.2.7: {}
 
   toposort@2.0.2:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,8 @@ overrides:
   esbuild: 0.28.1
   '@hono/node-server': 1.19.14
   devalue: 5.8.1
-  tmp@<0.2.6: '0.2.7'
+  tmp@<0.2.7: '0.2.7' # GHSA-7c78-jf6q-g5cm tmp path traversal via non-string template (nx-transitive, dev-only)
+  form-data@<4.0.6: '4.0.6' # GHSA-hmw2-7cc7-3qxx form-data CRLF injection in multipart field names (nx-transitive, dev-only)
   joi: 18.2.1 # GHSA-q7cg-457f-vx79 nested-input RangeError; superforms optional peer, unused (we use the Zod adapter)
   # Dev-only transitive CVE pins (Storybook, nx http-server); absent from prod bundle
   ws: '8.21.0' # GHSA-58qx-3vcg-4xpx ws uninitialized memory disclosure


### PR DESCRIPTION
## Summary

The CI **Security audit** step (`pnpm audit --audit-level high`) started failing on every PR once two advisories were published against transitive deps that `nx` pulls in:

- `tmp@0.2.6` - [GHSA-7c78-jf6q-g5cm](https://github.com/advisories/GHSA-7c78-jf6q-g5cm) (path traversal via non-string template), vulnerable `>=0.2.6 <0.2.7`.
- `form-data@4.0.5` - [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) (CRLF injection in multipart field names), vulnerable `>=4.0.0 <4.0.6`.

The existing `tmp@<0.2.6` override in `pnpm-workspace.yaml` predated this advisory and did not cover `0.2.6` itself. Fix:

- Widened `tmp@<0.2.6` -> `tmp@<0.2.7` (forces the patched `0.2.7`).
- Added `form-data@<4.0.6` -> `4.0.6`.

Both packages are **dev-only transitive deps** (nx tooling, path `.>nx>...`), absent from the shipped client bundle - no runtime/AGPL/native impact.

Lockfile regenerated with the exact CI toolchain (node 24.15.0 + pnpm 11.1.2) so `--frozen-lockfile` matches. Resulting delta: `form-data 4.0.5->4.0.6`, `tmp 0.2.6->0.2.7`, `hasown 2.0.3->2.0.4` (form-data's dep). No other churn.

This unblocks `main` and every open PR (e.g. #298), which are red purely on this audit gate.

## Test plan

- `pnpm audit --audit-level moderate --prod` -> only 1 low remains (below threshold), passes.
- `pnpm audit --audit-level high` -> 2 low + 1 moderate remain (no high), passes.
- CI re-runs lint / check / test / build on the refreshed lockfile (dev-only patch bumps, no source change).