### PR TITLE
fix(notes): gate image banner on render counter, not HTML scan

### DIFF
--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -15,7 +15,10 @@
     annotateTopLevelLines,
     applySourceLineAttrs
   } from '$lib/utils/source-line';
-  import { createMarkdownListRenderers } from '$lib/utils/markdown-to-html';
+  import {
+    createMarkdownListRenderers,
+    createMarkdownImageRenderer
+  } from '$lib/utils/markdown-to-html';
 
   const NOTE_LINK_RE = /^note:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 
@@ -136,48 +139,26 @@
     createMarkdownListRenderers();
   const renderer: RendererObject = { ...listRenderers };
 
-  // "Pinned" snapshot of the prop, synced at the start of every $derived html
-  // recomputation. The renderer.image closure reads this regular variable
-  // instead of `imageLoadMode` directly because:
-  //   1. Reading a Svelte 5 prop at script init (outside any reactive scope)
-  //      captures only the *initial* value, not the reactive binding —
-  //      svelte-check explicitly warns about this. The renderer is set up at
-  //      script init, so a direct closure over `imageLoadMode` would freeze
-  //      to 'ask' forever (the bug fixed in this commit).
-  //   2. `marked.parser()` calls renderer.image from a third-party call stack
-  //      with no reactive context; there's nothing for Svelte to attach the
-  //      read to even if it happened lazily.
-  // Initial value is a literal placeholder; the real value is assigned inside
-  // the `$derived html` block before each parse.
-  let imageModeSnapshot: ImageLoadMode = 'ask';
-
-  const IMAGE_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>';
-  const BLOCKED_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>';
-
-  renderer.image = ({ href, title, text }: Tokens.Image) => {
-    const isDataUri = href.startsWith('data:');
-    const escapedHref = href.replace(/"/g, '&quot;');
-    const escapedAlt = (text || '').replace(/"/g, '&quot;');
-    const escapedTitle = (title || '').replace(/"/g, '&quot;');
-
-    if (isDataUri) {
-      return `<div class="image-placeholder image-placeholder--blocked">
-      <div class="image-placeholder-icon">${BLOCKED_ICON_SVG}</div>
-      <div class="image-placeholder-url">${$t('editor.image_base64_blocked')}</div>
-    </div>`;
-    }
-
-    if (imageModeSnapshot === 'always') {
-      return `<img src="${escapedHref}" alt="${escapedAlt}" title="${escapedTitle}" loading="lazy" />`;
-    }
-
-    const showLoadBtn = imageModeSnapshot === 'ask';
-    return `<div class="image-placeholder" data-src="${escapedHref}" data-alt="${escapedAlt}" data-title="${escapedTitle}">
-      <div class="image-placeholder-icon">${IMAGE_ICON_SVG}</div>
-      <div class="image-placeholder-url">${escapedHref}</div>
-      ${showLoadBtn ? `<button class="image-placeholder-load" type="button">${$t('editor.image_load')}</button>` : ''}
-    </div>`;
-  };
+  // Image renderer lives in markdown-to-html.ts so its mode/placeholder logic is
+  // unit-tested without mounting this component (markdown-to-html.spec.ts). It
+  // owns `askPlaceholderCount` — the structural count of ask-mode Load buttons
+  // emitted, which gates the "Load all images" banner. Two reasons the mode is
+  // pushed in via setImageMode() rather than the renderer closing over the
+  // reactive `imageLoadMode` prop directly:
+  //   1. A Svelte 5 prop read at script init captures only the initial value,
+  //      not the reactive binding (svelte-check warns about this); the renderer
+  //      is built once at init, so a direct closure would freeze to 'ask'.
+  //   2. marked calls renderImage from a third-party call stack with no reactive
+  //      context, so there's nothing for Svelte to attach a lazy read to anyway.
+  // `(key) => $t(key)` resolves labels at render time so they follow locale —
+  // same call-time `$t` resolution the previous inline closure used.
+  const {
+    renderImage,
+    setMode: setImageMode,
+    reset: resetImageRenderer,
+    getAskPlaceholderCount
+  } = createMarkdownImageRenderer((key) => $t(key));
+  renderer.image = renderImage;
 
   // Fenced code blocks — share the highlight pipeline with Live Preview's
   // CodeBlockWidget (`highlightCodeToHtml`). Output is escaped text + safe
@@ -214,14 +195,15 @@
     //  - `langLoadTick` re-runs the derivation when a fenced-code language
     //    chunk has loaded so plaintext fallbacks get replaced with
     //    highlighted spans.
-    //  - `imageLoadMode` is read explicitly via assignment. The assignment
-    //    can't be DCE'd (it has a side effect), guaranteeing the prop is
-    //    tracked as a dep even if the compiler ever optimises plain reads.
-    //    The snapshot is consumed by `renderer.image` via the regular
-    //    variable `imageModeSnapshot`, sidestepping any uncertainty about
-    //    whether Svelte tracks reads inside a closure invoked from marked.
+    //  - `imageLoadMode` is read explicitly by passing it to setImageMode().
+    //    The call can't be DCE'd, guaranteeing the prop is tracked as a dep
+    //    even if the compiler ever optimises plain reads, and pushes the mode
+    //    into the renderer (which runs from marked's non-reactive call stack).
     void langLoadTick;
-    imageModeSnapshot = imageLoadMode;
+    setImageMode(imageLoadMode);
+    // Reset before parse — renderImage re-increments askPlaceholderCount for
+    // each ask-mode external image it emits during md.parser() below.
+    resetImageRenderer();
     // Defensive reset — renderer.list decrements after each list, so under
     // normal flow listDepth is already 0; resetting guards against a thrown
     // sanitize/parse leaving the counters stuck, and starts taskCounter at 0
@@ -366,17 +348,20 @@
     }
   }
 
-  // Show the "Load all images" button only when the rendered output actually
-  // contains per-image Load buttons. `renderer.image` emits the
-  // `image-placeholder-load` class only for ask-mode external-image tokens, and
-  // marked never calls it for image syntax inside inline code or fenced blocks.
-  // The previous check regex-matched the raw source, so documentation that
-  // mentions `![](https://example.com)` inside backticks lit the banner with no
-  // placeholder beneath it. Deriving from the rendered `html` keeps this
-  // reactive and consistent with what is actually shown.
-  const hasImagePlaceholders = $derived(
-    imageLoadMode === 'ask' && html.includes('image-placeholder-load')
-  );
+  // Show the "Load all images" button only when the render actually emitted
+  // per-image Load buttons. `renderImage` increments its placeholder counter
+  // exactly once per ask-mode external image, and marked never calls it for
+  // image syntax inside inline code or fenced blocks — so the count mirrors
+  // what is shown beneath the banner. Reading `html` registers the parse as a
+  // dependency and forces it to run first, populating the counter before we
+  // read it. We deliberately do NOT scan the rendered HTML for the placeholder
+  // class: a note can put that literal string into its own text (e.g. a note
+  // documenting this very class), which a substring check false-positives on;
+  // a counter driven by the renderer cannot be spoofed by content.
+  const hasImagePlaceholders = $derived.by(() => {
+    void html;
+    return getAskPlaceholderCount() > 0;
+  });
 </script>
 
 <!-- `data-sveltekit-preload-*="off"` stops SvelteKit's hover/touch preload

--- a/apps/reborn-notes/src/lib/utils/markdown-to-html.spec.ts
+++ b/apps/reborn-notes/src/lib/utils/markdown-to-html.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { Marked } from 'marked';
+import { createMarkdownImageRenderer } from './markdown-to-html';
+import type { ImageLoadMode } from '@reborn/storage';
+
+/**
+ * Render `content` through a fresh Marked instance wired with the image
+ * renderer, exactly as MarkdownPreview does, and report both the HTML and the
+ * ask-mode placeholder count that gates the "Load all images" banner. Going
+ * through real marked (not a direct renderImage() call) is the point: the
+ * regression is that marked must NOT invoke the renderer for image syntax
+ * inside code spans / fenced blocks. `translate` is the identity on the key so
+ * assertions can match on the key without pulling in i18n.
+ */
+function render(content: string, mode: ImageLoadMode) {
+  const { renderImage, setMode, reset, getAskPlaceholderCount } =
+    createMarkdownImageRenderer((key) => key);
+  const md = new Marked({ gfm: true, breaks: true });
+  md.use({ renderer: { image: renderImage } });
+  setMode(mode);
+  reset();
+  const html = md.parse(content) as string;
+  return { html, count: getAskPlaceholderCount() };
+}
+
+describe('createMarkdownImageRenderer — "Load all images" banner gating', () => {
+  it('counts a real external image in ask mode', () => {
+    const { html, count } = render('![alt](https://picsum.photos/200)', 'ask');
+    expect(count).toBe(1);
+    expect(html).toContain('image-placeholder-load');
+  });
+
+  it('counts each of several real images', () => {
+    const { count } = render(
+      '![a](https://a.test/1.png)\n\n![b](https://b.test/2.png)',
+      'ask'
+    );
+    expect(count).toBe(2);
+  });
+
+  it('does NOT count image syntax inside an inline code span', () => {
+    // A note documenting image markdown as code — the original false positive.
+    const { count } = render('see `![](https://attacker.com/track)` inline', 'ask');
+    expect(count).toBe(0);
+  });
+
+  it('does NOT count image syntax inside a fenced code block', () => {
+    const { count } = render('```md\n![](https://example.com/x.png)\n```', 'ask');
+    expect(count).toBe(0);
+  });
+
+  it('does NOT count a note that merely mentions the placeholder class name', () => {
+    // The exact false positive the previous HTML-substring gate suffered from:
+    // the rendered <code> contains the literal "image-placeholder-load" string,
+    // yet no real placeholder was emitted. A counter driven by the renderer is
+    // immune; a `html.includes('image-placeholder-load')` check is not.
+    const { html, count } = render(
+      "the gate read `html.includes('image-placeholder-load')`",
+      'ask'
+    );
+    expect(html).toContain('image-placeholder-load'); // present as escaped code text…
+    expect(count).toBe(0); // …but no real placeholder beneath it
+  });
+
+  it('always mode emits a plain <img> and counts nothing', () => {
+    const { html, count } = render('![](https://x.test/y.png)', 'always');
+    expect(html).toContain('<img');
+    expect(html).not.toContain('image-placeholder-load');
+    expect(count).toBe(0);
+  });
+
+  it('never mode emits a placeholder without a Load button and counts nothing', () => {
+    const { html, count } = render('![](https://x.test/y.png)', 'never');
+    expect(html).toContain('image-placeholder');
+    expect(html).not.toContain('image-placeholder-load');
+    expect(count).toBe(0);
+  });
+
+  it('blocks data: URIs and counts nothing', () => {
+    const { html, count } = render('![](data:image/png;base64,AAAA)', 'ask');
+    expect(html).toContain('image-placeholder--blocked');
+    expect(count).toBe(0);
+  });
+
+  it('reset() zeroes the counter between parses', () => {
+    const { renderImage, setMode, reset, getAskPlaceholderCount } =
+      createMarkdownImageRenderer((key) => key);
+    const md = new Marked({ gfm: true, breaks: true });
+    md.use({ renderer: { image: renderImage } });
+    setMode('ask');
+
+    reset();
+    md.parse('![](https://a.test/1.png)');
+    expect(getAskPlaceholderCount()).toBe(1);
+
+    reset();
+    md.parse('no images here');
+    expect(getAskPlaceholderCount()).toBe(0);
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/markdown-to-html.ts
+++ b/apps/reborn-notes/src/lib/utils/markdown-to-html.ts
@@ -1,5 +1,5 @@
 /**
- * Shared marked renderer overrides for list / task-list rendering.
+ * Shared marked renderer overrides for list / task-list / image rendering.
  *
  * Used by:
  *  - `MarkdownPreview.svelte` (interactive — checkbox click toggles source via
@@ -9,12 +9,13 @@
  *    output, and reusing the same shape keeps the export visually in step
  *    with what the user sees while editing)
  *
- * State (`listDepth`, `taskCounter`) is captured per factory call so two
- * concurrent renders don't interleave; call `reset()` at the start of each
- * parse so `data-task-index` ordinals start at 0 and `data-d` depth attrs
- * match Live Preview's geometry.
+ * State (`listDepth`, `taskCounter`, the image renderer's `askPlaceholderCount`)
+ * is captured per factory call so two concurrent renders don't interleave; call
+ * `reset()` at the start of each parse so `data-task-index` ordinals start at 0
+ * and `data-d` depth attrs match Live Preview's geometry.
  */
 import type { RendererObject, Tokens } from 'marked';
+import type { ImageLoadMode } from '@reborn/storage';
 
 /** Visual cap mirroring MAX_LIST_DEPTH in editor/live-preview/decorations.ts. */
 export const PREVIEW_MAX_LIST_DEPTH = 12;
@@ -115,5 +116,78 @@ export function createMarkdownListRenderers(): {
       listDepth = 0;
       taskCounter = 0;
     }
+  };
+}
+
+const IMAGE_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>';
+const BLOCKED_ICON_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>';
+
+/**
+ * Image renderer for Preview. Behaviour by `ImageLoadMode`:
+ *  - `always` — emit a plain lazy `<img>`.
+ *  - `ask`    — emit a click-to-load placeholder *with* a Load button.
+ *  - `never`  — emit the placeholder *without* a Load button.
+ * `data:` URIs are always blocked (base64 isn't supported) regardless of mode.
+ *
+ * `getAskPlaceholderCount()` returns how many ask-mode Load buttons the last
+ * parse emitted — the single source of truth for whether the "Load all images"
+ * banner should show. The count is structural (the renderer bumps it only when
+ * it actually runs the ask-mode branch), so unlike scanning the output HTML for
+ * the `.image-placeholder-load` class it cannot be tripped by a note whose own
+ * text happens to contain that class name or `![](…)` syntax inside a code span
+ * — marked never calls this renderer for image syntax inside inline code or
+ * fenced blocks. (That false positive is exactly what the prior source-regex
+ * and HTML-substring gates suffered from; see markdown-to-html.spec.ts.)
+ *
+ * `translate(key)` resolves an i18n key at render time — the caller wraps its
+ * reactive `$t` so placeholder labels follow locale changes. Call `setMode()`
+ * and `reset()` before each parse, then read `getAskPlaceholderCount()` after.
+ */
+export function createMarkdownImageRenderer(translate: (key: string) => string): {
+  renderImage: NonNullable<RendererObject['image']>;
+  setMode: (mode: ImageLoadMode) => void;
+  reset: () => void;
+  getAskPlaceholderCount: () => number;
+} {
+  let mode: ImageLoadMode = 'ask';
+  let askPlaceholderCount = 0;
+
+  const renderImage = ({ href, title, text }: Tokens.Image): string => {
+    const isDataUri = href.startsWith('data:');
+    const escapedHref = href.replace(/"/g, '&quot;');
+    const escapedAlt = (text || '').replace(/"/g, '&quot;');
+    const escapedTitle = (title || '').replace(/"/g, '&quot;');
+
+    if (isDataUri) {
+      return `<div class="image-placeholder image-placeholder--blocked">
+      <div class="image-placeholder-icon">${BLOCKED_ICON_SVG}</div>
+      <div class="image-placeholder-url">${translate('editor.image_base64_blocked')}</div>
+    </div>`;
+    }
+
+    if (mode === 'always') {
+      return `<img src="${escapedHref}" alt="${escapedAlt}" title="${escapedTitle}" loading="lazy" />`;
+    }
+
+    const showLoadBtn = mode === 'ask';
+    if (showLoadBtn) askPlaceholderCount++;
+    return `<div class="image-placeholder" data-src="${escapedHref}" data-alt="${escapedAlt}" data-title="${escapedTitle}">
+      <div class="image-placeholder-icon">${IMAGE_ICON_SVG}</div>
+      <div class="image-placeholder-url">${escapedHref}</div>
+      ${showLoadBtn ? `<button class="image-placeholder-load" type="button">${translate('editor.image_load')}</button>` : ''}
+    </div>`;
+  };
+
+  return {
+    renderImage,
+    setMode: (m: ImageLoadMode) => {
+      mode = m;
+    },
+    reset: () => {
+      askPlaceholderCount = 0;
+    },
+    getAskPlaceholderCount: () => askPlaceholderCount
   };
 }


### PR DESCRIPTION
## Summary

The "Load all images" banner appeared on notes that contain no images. The gate checked `html.includes('image-placeholder-load')`, but a note can put that literal class name into its own text via inline code or a fenced block. A changelog entry documenting this very class rendered `<code>...image-placeholder-load...</code>`, so the substring matched with **zero** real placeholders beneath it - the previous fix's own documentation re-triggered the bug it fixed. (The fix before that regex-scanned the raw source and tripped on `![](...)` syntax in code spans: the same string-matching flaw, third iteration of one bug.)

Replace the fragile string match with a **structural counter**:

- Extract the image renderer from `MarkdownPreview.svelte` into `createMarkdownImageRenderer` in `markdown-to-html.ts`, next to the existing `createMarkdownListRenderers` factory (same `reset()` pattern).
- The renderer bumps `askPlaceholderCount` exactly once per ask-mode external image; `hasImagePlaceholders` reads `getAskPlaceholderCount() > 0`. marked never calls the renderer for image syntax inside code spans, so note **content cannot spoof the count**.
- Rendered HTML output is byte-identical; only the gating signal changed.

The extraction is purely for testability, not an architectural change: it lets the logic be unit-tested without mounting the Svelte component. The new `markdown-to-html.spec.ts` (9 cases) locks in the regression, including a note that merely quotes the class name as text (asserts count 0). This is the first test on this path; the two prior fixes shipped without one, which is why it recurred.

No i18n keys added (reuses `editor.image_load` / `editor.image_base64_blocked`); no schema / crypto / server-visibility changes.

## Test plan

Automated (all green locally):
- `markdown-to-html.spec.ts` - 9/9 pass
- reborn-notes full suite - 740 pass (47 files)
- svelte-check - 0 errors / 0 warnings
- eslint - clean

Manual smoke (open in Reborn Notes via folder-sync):
- Open `reapps-docs/TODO-history.md` (it quotes `image-placeholder-load` and `![](...)` inside code): banner must NOT show.
- A note with a real external image `![](https://picsum.photos/200)` in "ask" mode: banner shows, "Load all images" loads it.
- Same note in "always" mode: image loads inline, no banner. In "never" mode: placeholder without a Load button, no banner.