### PR TITLE
fix(auth): allow entering all 6 2FA digits on iOS native

### DIFF
--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -163,7 +163,7 @@
 								type="text"
 								inputmode="numeric"
 								autocomplete="one-time-code"
-								maxlength={6}
+								oninput={(e) => { const next = e.currentTarget.value.replace(/\D/g, '').slice(0, 6); if (e.currentTarget.value !== next) e.currentTarget.value = next; code = next; }}
 								pattern="[0-9]*"
 								placeholder="000000"
 								bind:value={code}

--- a/apps/reborn-notes/src/routes/settings/security/two-factor/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/two-factor/+page.svelte
@@ -375,7 +375,7 @@
                   type="text"
                   inputmode="numeric"
                   autocomplete="one-time-code"
-                  maxlength={6}
+                  oninput={(e) => { const next = e.currentTarget.value.replace(/\D/g, '').slice(0, 6); if (e.currentTarget.value !== next) e.currentTarget.value = next; verificationCode = next; }}
                   pattern="[0-9]*"
                   placeholder="000000"
                   bind:value={verificationCode}

--- a/apps/reborn-task/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/2fa/+page.svelte
@@ -179,7 +179,7 @@
 								type="text"
 								inputmode="numeric"
 								autocomplete="one-time-code"
-								maxlength={6}
+								oninput={(e) => { const next = e.currentTarget.value.replace(/\D/g, '').slice(0, 6); if (e.currentTarget.value !== next) e.currentTarget.value = next; code = next; }}
 								pattern="[0-9]*"
 								placeholder="000000"
 								bind:value={code}

--- a/apps/reborn-task/src/routes/settings/security/two-factor/+page.svelte
+++ b/apps/reborn-task/src/routes/settings/security/two-factor/+page.svelte
@@ -425,7 +425,7 @@
 									type="text"
 									inputmode="numeric"
 									autocomplete="one-time-code"
-									maxlength={6}
+									oninput={(e) => { const next = e.currentTarget.value.replace(/\D/g, '').slice(0, 6); if (e.currentTarget.value !== next) e.currentTarget.value = next; verificationCode = next; }}
 									pattern="[0-9]*"
 									placeholder="000000"
 									bind:value={verificationCode}

--- a/packages/ui/src/components/auth/ReAuthModal.svelte
+++ b/packages/ui/src/components/auth/ReAuthModal.svelte
@@ -300,7 +300,7 @@
               type="text"
               inputmode="numeric"
               autocomplete="one-time-code"
-              maxlength={6}
+              oninput={(e) => { const next = e.currentTarget.value.replace(/\D/g, '').slice(0, 6); if (e.currentTarget.value !== next) e.currentTarget.value = next; totpCode = next; }}
               pattern="[0-9]*"
               required
               bind:value={totpCode}


### PR DESCRIPTION
## Summary

The 2FA TOTP code field accepted only 5 digits on iPad/iOS in the native Capacitor app, making 2FA login impossible. Web/PWA and Android native were fine.

**Root cause:** iOS WebKit (the WKWebView in the native shell) stops a letter-spaced text input one character short of its `maxlength`. The TOTP fields combine `maxlength={6}` with a large CSS `letter-spacing` (`tracking-[0.5em]` / `tracking-widest`), which trips this WebKit quirk. Blink (Android) and desktop browsers are unaffected, which matches the reported platform split.

**Fix:** drop the native `maxlength={6}` on every TOTP/2FA code field and enforce the 6-digit limit in an `oninput` handler instead (strip non-digits, cap at 6). Behaviour is identical on web/Android, the broken native enforcement no longer runs on iOS, and the spaced-digit styling is unchanged.

**Scope note (auto mode):** the bug was reported on re/notes login, but the same `maxlength` + letter-spacing pattern exists in five places sharing one root cause, so the fix is applied to all of them:
- `reborn-notes` & `reborn-task`: `/auth/2fa` login + settings 2FA setup
- `@reborn/ui` `ReAuthModal` (session re-auth, shared by both apps)

## Test plan

Local gate (green): `lint` (0 errors), `check` / svelte-check (0 errors, 0 warnings, both apps), `test` (812 app tests + `@reborn/ui`).

Smoke (needs an iOS native build):
- iOS/iPad native, 2FA login: type a full 6-digit TOTP code -> all 6 digits enterable and login succeeds; recovery-code link still works.
- iOS native settings: enable 2FA -> setup verification field accepts 6 digits.
- iOS native: trigger session re-auth (ReAuthModal) -> TOTP field accepts 6 digits.
- Regression on web/PWA + Android native: 2FA still accepts exactly 6 digits, rejects non-digits, pasting a code works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)