### PR TITLE
chore(vscode): drop personal Copilot agent settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,28 +35,5 @@
   },
 
   // Disable specific axe rules for template files
-  "axe-linter.disable": ["document-title", "html-lang-valid"],
-
-  // Copilot Agent — selektywne zatwierdzanie
-  "chat.agent.autoApprove": false, // NIE globalne auto-approve
-  "chat.tools.autoApprove": {
-    "editFiles": "always", // edycja plików — OK
-    "readFiles": "always", // odczyt — OK
-    "codebase": "always", // przeszukiwanie kodu — OK
-    "runInTerminal": "whitelisted" // komendy — tylko whitelist
-  },
-
-  // Bezpieczne komendy bez pytania
-  "chat.tools.terminalAllowList": [
-    "pnpm nx check *",
-    "pnpm nx lint *",
-    "pnpm nx test *",
-    "pnpm test",
-    "npx svelte-check*",
-    "npx tsc --noEmit*",
-    "cat *",
-    "ls *",
-    "grep *",
-    "pnpm nx build *"
-  ]
+  "axe-linter.disable": ["document-title", "html-lang-valid"]
 }


### PR DESCRIPTION
## Summary

The committed `.vscode/settings.json` carried a personal GitHub Copilot agent block (`chat.agent.autoApprove`, `chat.tools.autoApprove`, `chat.tools.terminalAllowList`) - a local workflow preference that should not ship in a public repo. This removes that block.

Kept on purpose (genuinely project-scoped, useful to contributors):
- `.vscode/extensions.json` - workspace extension recommendations (Svelte, ESLint, Prettier, Tailwind, Prisma, ...).
- The SvelteKit-specific settings in `settings.json`: HTML validation off for templates, `files.associations`, `files.exclude`, axe-linter rules.

Note: the block remains in older git history (it was committed previously); this only stops publishing it going forward. It contains no secrets, so rewriting public history is not warranted.

## Test plan

- Editor-config-only change; no app/package nx target is affected (nothing to lint/test/build).
- Open the repo in VS Code: extension recommendations still prompt, and SvelteKit template files still skip HTML validation.