### PR TITLE
fix(notes): account login from local-only mode (state + sync + UX)

### DIFF
--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -34,6 +34,7 @@
     Share2,
     Heart,
     UserPlus,
+    LogIn,
     Lock
   } from '@lucide/svelte';
   import * as Tooltip from '@reborn/ui/components/tooltip';
@@ -587,6 +588,10 @@
             <DropdownMenu.Separator />
             <DropdownMenu.Group>
               {#if $authStore.isLocalOnly}
+                <DropdownMenu.Item onclick={() => goto('/auth/login')}>
+                  <LogIn class="h-4 w-4" />
+                  {$t('nav.sign_in')}
+                </DropdownMenu.Item>
                 <DropdownMenu.Item onclick={() => goto('/auth/register')}>
                   <UserPlus class="h-4 w-4" />
                   {$t('local_mode.register')}
@@ -647,6 +652,17 @@
     </SheetHeader>
     <div class="mt-4 space-y-1">
       {#if $authStore.isLocalOnly}
+        <Button
+          variant="ghost"
+          class="w-full justify-start min-h-11"
+          onclick={() => {
+            userSheetOpen = false;
+            goto('/auth/login');
+          }}
+        >
+          <LogIn class="mr-2 h-5 w-5" />
+          {$t('nav.sign_in')}
+        </Button>
         <Button
           variant="ghost"
           class="w-full justify-start min-h-11"

--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -16,7 +16,7 @@ import {
   LOCAL_MODE_KEY,
   LOCAL_USER_ID_KEY
 } from '$lib/stores/auth.store';
-import { sessionExpired } from '$lib/stores/sync-status.store';
+import { sessionExpired, isInitialSync } from '$lib/stores/sync-status.store';
 import { noteIndex } from '$lib/services/note-index.svelte';
 import { notesStore } from '$lib/stores/notes.store';
 import { clearAllUserData, isDatabaseInitialized } from '@reborn/storage';
@@ -159,13 +159,16 @@ export function startAccountSessionSync(): void {
   localStorage.removeItem(LOCAL_MODE_KEY);
   localStorage.removeItem(LOCAL_USER_ID_KEY);
   if (!wasLocalOnly) return; // logged-out -> account: +layout effect handles the pull
+  // Show the first-load placeholder immediately and hold it across the whole
+  // arc (this pre-pull window + the pull + the post-pull store hydration), so
+  // the list never flashes the stale local notes or the empty state. The pull's
+  // refreshStoresAfterPull clears it once the account data is in memory.
+  isInitialSync.set(true);
   // The caller already ran clearAllUserData(), so IndexedDB is empty - but the
   // in-memory noteIndex + notesStore still hold the LOCAL session's notes. Reset
   // them now, synchronously, before the post-login goto renders, so the list
-  // shows the InitialSyncState placeholder during the pull instead of the
-  // just-deleted local notes (which would otherwise linger until the pull's
-  // refreshStoresAfterPull lands at the very end). clear() is synchronous;
-  // refresh() re-reads the now-empty index.
+  // shows the placeholder (not the just-deleted local notes). clear() is
+  // synchronous; refresh() re-reads the now-empty index.
   noteIndex.clear();
   void notesStore.refresh();
   void (async () => {
@@ -173,14 +176,12 @@ export function startAccountSessionSync(): void {
       const { pullFromServer, pushPendingItems, refreshStoresAfterPull } = await import(
         '$lib/services/notes-sync.service'
       );
-      // Reset folders/tags/saved-searches from the empty IDB too, so the sidebar
-      // doesn't show stale local entries during the pull (mirrors +layout runSync).
-      await refreshStoresAfterPull();
       await pushPendingItems();
       const synced = await pullFromServer();
       if (synced) await refreshStoresAfterPull();
     } catch {
       // Offline / transient failure - the periodic + resume sync converges later.
+      isInitialSync.set(false);
     }
   })();
 }

--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -17,6 +17,8 @@ import {
   LOCAL_USER_ID_KEY
 } from '$lib/stores/auth.store';
 import { sessionExpired } from '$lib/stores/sync-status.store';
+import { noteIndex } from '$lib/services/note-index.svelte';
+import { notesStore } from '$lib/stores/notes.store';
 import { clearAllUserData, isDatabaseInitialized } from '@reborn/storage';
 import { createLogger } from '@reborn/utils';
 import type { ReAuthResult } from '@reborn/ui';
@@ -157,11 +159,23 @@ export function startAccountSessionSync(): void {
   localStorage.removeItem(LOCAL_MODE_KEY);
   localStorage.removeItem(LOCAL_USER_ID_KEY);
   if (!wasLocalOnly) return; // logged-out -> account: +layout effect handles the pull
+  // The caller already ran clearAllUserData(), so IndexedDB is empty - but the
+  // in-memory noteIndex + notesStore still hold the LOCAL session's notes. Reset
+  // them now, synchronously, before the post-login goto renders, so the list
+  // shows the InitialSyncState placeholder during the pull instead of the
+  // just-deleted local notes (which would otherwise linger until the pull's
+  // refreshStoresAfterPull lands at the very end). clear() is synchronous;
+  // refresh() re-reads the now-empty index.
+  noteIndex.clear();
+  void notesStore.refresh();
   void (async () => {
     try {
       const { pullFromServer, pushPendingItems, refreshStoresAfterPull } = await import(
         '$lib/services/notes-sync.service'
       );
+      // Reset folders/tags/saved-searches from the empty IDB too, so the sidebar
+      // doesn't show stale local entries during the pull (mirrors +layout runSync).
+      await refreshStoresAfterPull();
       await pushPendingItems();
       const synced = await pullFromServer();
       if (synced) await refreshStoresAfterPull();

--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -9,7 +9,13 @@ import { API_BASE } from '$lib/utils/api-base';
 import { nativeAuthHeaders } from '$lib/utils/native-client';
 import { persistNativeRefreshToken } from '$lib/utils/native-auth-storage';
 import { persistNativeSessionId } from '$lib/utils/native-session';
-import { authStore, CREDENTIALS_KEY, ACCESS_TOKEN_KEY } from '$lib/stores/auth.store';
+import {
+  authStore,
+  CREDENTIALS_KEY,
+  ACCESS_TOKEN_KEY,
+  LOCAL_MODE_KEY,
+  LOCAL_USER_ID_KEY
+} from '$lib/stores/auth.store';
 import { sessionExpired } from '$lib/stores/sync-status.store';
 import { clearAllUserData, isDatabaseInitialized } from '@reborn/storage';
 import { createLogger } from '@reborn/utils';
@@ -118,6 +124,8 @@ export async function loginInNotes(username: string, password: string): Promise<
 
     // Hydrate auth store with the new session
     authStore.initialize();
+    // Leave local-only mode + run the first sync (see startAccountSessionSync).
+    startAccountSessionSync();
     return { success: true };
   } catch (err: unknown) {
     return {
@@ -125,6 +133,42 @@ export async function loginInNotes(username: string, password: string): Promise<
       message: err instanceof Error ? err.message : 'An error occurred. Please try again.'
     };
   }
+}
+
+/**
+ * Tail shared by the password login ({@link loginInNotes}) and the 2FA second
+ * step (`auth/2fa/+page.svelte`): drop the local-only markers - a real account
+ * session owns this device now - and, when this login REPLACED a local-only
+ * session, kick off the first pull so the UI leaves the "Local only" footer,
+ * shows the syncing indicator, and loads the account's notes immediately.
+ *
+ * The explicit pull is gated on the local -> account transition on purpose: a
+ * fresh login from a logged-out state toggles `hasE2E` false -> true, which the
+ * `+layout` initial-sync effect already reacts to. On a local -> account switch
+ * the master key never leaves memory (`hasE2E` stays true), so that effect
+ * never fires and we must trigger the first sync here. Mirrors the local ->
+ * account upgrade in `auth/register/+page.svelte`. Fire-and-forget so
+ * navigation proceeds immediately; the pull is coalesced (single-flight) with
+ * any other trigger.
+ */
+export function startAccountSessionSync(): void {
+  const wasLocalOnly = localStorage.getItem(LOCAL_MODE_KEY) === '1';
+  // Leaving local-only mode: the account session owns this device now.
+  localStorage.removeItem(LOCAL_MODE_KEY);
+  localStorage.removeItem(LOCAL_USER_ID_KEY);
+  if (!wasLocalOnly) return; // logged-out -> account: +layout effect handles the pull
+  void (async () => {
+    try {
+      const { pullFromServer, pushPendingItems, refreshStoresAfterPull } = await import(
+        '$lib/services/notes-sync.service'
+      );
+      await pushPendingItems();
+      const synced = await pullFromServer();
+      if (synced) await refreshStoresAfterPull();
+    } catch {
+      // Offline / transient failure - the periodic + resume sync converges later.
+    }
+  })();
 }
 
 /** Pull fresh data from server and refresh in-memory stores after re-auth. */

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -42,6 +42,7 @@ import {
   isSyncing,
   syncError,
   lastSyncedAt,
+  isInitialSync,
   refreshPendingCount
 } from '$lib/stores/sync-status.store';
 import { authFetch } from '$lib/utils/auth-fetch';
@@ -123,6 +124,10 @@ export async function refreshStoresAfterPull(): Promise<void> {
   ]);
   notesStore.refresh();
   await noteDetailService.refreshFromStorage();
+  // First-load placeholder stays up until the stores actually hold the pulled
+  // data (here), not just until the pull set lastSyncedAt - otherwise the list
+  // flashes the empty state in the gap. No-op on later (periodic) refreshes.
+  isInitialSync.set(false);
 
   // Surface multi-device periodic-note duplicates (guideline 57). Fire-and-forget
   // so it never blocks the UI refresh; cheap when there are none (title-prefix
@@ -179,6 +184,12 @@ async function runPullFromServer(): Promise<boolean> {
       return false;
     }
   }
+
+  // First-ever pull (nothing synced yet): show the loading placeholder. Cleared
+  // by refreshStoresAfterPull on success (once notes are in memory) or by the
+  // finally below if this pull fails - never left stuck. Placed after the
+  // storage-init early-return above so a failed re-init can't strand it true.
+  if (get(lastSyncedAt) === null) isInitialSync.set(true);
 
   isSyncing.set(true);
   syncError.set(false);
@@ -254,6 +265,10 @@ async function runPullFromServer(): Promise<boolean> {
     success = false;
   } finally {
     isSyncing.set(false);
+    // Drop the first-load placeholder if this pull failed (e.g. offline): the
+    // success path leaves it for refreshStoresAfterPull to clear once the stores
+    // are hydrated. No-op when it was never set (periodic pulls).
+    if (!success) isInitialSync.set(false);
     void refreshPendingCount();
     void refreshQuota();
   }

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -282,6 +282,10 @@ function createAuthStore() {
         await cryptoManager.setMasterKey(key);
       }
 
+      // No server session in local mode: clear any stale "session expired"
+      // flag left by a 401 from a previous account session, so the re-auth
+      // banner doesn't linger into local mode (it is also gated on !localOnly).
+      sessionExpired.set(false);
       commit({
         username: null,
         userId: localUserId,

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -140,6 +140,20 @@ function createAuthStore() {
   const { subscribe, set } = writable<AuthState>(readFromStorage());
 
   /**
+   * Single write-path for the auth state. Mirrors `isLocalOnly` into the
+   * `localOnly` sync-status store on EVERY update, so the footer ("Local only"
+   * vs syncing) can never drift from the session. Without this, paths that call
+   * `set()` but not `initialize()` - notably the 2FA login step, which only runs
+   * `unlockE2E()` - left `localOnly` stuck `true` and the footer showed
+   * "Local only" after a real login. One-way write (auth.store -> sync-status)
+   * keeps the no-import-cycle invariant noted on `localOnly`.
+   */
+  function commit(next: AuthState): void {
+    set(next);
+    localOnly.set(next.isLocalOnly);
+  }
+
+  /**
    * Mark E2E as unlocked when the master key was loaded by another path —
    * cross-app SSO (peer Task/Notes already unlocked the shared origin IDB
    * key) or fast-path on `/auth/unlock`. Re-reads the auth credentials from
@@ -148,15 +162,14 @@ function createAuthStore() {
   function markE2EUnlocked(): void {
     if (!browser) return;
     if (!cryptoManager.isInitialized()) return;
-    set({ ...readFromStorage(), hasE2E: true });
+    commit({ ...readFromStorage(), hasE2E: true });
   }
 
   /** Call once from the root layout to hydrate state and watch for cross-tab changes. */
   function initialize(): void {
     if (!browser) return;
     const initial = readFromStorage();
-    set(initial);
-    localOnly.set(initial.isLocalOnly);
+    commit(initial);
     // Detect login / logout in other tabs on the same origin.
     // The `storage` event fires ONLY in other tabs/windows — never in the tab
     // that changed localStorage. This means:
@@ -195,7 +208,7 @@ function createAuthStore() {
       }
 
       // Token refresh or other update — update store reactively
-      set(newState);
+      commit(newState);
     });
 
     // Cross-app E2E unlock — peer app (Task) just unlocked the master key in
@@ -210,7 +223,7 @@ function createAuthStore() {
         // memory-only per browsing context, so clear ours and show the lock
         // screen (unless already on an auth route).
         cryptoManager.lockLocal({ broadcast: false });
-        set({ ...readFromStorage(), hasE2E: false });
+        commit({ ...readFromStorage(), hasE2E: false });
         if (!window.location.pathname.includes('/auth/')) {
           window.location.href = `${base}/auth/lock`;
         }
@@ -230,7 +243,7 @@ function createAuthStore() {
       const stillAuthenticated = !!localStorage.getItem(CREDENTIALS_KEY);
       if (stillAuthenticated && !cryptoManager.isInitialized()) {
         logger.info('Cross-app key cleared without logout — flipping hasE2E to false');
-        set({ ...readFromStorage(), hasE2E: false });
+        commit({ ...readFromStorage(), hasE2E: false });
       }
     });
   }
@@ -269,7 +282,7 @@ function createAuthStore() {
         await cryptoManager.setMasterKey(key);
       }
 
-      set({
+      commit({
         username: null,
         userId: localUserId,
         accessToken: null,
@@ -278,7 +291,6 @@ function createAuthStore() {
         createdAt: null,
         hasE2E: cryptoManager.isInitialized()
       });
-      localOnly.set(true);
       return true;
     } catch (err) {
       logger.error('Failed to enter local-only mode', err);
@@ -312,7 +324,7 @@ function createAuthStore() {
         // before this call (e.g. 2FA page saves credentials, then calls unlockE2E).
         // Using readFromStorage() ensures isAuthenticated, username, userId etc.
         // are up-to-date, not stale from initial module import.
-        set({ ...readFromStorage(), hasE2E: true });
+        commit({ ...readFromStorage(), hasE2E: true });
         // Send encrypted device info to server (non-blocking, non-critical)
         import('$lib/services/device-info.service').then(({ sendEncryptedDeviceInfo }) =>
           // fire-and-forget: device info is non-critical
@@ -333,7 +345,7 @@ function createAuthStore() {
   async function unlockLocalPasscode(passcode: string): Promise<boolean> {
     if (!browser) return false;
     const ok = await cryptoManager.unlockWithLocalPasscode(passcode);
-    if (ok) set({ ...readFromStorage(), hasE2E: true });
+    if (ok) commit({ ...readFromStorage(), hasE2E: true });
     return ok;
   }
 
@@ -341,7 +353,7 @@ function createAuthStore() {
   function lockLocalNow(): void {
     if (!browser) return;
     cryptoManager.lockLocal();
-    set({ ...readFromStorage(), hasE2E: false });
+    commit({ ...readFromStorage(), hasE2E: false });
   }
 
   /**
@@ -354,7 +366,7 @@ function createAuthStore() {
   function lockAppNow(): void {
     if (!browser) return;
     cryptoManager.lockToVault();
-    set({ ...readFromStorage(), hasE2E: false });
+    commit({ ...readFromStorage(), hasE2E: false });
   }
 
   /**

--- a/apps/reborn-notes/src/lib/stores/shares.store.ts
+++ b/apps/reborn-notes/src/lib/stores/shares.store.ts
@@ -4,7 +4,7 @@ import { API_BASE } from '$lib/utils/api-base';
 import { getShareBase } from '$lib/utils/share-base';
 import { authFetch } from '$lib/utils/auth-fetch';
 import { connectivityStore } from '$lib/stores/connectivity.store';
-import { sessionExpired } from '$lib/stores/sync-status.store';
+import { sessionExpired, localOnly } from '$lib/stores/sync-status.store';
 import { refreshQuota } from '$lib/stores/storage-quota.store';
 import {
   cryptoManager,
@@ -99,6 +99,14 @@ function createSharesStore() {
 
   async function refresh(): Promise<void> {
     if (!browser) return;
+    // Sharing is account-only. In local-only mode there is no server session,
+    // so hitting /api/shares would 401, authFetch's refresh would 401 too, and
+    // onSessionExpired would raise a false "session expired" banner. Skip it -
+    // mirrors the synced-settings !localOnly gate (see guideline 65).
+    if (get(localOnly)) {
+      state.update((s) => ({ ...s, loading: false }));
+      return;
+    }
     if (!cryptoManager.isInitialized()) {
       state.update((s) => ({ ...s, loading: false }));
       return;

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -180,10 +180,15 @@ export const syncStatus = derived(
   }
 );
 
-// True only during the very first pull after a fresh login (IndexedDB empty,
-// `lastSyncedAt` not yet written). Used to swap empty-list placeholders for a
-// reassuring loading state so users don't think their notes were lost.
-export const isInitialSync = derived(
-  [isSyncing, lastSyncedAt],
-  ([$isSyncing, $lastSyncedAt]) => $isSyncing && $lastSyncedAt === null
-);
+// Shows the "syncing your notes" placeholder in the empty main area during the
+// FIRST load (IndexedDB empty after a fresh login), so users don't think their
+// notes were lost. A plain writable, NOT a derived on `isSyncing && lastSyncedAt
+// === null`: that derived flipped false the instant the pull wrote `lastSyncedAt`
+// - i.e. BEFORE refreshStoresAfterPull repopulated the in-memory stores - so the
+// list flashed the empty "no notes" state for a beat between "pull done" and
+// "notes rendered". Lifecycle (notes-sync.service): runPullFromServer sets it
+// true at the start of a first-ever pull and clears it if that pull fails;
+// refreshStoresAfterPull clears it once the stores actually hold the pulled
+// data. A local -> account login sets it true up-front (notes-auth.service) to
+// also cover the pre-pull window.
+export const isInitialSync = writable(false);

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
   import { verifyAndRebuildLocalShadowIndexes } from '$lib/services/shadow-index-reconciler.service';
   import { noteIndex } from '$lib/services/note-index.svelte';
   import { cleanupNullFkFields } from '$lib/services/idb-cleanup.service';
-  import { refreshPendingCount, isOnline, sessionExpired } from '$lib/stores/sync-status.store';
+  import { refreshPendingCount, isOnline, sessionExpired, localOnly } from '$lib/stores/sync-status.store';
   import { platform } from '$lib/platform';
   import { initI18n, setLocale, locale } from '$lib/stores/i18n.store';
   import { reAuthenticate, verifyTotpForReauth } from '$lib/services/notes-auth.service';
@@ -505,7 +505,7 @@
   >
     <div bind:clientHeight={sessionBannerHeight}>
       <SessionExpiredBanner
-        visible={$sessionExpired && navigator.onLine}
+        visible={$sessionExpired && navigator.onLine && !$localOnly}
         username={$authStore.username ?? ''}
         onReAuth={reAuthenticate}
         onVerifyTotp={verifyTotpForReauth}

--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -9,6 +9,9 @@
 	import { page } from '$app/stores';
 	import { t } from '$lib/stores/i18n.store';
 	import { authStore, CREDENTIALS_KEY, ACCESS_TOKEN_KEY } from '$lib/stores/auth.store';
+	import { sessionExpired } from '$lib/stores/sync-status.store';
+	import { startAccountSessionSync } from '$lib/services/notes-auth.service';
+	import { clearAllUserData, isDatabaseInitialized } from '@reborn/storage';
 	import {
 		Card,
 		CardContent,
@@ -102,7 +105,24 @@
 			const savedPassword = sessionStorage.getItem('2fa_pending_password');
 			if (savedPassword) {
 				sessionStorage.removeItem('2fa_pending_password');
-				await authStore.unlockE2E(savedPassword);
+				// Replace any previous (local-only or other-account) on-device data
+				// before the new session's key + pull. Mirrors loginInNotes, which 2FA
+				// users skip: login() returns early at the twoFactorRequired branch,
+				// so this page owns the full session finalization.
+				if (isDatabaseInitialized()) {
+					try {
+						await clearAllUserData();
+					} catch {
+						/* best-effort - the pull below repopulates from the server */
+					}
+				}
+				sessionExpired.set(false);
+				const unlocked = await authStore.unlockE2E(savedPassword);
+				// Leave local-only mode + run the first sync so the footer drops
+				// "Local only" and the account's notes load now. The +layout one-shot
+				// initial-sync effect won't re-fire on a local -> account switch (the
+				// master key never leaves memory, so hasE2E never toggles).
+				if (unlocked) startAccountSessionSync();
 			} else {
 				// No saved password - hydrate auth state and let unlock page handle E2E
 				authStore.initialize();

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -684,7 +684,7 @@
     "session_expired": "Sesja wygasła",
     "re_login": "Zaloguj ponownie",
     "initial": {
-      "title": "Synchronizujemy Twoje notatki",
+      "title": "Trwa synchronizacja Twoich notatek",
       "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać."
     },
     "errors": {

--- a/packages/i18n/src/translations/tasks/pl/sync.json
+++ b/packages/i18n/src/translations/tasks/pl/sync.json
@@ -70,7 +70,7 @@
     "toast_marked": "Te elementy są oznaczone na liście."
   },
   "initial": {
-    "title": "Synchronizujemy Twoje zadania",
+    "title": "Trwa synchronizacja Twoich zadań",
     "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać."
   }
 }


### PR DESCRIPTION
## Summary

Reported from the iOS emulator: after signing into an account from local-only (no-account) mode, the footer stayed **"Local only"**, no syncing indicator showed, and the account's notes appeared only after the 5-minute periodic / app-resume sync. There was also no **Sign in** entry in the local-mode user menu (only "Register account"), and the Polish first-sync message used a first-person-plural "we" voice the other languages don't.

### Root cause (sync state)

The login went through the **2FA second step** (`/auth/2fa`), which finalizes the session itself - `loginInNotes` returns early at the `twoFactorRequired` branch before its own cleanup runs. That page reached an account session via `unlockE2E()` alone, which:

- updated the auth store via `set()` **without** touching the `localOnly` sync-status flag (the footer reads that, not `authStore.isLocalOnly` - they drifted), and
- never triggered a pull. The `+layout` initial-sync effect is one-shot per E2E unlock and does **not** re-fire on a local to account switch (the master key never leaves memory, so `hasE2E` stays `true`).

### Fix

- **`auth.store`**: every auth-state write now goes through a single `commit()` that mirrors `isLocalOnly` into `localOnly`, so the footer can never drift from the session again.
- **`notes-auth.service`**: new shared `startAccountSessionSync()` (used by `loginInNotes` + the 2FA page) drops the local-only markers and, **only** on a local to account transition, kicks off the first push/pull/refresh. A logged-out to account login already toggles `hasE2E`, which the layout effect handles, so there is no double pull. Mirrors the local to account upgrade already in the register page.
- **`/auth/2fa`**: also clears stale on-device data + the session-expired flag, matching `loginInNotes`.
- **UX**: added a **Sign in** entry above Register in the local-mode user menu (desktop dropdown + mobile sheet), reusing the existing `nav.sign_in` key (already present in all 5 locales).
- **Copy**: PL `sync_status.initial.title` (notes + tasks) becomes the impersonal "Trwa synchronizacja Twoich notatek/zadań", matching EN/DE/FR/ES.

No change to the encryption model or server visibility - client-side session-state transitions only.

## Test plan

On the iOS emulator (or any build), against a 2FA-enabled account:

1. Use the app in local-only mode ("use without account"); optionally create a local note.
2. Open the user menu (avatar) and confirm a **Sign in** entry appears above Register; tap it.
3. Sign in (including the 2FA code). Confirm the replace-local-notes warning still appears first.
4. After login: the main area shows the **"Trwa synchronizacja Twoich notatek"** placeholder, the footer flips from **"Local only"** to a syncing/synced state, and the account's notes load **immediately** (not after minutes).
5. Regression sanity: a normal login from a logged-out state (no local mode), with and without 2FA, still loads notes once. Logout still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)