### PR TITLE
fix(notes): keep iOS keyboard off auth & settings password fields

### DIFF
--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -120,8 +120,11 @@
 	<title>{$t('auth.two_factor.title')} - re/notes</title>
 </svelte:head>
 
-<div class="h-dvh overflow-y-auto">
-<div class="flex min-h-dvh items-center justify-center px-4 py-12">
+<!-- height/min-height subtract --rn-keyboard-inset (set on :root by the layout's
+     visual-viewport tracker) so the soft keyboard does not cover the focused
+     code field on iOS native - matches AuthLayout (this page predates it). -->
+<div class="h-[calc(100dvh-var(--rn-keyboard-inset,0px))] overflow-y-auto">
+<div class="flex min-h-[calc(100dvh-var(--rn-keyboard-inset,0px))] items-center justify-center px-4 py-12">
 	<div class="w-full max-w-md space-y-6">
 		<!-- Header -->
 		<div class="text-center space-y-2">

--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -81,7 +81,7 @@
 
 			const { data } = body;
 
-			// Save credentials to localStorage (same format as reborn-task — SSO-compatible)
+			// Save credentials to localStorage (same format as reborn-task - SSO-compatible)
 			const credentials = {
 				id: data.user.id,
 				// refresh_token is managed exclusively via httpOnly cookie (set by server)
@@ -98,13 +98,13 @@
 			// session_id arrives in this response - stash it for device-info + list highlight.
 			persistNativeSessionId(data.session_id);
 
-			// Unlock E2E — use password saved by login page before redirect
+			// Unlock E2E - use password saved by login page before redirect
 			const savedPassword = sessionStorage.getItem('2fa_pending_password');
 			if (savedPassword) {
 				sessionStorage.removeItem('2fa_pending_password');
 				await authStore.unlockE2E(savedPassword);
 			} else {
-				// No saved password — hydrate auth state and let unlock page handle E2E
+				// No saved password - hydrate auth state and let unlock page handle E2E
 				authStore.initialize();
 			}
 

--- a/apps/reborn-notes/src/routes/settings/security/delete-account/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/delete-account/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { authFetch } from '$lib/utils/auth-fetch';
   import { API_BASE } from '$lib/utils/api-base';
-  import { AlertTriangle, Trash2 } from '@lucide/svelte';
+  import { AlertTriangle, Trash2, Eye, EyeOff } from '@lucide/svelte';
   import {
     SettingsLayout,
     Card,
@@ -22,6 +22,7 @@
   const logger = createLogger('Notes-DeleteAccountPage');
 
   let password = $state('');
+  let showPassword = $state(false);
   let isLoading = $state(false);
   let error = $state<string | null>(null);
   let submitAttempted = $state(false);
@@ -70,6 +71,18 @@
   <title>{$t('security.delete_account.title')} - re/notes</title>
 </svelte:head>
 
+{#snippet revealToggle()}
+  <button
+    type="button"
+    class="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+    onclick={() => (showPassword = !showPassword)}
+    tabindex={-1}
+    aria-label={$t('security.delete_account.toggle_visibility')}
+  >
+    {#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+  </button>
+{/snippet}
+
 <SettingsLayout title={$t('security.delete_account.title')} backHref="/settings">
   <div class="space-y-6">
     <!-- Danger warning -->
@@ -99,15 +112,18 @@
         <form onsubmit={handleDelete} class="space-y-4">
           <div class="space-y-2">
             <Label for="confirm-password">{$t('security.delete_account.password')}</Label>
-            <Input
-              id="confirm-password"
-              type="password"
-              bind:value={password}
-              placeholder={$t('security.delete_account.password_placeholder')}
-              autocomplete="current-password"
-              disabled={isLoading}
-              class={passwordError ? 'border-destructive' : ''}
-            />
+            <div class="relative">
+              <Input
+                id="confirm-password"
+                type={showPassword ? 'text' : 'password'}
+                bind:value={password}
+                placeholder={$t('security.delete_account.password_placeholder')}
+                autocomplete="current-password"
+                disabled={isLoading}
+                class="pr-10 {passwordError ? 'border-destructive' : ''}"
+              />
+              {@render revealToggle()}
+            </div>
             {#if passwordError}
               <p class="text-sm text-destructive">{passwordError}</p>
             {/if}

--- a/apps/reborn-notes/src/routes/settings/security/password/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/password/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { API_BASE } from '$lib/utils/api-base';
   import { authFetch } from '$lib/utils/auth-fetch';
-  import { Lock, AlertTriangle } from '@lucide/svelte';
+  import { Lock, AlertTriangle, Eye, EyeOff } from '@lucide/svelte';
   import {
     SettingsLayout,
     Card,
@@ -26,6 +26,7 @@
   let currentPassword = $state('');
   let newPassword = $state('');
   let confirmPassword = $state('');
+  let showPassword = $state(false);
   let isLoading = $state(false);
   let error = $state<string | null>(null);
   let submitAttempted = $state(false);
@@ -97,7 +98,7 @@
 
       toast.success($t('security.password.changed_toast'));
 
-      // Logout — all tokens invalidated
+      // Logout - all tokens invalidated
       authStore.logout();
     } catch (err: unknown) {
       logger.error('Failed to change password:', err);
@@ -109,8 +110,20 @@
 </script>
 
 <svelte:head>
-  <title>{$t('security.password.title')} — re/notes</title>
+  <title>{$t('security.password.title')} - re/notes</title>
 </svelte:head>
+
+{#snippet revealToggle()}
+  <button
+    type="button"
+    class="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground"
+    onclick={() => (showPassword = !showPassword)}
+    tabindex={-1}
+    aria-label={$t('security.password.toggle_visibility')}
+  >
+    {#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+  </button>
+{/snippet}
 
 <SettingsLayout title={$t('security.password.title')} backHref="/settings">
   <div class="space-y-6">
@@ -141,14 +154,17 @@
           <!-- Current password -->
           <div class="space-y-2">
             <Label for="current-password">{$t('security.password.current')}</Label>
-            <Input
-              id="current-password"
-              type="password"
-              bind:value={currentPassword}
-              autocomplete="current-password"
-              disabled={isLoading}
-              class={currentPasswordError ? 'border-destructive' : ''}
-            />
+            <div class="relative">
+              <Input
+                id="current-password"
+                type={showPassword ? 'text' : 'password'}
+                bind:value={currentPassword}
+                autocomplete="current-password"
+                disabled={isLoading}
+                class="pr-10 {currentPasswordError ? 'border-destructive' : ''}"
+              />
+              {@render revealToggle()}
+            </div>
             {#if currentPasswordError}
               <p class="text-sm text-destructive">{currentPasswordError}</p>
             {/if}
@@ -157,14 +173,17 @@
           <!-- New password -->
           <div class="space-y-2">
             <Label for="new-password">{$t('security.password.new_pwd')}</Label>
-            <Input
-              id="new-password"
-              type="password"
-              bind:value={newPassword}
-              autocomplete="new-password"
-              disabled={isLoading}
-              class={newPasswordError ? 'border-destructive' : ''}
-            />
+            <div class="relative">
+              <Input
+                id="new-password"
+                type={showPassword ? 'text' : 'password'}
+                bind:value={newPassword}
+                autocomplete="new-password"
+                disabled={isLoading}
+                class="pr-10 {newPasswordError ? 'border-destructive' : ''}"
+              />
+              {@render revealToggle()}
+            </div>
             {#if newPasswordError}
               <p class="text-sm text-destructive">{newPasswordError}</p>
             {/if}
@@ -173,14 +192,17 @@
           <!-- Confirm password -->
           <div class="space-y-2">
             <Label for="confirm-password">{$t('security.password.confirm')}</Label>
-            <Input
-              id="confirm-password"
-              type="password"
-              bind:value={confirmPassword}
-              autocomplete="new-password"
-              disabled={isLoading}
-              class={confirmPasswordError ? 'border-destructive' : ''}
-            />
+            <div class="relative">
+              <Input
+                id="confirm-password"
+                type={showPassword ? 'text' : 'password'}
+                bind:value={confirmPassword}
+                autocomplete="new-password"
+                disabled={isLoading}
+                class="pr-10 {confirmPasswordError ? 'border-destructive' : ''}"
+              />
+              {@render revealToggle()}
+            </div>
             {#if confirmPasswordError}
               <p class="text-sm text-destructive">{confirmPasswordError}</p>
             {/if}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1027,6 +1027,7 @@
   "security": {
     "password": {
       "title": "Passwort ändern",
+      "toggle_visibility": "Passwort ein- oder ausblenden",
       "warning": "Nach der Passwortänderung werden Sie auf allen Geräten abgemeldet und müssen sich erneut anmelden.",
       "card_title": "Passwort ändern",
       "card_desc": "Das Passwort muss mindestens 8 Zeichen lang sein. Der Verschlüsselungsschlüssel wird mit dem neuen Passwort neu verschlüsselt.",
@@ -1139,6 +1140,7 @@
     },
     "delete_account": {
       "title": "Konto löschen",
+      "toggle_visibility": "Passwort ein- oder ausblenden",
       "irreversible_title": "Diese Aktion ist unwiderruflich!",
       "irreversible_desc": "Das Löschen Ihres Kontos entfernt dauerhaft alle Ihre Daten, Notizen, Ordner und Einstellungen. Diese Aktion kann nicht rückgängig gemacht werden.",
       "card_title": "Konto dauerhaft löschen",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1027,6 +1027,7 @@
   "security": {
     "password": {
       "title": "Change password",
+      "toggle_visibility": "Toggle password visibility",
       "warning": "After changing the password, you will be logged out on all devices and will need to sign in again.",
       "card_title": "Change password",
       "card_desc": "Password must be at least 8 characters. The encryption key will be re-encrypted with the new password.",
@@ -1139,6 +1140,7 @@
     },
     "delete_account": {
       "title": "Delete account",
+      "toggle_visibility": "Toggle password visibility",
       "irreversible_title": "This action is irreversible!",
       "irreversible_desc": "Deleting your account will permanently remove all your data, notes, folders and settings. This action cannot be undone.",
       "card_title": "Permanently delete account",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1027,6 +1027,7 @@
   "security": {
     "password": {
       "title": "Cambiar contraseña",
+      "toggle_visibility": "Mostrar u ocultar la contraseña",
       "warning": "Después de cambiar la contraseña, se cerrará la sesión en todos los dispositivos y deberá iniciar sesión de nuevo.",
       "card_title": "Cambiar contraseña",
       "card_desc": "La contraseña debe tener al menos 8 caracteres. La clave de cifrado se volverá a cifrar con la nueva contraseña.",
@@ -1139,6 +1140,7 @@
     },
     "delete_account": {
       "title": "Eliminar cuenta",
+      "toggle_visibility": "Mostrar u ocultar la contraseña",
       "irreversible_title": "¡Esta acción es irreversible!",
       "irreversible_desc": "Eliminar su cuenta borrará permanentemente todos sus datos, notas, carpetas y configuración. Esta acción no se puede deshacer.",
       "card_title": "Eliminar cuenta permanentemente",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1027,6 +1027,7 @@
   "security": {
     "password": {
       "title": "Changer le mot de passe",
+      "toggle_visibility": "Afficher ou masquer le mot de passe",
       "warning": "Après le changement de mot de passe, vous serez déconnecté de tous les appareils et devrez vous reconnecter.",
       "card_title": "Changer le mot de passe",
       "card_desc": "Le mot de passe doit comporter au moins 8 caractères. La clé de chiffrement sera rechiffrée avec le nouveau mot de passe.",
@@ -1139,6 +1140,7 @@
     },
     "delete_account": {
       "title": "Supprimer le compte",
+      "toggle_visibility": "Afficher ou masquer le mot de passe",
       "irreversible_title": "Cette action est irréversible !",
       "irreversible_desc": "La suppression de votre compte effacera définitivement toutes vos données, notes, dossiers et paramètres. Cette action ne peut pas être annulée.",
       "card_title": "Supprimer définitivement le compte",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1027,6 +1027,7 @@
   "security": {
     "password": {
       "title": "Zmiana hasła",
+      "toggle_visibility": "Pokaż lub ukryj hasło",
       "warning": "Po zmianie hasła zostaniesz wylogowany na wszystkich urządzeniach i będziesz musiał zalogować się ponownie.",
       "card_title": "Zmień hasło",
       "card_desc": "Hasło musi mieć co najmniej 8 znaków. Klucz szyfrujący zostanie ponownie zaszyfrowany nowym hasłem.",
@@ -1139,6 +1140,7 @@
     },
     "delete_account": {
       "title": "Usuń konto",
+      "toggle_visibility": "Pokaż lub ukryj hasło",
       "irreversible_title": "Ta operacja jest nieodwracalna!",
       "irreversible_desc": "Usunięcie konta spowoduje trwałe usunięcie wszystkich Twoich danych, notatek, folderów i ustawień. Tej operacji nie można cofnąć.",
       "card_title": "Trwałe usunięcie konta",

--- a/packages/ui/src/components/auth/AuthLayout.svelte
+++ b/packages/ui/src/components/auth/AuthLayout.svelte
@@ -26,8 +26,15 @@
   }>();
 </script>
 
-<div class="h-dvh overflow-y-auto">
-  <div class="min-h-dvh flex items-center justify-center px-4 sm:px-6 lg:px-8 py-8 relative">
+<!-- height/min-height subtract --rn-keyboard-inset (set on :root by the app
+     layout's visual-viewport tracker; 0/unset elsewhere) so the soft keyboard
+     does not overlap the focused field on iOS native: the scroll viewport
+     shrinks to the area above the keyboard, re-centering a short card there and
+     letting a tall form scroll its focused input into view. -->
+<div class="h-[calc(100dvh-var(--rn-keyboard-inset,0px))] overflow-y-auto">
+  <div
+    class="min-h-[calc(100dvh-var(--rn-keyboard-inset,0px))] flex items-center justify-center px-4 sm:px-6 lg:px-8 py-8 relative"
+  >
     {#if showLocaleSwitcher || showThemeSwitcher}
       <!-- top: max() keeps the switchers below the iOS notch/Dynamic Island (env() is 0 elsewhere) -->
       <div

--- a/packages/ui/src/components/settings/settings-layout.svelte
+++ b/packages/ui/src/components/settings/settings-layout.svelte
@@ -26,10 +26,18 @@
   );
 </script>
 
-<!-- height: subtract the session-expired banner (--rn-banner-h, set by the
-     notes layout; 0/unset elsewhere) so it does not push the page bottom off
-     screen when visible -->
-<div class={cn('h-[calc(100dvh-var(--rn-banner-h,0px))] overflow-y-auto bg-background', className)}>
+<!-- height: subtract the session-expired banner (--rn-banner-h) and the soft
+     keyboard inset (--rn-keyboard-inset) - both set on :root by the notes
+     layout's trackers; 0/unset elsewhere. Banner keeps the page bottom on
+     screen when visible; keyboard inset shrinks the scroll viewport to the area
+     above the iOS keyboard so a focused field (e.g. change-password / delete
+     account) scrolls into view instead of being covered. -->
+<div
+  class={cn(
+    'h-[calc(100dvh-var(--rn-banner-h,0px)-var(--rn-keyboard-inset,0px))] overflow-y-auto bg-background',
+    className
+  )}
+>
   <!-- pt: keep the header below the iOS notch/Dynamic Island (env() is 0 elsewhere) -->
   <div class="sticky top-0 z-10 bg-background border-b pt-[env(safe-area-inset-top,0px)]">
     <div class="container mx-auto max-w-4xl px-4 sm:px-6">


### PR DESCRIPTION
## Summary

Native v1 polish item (8). On iOS native the soft keyboard overlays the webview without shrinking the layout viewport, so the **login** screen and **settings > change password / delete account** centered their card in full `100dvh` - the focused field stayed behind the keyboard with no scroll bringing it up.

- `AuthLayout` and `SettingsLayout` (`@reborn/ui`) now size their scroll viewport to `calc(100dvh - var(--rn-keyboard-inset))` (settings also minus `--rn-banner-h`), reusing the visual-viewport tracker the note editor already feeds. A short card re-centers above the keyboard; a tall form scrolls the focused field into view. Covers **all** auth pages (login / register / unlock / lock / applock share `AuthLayout`) and all `/settings/*`.
- `/auth/2fa` duplicates the layout inline (predates `AuthLayout`), so it gets the same `calc` locally.
- Added a show/hide ("eye") toggle to the change-password (3 fields) and delete-account password inputs, which previously masked input with no reveal - matching the existing login / passcode pattern. New i18n key `security.{password,delete_account}.toggle_visibility` across all 5 locales.

Fallback `0px` means no behavioral change on web/desktop or in apps without the tracker (reborn-task unaffected; shared components still build there).

## Test plan

Real iOS device / iPad needed (desktop emulation does not reproduce the keyboard visual-viewport):

- [ ] Login: focus username/password -> field stays above the keyboard.
- [ ] Settings > Change password: focus current/new/confirm -> each stays visible; eye icon reveals/hides all three.
- [ ] Settings > Delete account: focus password -> visible above keyboard; eye icon reveals/hides.
- [ ] 2FA: focus code field -> visible above keyboard.
- [ ] Close keyboard -> layout relaxes back to full height, no empty gap.
- [ ] Web/desktop (notes + task) unchanged.

Gate: i18n parity OK, svelte-check 0/0, eslint 0 errors, notes+ui+i18n tests pass, reborn-notes & reborn-task build OK (new arbitrary classes verified in built CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)