### PR TITLE
chore(release): v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.33.0 (2026-06-20)
+
+### 🚀 Features
+
+- **notes:** native folder sync (FolderSource + FolderFs plugin) ([#310](https://github.com/fundacja-reborn/reapps/pull/310))
+- **notes:** native folder sync on Android (FolderFs Java/SAF plugin) ([#312](https://github.com/fundacja-reborn/reapps/pull/312))
+
+### 🩹 Fixes
+
+- **auth:** allow entering all 6 2FA digits on iOS native ([#313](https://github.com/fundacja-reborn/reapps/pull/313))
+- **notes:** persist native refresh token on local-to-account upgrade ([#306](https://github.com/fundacja-reborn/reapps/pull/306))
+- **notes:** layout height tracks window resize ([#3](https://github.com/fundacja-reborn/reapps/pull/3), [#307](https://github.com/fundacja-reborn/reapps/pull/307))
+- **notes:** align split preview header with the variable-height editor toolbar ([#308](https://github.com/fundacja-reborn/reapps/pull/308))
+- **notes:** pull note versions only for changed notes (native sync speed) ([#309](https://github.com/fundacja-reborn/reapps/pull/309))
+- **notes:** keep iOS keyboard off auth & settings password fields ([#311](https://github.com/fundacja-reborn/reapps/pull/311))
+- **notes:** account login from local-only mode (state + sync + UX) ([#314](https://github.com/fundacja-reborn/reapps/pull/314))
+
 ## 0.32.2 (2026-06-17)
 
 ### 🩹 Fixes

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/reborn-notes",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/apps/reborn-task/package.json
+++ b/apps/reborn-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reborn-task",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn-apps/source",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@11.1.2",
   "scripts": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/api-client",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "description": "Universal API client for Reborn apps with E2E encryption support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/auth",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/crypto",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/database",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/i18n",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "private": true,
   "type": "module",
   "description": "Internationalization package for Reborn apps",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/platform",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/storage",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/types",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/ui",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "svelte": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reborn/utils",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release v0.33.0. Version bump + CHANGELOG, routed through a PR because main is protected (no direct pushes).

After this merges, run `pnpm release:finalize` on main to tag v0.33.0 and create the GitHub Release.

Generated by scripts/release.mjs.