### PR TITLE
fix(notes): align split preview header to editor toolbar height

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -61,6 +61,7 @@
     onviewdestroy,
     onnotelinkrequest,
     onnotelinkclick,
+    ontoolbarheight,
     availableNotes = [],
     currentNoteId = null,
     imageLoadMode = 'ask' as ImageLoadMode
@@ -88,6 +89,13 @@
     onnotelinkrequest?: () => void;
     /** Called when a rendered note-link widget is clicked (Live Preview mode) */
     onnotelinkclick?: (noteId: string) => void;
+    /**
+     * Split view only - reports the formatting toolbar's measured height
+     * (border-box, px) whenever it changes. The toolbar wraps to 1-2 rows by
+     * pane width, so the preview pane uses this to match its header height and
+     * keep the first line of both columns aligned. Measured, never hardcoded.
+     */
+    ontoolbarheight?: (height: number) => void;
     /** Notes available for [[ autocomplete */
     availableNotes?: NoteLinkItem[];
     /** Current note id (excluded from autocomplete suggestions) */
@@ -98,6 +106,8 @@
 
   let editorRootEl: HTMLDivElement;
   let editorContainer: HTMLDivElement;
+  /** Split-view formatting toolbar element - measured to align the preview header. */
+  let toolbarEl = $state<HTMLDivElement | null>(null);
   let view: EditorView | undefined;
   let isExternalUpdate = false;
   const themeCompartment = new Compartment();
@@ -616,6 +626,23 @@
     });
   });
 
+  // Split view: the formatting toolbar wraps to 1 or 2 rows depending on pane
+  // width, so its height is variable. Measure it (ResizeObserver - never a
+  // hardcoded constant) and report upward so the preview pane can match its
+  // header height; that keeps the first line of both columns aligned. Inert
+  // outside split view and when readonly (no toolbar element rendered). No
+  // feedback loop: the reported height drives the *preview* header in the other
+  // column, which can't change this column's width, so the toolbar never rewraps.
+  $effect(() => {
+    const el = toolbarEl;
+    if (!splitView || !el) return;
+    const report = () => ontoolbarheight?.(el.getBoundingClientRect().height);
+    const ro = new ResizeObserver(report);
+    ro.observe(el);
+    report();
+    return () => ro.disconnect();
+  });
+
   onDestroy(() => {
     onviewdestroy?.();
     view?.destroy();
@@ -832,7 +859,7 @@
         </div>
       </div>
     {:else}
-      <div class="flex flex-wrap items-center gap-0.5 border-b bg-background px-2 py-1.5">
+      <div bind:this={toolbarEl} class="flex flex-wrap items-center gap-0.5 border-b bg-background px-2 py-1.5">
         {@render toolbarButtons()}
       </div>
     {/if}

--- a/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
@@ -72,6 +72,12 @@
   // the parent scroll (parent grows with content, sticky toolbar/header work).
   const isParentScrollActive = $derived(parentScroll && effectiveViewMode !== 'split');
 
+  // Split view: the editor's formatting toolbar wraps to 1-2 rows by pane width
+  // (variable height). NoteEditor measures it and reports here; we mirror it onto
+  // the preview header's min-height so both panes' first line stays aligned
+  // regardless of how the toolbar wraps. Measured upstream, never hardcoded.
+  let splitToolbarHeight = $state(0);
+
   const placeholderText = $derived(
     noteKind ? $t(`notes.periodic.${noteKind}.placeholder`) : $t('editor.placeholder')
   );
@@ -182,12 +188,16 @@
               currentNoteId={noteId}
               parentScroll={false}
               splitView
+              ontoolbarheight={(h) => (splitToolbarHeight = h)}
               {isMobile}
               {imageLoadMode}
             />
           </div>
           <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
-            <div class="flex shrink-0 items-center border-b bg-background/95 backdrop-blur-sm px-4 py-1.5">
+            <div
+              class="flex shrink-0 items-center border-b bg-background/95 backdrop-blur-sm px-4 py-1.5"
+              style:min-height={splitToolbarHeight ? `${splitToolbarHeight}px` : null}
+            >
               <span class="flex h-7 items-center text-xs font-medium text-muted-foreground">{$t('editor.preview')}</span>
             </div>
             <MarkdownPreview


### PR DESCRIPTION
## Summary

In split view (`effectiveViewMode === 'split'`, desktop-only / wide windows, also iPad landscape), the editor's formatting toolbar wraps to 1 or 2 rows by pane width (`NoteEditor.svelte` `else` toolbar branch, `flex flex-wrap`), while the preview pane's "Preview" header was a fixed single row (~40px). When the toolbar wrapped, the editor content started lower than the preview content, so the first line of the two columns drifted out of alignment - and the offset changed with window width. This is component (1) of native-polish item #2.

Fix (option a from the cluster diagnosis - measure, don't hardcode):
- `NoteEditor` measures the split toolbar via `ResizeObserver` and reports its border-box height through a new `ontoolbarheight` callback. Active only in split view; inert on web single-pane, mobile, and readonly (no toolbar).
- `NoteContentArea` mirrors that height onto the preview header's `min-height`, so both columns' scrollers start at the same Y regardless of how the toolbar wraps.

### Decisions (auto mode) - for review
- Kept the wrapping (variable-height) toolbar and made the header track it via measurement, per the explicit constraint that the fix must handle a variable toolbar height. Rejected forcing a non-wrapping single-row toolbar (`overflow-x-auto`), which would hide buttons behind a horizontal scroll on narrow panes.
- Chose a localized callback + `ResizeObserver` over extracting the toolbar into a shared full-width header row (which would auto-equalize via flex, but is a larger refactor of the tightly-coupled toolbar). Proportionate to a polish fix.
- Out of scope: the residual downward drift deeper into a long document is inherent to line-anchored top sync; full alignment needs block-anchored sync, which stays a separate task with its own gate (unchanged here).

No new i18n keys. No schema / API / ZK surface touched.

## Test plan
- `lint`, `check` (svelte-check 0/0 over 5472 files), `test` (740 passed), and `build` are green locally.
- Smoke (desktop / wide window, or iPad landscape), open a note in split view:
  - Narrow the window until the editor toolbar wraps to 2 rows - the "Preview" header should grow to match and the first line of both panes should stay level; widen back to 1 row and they should re-level.
  - Confirm web single-pane edit / preview and mobile are visually unchanged.