### PR TITLE
feat(notes): native folder sync on Android (FolderFs Java/SAF)

### DIFF
--- a/apps/reborn-notes/android/app/src/main/java/eu/reapps/notes/FolderFsPlugin.java
+++ b/apps/reborn-notes/android/app/src/main/java/eu/reapps/notes/FolderFsPlugin.java
@@ -1,0 +1,451 @@
+package eu.reapps.notes;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.DocumentsContract;
+import android.provider.DocumentsContract.Document;
+
+import androidx.activity.result.ActivityResult;
+
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.ActivityCallback;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * FolderFs - app-local Capacitor plugin: persistent read access to a user-picked
+ * directory OUTSIDE the app sandbox, for the one-way native folder sync (disk ->
+ * app). Android counterpart of FolderFsPlugin.swift; both satisfy the same
+ * 4-method JS contract (native-folder-fs.ts), so the FolderSource abstraction,
+ * sync runner, manifest, watermark and import engine are shared verbatim across
+ * platforms. See planning/native-folder-sync-plan.md (Android section).
+ *
+ * Android model (Storage Access Framework):
+ *  - Pick a folder with ACTION_OPEN_DOCUMENT_TREE. The grant is recursive over
+ *    the whole subtree - no per-file picking.
+ *  - Persist access with takePersistableUriPermission(READ): survives relaunch
+ *    AND reboot. It dies when the folder is deleted/moved or the user revokes it
+ *    (the SAF analogue of a stale iOS bookmark) - surfaced as a thrown listFiles
+ *    (SecurityException), which the runner treats as a failed sync until the user
+ *    re-links (a fresh pick). There is no silent "recreate", so staleBookmark is
+ *    never returned (unlike iOS).
+ *  - The "bookmark" is simply the tree Uri string (e.g.
+ *    content://com.android.externalstorage.documents/tree/primary%3ANotes).
+ *  - SAF document URIs are NOT path-addressable (only opaque documentIds are).
+ *    listFiles therefore carries each file's documentId back as `id`, and readFile
+ *    resolves it O(1) via buildDocumentUriUsingTree(id) - falling back to a path
+ *    re-walk only when no `id` is supplied. iOS, whose URLs are path-addressable,
+ *    omits `id` and resolves from `path` alone.
+ *
+ * Registered app-local (not an npm package) via MainActivity.registerPlugin().
+ * No manifest permission is required - SAF grants per-URI access at runtime.
+ */
+@CapacitorPlugin(name = "FolderFs")
+public class FolderFsPlugin extends Plugin {
+
+    private static final String[] LIST_PROJECTION = new String[] {
+        Document.COLUMN_DOCUMENT_ID,
+        Document.COLUMN_DISPLAY_NAME,
+        Document.COLUMN_MIME_TYPE,
+        Document.COLUMN_LAST_MODIFIED,
+        Document.COLUMN_SIZE
+    };
+
+    // MARK: - pickDirectory
+
+    @PluginMethod
+    public void pickDirectory(PluginCall call) {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        // Request a persistable READ grant so takePersistableUriPermission below
+        // can survive process death and reboot.
+        intent.addFlags(
+            Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+        );
+        startActivityForResult(call, intent, "handlePickResult");
+    }
+
+    @ActivityCallback
+    private void handlePickResult(PluginCall call, ActivityResult result) {
+        if (call == null) {
+            return;
+        }
+        Intent data = result.getData();
+        if (result.getResultCode() != Activity.RESULT_OK || data == null || data.getData() == null) {
+            JSObject ret = new JSObject();
+            ret.put("cancelled", true);
+            call.resolve(ret);
+            return;
+        }
+        Uri treeUri = data.getData();
+        try {
+            // Take only READ (sync is read-only; never request WRITE). This grant
+            // is what makes the tree Uri usable after a relaunch/reboot.
+            getContext()
+                .getContentResolver()
+                .takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        } catch (Exception e) {
+            call.reject("Failed to persist folder access: " + e.getMessage());
+            return;
+        }
+        JSObject ret = new JSObject();
+        ret.put("bookmark", treeUri.toString());
+        ret.put("name", displayNameOfTree(treeUri));
+        call.resolve(ret);
+    }
+
+    // MARK: - listFiles
+
+    @PluginMethod
+    public void listFiles(PluginCall call) {
+        String bookmark = call.getString("bookmark");
+        if (bookmark == null) {
+            call.reject("Missing or invalid bookmark");
+            return;
+        }
+        Set<String> extensions = parseExtensions(call.getArray("extensions"));
+
+        Uri treeUri;
+        try {
+            treeUri = Uri.parse(bookmark);
+        } catch (Exception e) {
+            call.reject("Missing or invalid bookmark");
+            return;
+        }
+
+        try {
+            String rootDocId = DocumentsContract.getTreeDocumentId(treeUri);
+            String rootLeaf = displayNameOfTree(treeUri);
+            ContentResolver resolver = getContext().getContentResolver();
+            JSArray files = new JSArray();
+
+            // Iterative DFS (an explicit stack, not recursion) over the document
+            // tree: one children query per directory. Deliberately NOT
+            // DocumentFile.listFiles(), which is ~100x slower (it re-queries per
+            // child). Relative paths are rooted at the directory leaf name
+            // (<leaf>/<sub>/<file>), matching the web/iOS walk shape so the shared
+            // importFolder engine is blind to which platform produced them.
+            Deque<Frame> stack = new ArrayDeque<>();
+            stack.push(new Frame(rootDocId, rootLeaf));
+
+            while (!stack.isEmpty()) {
+                Frame frame = stack.pop();
+                Uri childrenUri =
+                    DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, frame.docId);
+                Cursor cursor = resolver.query(childrenUri, LIST_PROJECTION, null, null, null);
+                if (cursor == null) {
+                    continue;
+                }
+                try {
+                    int idIdx = cursor.getColumnIndexOrThrow(Document.COLUMN_DOCUMENT_ID);
+                    int nameIdx = cursor.getColumnIndexOrThrow(Document.COLUMN_DISPLAY_NAME);
+                    int mimeIdx = cursor.getColumnIndexOrThrow(Document.COLUMN_MIME_TYPE);
+                    // mtime/size are optional columns for some providers - tolerate absence.
+                    int mtimeIdx = cursor.getColumnIndex(Document.COLUMN_LAST_MODIFIED);
+                    int sizeIdx = cursor.getColumnIndex(Document.COLUMN_SIZE);
+
+                    while (cursor.moveToNext()) {
+                        String name = cursor.getString(nameIdx);
+                        if (name == null) {
+                            continue;
+                        }
+                        // Prune hidden (dot) segments - .obsidian/, .trash/ - whole
+                        // subtree for dirs. (No iCloud-placeholder analogue here.)
+                        if (name.startsWith(".")) {
+                            continue;
+                        }
+
+                        String childId = cursor.getString(idIdx);
+                        String mime = cursor.getString(mimeIdx);
+                        String childRel = frame.relPath + "/" + name;
+
+                        if (Document.MIME_TYPE_DIR.equals(mime)) {
+                            stack.push(new Frame(childId, childRel));
+                            continue;
+                        }
+
+                        if (!extensions.contains(extensionOf(name))) {
+                            continue;
+                        }
+
+                        long mtime = (mtimeIdx >= 0 && !cursor.isNull(mtimeIdx))
+                            ? cursor.getLong(mtimeIdx)
+                            : 0L;
+                        long size = (sizeIdx >= 0 && !cursor.isNull(sizeIdx))
+                            ? cursor.getLong(sizeIdx)
+                            : 0L;
+
+                        JSObject entry = new JSObject();
+                        entry.put("path", childRel);
+                        entry.put("mtime", mtime);
+                        entry.put("size", size);
+                        // Opaque SAF documentId - readFile resolves O(1) from it,
+                        // avoiding a per-file path re-walk on the first full sync.
+                        entry.put("id", childId);
+                        files.put(entry);
+                    }
+                } finally {
+                    cursor.close();
+                }
+            }
+
+            JSObject ret = new JSObject();
+            ret.put("files", files);
+            call.resolve(ret);
+        } catch (SecurityException e) {
+            call.reject("Access denied to bookmarked folder", "ACCESS_DENIED");
+        } catch (Exception e) {
+            call.reject("Failed to list folder: " + e.getMessage(), "RESOLVE_FAILED");
+        }
+    }
+
+    // MARK: - readFile
+
+    @PluginMethod
+    public void readFile(PluginCall call) {
+        String bookmark = call.getString("bookmark");
+        String path = call.getString("path");
+        if (bookmark == null || path == null) {
+            call.reject("Missing bookmark or path");
+            return;
+        }
+
+        try {
+            Uri treeUri = Uri.parse(bookmark);
+            String docId = call.getString("id");
+            Uri fileUri = (docId != null)
+                ? DocumentsContract.buildDocumentUriUsingTree(treeUri, docId)
+                : resolveByPath(treeUri, path);
+            if (fileUri == null) {
+                call.reject("File not found: " + path, "READ_FAILED");
+                return;
+            }
+            String content = readUtf8(fileUri);
+            long mtime = lastModifiedOf(fileUri);
+            JSObject ret = new JSObject();
+            ret.put("content", content);
+            ret.put("mtime", mtime);
+            call.resolve(ret);
+        } catch (SecurityException e) {
+            call.reject("Access denied to bookmarked folder", "ACCESS_DENIED");
+        } catch (Exception e) {
+            call.reject("Failed to read file: " + e.getMessage(), "READ_FAILED");
+        }
+    }
+
+    // MARK: - isSameDirectory
+
+    @PluginMethod
+    public void isSameDirectory(PluginCall call) {
+        String a = call.getString("a");
+        String b = call.getString("b");
+        if (a == null || b == null) {
+            call.reject("Missing bookmarks");
+            return;
+        }
+        try {
+            Uri ua = Uri.parse(a);
+            Uri ub = Uri.parse(b);
+            boolean same =
+                stringsEqual(ua.getAuthority(), ub.getAuthority())
+                    && stringsEqual(
+                        DocumentsContract.getTreeDocumentId(ua),
+                        DocumentsContract.getTreeDocumentId(ub)
+                    );
+            JSObject ret = new JSObject();
+            ret.put("same", same);
+            call.resolve(ret);
+        } catch (Exception e) {
+            call.reject("Failed to compare bookmarks: " + e.getMessage());
+        }
+    }
+
+    // MARK: - helpers
+
+    /** Walk frame: a directory's documentId plus its accumulated <leaf>/<sub> path. */
+    private static final class Frame {
+        final String docId;
+        final String relPath;
+
+        Frame(String docId, String relPath) {
+            this.docId = docId;
+            this.relPath = relPath;
+        }
+    }
+
+    /** Lower-cased extension set; defaults to {"md"} when none supplied. */
+    private Set<String> parseExtensions(JSArray raw) {
+        Set<String> extensions = new HashSet<>();
+        if (raw != null) {
+            try {
+                List<Object> list = raw.toList();
+                for (Object item : list) {
+                    if (item instanceof String) {
+                        String ext = ((String) item).toLowerCase(Locale.ROOT);
+                        if (!ext.isEmpty()) {
+                            extensions.add(ext);
+                        }
+                    }
+                }
+            } catch (Exception ignored) {
+                // Malformed array -> fall through to the default below.
+            }
+        }
+        if (extensions.isEmpty()) {
+            extensions.add("md");
+        }
+        return extensions;
+    }
+
+    private static String extensionOf(String name) {
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) {
+            return "";
+        }
+        return name.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean stringsEqual(String a, String b) {
+        return a == null ? b == null : a.equals(b);
+    }
+
+    /** Display name (leaf) of the tree root; falls back to the doc-id tail. */
+    private String displayNameOfTree(Uri treeUri) {
+        String docId = DocumentsContract.getTreeDocumentId(treeUri);
+        Uri rootDoc = DocumentsContract.buildDocumentUriUsingTree(treeUri, docId);
+        String name = queryDisplayName(rootDoc);
+        if (name != null && !name.isEmpty()) {
+            return name;
+        }
+        // Fallback: tail of "primary:Some/Folder" (provider-dependent doc ids).
+        String tail = docId;
+        int colon = tail.lastIndexOf(':');
+        if (colon >= 0) {
+            tail = tail.substring(colon + 1);
+        }
+        int slash = tail.lastIndexOf('/');
+        if (slash >= 0) {
+            tail = tail.substring(slash + 1);
+        }
+        return tail.isEmpty() ? "Folder" : tail;
+    }
+
+    private String queryDisplayName(Uri docUri) {
+        Cursor cursor = getContext()
+            .getContentResolver()
+            .query(docUri, new String[] { Document.COLUMN_DISPLAY_NAME }, null, null, null);
+        if (cursor == null) {
+            return null;
+        }
+        try {
+            if (cursor.moveToFirst() && !cursor.isNull(0)) {
+                return cursor.getString(0);
+            }
+        } finally {
+            cursor.close();
+        }
+        return null;
+    }
+
+    private long lastModifiedOf(Uri docUri) {
+        Cursor cursor = getContext()
+            .getContentResolver()
+            .query(docUri, new String[] { Document.COLUMN_LAST_MODIFIED }, null, null, null);
+        if (cursor == null) {
+            return 0L;
+        }
+        try {
+            if (cursor.moveToFirst() && !cursor.isNull(0)) {
+                return cursor.getLong(0);
+            }
+        } finally {
+            cursor.close();
+        }
+        return 0L;
+    }
+
+    /**
+     * Fallback resolver: map a <leaf>/<sub>/<file> path to a document Uri by
+     * walking the tree and matching display names. Only used when readFile is
+     * called without an `id` (normally listFiles supplies one, making reads O(1)).
+     */
+    private Uri resolveByPath(Uri treeUri, String relPath) {
+        ContentResolver resolver = getContext().getContentResolver();
+        String currentDocId = DocumentsContract.getTreeDocumentId(treeUri);
+        String[] segments = relPath.split("/");
+        // Drop the leading leaf segment (it names the tree root itself).
+        int start = 0;
+        if (segments.length > 0 && segments[0].equals(displayNameOfTree(treeUri))) {
+            start = 1;
+        }
+
+        for (int i = start; i < segments.length; i++) {
+            String seg = segments[i];
+            if (seg.isEmpty()) {
+                continue;
+            }
+            Uri childrenUri =
+                DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, currentDocId);
+            Cursor cursor = resolver.query(
+                childrenUri,
+                new String[] { Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME },
+                null,
+                null,
+                null
+            );
+            if (cursor == null) {
+                return null;
+            }
+            String matchId = null;
+            try {
+                while (cursor.moveToNext()) {
+                    if (seg.equals(cursor.getString(1))) {
+                        matchId = cursor.getString(0);
+                        break;
+                    }
+                }
+            } finally {
+                cursor.close();
+            }
+            if (matchId == null) {
+                return null;
+            }
+            currentDocId = matchId;
+        }
+        return DocumentsContract.buildDocumentUriUsingTree(treeUri, currentDocId);
+    }
+
+    private String readUtf8(Uri fileUri) throws IOException {
+        InputStream input = getContext().getContentResolver().openInputStream(fileUri);
+        if (input == null) {
+            throw new IOException("openInputStream returned null");
+        }
+        try {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            int read;
+            while ((read = input.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+            return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+        } finally {
+            input.close();
+        }
+    }
+}

--- a/apps/reborn-notes/android/app/src/main/java/eu/reapps/notes/MainActivity.java
+++ b/apps/reborn-notes/android/app/src/main/java/eu/reapps/notes/MainActivity.java
@@ -1,5 +1,18 @@
 package eu.reapps.notes;
 
+import android.os.Bundle;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        // Register the app-local FolderFs plugin (native folder sync, disk -> app)
+        // BEFORE super.onCreate so the bridge wires it up during initialization.
+        // This is the Android counterpart of iOS
+        // MainViewController.capacitorDidLoad(); add future app-local plugins here
+        // the same way.
+        registerPlugin(FolderFsPlugin.class);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/apps/reborn-notes/src/lib/platform/folder-source/native.spec.ts
+++ b/apps/reborn-notes/src/lib/platform/folder-source/native.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Locks the native FolderSource's mapping onto the FolderFs plugin contract: the
+ * lazy-entry shape, the stale-bookmark refresh, and - crucially - that the opaque
+ * per-file handle (`id`, the Android SAF documentId) from `listFiles` is threaded
+ * back into `readFile` so a changed file reads O(1) instead of re-walking the tree.
+ *
+ * `$lib/utils/native-folder-fs` is fully mocked, so the module's own
+ * `__REBORN_NATIVE__` ("native-only") guard is never reached and this runs under
+ * the vitest web define like every other native bridge spec.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fakePlugin = {
+  pickDirectory: vi.fn(),
+  listFiles: vi.fn(),
+  readFile: vi.fn(),
+  isSameDirectory: vi.fn()
+};
+
+vi.mock('$lib/utils/native-folder-fs', () => ({
+  getFolderFs: () => fakePlugin
+}));
+
+import { createNativeFolderSource } from './native';
+
+describe('native FolderSource', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pick maps a picked bookmark to a ref', async () => {
+    fakePlugin.pickDirectory.mockResolvedValue({ bookmark: 'content://tree/x', name: 'Vault' });
+    const out = await createNativeFolderSource().pick();
+    expect(out).toEqual({
+      kind: 'picked',
+      ref: { bookmark: 'content://tree/x', name: 'Vault' },
+      name: 'Vault'
+    });
+  });
+
+  it('pick reports cancellation when the picker is dismissed', async () => {
+    fakePlugin.pickDirectory.mockResolvedValue({ cancelled: true });
+    expect(await createNativeFolderSource().pick()).toEqual({ kind: 'cancelled' });
+  });
+
+  it('listMarkdown threads the SAF id into the lazy read and builds the File', async () => {
+    fakePlugin.listFiles.mockResolvedValue({
+      files: [{ path: 'Vault/sub/note.md', mtime: 111, size: 9, id: 'doc-42' }]
+    });
+    fakePlugin.readFile.mockResolvedValue({ content: '# hi', mtime: 111 });
+
+    const { entries, refreshedRef } = await createNativeFolderSource().listMarkdown({
+      bookmark: 'bm',
+      name: 'Vault'
+    });
+
+    expect(refreshedRef).toBeUndefined();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].relativePath).toBe('Vault/sub/note.md');
+    expect(entries[0].lastModified).toBe(111);
+
+    const file = await entries[0].getFile();
+    expect(fakePlugin.readFile).toHaveBeenCalledWith({
+      bookmark: 'bm',
+      path: 'Vault/sub/note.md',
+      id: 'doc-42'
+    });
+    expect(file.name).toBe('note.md');
+    expect(file.lastModified).toBe(111);
+    expect(await file.text()).toBe('# hi');
+  });
+
+  it('listMarkdown surfaces a stale bookmark as refreshedRef and reads with the fresh one', async () => {
+    fakePlugin.listFiles.mockResolvedValue({
+      files: [{ path: 'Vault/a.md', mtime: 5, size: 1, id: 'd1' }],
+      staleBookmark: 'fresh-bm'
+    });
+    fakePlugin.readFile.mockResolvedValue({ content: 'x', mtime: 5 });
+
+    const { entries, refreshedRef } = await createNativeFolderSource().listMarkdown({
+      bookmark: 'old-bm',
+      name: 'Vault'
+    });
+
+    expect(refreshedRef).toEqual({ bookmark: 'fresh-bm', name: 'Vault' });
+    await entries[0].getFile();
+    expect(fakePlugin.readFile).toHaveBeenCalledWith({
+      bookmark: 'fresh-bm',
+      path: 'Vault/a.md',
+      id: 'd1'
+    });
+  });
+
+  it('isSame delegates to the plugin and swallows bridge errors as false', async () => {
+    const src = createNativeFolderSource();
+    fakePlugin.isSameDirectory.mockResolvedValue({ same: true });
+    expect(await src.isSame({ bookmark: 'a' }, { bookmark: 'b' })).toBe(true);
+    fakePlugin.isSameDirectory.mockRejectedValue(new Error('boom'));
+    expect(await src.isSame({ bookmark: 'a' }, { bookmark: 'b' })).toBe(false);
+  });
+
+  it('queryAccess is optimistically granted (native bookmarks resolve silently)', async () => {
+    expect(await createNativeFolderSource().queryAccess({ bookmark: 'a' })).toBe('granted');
+  });
+
+  it('isSupported is always true on the native shell', () => {
+    expect(createNativeFolderSource().isSupported()).toBe(true);
+  });
+});

--- a/apps/reborn-notes/src/lib/platform/folder-source/native.ts
+++ b/apps/reborn-notes/src/lib/platform/folder-source/native.ts
@@ -1,12 +1,13 @@
 /**
- * Native (Capacitor, iOS) FolderSource - the app-local FolderFs plugin.
+ * Native (Capacitor: iOS + Android) FolderSource - the app-local FolderFs plugin.
  *
- * The `DirectoryRef` is `{ bookmark, name }`: a base64 security-scoped bookmark
- * (persistent read access to a user-picked out-of-sandbox directory, survives
- * relaunch + reboot - validated on device) plus the on-disk leaf name for
- * display. The plugin enumerates `.md` files (path + mtime + size, no content)
- * and reads one file's content on demand, so a sync run only reads the files
- * that changed - the same laziness the web File has.
+ * The `DirectoryRef` is `{ bookmark, name }`: persistent read access to a
+ * user-picked out-of-sandbox directory (iOS: a base64 security-scoped bookmark;
+ * Android: a SAF tree-Uri string + takePersistableUriPermission) that survives
+ * relaunch + reboot, plus the on-disk leaf name for display. The plugin
+ * enumerates `.md` files (path + mtime + size, no content) and reads one file's
+ * content on demand, so a sync run only reads the files that changed - the same
+ * laziness the web File has.
  *
  * Loaded only on the native build (the selector in `./index.ts` picks this when
  * `__REBORN_NATIVE__` is true); on web this whole module - and the plugin behind
@@ -86,7 +87,9 @@ export function createNativeFolderSource(): FolderSource {
         relativePath: f.path,
         lastModified: f.mtime,
         getFile: async () => {
-          const { content } = await getFolderFs().readFile({ bookmark, path: f.path });
+          // Pass the opaque handle through (Android SAF documentId -> O(1) read;
+          // undefined on iOS, which resolves from `path`).
+          const { content } = await getFolderFs().readFile({ bookmark, path: f.path, id: f.id });
           const name = f.path.split('/').pop() ?? f.path;
           return new File([content], name, { lastModified: f.mtime });
         }

--- a/apps/reborn-notes/src/lib/platform/folder-source/types.ts
+++ b/apps/reborn-notes/src/lib/platform/folder-source/types.ts
@@ -5,10 +5,11 @@
  *
  * Web (PWA, Chromium) implements it with the File System Access API
  * (`showDirectoryPicker` + `FileSystemDirectoryHandle`); the native shell
- * (Capacitor, iOS) implements it with the app-local FolderFs plugin (a
- * security-scoped bookmark). The folder-sync service talks only to this
- * interface, so the multi-config runner, manifest, watermark, dedup and import
- * engine are shared verbatim across platforms.
+ * (Capacitor: iOS + Android) implements it with the app-local FolderFs plugin
+ * (iOS: a security-scoped bookmark; Android: a Storage Access Framework tree
+ * Uri). The folder-sync service talks only to this interface, so the
+ * multi-config runner, manifest, watermark, dedup and import engine are shared
+ * verbatim across platforms.
  *
  * App-local (not in `@reborn/platform`) on purpose: Notes is the only consumer,
  * the web impl pulls in WICG File System Access typings, and the native walker
@@ -22,7 +23,8 @@
  * service treats it as a black box and stores it in the config record's `handle`
  * field; only the FolderSource impl knows its real shape:
  *  - Web: a `FileSystemDirectoryHandle` (structured-cloneable into IndexedDB).
- *  - Native: `{ bookmark: string (base64 security-scoped bookmark), name: string }`.
+ *  - Native: `{ bookmark: string, name: string }`, where `bookmark` is a base64
+ *    security-scoped bookmark (iOS) or a SAF tree-Uri string (Android).
  *
  * Web and native never share a browser profile / install, so the same field
  * holding two shapes needs no migration.

--- a/apps/reborn-notes/src/lib/utils/native-folder-fs.ts
+++ b/apps/reborn-notes/src/lib/utils/native-folder-fs.ts
@@ -5,8 +5,8 @@
  * OUTSIDE the app sandbox - the capability WKWebView/Android WebView lack (no File
  * System Access API). It is the native counterpart of the web
  * `FileSystemDirectoryHandle`: an opaque, persistable reference (a base64
- * security-scoped bookmark on iOS) plus recursive `.md` enumeration and lazy file
- * reads. See `planning/native-folder-sync-plan.md`.
+ * security-scoped bookmark on iOS, a SAF tree-Uri string on Android) plus recursive
+ * `.md` enumeration and lazy file reads. See `planning/native-folder-sync-plan.md`.
  *
  * Talks DIRECTLY to the natively-registered plugin via `registerPlugin('FolderFs')`
  * - the same raw-proxy pattern as `native-secure-storage.ts` / `native-system-bars.ts`
@@ -28,6 +28,14 @@ export interface NativeFsEntry {
   mtime: number;
   /** File size in bytes. */
   size: number;
+  /**
+   * Opaque platform handle to the file, threaded back into `readFile` so the
+   * lazy read is O(1). Android: the SAF documentId (SAF Uris are NOT
+   * path-addressable, so a documentId is the only cheap way back to the file).
+   * iOS omits it - its URLs are path-addressable, so `readFile` resolves from
+   * `path` alone.
+   */
+  id?: string;
 }
 
 /** Native FolderFs plugin method surface (see FolderFsPlugin.swift). */
@@ -43,8 +51,16 @@ export interface FolderFsPlugin {
     bookmark: string;
     extensions?: string[];
   }): Promise<{ files: NativeFsEntry[]; staleBookmark?: string }>;
-  /** Read one file's UTF-8 content (downloads iCloud placeholders first). */
-  readFile(options: { bookmark: string; path: string }): Promise<{ content: string; mtime: number }>;
+  /**
+   * Read one file's UTF-8 content (iOS downloads iCloud placeholders first).
+   * `id` is the optional opaque handle from `listFiles` (Android SAF documentId);
+   * iOS ignores it and resolves the file from `path`.
+   */
+  readFile(options: {
+    bookmark: string;
+    path: string;
+    id?: string;
+  }): Promise<{ content: string; mtime: number }>;
   /** Same on-disk directory? (dedup at link time). */
   isSameDirectory(options: { a: string; b: string }): Promise<{ same: boolean }>;
 }


### PR DESCRIPTION
## Summary

Ports the native folder sync (one-way disk -> app) from iOS to Android. The `FolderSource` abstraction's 4-method JS contract is shared verbatim, so `native.ts`, the sync runner, manifest, settings UI, i18n and the resume trigger are **untouched** - only the native plugin is new. On Android the folder-sync page was already visible (`isSupported()` is always true on native) but `pick()` failed with no plugin registered; this makes it work.

- **`FolderFsPlugin.java`** - Capacitor plugin on the Storage Access Framework:
  - `pickDirectory` - `ACTION_OPEN_DOCUMENT_TREE` via `startActivityForResult` + `@ActivityCallback`; grant persisted with `takePersistableUriPermission(READ)` (survives relaunch + reboot).
  - `listFiles` - iterative `DocumentsContract` walk, one `query` per directory (not the ~100x slower `DocumentFile.listFiles()`); mtime from `COLUMN_LAST_MODIFIED`, extension filter from display name, dot-segments pruned, paths rooted at the dir leaf (web/iOS walk shape).
  - `readFile` - `openInputStream`; O(1) via the SAF documentId, path re-walk fallback.
  - `isSameDirectory` - authority + tree-doc-id compare.
- **`MainActivity.java`** - `registerPlugin(FolderFsPlugin.class)` before `super.onCreate` (first app-local Android plugin; mirrors iOS `capacitorDidLoad`). No manifest permission needed (SAF grants per-URI at runtime).
- **Shared TS contract** gains an optional, additive `id` (the SAF documentId) threaded `listFiles -> readFile`; iOS ignores it.

**Zero Knowledge:** no change. Still a plaintext read from disk that is encrypted at import; the SAF grant is device-local, never synced, cleared on logout - same guarantee as the web handle / iOS bookmark.

### Decisions flagged for review
1. **Java, not Kotlin** (the plan said Kotlin). The Android project is pure Java (Capacitor template, `MainActivity.java`); adding Kotlin means the Gradle plugin + stdlib + compiler - new build infra for no gain on a ~450-line plugin. Java keeps the maintenance surface smaller. Reversible.
2. **Optional `id` on the shared `NativeFsEntry`/`readFile`.** SAF document URIs are NOT path-addressable (unlike iOS URLs), so `readFile` needs either the documentId or a per-file re-walk. Carrying the documentId from `listFiles` makes first-sync reads O(1) (closes the "first sync slow" risk from the plan). Additive + optional; iOS behaviour unchanged.

## Test plan

JS gate is green in-sandbox; the Android build + on-device smoke run outside the sandbox (native toolchain).

- [x] `svelte-check` 0 errors / 0 warnings
- [x] eslint 0 errors
- [x] `native.spec.ts` 7/7 (locks the native FolderSource mapping + `id` threading), folder-sync suite 57 green
- [x] Capacitor 8.4.0 APIs used by the plugin verified present in `node_modules` (`startActivityForResult(PluginCall,Intent,String)`, `@ActivityCallback`, `JSObject.put(long)`, `JSArray.toList`)
- [x] **Android build (AAB) compiles** (outside sandbox)
- [x] **On-device/emulator smoke**: pick a folder -> initial `.md` import -> edit a file on disk -> re-sync picks it up -> add/delete a file -> reboot (grant + sync still work) -> revoke access (surfaces as failed sync, re-link fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)