### PR TITLE
fix(notes): pull note versions only for changed notes

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -343,6 +343,41 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(src).not.toMatch(/PULL_VERSIONS_BATCH_SIZE/);
   });
 
+  it('pulls versions only for notes pullNotes actually changed, not all notes (native GET storm)', () => {
+    // Native CapacitorHttp does ~1 GET/note for versions; pulling versions for
+    // EVERY note on EVERY sync dominated native sync time (e.g. 122 notes ×
+    // ~700ms). A note's server-side version list grows only when the note is
+    // edited (which bumps its sync_version), so an unchanged note cannot have
+    // new versions. pullNotes therefore reports the ids it wrote and the
+    // orchestrator pulls versions for only those. Cold start still backfills:
+    // every note is new → "changed". Guards the optimization from regressing
+    // back to the all-notes pull.
+    const src = readSource('./notes-sync.service.ts');
+
+    // pullNotes reports the changed set instead of returning void.
+    expect(src).toMatch(/async function pullNotes\(\): Promise<string\[\]>/);
+    const pullNotes = src.slice(
+      src.indexOf('async function pullNotes'),
+      src.indexOf('// ── Push helpers')
+    );
+    // Main write path returns the id; skip paths return null; result filtered.
+    expect(pullNotes).toMatch(/return n\.id;/);
+    expect(pullNotes).toMatch(/return null;/);
+    expect(pullNotes).toMatch(/return changedResults\.filter\(/);
+
+    // The orchestrator feeds pullNotes' result into pullNoteVersions - it must
+    // NOT re-derive the version target from a fresh getAll() of every note.
+    const orchestrator = src.slice(
+      src.indexOf('async function runPullFromServer'),
+      src.indexOf('async function pullFolders')
+    );
+    expect(orchestrator).toMatch(/const changedNoteIds = await pullNotes\(/);
+    expect(orchestrator).toMatch(/pullNoteVersions\(changedNoteIds\)/);
+    // The old all-notes version pull is gone.
+    expect(orchestrator).not.toMatch(/pullNoteVersions\(noteIds\)/);
+    expect(orchestrator).not.toMatch(/noteStore\.getAll\(\) as NoteEncrypted/);
+  });
+
   it('archived-pending retry joins the per-entity chain so the cap is real', () => {
     // pushNoteUpdate/pushNoteDelete are fire-and-forget (void). If the sweep
     // didn't await something, settleInBatches would enqueue every archived note
@@ -475,9 +510,10 @@ describe('notes-sync - regression (offline data loss)', () => {
       expect(body, `${fnName} must capture userId at top`).toMatch(
         /const\s+userId\s*=\s*get\(authStore\)\.userId/
       );
-      // Bail out when userId is absent.
+      // Bail out when userId is absent. (pullNotes returns string[] so its
+      // guard is `return []`; the void pull helpers use bare `return;`.)
       expect(body, `${fnName} must early-return on missing userId`).toMatch(
-        /if\s*\(\s*!userId\s*\)\s*return\s*;/
+        /if\s*\(\s*!userId\s*\)\s*return\b[^;]*;/
       );
       // No more non-null assertions on authStore.userId inside the body.
       expect(body, `${fnName} must not use \`get(authStore).userId!\``).not.toMatch(
@@ -565,7 +601,9 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(callMatch).not.toBeNull();
     const window = pullNotes.slice(callMatch!.index, callMatch!.index + 600);
     expect(window).toMatch(/catch\s*\(/);
-    expect(window).toMatch(/return;/);
+    // Skip path returns `null` from the map callback (pullNotes collects the
+    // ids it actually wrote; skipped notes contribute null and are filtered).
+    expect(window).toMatch(/return null;/);
   });
 
   it('post-pull reconciler runs in +layout.svelte runSync and onMount paths', () => {

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -215,21 +215,32 @@ async function runPullFromServer(): Promise<boolean> {
         success = false;
       })
     ]);
-    // Notes after folders/tags (they reference them)
-    await pullNotes().catch((e) => {
+    // Notes after folders/tags (they reference them). pullNotes returns the IDs
+    // it actually wrote (new, or server sync_version newer) - the only notes
+    // whose server-side version history can have grown since the last sync.
+    const changedNoteIds = await pullNotes().catch((e) => {
       reportSyncError(e);
       logger.error('Pull notes failed:', e);
       success = false;
+      return [] as string[];
     });
 
-    // Pull note versions after notes
-    const allNotes = (await noteStore.getAll()) as NoteEncrypted[];
-    const noteIds = allNotes.map((n) => n.id);
-    await pullNoteVersions(noteIds).catch((e) => {
-      reportSyncError(e);
-      logger.error('Pull note versions failed:', e);
-      // Non-critical - don't set success=false
-    });
+    // Pull versions only for changed notes, not all of them. A note's version
+    // list grows only when the note is edited (which bumps its sync_version), so
+    // an unchanged note cannot have new server-side versions. Cold start treats
+    // every note as new → full backfill. This removes the per-note GET storm
+    // (1 request/note/sync) that dominated native CapacitorHttp sync time. The
+    // tradeoff (a snapshot created without a sync_version bump - e.g. opening the
+    // history panel - may lag on other devices until the note's next edit) is
+    // acceptable: that content equals the live note and each device regenerates
+    // its own such snapshot locally. History is non-critical. See guideline 36.
+    if (changedNoteIds.length > 0) {
+      await pullNoteVersions(changedNoteIds).catch((e) => {
+        reportSyncError(e);
+        logger.error('Pull note versions failed:', e);
+        // Non-critical - don't set success=false
+      });
+    }
 
     if (success) {
       logger.info('Pull sync completed');
@@ -474,15 +485,15 @@ async function pullSavedSearches(): Promise<void> {
   }
 }
 
-async function pullNotes(): Promise<void> {
+async function pullNotes(): Promise<string[]> {
   // See pullFolders() for rationale on the userId guard.
   const userId = get(authStore).userId;
-  if (!userId) return;
+  if (!userId) return [];
   const res = await authFetch(`${API_BASE}/notes?include_archived=true`);
   if (!res.ok) throw new Error(`GET /api/notes: ${res.status}`);
   const { data } = await res.json();
 
-  await Promise.all(
+  const changedResults = await Promise.all(
     (
       data as Array<{
         id: string;
@@ -509,7 +520,7 @@ async function pullNotes(): Promise<void> {
         (localNote.sync_status === 'pending' || localNote.sync_status === 'sync_error')
       ) {
         logger.debug(`Skipping pull for note ${n.id} - has unsynced local changes`);
-        return;
+        return null;
       }
 
       // Skip if server version is not newer than local (sync_version conflict detection)
@@ -547,7 +558,7 @@ async function pullNotes(): Promise<void> {
           logger.warn(`Reconciling orphaned note edit ${n.id} - marking pending`);
           await noteStore.save({ ...localNote, sync_status: 'pending' });
         }
-        return;
+        return null;
       }
 
       // Rebuild shadow indexes from metadata_encrypted. extractShadowIndexes throws when
@@ -569,7 +580,7 @@ async function pullNotes(): Promise<void> {
           `Skipping save of note ${n.id} - shadow indexes could not be derived. Will retry on next successful sync.`,
           err
         );
-        return;
+        return null;
       }
 
       const note: NoteStoredLocal = {
@@ -607,6 +618,10 @@ async function pullNotes(): Promise<void> {
           )
         ]);
       }
+
+      // This note's server state advanced (new, or newer sync_version) → its
+      // version list may have grown. Return its id for the targeted version pull.
+      return n.id;
     })
   );
 
@@ -624,6 +639,10 @@ async function pullNotes(): Promise<void> {
     await noteStore.deleteMany(orphanNoteIds);
     logger.debug(`Removed ${orphanNoteIds.length} locally-synced notes no longer on server`);
   }
+
+  // Notes whose server state advanced this pull - the only ones whose
+  // server-side version history can have grown. Drives the targeted version pull.
+  return changedResults.filter((id): id is string => id !== null);
 }
 
 // ── Push helpers - IndexedDB → server ────────────────────────────


### PR DESCRIPTION
## Summary

`pullNoteVersions` issued one `GET /api/notes/[id]/versions` per note on every sync. On native (CapacitorHttp) each request carries high fixed bridge overhead, so this was the dominant cost of native sync (e.g. 122 notes x ~700ms). Web never felt it (fast same-origin).

A note's server-side version list grows only when the note is edited, which bumps its `sync_version`. So an **unchanged note cannot have new server-side versions** and re-fetching them is pure overhead. After this change:

- `pullNotes()` returns the ids it actually wrote (server `sync_version` newer, or a brand-new note) instead of `void`. Skip paths (unsynced local edit, server-not-newer, shadow-index decode failure) return `null` and are filtered out.
- `runPullFromServer` pulls versions for only that changed set, and skips the call entirely when the set is empty (the common steady-state sync does 0 version requests).
- **Cold start backfills naturally**: on a fresh install / after `clearAllUserData`, every note is new, lands in the changed set, and gets a full version pull.

### Approved tradeoff (changed-only over a delta endpoint)
A snapshot created **without** bumping the note's `sync_version` (e.g. opening the history panel, or the last 30-min checkpoint with no following edit) may lag on other devices until the note's next edit. This is acceptable: that content equals the live note (the device already has it) and each device regenerates its own such snapshot locally on history open; version history is explicitly non-critical. The meaningful edit history (snapshots of distinct prior states) still propagates, because every edit bumps `sync_version`. Full cross-device completeness would require a `?since=<cursor>` delta endpoint, deferred.

`lazy/on-open` was rejected: it would regress offline availability of history (a cardinal offline-first rule). Decision approved before implementation (Option A of the version-sync gate).

## Test plan

Automated (all green locally, mirrors CI lint -> check -> test -> build):
- `nx run reborn-notes:lint` - 0 errors
- `nx run reborn-notes:check` (svelte-check) - 0 errors / 0 warnings (5472 files)
- `nx run reborn-notes:test` - 741 passed, incl. new regression test `pulls versions only for notes pullNotes actually changed`
- `nx run reborn-notes:build` - ok

Manual smoke (native, where the win is):
1. Fresh install with several already-synced notes: first sync pulls all version histories (cold-start backfill); open history on a note to confirm prior versions are present offline.
2. Trigger a sync with no changes: confirm it is fast and issues no per-note version GETs.
3. Edit a note on device A, sync device B: B pulls that note + its versions; open history on B to confirm the new snapshot is there.
4. Web regression: split/edit/history unaffected; sync with no changes is a no-op for versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)