### PR TITLE
fix(docker): align container pnpm to packageManager (11.1.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # ─── Base: shared Node + pnpm layer ────────────────────────────
 FROM node:24.15.0-alpine AS base
 WORKDIR /app
-RUN npm install -g pnpm@11.0.9 --quiet
+RUN npm install -g pnpm@11.1.2 --quiet
 
 # ─── Deps: install workspace + build shared packages ───────────
 # Kept separate from app builds so its cache is reused between task/notes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       CI: 'true'
     command: >
       sh -c "
-        npm install -g pnpm@10 --quiet &&
+        npm install -g pnpm@11.1.2 --quiet &&
         pnpm install &&
         pnpm --filter @reborn/database exec prisma migrate deploy &&
         pnpm nx build @reborn/database &&
@@ -100,7 +100,7 @@ services:
       CI: 'true'
     command: >
       sh -c "
-        npm install -g pnpm@10 --quiet &&
+        npm install -g pnpm@11.1.2 --quiet &&
         pnpm nx dev-host reborn-notes
       "
     healthcheck:


### PR DESCRIPTION
## Summary

Regression from #300. Adding `"packageManager": "pnpm@11.1.2"` made every pnpm invocation in the repo expect 11.1.2, but the containers install pnpm explicitly at different versions:

- `Dockerfile` (prod + localprod runtime): `pnpm@11.0.9`
- `docker-compose.yml` dev services (task + notes): `pnpm@10`

pnpm's `manage-package-manager-versions` (on by default) makes a mismatched pnpm **self-switch** to the declared version at runtime - it stages the new pnpm by writing `_tmp_<hash>` files into the current working directory. In the `reborn-task` runtime stage the cwd is `/app`, owned by `root` while the process runs as `USER node`, so those writes fail:

```
[ERROR] EACCES: permission denied, open '/app/_tmp_8_...'
For help, run: pnpm help exec
```

The boot command `pnpm --filter @reborn/database exec prisma migrate deploy && node apps/reborn-task/build` therefore never gets past the pnpm step, the server never starts, and the container is unhealthy. `reborn-notes` was unaffected because it boots with plain `node` (no pnpm). **This would also break production** - same Dockerfile, same CMD.

## Fix

Pin all three explicit pnpm installs to **11.1.2**, matching the `packageManager` field (and CI's `pnpm/action-setup`). When the running pnpm equals the declared version there is no self-switch, no temp staging, no EACCES. Also stops the bind-mounted dev services from dropping pnpm temp files into the working tree.

No application code change.

## Test plan (Michał - needs Docker, sandbox-off)

```bash
git fetch origin && git checkout fix/docker-pnpm-version-align
docker compose -f docker-compose.yml -f docker-compose.localprod.yml \
  -f docker-compose.proxy.yml --profile with-notes -p reborn-localprod \
  up -d --build --wait
```

Expect `reborn-localprod-app-1` to become **healthy** (previously: unhealthy, EACCES loop). CI (lint/check/test/build) is unaffected - it does not build the Docker image.