### PR TITLE
feat(notes): convert Obsidian wikilinks on Markdown import (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Built by [Reborn Foundation](https://reborn.org.pl) (Poland), a European non-pro
 - **Encryption X-Ray** - see exactly what the server sees (encrypted blobs)
 - **Full-text search** with operators - `tag:work`, `folder:projects/active`, `created:<7d`, `has:link`, `-tag:archived`, … ([reference](docs/search-operators.md))
 - **Trash & recovery** - safely delete and restore notes
-- **Import & export** - Markdown, JSON, or encrypted backup; import single `.md` files or entire folders with subfolders (e.g., an Obsidian vault) preserving directory structure
+- **Import & export** - Markdown, JSON, or encrypted backup; import single `.md` files or entire folders with subfolders (e.g., an Obsidian vault) preserving directory structure, optionally rewriting links between imported notes (relative Markdown links and `[[wikilinks]]`) so they navigate in-app
 - **Local folder sync** - link a folder of Markdown files on your disk and changed files are re-imported (and encrypted) automatically; one-way disk → app, never deletes notes (Chromium-based browsers)
 - **Read-only share links** - publish a frozen snapshot of a note via an encrypted public URL; the snapshot key lives in the URL fragment so the server never sees it. Optional password, expiry, and view-count limit; revoke anytime ([blog post](https://reapps.eu/blog/sharing-notes-tasks-zero-knowledge-snapshots/)).
 

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -66,7 +66,7 @@ import {
   type TitleLookup
 } from './import-dedup-utils';
 import { sanitizeMarkdownContent, sanitizeTags } from '$lib/utils/markdown-sanitizer';
-import { rewriteInterNoteLinks } from './internal-link-rewrite-utils';
+import { rewriteInterNoteLinks, buildWikilinkIndex } from './internal-link-rewrite-utils';
 import { shouldRestoreFromTrash, shouldRelinkToBackupFolder } from './export-import-trash-utils';
 import {
   normalizeNullToUndefined,
@@ -1733,9 +1733,9 @@ export type ImportFolderResult = {
    */
   pathToNoteId: Record<string, string>;
   /**
-   * Relative Markdown links between imported files rewritten to internal
-   * `note:UUID` links. Always 0 unless `rewriteInterNoteLinks` is enabled (see
-   * {@link ImportFolderOptions}).
+   * Links between imported files rewritten to internal `note:UUID` links -
+   * relative Markdown path links and Obsidian wikilinks combined. Always 0
+   * unless `rewriteInterNoteLinks` is enabled (see {@link ImportFolderOptions}).
    */
   linksRewritten: number;
 };
@@ -1771,15 +1771,18 @@ export type ImportFolderOptions = {
    */
   pathManifest?: Record<string, string>;
   /**
-   * Rewrite relative Markdown links between imported files (`[x](../b.md)`) into
-   * reborn-notes internal note links (`[x](note:UUID)`) so they navigate inside
-   * the app. Opt-in (default OFF). Requires the two-phase import: every file's
-   * target id is resolved up-front (so a file can link to one imported later in
-   * the same batch), the link rewrite is applied to each file's content BEFORE
-   * the unchanged-comparison (keeping re-imports idempotent), then the notes are
-   * written. Targets that don't resolve to an imported note, images, external /
-   * anchor links, and code spans are left untouched. See
-   * {@link rewriteInterNoteLinks}.
+   * Rewrite links between imported files into reborn-notes internal note links
+   * (`[x](note:UUID)`) so they navigate inside the app. Covers both relative
+   * Markdown path links (`[x](../b.md)`) and Obsidian wikilinks (`[[Note]]`,
+   * `[[Note|alias]]`, with `#heading`/`^block` subpaths dropped). Opt-in
+   * (default OFF). Requires the two-phase import: every file's target id is
+   * resolved up-front (so a file can link to one imported later in the same
+   * batch), the rewrite is applied to each file's content BEFORE the
+   * unchanged-comparison (keeping re-imports idempotent), then the notes are
+   * written. Targets that don't resolve to an imported note (and, for bare
+   * wikilinks, ambiguous basenames), images, `![[embeds]]`, external / anchor
+   * links, and code spans are left untouched. See {@link rewriteInterNoteLinks}
+   * and {@link buildWikilinkIndex}.
    */
   rewriteInterNoteLinks?: boolean;
 };
@@ -2111,11 +2114,16 @@ export async function importFolder(
       }
     }
 
-    // Pass 2 (7c): rewrite links against the complete map, then write.
+    // Pass 2 (7c): rewrite links against the complete map, then write. The
+    // wikilink index (basename / vault-relative path → note id) is derived once
+    // from the same complete map and shared across every file's rewrite.
+    const wikilinkIndex = buildWikilinkIndex(linkMap);
     for (let i = 0; i < prepared.length; i++) {
       const { file, target } = prepared[i];
       try {
-        const rewrite = rewriteInterNoteLinks(file.sanitizedContent, file.relativePath, linkMap);
+        const rewrite = rewriteInterNoteLinks(file.sanitizedContent, file.relativePath, linkMap, {
+          wikilinks: wikilinkIndex
+        });
         const dedup = await writeResolvedNote({
           target,
           content: rewrite.content,

--- a/apps/reborn-notes/src/lib/services/internal-link-rewrite-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/internal-link-rewrite-utils.spec.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { rewriteInterNoteLinks } from './internal-link-rewrite-utils';
+import { rewriteInterNoteLinks, buildWikilinkIndex } from './internal-link-rewrite-utils';
 
 const UUID_A = '11111111-1111-4111-8111-111111111111';
 const UUID_B = '22222222-2222-4222-8222-222222222222';
 const UUID_C = '33333333-3333-4333-8333-333333333333';
+const UUID_D = '44444444-4444-4444-8444-444444444444';
 
 describe('rewriteInterNoteLinks', () => {
   it('rewrites a same-directory relative .md link to a note: link', () => {
@@ -165,5 +166,171 @@ describe('rewriteInterNoteLinks', () => {
     const map = { 'vault/b.md': UUID_A };
     const { content } = rewriteInterNoteLinks('[B](b.md)', 'vault/index.md', map);
     expect(content).toBe(`[B](note:${UUID_A})`);
+  });
+});
+
+// ── Obsidian wikilinks ────────────────────────────────────────────────────
+
+/** Rewrite `content` with a wikilink index derived from the same path→id map. */
+function wiki(content: string, currentPath: string, map: Record<string, string>) {
+  return rewriteInterNoteLinks(content, currentPath, map, { wikilinks: buildWikilinkIndex(map) });
+}
+
+describe('buildWikilinkIndex', () => {
+  it('indexes a unique basename and its vault-relative path', () => {
+    const idx = buildWikilinkIndex({ 'vault/sub/Note.md': UUID_B });
+    expect(idx.byBasename.get('note')).toBe(UUID_B);
+    expect(idx.byPath.get('sub/note')).toBe(UUID_B); // root "vault" stripped
+  });
+
+  it('drops a basename shared by two distinct notes (ambiguous)', () => {
+    const idx = buildWikilinkIndex({ 'vault/x/Note.md': UUID_B, 'vault/y/Note.md': UUID_C });
+    expect(idx.byBasename.has('note')).toBe(false);
+    // …but each full path still resolves unambiguously.
+    expect(idx.byPath.get('x/note')).toBe(UUID_B);
+    expect(idx.byPath.get('y/note')).toBe(UUID_C);
+  });
+
+  it('keeps a basename that maps to ONE note carried under two paths', () => {
+    // Folder sync: the same note appears under this run's path and the manifest.
+    const idx = buildWikilinkIndex({ 'vault/Note.md': UUID_B, 'vault/old/Note.md': UUID_B });
+    expect(idx.byBasename.get('note')).toBe(UUID_B);
+  });
+
+  it('strips no root when keys do not share a first segment', () => {
+    const idx = buildWikilinkIndex({ 'a/Note.md': UUID_B, 'b/Other.md': UUID_C });
+    expect(idx.byPath.get('a/note')).toBe(UUID_B);
+    expect(idx.byPath.get('b/other')).toBe(UUID_C);
+  });
+});
+
+describe('rewriteInterNoteLinks - wikilinks', () => {
+  it('rewrites a bare [[Note]] to a note: link by unique basename', () => {
+    const map = { 'vault/B.md': UUID_B };
+    const { content, rewritten } = rewriteInterNoteLinks('See [[B]].', 'vault/a.md', map, {
+      wikilinks: buildWikilinkIndex(map)
+    });
+    expect(content).toBe(`See [B](note:${UUID_B}).`);
+    expect(rewritten).toBe(1);
+  });
+
+  it('uses the alias as the link label', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('[[B|the bee]]', 'vault/a.md', map).content).toBe(`[the bee](note:${UUID_B})`);
+  });
+
+  it('drops a #heading subpath and labels with the target', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('[[B#Section]]', 'vault/a.md', map).content).toBe(`[B](note:${UUID_B})`);
+  });
+
+  it('drops a #^block subpath', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('[[B#^block1]]', 'vault/a.md', map).content).toBe(`[B](note:${UUID_B})`);
+  });
+
+  it('combines #heading and |alias', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('[[B#Section|go]]', 'vault/a.md', map).content).toBe(`[go](note:${UUID_B})`);
+  });
+
+  it('resolves a path-form wikilink [[sub/C]]', () => {
+    const map = { 'vault/sub/C.md': UUID_C, 'vault/a.md': UUID_A };
+    expect(wiki('[[sub/C]]', 'vault/a.md', map).content).toBe(`[sub/C](note:${UUID_C})`);
+  });
+
+  it('resolves a basename case-insensitively', () => {
+    const map = { 'vault/Note.md': UUID_B };
+    expect(wiki('[[note]]', 'vault/a.md', map).content).toBe(`[note](note:${UUID_B})`);
+  });
+
+  it('accepts an explicit .md extension in the target', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('[[B.md]]', 'vault/a.md', map).content).toBe(`[B.md](note:${UUID_B})`);
+  });
+
+  it('disambiguates a shared basename via the path form', () => {
+    const map = { 'vault/x/Note.md': UUID_B, 'vault/y/Note.md': UUID_C };
+    expect(wiki('[[x/Note]]', 'vault/a.md', map).content).toBe(`[x/Note](note:${UUID_B})`);
+  });
+
+  it('rewrites several wikilinks and counts them', () => {
+    const map = { 'vault/B.md': UUID_B, 'vault/C.md': UUID_C };
+    const { content, rewritten } = wiki('[[B]] and [[C]]', 'vault/a.md', map);
+    expect(content).toBe(`[B](note:${UUID_B}) and [C](note:${UUID_C})`);
+    expect(rewritten).toBe(2);
+  });
+
+  it('counts path links and wikilinks together', () => {
+    const map = { 'vault/B.md': UUID_B, 'vault/C.md': UUID_C };
+    const { content, rewritten } = wiki('[B](B.md) then [[C]]', 'vault/a.md', map);
+    expect(content).toBe(`[B](note:${UUID_B}) then [C](note:${UUID_C})`);
+    expect(rewritten).toBe(2);
+  });
+
+  // ── Left untouched ───────────────────────────────────────────────────────
+
+  it('leaves a wikilink untouched when no index is supplied', () => {
+    const map = { 'vault/B.md': UUID_B };
+    // Path-link-only call (no opts) — wikilinks are not in scope.
+    expect(rewriteInterNoteLinks('[[B]]', 'vault/a.md', map).content).toBe('[[B]]');
+  });
+
+  it('leaves an ambiguous bare [[Note]] untouched', () => {
+    const map = { 'vault/x/Note.md': UUID_B, 'vault/y/Note.md': UUID_C };
+    expect(wiki('[[Note]]', 'vault/a.md', map).content).toBe('[[Note]]');
+  });
+
+  it('leaves an unresolved [[Missing]] untouched', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('[[Missing]]', 'vault/a.md', map).content).toBe('[[Missing]]');
+  });
+
+  it('leaves a path-form target that does not exist untouched', () => {
+    const map = { 'vault/B.md': UUID_B };
+    // basename B is unique, but the path form must match a real path exactly.
+    expect(wiki('[[wrong/B]]', 'vault/a.md', map).content).toBe('[[wrong/B]]');
+  });
+
+  it('leaves embeds ![[..]] untouched', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('![[B]]', 'vault/a.md', map).content).toBe('![[B]]');
+  });
+
+  it('leaves an intra-note [[#heading]] untouched', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('[[#Section]]', 'vault/a.md', map).content).toBe('[[#Section]]');
+  });
+
+  it('does not rewrite a wikilink inside inline code', () => {
+    const map = { 'vault/B.md': UUID_B };
+    expect(wiki('Type `[[B]]` literally.', 'vault/a.md', map).content).toBe('Type `[[B]]` literally.');
+  });
+
+  it('does not rewrite a wikilink inside a fenced block', () => {
+    const map = { 'vault/B.md': UUID_B };
+    const input = '```\n[[B]]\n```';
+    expect(wiki(input, 'vault/a.md', map).content).toBe(input);
+  });
+
+  it('rewrites a wikilink outside code but not the one inside', () => {
+    const map = { 'vault/B.md': UUID_B };
+    const { content, rewritten } = wiki('Real [[B]] and `[[B]]`.', 'vault/a.md', map);
+    expect(content).toBe(`Real [B](note:${UUID_B}) and \`[[B]]\`.`);
+    expect(rewritten).toBe(1);
+  });
+
+  it('is idempotent: a rewritten wikilink is a note: link on the second pass', () => {
+    const map = { 'vault/B.md': UUID_B };
+    const once = wiki('[[B]]', 'vault/a.md', map).content;
+    const twice = wiki(once, 'vault/a.md', map).content;
+    expect(once).toBe(`[B](note:${UUID_B})`);
+    expect(twice).toBe(`[B](note:${UUID_B})`);
+  });
+
+  it('rewrites wikilinks even when the path-link map has no usable targets', () => {
+    // Only this note in the map, but it can still link to itself by name.
+    const map = { 'vault/Self.md': UUID_D };
+    expect(wiki('[[Self]]', 'vault/Self.md', map).content).toBe(`[Self](note:${UUID_D})`);
   });
 });

--- a/apps/reborn-notes/src/lib/services/internal-link-rewrite-utils.ts
+++ b/apps/reborn-notes/src/lib/services/internal-link-rewrite-utils.ts
@@ -19,8 +19,11 @@
  *    scheme, so a second pass skips it (scheme check below). This is what lets
  *    live folder sync re-apply the rewrite on every run without thrashing.
  *
- * Scope (v1): relative path links only. Obsidian `[[wikilinks]]` and
- * reference-style `[label][ref]` definitions are intentionally left untouched.
+ * Scope: relative path links `[x](../b.md)` and, when a wikilink index is
+ * supplied (see {@link buildWikilinkIndex}), Obsidian `[[wikilinks]]` -
+ * resolved by vault-relative path or unique basename. Reference-style
+ * `[label][ref]` definitions and `![[embeds]]` (transclusions - reborn-notes
+ * has no include semantics) are intentionally left untouched.
  */
 
 /** Result of a rewrite pass: the new content and how many links were rewritten. */
@@ -32,13 +35,22 @@ export type LinkRewriteResult = { content: string; rewritten: number };
  *     `(`+)[\s\S]*?\1` - the backreference forces a matching run length, so it
  *     covers both inline code and fenced blocks. Left untouched.
  *  2. A tilde-fenced code block (`~~~ ... ~~~`). Left untouched.
- *  3. An inline Markdown link or image: `(!?)[label](dest)`. The `!` marks an
+ *  3. An Obsidian wikilink: `(!?)[[inner]]`. The `!` marks an embed
+ *     (transclusion) - left untouched; only plain `[[..]]` is a candidate, and
+ *     only when a wikilink index was supplied. Matched BEFORE the inline-link
+ *     alternative so `[[x]]` is not mis-read as `[label]` + stray `[x]`.
+ *  4. An inline Markdown link or image: `(!?)[label](dest)`. The `!` marks an
  *     image (embed) - left untouched; only real links are candidates.
+ *
+ * Capture groups: 1 = code fence, 2 = wikilink bang, 3 = wikilink inner,
+ * 4 = link bang, 5 = link label, 6 = link dest. The alternative that did not
+ * match leaves its groups `undefined`, which the callback uses to dispatch.
  *
  * Negated character classes only (no nested quantifiers over overlapping
  * classes), so there is no catastrophic-backtracking risk on note-sized input.
  */
-const TOKEN_RE = /(`+)[\s\S]*?\1|~~~[\s\S]*?~~~|(!?)\[([^\]]*)\]\(([^)]+)\)/g;
+const TOKEN_RE =
+  /(`+)[\s\S]*?\1|~~~[\s\S]*?~~~|(!?)\[\[([^[\]\n]+)\]\]|(!?)\[([^\]]*)\]\(([^)]+)\)/g;
 
 /** A destination has a URI scheme (`http:`, `mailto:`, `note:`, …). */
 const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
@@ -72,6 +84,116 @@ function stripAngleBrackets(url: string): string {
   return url.startsWith('<') && url.endsWith('>') ? url.slice(1, -1) : url;
 }
 
+// ── Obsidian wikilinks (`[[Target]]`) ───────────────────────────────────────
+
+/**
+ * Resolution index for Obsidian `[[wikilinks]]`, built once per import from the
+ * importer's `relativePath → note id` map by {@link buildWikilinkIndex}.
+ *
+ *  - `byPath` - vault-relative path without extension (lowercased) → note id.
+ *    Resolves the path form Obsidian emits to disambiguate (`[[folder/Note]]`,
+ *    its "shortest unique path"). A full path names exactly one file, so this
+ *    map is never ambiguous.
+ *  - `byBasename` - file basename without extension (lowercased) → note id, but
+ *    ONLY for basenames unique across the vault. A basename shared by two
+ *    distinct notes is absent, so a bare ambiguous `[[Note]]` is left untouched
+ *    (the agreed fallback) instead of guessing.
+ */
+export type WikilinkIndex = {
+  byPath: Map<string, string>;
+  byBasename: Map<string, string>;
+};
+
+/** First `/`-separated segment of a path (`a/b/c` → `a`; `c` → ''). */
+function firstSegment(path: string): string {
+  const idx = path.indexOf('/');
+  return idx === -1 ? '' : path.slice(0, idx);
+}
+
+/**
+ * Build a {@link WikilinkIndex} from the importer's `relativePath → note id`
+ * map. Obsidian resolves wikilinks against the VAULT ROOT (not the linking
+ * file's directory), so paths are made vault-relative by stripping the common
+ * root segment - the single selected directory of a folder import / folder
+ * sync. When the keys don't share a first segment they are treated as already
+ * vault-relative and nothing is stripped.
+ *
+ * Basenames are de-duplicated by note id first: one note carried under two
+ * paths (a folder-sync manifest entry plus this run's path) is a single target,
+ * not a collision. Only genuinely shared basenames (two distinct ids) drop out
+ * of `byBasename`.
+ */
+export function buildWikilinkIndex(
+  pathToNoteId: Map<string, string> | Record<string, string>
+): WikilinkIndex {
+  const map = pathToNoteId instanceof Map ? pathToNoteId : new Map(Object.entries(pathToNoteId));
+  const keys = [...map.keys()];
+
+  // Vault root = shared first segment, only when ALL keys share it.
+  let root = '';
+  if (keys.length > 0) {
+    const candidate = firstSegment(keys[0]);
+    if (candidate && keys.every((k) => firstSegment(k) === candidate)) root = candidate;
+  }
+  const toVaultRelative = (p: string): string =>
+    root && (p === root || p.startsWith(`${root}/`)) ? p.slice(root.length + 1) : p;
+
+  const byPath = new Map<string, string>();
+  const basenameIds = new Map<string, Set<string>>();
+  for (const [path, id] of map) {
+    const rel = toVaultRelative(path)
+      .replace(/\.md$/i, '')
+      .toLowerCase();
+    if (rel === '') continue;
+    if (!byPath.has(rel)) byPath.set(rel, id);
+    const base = rel.slice(rel.lastIndexOf('/') + 1);
+    const ids = basenameIds.get(base) ?? new Set<string>();
+    ids.add(id);
+    basenameIds.set(base, ids);
+  }
+
+  const byBasename = new Map<string, string>();
+  for (const [base, ids] of basenameIds) {
+    if (ids.size === 1) byBasename.set(base, [...ids][0]);
+  }
+
+  return { byPath, byBasename };
+}
+
+/**
+ * Split a wikilink body (`Target#sub|alias`) into the resolvable target and the
+ * display label. `target` is the text before the first `#` (subpath) and first
+ * `|` (alias); the label is the alias when present, else the target as written.
+ * The `#heading` / `#^block` subpath is dropped - `note:` links have no
+ * intra-note anchors yet, so the link lands on the note.
+ */
+function parseWikilink(inner: string): { target: string; label: string } {
+  const pipeIdx = inner.indexOf('|');
+  const beforePipe = pipeIdx === -1 ? inner : inner.slice(0, pipeIdx);
+  const alias = (pipeIdx === -1 ? '' : inner.slice(pipeIdx + 1)).trim();
+  const hashIdx = beforePipe.indexOf('#');
+  const target = (hashIdx === -1 ? beforePipe : beforePipe.slice(0, hashIdx)).trim();
+  return { target, label: alias || target };
+}
+
+/**
+ * Resolve a wikilink target to a note id against a {@link WikilinkIndex}. A
+ * target containing `/` is a path form → exact vault-relative match only
+ * (Obsidian does not basename-fall-back a path that doesn't exist). A bare
+ * basename resolves via the unique-basename map (ambiguous → undefined → the
+ * caller leaves the link untouched).
+ */
+function resolveWikilink(target: string, index: WikilinkIndex): string | undefined {
+  const norm = target
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\.?\//, '')
+    .replace(/\.md$/i, '')
+    .toLowerCase();
+  if (norm === '') return undefined;
+  return norm.includes('/') ? index.byPath.get(norm) : index.byBasename.get(norm);
+}
+
 /**
  * Rewrite relative `.md` links in `content` to `note:UUID` links using the
  * importer's path→note-id map.
@@ -89,14 +211,23 @@ function stripAngleBrackets(url: string): string {
  * (`![..](..)`), external/`note:`/anchor-only/absolute destinations, non-`.md`
  * targets, code spans, and unresolved targets are left untouched. Any
  * `#fragment` is dropped (the `note:` scheme has no heading anchors yet).
+ *
+ * @param opts.wikilinks Optional {@link WikilinkIndex}. When supplied, Obsidian
+ *                       `[[Target]]` / `[[Target|alias]]` links are also
+ *                       rewritten (target resolved by vault-relative path or
+ *                       unique basename; `#heading`/`^block` subpaths dropped).
+ *                       `![[embeds]]` stay untouched. Without it, every `[[..]]`
+ *                       is left as-is (the path-link-only behavior).
  */
 export function rewriteInterNoteLinks(
   content: string,
   currentRelativePath: string,
-  pathToNoteId: Map<string, string> | Record<string, string>
+  pathToNoteId: Map<string, string> | Record<string, string>,
+  opts?: { wikilinks?: WikilinkIndex }
 ): LinkRewriteResult {
   const map = pathToNoteId instanceof Map ? pathToNoteId : new Map(Object.entries(pathToNoteId));
-  if (map.size === 0) return { content, rewritten: 0 };
+  const wikilinks = opts?.wikilinks;
+  if (map.size === 0 && wikilinks === undefined) return { content, rewritten: 0 };
 
   // Case-insensitive fallback index, built once. Exact match wins so a vault
   // with case-distinct files on a case-sensitive FS still resolves precisely.
@@ -117,10 +248,31 @@ export function rewriteInterNoteLinks(
 
   const newContent = content.replace(
     TOKEN_RE,
-    (match, codeFence: string | undefined, bang: string | undefined, label: string, dest: string): string => {
+    (
+      match,
+      codeFence: string | undefined,
+      wikiBang: string | undefined,
+      wikiInner: string | undefined,
+      bang: string | undefined,
+      label: string,
+      dest: string
+    ): string => {
       // Group 1 set → backtick code span/fence; tilde fence has no capture but
       // starts with `~~~`. Either way it is code: leave verbatim.
       if (codeFence !== undefined || match.startsWith('~~~')) return match;
+
+      // Obsidian wikilink `[[Target]]` / `[[Target|alias]]` (group 3 set). Only
+      // rewritten when an index was supplied; `![[embed]]` (transclusion) and
+      // unresolved/ambiguous targets are left as-is.
+      if (wikiInner !== undefined) {
+        if (wikilinks === undefined || wikiBang === '!') return match;
+        const { target, label: wikiLabel } = parseWikilink(wikiInner);
+        const noteId = resolveWikilink(target, wikilinks);
+        if (noteId === undefined) return match;
+        rewritten++;
+        return `[${wikiLabel}](note:${noteId})`;
+      }
+
       // Image / embed (`![..](..)`): not a navigable link.
       if (bang === '!') return match;
 

--- a/apps/reborn-notes/src/lib/services/internal-link-rewrite.integration.spec.ts
+++ b/apps/reborn-notes/src/lib/services/internal-link-rewrite.integration.spec.ts
@@ -160,3 +160,58 @@ describe('importFolder inter-note link rewriting', () => {
     expect(notes.get(idA)?.content).toBe(`Go [B](note:${idB}) now.`);
   });
 });
+
+describe('importFolder Obsidian wikilink rewriting', () => {
+  it('leaves wikilinks untouched when the flag is off (default)', async () => {
+    const files: ImportFolderInput[] = [
+      input('a.md', 'vault/a.md', '---\ntitle: A\n---\nSee [[B]].'),
+      input('b.md', 'vault/b.md', '---\ntitle: B\n---\nHi.')
+    ];
+    const res = await importFolder(files, 'rename');
+    expect(res.linksRewritten).toBe(0);
+    const idA = res.pathToNoteId['vault/a.md'];
+    expect(notes.get(idA)?.content).toBe('See [[B]].');
+  });
+
+  it('rewrites [[wikilinks]] (with alias) to note: links when the flag is on', async () => {
+    const files: ImportFolderInput[] = [
+      input('a.md', 'vault/a.md', '---\ntitle: A\n---\nSee [[B]] and [[B|the bee]].'),
+      input('b.md', 'vault/b.md', '---\ntitle: B\n---\nHi.')
+    ];
+    const res = await importFolder(files, 'rename', undefined, { rewriteInterNoteLinks: true });
+    expect(res.imported).toBe(2);
+    expect(res.linksRewritten).toBe(2);
+    const idA = res.pathToNoteId['vault/a.md'];
+    const idB = res.pathToNoteId['vault/b.md'];
+    expect(notes.get(idA)?.content).toBe(`See [B](note:${idB}) and [the bee](note:${idB}).`);
+  });
+
+  it('resolves a wikilink by FILE basename, not by frontmatter title', async () => {
+    const files: ImportFolderInput[] = [
+      input('a.md', 'vault/a.md', '---\ntitle: Alpha\n---\nGo to [[target]].'),
+      // File basename is "target", but the note title is "Renamed". Obsidian
+      // wikilinks address the file, so resolution must use the basename.
+      input('target.md', 'vault/target.md', '---\ntitle: Renamed\n---\nHere.')
+    ];
+    const res = await importFolder(files, 'rename', undefined, { rewriteInterNoteLinks: true });
+    const idA = res.pathToNoteId['vault/a.md'];
+    const idTarget = res.pathToNoteId['vault/target.md'];
+    expect(notes.get(idTarget)?.title).toBe('Renamed');
+    expect(notes.get(idA)?.content).toBe(`Go to [target](note:${idTarget}).`);
+    expect(res.linksRewritten).toBe(1);
+  });
+
+  it('leaves an ambiguous bare [[wikilink]] untouched but resolves the path form', async () => {
+    const files: ImportFolderInput[] = [
+      input('a.md', 'vault/a.md', '---\ntitle: A\n---\nBare [[Dup]] vs path [[x/Dup]].'),
+      input('Dup.md', 'vault/x/Dup.md', 'one'),
+      input('Dup.md', 'vault/y/Dup.md', 'two')
+    ];
+    const res = await importFolder(files, 'rename', undefined, { rewriteInterNoteLinks: true });
+    const idA = res.pathToNoteId['vault/a.md'];
+    const idDupX = res.pathToNoteId['vault/x/Dup.md'];
+    // Bare [[Dup]] is ambiguous → untouched; [[x/Dup]] names one file → resolved.
+    expect(notes.get(idA)?.content).toBe(`Bare [[Dup]] vs path [x/Dup](note:${idDupX}).`);
+    expect(res.linksRewritten).toBe(1);
+  });
+});

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -844,7 +844,7 @@
       "preserve_tags_label": "In der App hinzugefügte Tags behalten",
       "preserve_tags_desc": "Tags aus der Datei werden mit den vorhandenen Tags der Notiz zusammengeführt statt sie zu ersetzen. Sterne und Pins werden vom Import nie verändert.",
       "rewrite_links_label": "Verknüpfungen zwischen Notizen umwandeln",
-      "rewrite_links_desc": "Relative Markdown-Links zwischen den importierten Dateien (z. B. [Text](../andere.md)) werden zu internen Notizverknüpfungen, die in der App geöffnet werden. Links zu Dateien außerhalb dieses Imports bleiben unverändert.",
+      "rewrite_links_desc": "Relative Markdown-Links und Obsidian-Wikilinks zwischen den importierten Dateien (z. B. [Text](../andere.md) oder [[Notiz]]) werden zu internen Notizverknüpfungen, die in der App geöffnet werden. Links zu Dateien außerhalb dieses Imports bleiben unverändert.",
       "links_rewritten_count": "{count} Verknüpfung(en) zwischen Notizen umgewandelt",
       "dedup_start": "Import starten",
       "dedup_count_overwritten": "{count} bestehende Notiz(en) überschrieben",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -844,7 +844,7 @@
       "preserve_tags_label": "Keep tags added in the app",
       "preserve_tags_desc": "Tags from the file are merged with the note's existing tags instead of replacing them. Stars and pins are never affected by import.",
       "rewrite_links_label": "Convert links between notes",
-      "rewrite_links_desc": "Relative Markdown links between the imported files (e.g. [text](../other.md)) become internal note links that open in the app. Links to files outside this import are left unchanged.",
+      "rewrite_links_desc": "Relative Markdown links and Obsidian wikilinks between the imported files (e.g. [text](../other.md) or [[Note]]) become internal note links that open in the app. Links to files outside this import are left unchanged.",
       "links_rewritten_count": "Converted {count} link(s) between notes",
       "dedup_start": "Start import",
       "dedup_count_overwritten": "Overwrote {count} existing note(s)",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -844,7 +844,7 @@
       "preserve_tags_label": "Conservar las etiquetas añadidas en la aplicación",
       "preserve_tags_desc": "Las etiquetas del archivo se combinan con las etiquetas existentes de la nota en lugar de reemplazarlas. Las estrellas y los pines nunca se modifican durante la importación.",
       "rewrite_links_label": "Convertir enlaces entre notas",
-      "rewrite_links_desc": "Los enlaces Markdown relativos entre los archivos importados (p. ej. [texto](../otra.md)) se convierten en enlaces internos que abren la nota en la aplicación. Los enlaces a archivos fuera de esta importación no se modifican.",
+      "rewrite_links_desc": "Los enlaces Markdown relativos y los wikilinks de Obsidian entre los archivos importados (p. ej. [texto](../otra.md) o [[Nota]]) se convierten en enlaces internos que abren la nota en la aplicación. Los enlaces a archivos fuera de esta importación no se modifican.",
       "links_rewritten_count": "Se convirtieron {count} enlace(s) entre notas",
       "dedup_start": "Iniciar importación",
       "dedup_count_overwritten": "Se sobrescribieron {count} nota(s) existente(s)",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -844,7 +844,7 @@
       "preserve_tags_label": "Conserver les tags ajoutés dans l'application",
       "preserve_tags_desc": "Les tags du fichier sont fusionnés avec les tags existants de la note au lieu de les remplacer. Les étoiles et les épingles ne sont jamais modifiées par l'import.",
       "rewrite_links_label": "Convertir les liens entre notes",
-      "rewrite_links_desc": "Les liens Markdown relatifs entre les fichiers importés (par ex. [texte](../autre.md)) deviennent des liens internes qui ouvrent la note dans l'application. Les liens vers des fichiers hors de cet import restent inchangés.",
+      "rewrite_links_desc": "Les liens Markdown relatifs et les wikilinks Obsidian entre les fichiers importés (par ex. [texte](../autre.md) ou [[Note]]) deviennent des liens internes qui ouvrent la note dans l'application. Les liens vers des fichiers hors de cet import restent inchangés.",
       "links_rewritten_count": "{count} lien(s) entre notes converti(s)",
       "dedup_start": "Lancer l'import",
       "dedup_count_overwritten": "{count} note(s) existante(s) remplacée(s)",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -844,7 +844,7 @@
       "preserve_tags_label": "Zachowaj tagi dodane w aplikacji",
       "preserve_tags_desc": "Tagi z pliku zostaną dołączone do istniejących tagów notatki zamiast je zastąpić. Gwiazdki i pinezki nigdy nie są zmieniane przez import.",
       "rewrite_links_label": "Konwertuj linki między notatkami",
-      "rewrite_links_desc": "Względne linki Markdown między importowanymi plikami (np. [tekst](../inna.md)) stają się wewnętrznymi linkami otwierającymi notatkę w aplikacji. Linki do plików spoza tego importu pozostają bez zmian.",
+      "rewrite_links_desc": "Względne linki Markdown i wikilinki Obsidiana między importowanymi plikami (np. [tekst](../inna.md) lub [[Notatka]]) stają się wewnętrznymi linkami otwierającymi notatkę w aplikacji. Linki do plików spoza tego importu pozostają bez zmian.",
       "links_rewritten_count": "Przekonwertowano {count} link(ów) między notatkami",
       "dedup_start": "Rozpocznij import",
       "dedup_count_overwritten": "Zastąpiono {count} istniejących notatek",


### PR DESCRIPTION
## Summary

Follow-up to #317. Extends the opt-in import link rewriting (`rewriteInterNoteLinks`, default OFF) to also convert Obsidian `[[wikilinks]]` - the link format a real Obsidian vault predominantly uses - into internal `note:UUID` links that navigate in-app. One flag drives both relative path links and wikilinks.

**Engine** (`internal-link-rewrite-utils.ts`):
- New `[[..]]` tokenizer alternative, matched before inline links and behind the code-span guard (so `[[x]]` inside code is left alone).
- `buildWikilinkIndex()` resolves a wikilink target from the same `path->id` map the two-phase importer already builds: an exact vault-relative path map (common root stripped, since Obsidian resolves wikilinks against the vault root) plus a unique-basename map.
- `rewriteInterNoteLinks` gains an optional `{ wikilinks }`; without it every `[[..]]` is left untouched, so path-link behavior (and all prior tests) is unchanged.
- `importFolder` pass 2 builds the index once and shares it; `linksRewritten` now counts both kinds.

**Key decisions to review** (approved in conversation 2026-06-21, detailed in commit `84fd05e`):
1. **Resolve by file basename, not note title** - `[[Foo]]` targets `Foo.md` even if its frontmatter `title:` differs (Obsidian addresses files). An integration test covers this explicitly.
2. **Shortest-unique-path + leave-untouched fallback** - a path form `[[sub/Foo]]` matches that exact file; a bare `[[Foo]]` resolves only when the basename is unique vault-wide; an ambiguous `[[Foo]]` (two `Foo.md`) is left as-is, never guessed.
3. **`\![[embeds]]` left untouched** - reborn-notes has no transclusion; degrading them to links would change meaning. `#heading`/`^block` precision degrades to note-level (documented limitation).

Zero Knowledge unaffected: rewriting is client-side on plaintext before encryption; `note:UUID` is encrypted with the rest.

## Test plan

Automated (green locally): `nx affected -t lint check typecheck test build`, `check-i18n-parity.mjs`.
- 50 unit + 8 integration tests on the rewrite engine and real `importFolder` (incl. basename-vs-title, ambiguity, code-span, idempotency).
- Full reborn-notes suite: 809 tests, no regression.

Smoke (Michał):
1. Notes -> Settings -> import/export -> import a folder of `.md` files that use `[[wikilinks]]` (e.g. a small Obsidian vault) with **"Convert links between notes" ON**.
2. Open an imported note that linked `[[Other]]` -> the link should be clickable and open the target note in-app.
3. Check `[[Other|alias]]` (label = alias), `[[Other#heading]]` (lands on the note), and a name shared by two files (bare `[[Dup]]` stays literal; `[[folder/Dup]]` resolves).
4. Re-import the same folder (overwrite / folder sync) -> no churn, links rewritten = 0 on the idempotent pass.
5. Flag OFF -> wikilinks stay as literal `[[..]]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8QhyVX9HcAxNt41xExQY9