### PR TITLE
chore: pin pnpm@11.1.2 via packageManager field (corepack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@reborn-apps/source",
   "version": "0.32.0",
   "license": "AGPL-3.0-only",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "clean": "chmod +x ./scripts/clean-all.sh && ./scripts/clean-all.sh",
     "clean:install": "pnpm clean && pnpm install && pnpm nx reset",


### PR DESCRIPTION
## Summary

Pins the pnpm version for the whole repo via the `packageManager` field so local installs match CI exactly and stop producing divergent lockfile churn.

**Problem.** CI hardcodes node 24 + pnpm 11.1.2, but nothing pinned pnpm for local use. A contributor whose global pnpm differs (e.g. 10.11.1, the newest that runs on node 20) regenerates `pnpm-lock.yaml` differently than CI - it re-resolves `@emnapi/core`/`@emnapi/runtime` across the whole storybook tree (~300 lines of noise) and diverges from what `--frozen-lockfile` expects. This surfaced while fixing the tmp/form-data audit CVEs (#299): a clean lockfile required driving corepack with the exact CI toolchain by hand.

**Fix.** `"packageManager": "pnpm@11.1.2"`. With Corepack enabled, every `pnpm` invocation in this repo uses 11.1.2 automatically - local == CI, for everyone, permanently.

**Why it's CI-safe.** `pnpm/action-setup` (already at `version: 11.1.2` in `ci.yml`) throws *only* when its `version` input and the `packageManager` field differ; equal values return cleanly (verified in `src/install-pnpm/run.ts`). No `ci.yml` change needed. No dependency or lockfile change.

## Local setup (one-time, per machine)

After this merges, enable Corepack and use the repo's node (`.nvmrc` = node 24):

```
corepack enable
nvm use
pnpm -v   # -> 11.1.2
```

## Test plan

- CI: `pnpm install --frozen-lockfile` unaffected (packageManager is not a lockfile input); lint / check / test / build run as usual.
- `node -e "require('./package.json').packageManager"` -> `pnpm@11.1.2`.