### PR TITLE
feat(notes): linked-notes panel (backlinks + outgoing links)

### DIFF
--- a/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { Waypoints, ArrowDownLeft, ArrowUpRight, Loader2 } from '@lucide/svelte';
+  import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@reborn/ui';
+  import { noteLinkGraph } from '$lib/services/note-link-graph.svelte';
+  import { noteIndex } from '$lib/services/note-index.svelte';
+  import { t } from '$lib/stores/i18n.store';
+
+  let {
+    noteId,
+    open,
+    onnavigate,
+    onclose
+  }: {
+    noteId: string;
+    open: boolean;
+    /** Navigate to a linked note (parent decides whether to also close on mobile). */
+    onnavigate: (noteId: string) => void;
+    onclose: () => void;
+  } = $props();
+
+  // Lazy-build the graph when the panel opens. Reading isBuilt/isBuilding keeps
+  // this reactive, so it also recovers if the graph was invalidated (sync /
+  // import) while the panel stayed open.
+  $effect(() => {
+    if (open && !noteLinkGraph.isBuilt && !noteLinkGraph.isBuilding) {
+      void noteLinkGraph.ensureBuilt();
+    }
+  });
+
+  interface LinkItem {
+    id: string;
+    title: string;
+  }
+
+  /** Resolve ids → titles via NoteIndex; drop unknown / trashed notes, sort by title. */
+  function resolve(ids: string[]): LinkItem[] {
+    const out: LinkItem[] = [];
+    for (const id of ids) {
+      const entry = noteIndex.get(id);
+      if (!entry || entry.isArchived) continue;
+      out.push({ id, title: entry.title || $t('notes.untitled') });
+    }
+    out.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+    return out;
+  }
+
+  const backlinks = $derived(open ? resolve(noteLinkGraph.incomingIds(noteId)) : []);
+  const outgoing = $derived(open ? resolve(noteLinkGraph.outgoingIds(noteId)) : []);
+  const loading = $derived(open && !noteLinkGraph.isBuilt);
+  const isEmpty = $derived(
+    open && noteLinkGraph.isBuilt && backlinks.length === 0 && outgoing.length === 0
+  );
+
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) onclose();
+  }
+</script>
+
+<Sheet {open} onOpenChange={handleOpenChange}>
+  <SheetContent side="right" class="flex w-80 flex-col p-0 sm:max-w-sm">
+    <SheetHeader class="shrink-0 border-b px-4 py-3">
+      <SheetTitle class="flex items-center gap-2 text-sm">
+        <Waypoints class="h-4 w-4 text-muted-foreground" />
+        {$t('linked_notes.title')}
+      </SheetTitle>
+    </SheetHeader>
+
+    <div class="flex-1 overflow-y-auto">
+      {#if loading}
+        <div class="flex items-center justify-center py-12 text-sm text-muted-foreground">
+          <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+          {$t('linked_notes.loading')}
+        </div>
+      {:else if isEmpty}
+        <div
+          class="flex items-center justify-center px-4 py-12 text-center text-sm text-muted-foreground"
+        >
+          {$t('linked_notes.empty')}
+        </div>
+      {:else}
+        <!-- Backlinks (incoming) -->
+        <section>
+          <h3
+            class="flex items-center gap-1.5 px-4 pb-2 pt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            <ArrowDownLeft class="h-3.5 w-3.5" />
+            {$t('linked_notes.incoming')}
+            <span class="ml-auto tabular-nums">{backlinks.length}</span>
+          </h3>
+          {#if backlinks.length === 0}
+            <p class="px-4 pb-3 text-sm text-muted-foreground">
+              {$t('linked_notes.incoming_empty')}
+            </p>
+          {:else}
+            <ul>
+              {#each backlinks as item (item.id)}
+                <li>
+                  <button
+                    type="button"
+                    onclick={() => onnavigate(item.id)}
+                    class="block w-full truncate px-4 py-2 text-left text-sm text-foreground transition-colors hover:bg-accent/50 active:bg-accent"
+                  >
+                    {item.title}
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </section>
+
+        <!-- Outgoing -->
+        <section class="border-t">
+          <h3
+            class="flex items-center gap-1.5 px-4 pb-2 pt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            <ArrowUpRight class="h-3.5 w-3.5" />
+            {$t('linked_notes.outgoing')}
+            <span class="ml-auto tabular-nums">{outgoing.length}</span>
+          </h3>
+          {#if outgoing.length === 0}
+            <p class="px-4 pb-3 text-sm text-muted-foreground">
+              {$t('linked_notes.outgoing_empty')}
+            </p>
+          {:else}
+            <ul>
+              {#each outgoing as item (item.id)}
+                <li>
+                  <button
+                    type="button"
+                    onclick={() => onnavigate(item.id)}
+                    class="block w-full truncate px-4 py-2 text-left text-sm text-foreground transition-colors hover:bg-accent/50 active:bg-accent"
+                  >
+                    {item.title}
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </section>
+      {/if}
+    </div>
+  </SheetContent>
+</Sheet>

--- a/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
@@ -78,18 +78,22 @@
 </script>
 
 {#snippet linkRow(item: LinkItem)}
-  <!-- Inset divider: starts at the text's left edge, padded from the right. -->
-  <li
-    class="relative after:pointer-events-none after:absolute after:bottom-0 after:left-4 after:right-4 after:h-px after:bg-border/60 after:content-[''] last:after:hidden"
-  >
+  <!-- No dividers: rows are separated by spacing + an inset, rounded hover.
+       Every row reserves a fixed-width trailing slot (w-6) so the "↔" badges
+       form a clean column and the title's ellipsis never runs under the icon.
+       The button is inset 8px (ul px-2) so its hover is inset + rounded; text
+       lands at 16px from the panel edge (aligned with the section header), and
+       the slot ends 16px from the right (matching the left inset). -->
+  <li>
     {#if item.missing}
       <div
-        class="flex w-full items-center gap-2 px-4 py-2"
+        class="flex w-full items-center gap-2 rounded-lg px-2 py-2"
         title={$t('linked_notes.missing')}
       >
         <span class="min-w-0 flex-1 truncate text-sm italic text-muted-foreground/50"
           >{$t('linked_notes.missing')}</span
         >
+        <span class="w-6 shrink-0" aria-hidden="true"></span>
       </div>
     {:else}
       <button
@@ -99,17 +103,19 @@
         aria-label={mutual.has(item.id)
           ? `${item.title}, ${$t('linked_notes.mutual')}`
           : undefined}
-        class="group flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:bg-accent"
+        class="group flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:bg-accent"
       >
         <span
           class="min-w-0 flex-1 truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"
           >{item.title}</span
         >
-        {#if mutual.has(item.id)}
-          <span class="shrink-0 text-muted-foreground/70" title={$t('linked_notes.mutual')}>
-            <ArrowLeftRight class="h-3.5 w-3.5" aria-hidden="true" />
-          </span>
-        {/if}
+        <span class="flex w-6 shrink-0 items-center justify-center">
+          {#if mutual.has(item.id)}
+            <span title={$t('linked_notes.mutual')} class="text-muted-foreground/70">
+              <ArrowLeftRight class="h-3.5 w-3.5" aria-hidden="true" />
+            </span>
+          {/if}
+        </span>
       </button>
     {/if}
   </li>
@@ -173,7 +179,7 @@
               {$t('linked_notes.incoming_empty')}
             </p>
           {:else}
-            <ul role="list" aria-labelledby="linked-notes-incoming" class="pt-1">
+            <ul role="list" aria-labelledby="linked-notes-incoming" class="space-y-0.5 px-2 py-1">
               {#each backlinks as item (item.id)}
                 {@render linkRow(item)}
               {/each}
@@ -201,7 +207,7 @@
               {$t('linked_notes.outgoing_empty')}
             </p>
           {:else}
-            <ul role="list" aria-labelledby="linked-notes-outgoing" class="pt-1">
+            <ul role="list" aria-labelledby="linked-notes-outgoing" class="space-y-0.5 px-2 py-1">
               {#each outgoing as item (item.id)}
                 {@render linkRow(item)}
               {/each}

--- a/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Waypoints, ArrowDownLeft, ArrowUpRight, Loader2 } from '@lucide/svelte';
+  import { Waypoints, ArrowDownLeft, ArrowUpRight, ArrowLeftRight, Loader2 } from '@lucide/svelte';
   import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@reborn/ui';
   import { noteLinkGraph } from '$lib/services/note-link-graph.svelte';
   import { noteIndex } from '$lib/services/note-index.svelte';
@@ -30,22 +30,37 @@
   interface LinkItem {
     id: string;
     title: string;
+    /** Link target whose note no longer exists (deleted) - shown disabled. */
+    missing: boolean;
   }
 
-  /** Resolve ids → titles via NoteIndex; drop unknown / trashed notes, sort by title. */
+  /**
+   * Resolve ids → titles via NoteIndex. Trashed (archived) notes stay hidden;
+   * ids with no index entry are surfaced as `missing` (broken link) rather than
+   * silently dropped. Missing rows sort last, the rest by title.
+   */
   function resolve(ids: string[]): LinkItem[] {
     const out: LinkItem[] = [];
     for (const id of ids) {
       const entry = noteIndex.get(id);
-      if (!entry || entry.isArchived) continue;
-      out.push({ id, title: entry.title || $t('notes.untitled') });
+      if (entry?.isArchived) continue;
+      if (!entry) {
+        out.push({ id, title: $t('linked_notes.missing'), missing: true });
+      } else {
+        out.push({ id, title: entry.title || $t('notes.untitled'), missing: false });
+      }
     }
-    out.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+    out.sort((a, b) => {
+      if (a.missing !== b.missing) return a.missing ? 1 : -1;
+      return a.title.localeCompare(b.title, undefined, { sensitivity: 'base' });
+    });
     return out;
   }
 
   const backlinks = $derived(open ? resolve(noteLinkGraph.incomingIds(noteId)) : []);
   const outgoing = $derived(open ? resolve(noteLinkGraph.outgoingIds(noteId)) : []);
+  /** Ids linked both ways - badged "↔" in both lists. Cheap; computed unconditionally. */
+  const mutual = $derived(noteLinkGraph.mutualIds(noteId));
   const loading = $derived(open && !noteLinkGraph.isBuilt);
   const isEmpty = $derived(
     open && noteLinkGraph.isBuilt && backlinks.length === 0 && outgoing.length === 0
@@ -61,6 +76,44 @@
     if (!isOpen) onclose();
   }
 </script>
+
+{#snippet linkRow(item: LinkItem)}
+  <!-- Inset divider: starts at the text's left edge, padded from the right. -->
+  <li
+    class="relative after:pointer-events-none after:absolute after:bottom-0 after:left-4 after:right-4 after:h-px after:bg-border/60 after:content-[''] last:after:hidden"
+  >
+    {#if item.missing}
+      <div
+        class="flex w-full items-center gap-2 px-4 py-2"
+        title={$t('linked_notes.missing')}
+      >
+        <span class="min-w-0 flex-1 truncate text-sm italic text-muted-foreground/50"
+          >{$t('linked_notes.missing')}</span
+        >
+      </div>
+    {:else}
+      <button
+        type="button"
+        onclick={() => onnavigate(item.id)}
+        title={item.title}
+        aria-label={mutual.has(item.id)
+          ? `${item.title}, ${$t('linked_notes.mutual')}`
+          : undefined}
+        class="group flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:bg-accent"
+      >
+        <span
+          class="min-w-0 flex-1 truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"
+          >{item.title}</span
+        >
+        {#if mutual.has(item.id)}
+          <span class="shrink-0 text-muted-foreground/70" title={$t('linked_notes.mutual')}>
+            <ArrowLeftRight class="h-3.5 w-3.5" aria-hidden="true" />
+          </span>
+        {/if}
+      </button>
+    {/if}
+  </li>
+{/snippet}
 
 <Sheet {open} onOpenChange={handleOpenChange}>
   <SheetContent side="right" class="flex w-80 flex-col gap-0 p-0 sm:max-w-sm">
@@ -101,79 +154,56 @@
       {:else}
         <!-- Backlinks (incoming). Header: bold/uppercase type, no gray band
              (opaque bg-background only so the sticky label stays readable). -->
-        <section>
+        <section aria-labelledby="linked-notes-incoming">
           <h3
+            id="linked-notes-incoming"
             class="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-foreground/80"
           >
-            <ArrowDownLeft class="h-3.5 w-3.5 text-muted-foreground" />
+            <ArrowDownLeft class="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
             {$t('linked_notes.incoming')}
             <span
               class="ml-auto rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground"
-            >{backlinks.length}</span>
+              aria-label={$t('linked_notes.incoming_count', {
+                values: { count: backlinks.length }
+              })}>{backlinks.length}</span
+            >
           </h3>
           {#if backlinks.length === 0}
             <p class="px-4 py-3 text-sm text-muted-foreground">
               {$t('linked_notes.incoming_empty')}
             </p>
           {:else}
-            <ul class="pt-2">
+            <ul role="list" aria-labelledby="linked-notes-incoming" class="pt-1">
               {#each backlinks as item (item.id)}
-                <!-- Inset divider (aligned with the title, padded from both edges). -->
-                <li
-                  class="relative after:pointer-events-none after:absolute after:bottom-0 after:left-8 after:right-4 after:h-px after:bg-border/60 after:content-[''] last:after:hidden"
-                >
-                  <button
-                    type="button"
-                    onclick={() => onnavigate(item.id)}
-                    class="group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
-                  >
-                    <span
-                      class="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/30 transition-colors group-hover:bg-muted-foreground/60"
-                    ></span>
-                    <span
-                      class="truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"
-                    >{item.title}</span>
-                  </button>
-                </li>
+                {@render linkRow(item)}
               {/each}
             </ul>
           {/if}
         </section>
 
         <!-- Outgoing (clear empty-row gap above). -->
-        <section class="mt-6">
+        <section class="mt-6" aria-labelledby="linked-notes-outgoing">
           <h3
+            id="linked-notes-outgoing"
             class="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-foreground/80"
           >
-            <ArrowUpRight class="h-3.5 w-3.5 text-muted-foreground" />
+            <ArrowUpRight class="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
             {$t('linked_notes.outgoing')}
             <span
               class="ml-auto rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground"
-            >{outgoing.length}</span>
+              aria-label={$t('linked_notes.outgoing_count', {
+                values: { count: outgoing.length }
+              })}>{outgoing.length}</span
+            >
           </h3>
           {#if outgoing.length === 0}
             <p class="px-4 py-3 text-sm text-muted-foreground">
               {$t('linked_notes.outgoing_empty')}
             </p>
           {:else}
-            <ul class="pt-2">
+            <ul role="list" aria-labelledby="linked-notes-outgoing" class="pt-1">
               {#each outgoing as item (item.id)}
-                <li
-                  class="relative after:pointer-events-none after:absolute after:bottom-0 after:left-8 after:right-4 after:h-px after:bg-border/60 after:content-[''] last:after:hidden"
-                >
-                  <button
-                    type="button"
-                    onclick={() => onnavigate(item.id)}
-                    class="group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
-                  >
-                    <span
-                      class="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/30 transition-colors group-hover:bg-muted-foreground/60"
-                    ></span>
-                    <span
-                      class="truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"
-                    >{item.title}</span>
-                  </button>
-                </li>
+                {@render linkRow(item)}
               {/each}
             </ul>
           {/if}

--- a/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
@@ -99,15 +99,16 @@
           {$t('linked_notes.empty')}
         </div>
       {:else}
-        <!-- Backlinks (incoming) -->
+        <!-- Backlinks (incoming). Header: bold/uppercase type, no gray band
+             (opaque bg-background only so the sticky label stays readable). -->
         <section>
           <h3
-            class="sticky top-0 z-10 flex items-center gap-2 border-b bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+            class="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-foreground/80"
           >
-            <ArrowDownLeft class="h-3.5 w-3.5" />
+            <ArrowDownLeft class="h-3.5 w-3.5 text-muted-foreground" />
             {$t('linked_notes.incoming')}
             <span
-              class="ml-auto rounded bg-background px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+              class="ml-auto rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground"
             >{backlinks.length}</span>
           </h3>
           {#if backlinks.length === 0}
@@ -115,15 +116,23 @@
               {$t('linked_notes.incoming_empty')}
             </p>
           {:else}
-            <ul>
+            <ul class="pt-2">
               {#each backlinks as item (item.id)}
-                <li>
+                <!-- Inset divider (aligned with the title, padded from both edges). -->
+                <li
+                  class="relative after:pointer-events-none after:absolute after:bottom-0 after:left-8 after:right-4 after:h-px after:bg-border/60 after:content-[''] last:after:hidden"
+                >
                   <button
                     type="button"
                     onclick={() => onnavigate(item.id)}
-                    class="block w-full truncate px-4 py-2 text-left text-sm text-foreground transition-colors hover:bg-accent/50 active:bg-accent"
+                    class="group flex w-full items-center gap-2.5 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
                   >
-                    {item.title}
+                    <span
+                      class="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40 transition-colors group-hover:bg-foreground/60"
+                    ></span>
+                    <span
+                      class="truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"
+                    >{item.title}</span>
                   </button>
                 </li>
               {/each}
@@ -131,15 +140,15 @@
           {/if}
         </section>
 
-        <!-- Outgoing (clear empty-row gap above, fully bordered band) -->
+        <!-- Outgoing (clear empty-row gap above). -->
         <section class="mt-6">
           <h3
-            class="sticky top-0 z-10 flex items-center gap-2 border-y bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+            class="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-foreground/80"
           >
-            <ArrowUpRight class="h-3.5 w-3.5" />
+            <ArrowUpRight class="h-3.5 w-3.5 text-muted-foreground" />
             {$t('linked_notes.outgoing')}
             <span
-              class="ml-auto rounded bg-background px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+              class="ml-auto rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground"
             >{outgoing.length}</span>
           </h3>
           {#if outgoing.length === 0}
@@ -147,15 +156,22 @@
               {$t('linked_notes.outgoing_empty')}
             </p>
           {:else}
-            <ul>
+            <ul class="pt-2">
               {#each outgoing as item (item.id)}
-                <li>
+                <li
+                  class="relative after:pointer-events-none after:absolute after:bottom-0 after:left-8 after:right-4 after:h-px after:bg-border/60 after:content-[''] last:after:hidden"
+                >
                   <button
                     type="button"
                     onclick={() => onnavigate(item.id)}
-                    class="block w-full truncate px-4 py-2 text-left text-sm text-foreground transition-colors hover:bg-accent/50 active:bg-accent"
+                    class="group flex w-full items-center gap-2.5 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
                   >
-                    {item.title}
+                    <span
+                      class="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40 transition-colors group-hover:bg-foreground/60"
+                    ></span>
+                    <span
+                      class="truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"
+                    >{item.title}</span>
                   </button>
                 </li>
               {/each}

--- a/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
@@ -125,10 +125,10 @@
                   <button
                     type="button"
                     onclick={() => onnavigate(item.id)}
-                    class="group flex w-full items-center gap-2.5 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
+                    class="group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
                   >
                     <span
-                      class="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40 transition-colors group-hover:bg-foreground/60"
+                      class="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/30 transition-colors group-hover:bg-muted-foreground/60"
                     ></span>
                     <span
                       class="truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"
@@ -164,10 +164,10 @@
                   <button
                     type="button"
                     onclick={() => onnavigate(item.id)}
-                    class="group flex w-full items-center gap-2.5 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
+                    class="group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent"
                   >
                     <span
-                      class="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40 transition-colors group-hover:bg-foreground/60"
+                      class="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/30 transition-colors group-hover:bg-muted-foreground/60"
                     ></span>
                     <span
                       class="truncate text-sm text-muted-foreground transition-colors group-hover:text-foreground"

--- a/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
@@ -51,13 +51,19 @@
     open && noteLinkGraph.isBuilt && backlinks.length === 0 && outgoing.length === 0
   );
 
+  // Build progress - only meaningful while the first build runs on a large vault.
+  const progress = $derived(noteLinkGraph.buildProgress);
+  const progressPct = $derived(
+    progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0
+  );
+
   function handleOpenChange(isOpen: boolean) {
     if (!isOpen) onclose();
   }
 </script>
 
 <Sheet {open} onOpenChange={handleOpenChange}>
-  <SheetContent side="right" class="flex w-80 flex-col p-0 sm:max-w-sm">
+  <SheetContent side="right" class="flex w-80 flex-col gap-0 p-0 sm:max-w-sm">
     <SheetHeader class="shrink-0 border-b px-4 py-3">
       <SheetTitle class="flex items-center gap-2 text-sm">
         <Waypoints class="h-4 w-4 text-muted-foreground" />
@@ -67,9 +73,24 @@
 
     <div class="flex-1 overflow-y-auto">
       {#if loading}
-        <div class="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          <Loader2 class="mr-2 h-4 w-4 animate-spin" />
-          {$t('linked_notes.loading')}
+        <div
+          class="flex flex-col items-center justify-center gap-3 px-6 py-12 text-sm text-muted-foreground"
+        >
+          <Loader2 class="h-5 w-5 animate-spin" />
+          <span>{$t('linked_notes.loading')}</span>
+          {#if progress.total > 0}
+            <div class="w-full max-w-[12rem]">
+              <div class="h-1 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full bg-primary transition-[width] duration-200"
+                  style="width: {progressPct}%"
+                ></div>
+              </div>
+              <div class="mt-1.5 text-center text-xs tabular-nums">
+                {progress.done} / {progress.total}
+              </div>
+            </div>
+          {/if}
         </div>
       {:else if isEmpty}
         <div
@@ -110,10 +131,10 @@
           {/if}
         </section>
 
-        <!-- Outgoing -->
-        <section class="mt-2 border-t">
+        <!-- Outgoing (clear empty-row gap above, fully bordered band) -->
+        <section class="mt-6">
           <h3
-            class="sticky top-0 z-10 flex items-center gap-2 border-b bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+            class="sticky top-0 z-10 flex items-center gap-2 border-y bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground"
           >
             <ArrowUpRight class="h-3.5 w-3.5" />
             {$t('linked_notes.outgoing')}

--- a/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/LinkedNotesSheet.svelte
@@ -81,14 +81,16 @@
         <!-- Backlinks (incoming) -->
         <section>
           <h3
-            class="flex items-center gap-1.5 px-4 pb-2 pt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            class="sticky top-0 z-10 flex items-center gap-2 border-b bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground"
           >
             <ArrowDownLeft class="h-3.5 w-3.5" />
             {$t('linked_notes.incoming')}
-            <span class="ml-auto tabular-nums">{backlinks.length}</span>
+            <span
+              class="ml-auto rounded bg-background px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+            >{backlinks.length}</span>
           </h3>
           {#if backlinks.length === 0}
-            <p class="px-4 pb-3 text-sm text-muted-foreground">
+            <p class="px-4 py-3 text-sm text-muted-foreground">
               {$t('linked_notes.incoming_empty')}
             </p>
           {:else}
@@ -109,16 +111,18 @@
         </section>
 
         <!-- Outgoing -->
-        <section class="border-t">
+        <section class="mt-2 border-t">
           <h3
-            class="flex items-center gap-1.5 px-4 pb-2 pt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            class="sticky top-0 z-10 flex items-center gap-2 border-b bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground"
           >
             <ArrowUpRight class="h-3.5 w-3.5" />
             {$t('linked_notes.outgoing')}
-            <span class="ml-auto tabular-nums">{outgoing.length}</span>
+            <span
+              class="ml-auto rounded bg-background px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+            >{outgoing.length}</span>
           </h3>
           {#if outgoing.length === 0}
-            <p class="px-4 pb-3 text-sm text-muted-foreground">
+            <p class="px-4 py-3 text-sm text-muted-foreground">
               {$t('linked_notes.outgoing_empty')}
             </p>
           {:else}

--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -4,6 +4,7 @@
     Columns2,
     Eye,
     Clock,
+    Waypoints,
     ArrowLeft,
     Lock,
     Loader2,
@@ -29,6 +30,8 @@
     viewMode = $bindable('edit'),
     effectiveViewMode,
     historyMode = $bindable<HistoryMode>('closed'),
+    linkedNotesActive = false,
+    ontogglelinkednotes,
     onback,
     onshowxray,
     onrestore,
@@ -45,6 +48,10 @@
     viewMode: ViewMode;
     effectiveViewMode: ViewMode;
     historyMode: HistoryMode;
+    /** Whether the Linked notes panel is open (drives the toggle's pressed state). */
+    linkedNotesActive?: boolean;
+    /** Toggle the Linked notes panel (desktop only - mobile uses the kebab menu). */
+    ontogglelinkednotes?: () => void;
     onback: () => void;
     onshowxray: () => void;
     onrestore: () => void;
@@ -218,6 +225,22 @@
         {/if}
       {/each}
     </div>
+
+    <!-- Linked notes toggle (desktop only - on mobile it's in kebab menu) -->
+    {#if !isMobile && ontogglelinkednotes}
+      <button
+        type="button"
+        onclick={ontogglelinkednotes}
+        title={$t('linked_notes.title')}
+        aria-label={$t('linked_notes.title')}
+        aria-pressed={linkedNotesActive}
+        class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground
+           transition-colors hover:bg-accent hover:text-accent-foreground
+           {linkedNotesActive ? 'bg-accent text-accent-foreground' : ''}"
+      >
+        <Waypoints class="h-4 w-4" />
+      </button>
+    {/if}
 
     <!-- History toggle (desktop only — on mobile it's in kebab menu) -->
     {#if !isMobile}

--- a/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
@@ -13,7 +13,8 @@
     Trash2,
     RotateCcw,
     Trash,
-    Clock
+    Clock,
+    Waypoints
   } from '@lucide/svelte';
   import { Button, Sheet, SheetContent, SheetHeader, SheetTitle } from '@reborn/ui';
   import { t } from '$lib/stores/i18n.store';
@@ -34,6 +35,7 @@
     onrestore,
     onpermanentdelete,
     onhistory,
+    onlinkednotes,
     onshowxray
   }: {
     open: boolean;
@@ -53,6 +55,8 @@
     onpermanentdelete: (id: string) => void;
     /** Opens version history panel (mobile only) */
     onhistory?: () => void;
+    /** Opens Linked notes panel (mobile only) */
+    onlinkednotes?: () => void;
     /** Opens Encryption X-Ray panel */
     onshowxray?: () => void;
   } = $props();
@@ -168,6 +172,19 @@
           >
             <Clock class="mr-2 h-4 w-4" />
             {$t('history.title')}
+          </Button>
+        {/if}
+        {#if onlinkednotes}
+          <Button
+            variant="ghost"
+            class="w-full justify-start"
+            onclick={() => {
+              open = false;
+              onlinkednotes?.();
+            }}
+          >
+            <Waypoints class="mr-2 h-4 w-4" />
+            {$t('linked_notes.title')}
           </Button>
         {/if}
         {#if onshowxray}

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -14,6 +14,7 @@
 import { noteStore, noteTagStore } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
 import { decryptTitleOnly } from './note.service';
+import { noteLinkGraph } from './note-link-graph.svelte';
 import type { NoteDecrypted } from '@reborn/types';
 import { evaluate, type QueryAST, type SearchContext, type SearchEntity } from '@reborn/utils';
 
@@ -89,6 +90,9 @@ class NoteIndex {
   /** Build the cache from scratch (after unlock). Non-blocking — processes in batches. */
   async build(): Promise<void> {
     if (!cryptoManager.isInitialized()) return;
+    // The link graph shadows the same note set; invalidate it so it rebuilds
+    // lazily against the fresh data (covers unlock + post-import refresh).
+    noteLinkGraph.clear();
     this._building = true;
     try {
       const allEncrypted = await noteStore.getAll();
@@ -142,6 +146,7 @@ class NoteIndex {
   clear(): void {
     this._map.clear();
     this._version++;
+    noteLinkGraph.clear();
   }
 
   // ── Incremental updates ────────────────────────────────────────

--- a/apps/reborn-notes/src/lib/services/note-link-graph.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-graph.svelte.ts
@@ -38,6 +38,9 @@ class NoteLinkGraph {
   private _built = false;
   /** Generation guard - a clear() mid-build cancels the in-flight build's commit. */
   private _gen = 0;
+  /** Progress of the lazy first build, so the panel can show a bar on big vaults. */
+  private _progressDone = $state(0);
+  private _progressTotal = $state(0);
 
   // ── State ───────────────────────────────────────────────────────
 
@@ -50,6 +53,14 @@ class NoteLinkGraph {
   /** Whether a build() is currently running. Reactive. */
   get isBuilding(): boolean {
     return this._building;
+  }
+
+  /**
+   * Progress of the in-flight build as {done, total}. `total` is 0 until the
+   * note set is loaded / when idle. Reactive - drives the panel's progress bar.
+   */
+  get buildProgress(): { done: number; total: number } {
+    return { done: this._progressDone, total: this._progressTotal };
   }
 
   // ── Build / maintain ────────────────────────────────────────────
@@ -71,6 +82,8 @@ class NoteLinkGraph {
     this._building = true;
     try {
       const all = await noteStore.getAll();
+      this._progressTotal = all.length;
+      this._progressDone = 0;
       // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp, not reactive state
       const outgoing = new Map<string, Set<string>>();
       // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp, not reactive state
@@ -98,6 +111,7 @@ class NoteLinkGraph {
             sources.add(id);
           }
         }
+        this._progressDone = Math.min(i + batch.length, all.length);
         await new Promise((r) => setTimeout(r, 0)); // yield to event loop
       }
 
@@ -169,6 +183,8 @@ class NoteLinkGraph {
     this._incoming = new Map();
     this._built = false;
     this._building = false;
+    this._progressDone = 0;
+    this._progressTotal = 0;
     this._version++;
   }
 

--- a/apps/reborn-notes/src/lib/services/note-link-graph.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-graph.svelte.ts
@@ -1,0 +1,201 @@
+/**
+ * NoteLinkGraph - in-memory note-to-note link graph (outgoing + backlinks).
+ *
+ * Derives the internal-link graph (`[label](note:UUID)` references) from the
+ * decrypted content of every note. Powers the "Linked notes" panel: outgoing
+ * links (this note → others) and backlinks (other notes → this note).
+ *
+ * Security / Zero-Knowledge:
+ *   - RAM-only. NEVER persisted to IndexedDB/localStorage/sessionStorage and
+ *     NEVER sent to the server. A note-to-note link map is a correlation graph -
+ *     exactly the metadata ZK hides (cf. the tag N-to-M design: relations live
+ *     inside each note's own ciphertext, never as a server-visible join). Here
+ *     the graph lives only in memory, derived from already-decrypted content,
+ *     and is cleared on lock/logout.
+ *   - Single source of truth is the note content itself (`content_encrypted`
+ *     holds the `[label](note:UUID)` markdown). This graph is a self-healing
+ *     cache: built lazily on first use (one streamed content scan, like content
+ *     search - peak RAM ≈ one note), then maintained incrementally on each save.
+ *
+ * Lifecycle mirrors NoteIndex: invalidated by `noteIndex.build()` / `clear()`
+ * (which call `noteLinkGraph.clear()`), then rebuilt lazily on next use.
+ */
+import { noteStore } from '@reborn/storage';
+import { cryptoManager } from '@reborn/crypto';
+import { extractNoteLinkTargets } from './note-link-utils';
+
+const BATCH_SIZE = 100;
+
+class NoteLinkGraph {
+  /** source note id → set of target ids it links to. Non-reactive; _version signals changes. */
+  private _outgoing = new Map<string, Set<string>>();
+  /** target note id → set of source ids that link to it (backlinks). */
+  private _incoming = new Map<string, Set<string>>();
+
+  /** Svelte 5 reactive version counter - consumers that read links re-render on bump. */
+  private _version = $state(0);
+  private _building = $state(false);
+  private _built = false;
+  /** Generation guard - a clear() mid-build cancels the in-flight build's commit. */
+  private _gen = 0;
+
+  // ── State ───────────────────────────────────────────────────────
+
+  /** Whether the graph has been built this session. Reactive. */
+  get isBuilt(): boolean {
+    void this._version;
+    return this._built;
+  }
+
+  /** Whether a build() is currently running. Reactive. */
+  get isBuilding(): boolean {
+    return this._building;
+  }
+
+  // ── Build / maintain ────────────────────────────────────────────
+
+  /** Build lazily - no-op if already built or a build is already in progress. */
+  async ensureBuilt(): Promise<void> {
+    if (this._built || this._building) return;
+    await this.build();
+  }
+
+  /**
+   * Full rebuild from scratch. Streams one decrypted note body at a time
+   * (peak RAM ≈ one note + the edge sets), extracts link targets, and never
+   * retains content. Non-blocking: processes in batches with a yield between.
+   */
+  async build(): Promise<void> {
+    if (!cryptoManager.isInitialized()) return;
+    const gen = ++this._gen;
+    this._building = true;
+    try {
+      const all = await noteStore.getAll();
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp, not reactive state
+      const outgoing = new Map<string, Set<string>>();
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp, not reactive state
+      const incoming = new Map<string, Set<string>>();
+
+      for (let i = 0; i < all.length; i += BATCH_SIZE) {
+        if (this._gen !== gen) return; // cancelled by clear()
+        const batch = all.slice(i, i + BATCH_SIZE);
+        const decrypted = await Promise.all(
+          batch.map(async (enc) => ({
+            id: enc.id,
+            targets: extractNoteLinkTargets(await safeDecrypt(enc.content_encrypted), enc.id)
+          }))
+        );
+        for (const { id, targets } of decrypted) {
+          if (targets.size === 0) continue;
+          outgoing.set(id, targets);
+          for (const target of targets) {
+            let sources = incoming.get(target);
+            if (!sources) {
+              // eslint-disable-next-line svelte/prefer-svelte-reactivity -- plain Set inside non-reactive map
+              sources = new Set<string>();
+              incoming.set(target, sources);
+            }
+            sources.add(id);
+          }
+        }
+        await new Promise((r) => setTimeout(r, 0)); // yield to event loop
+      }
+
+      if (this._gen !== gen) return; // cancelled mid-flight
+      this._outgoing = outgoing;
+      this._incoming = incoming;
+      this._built = true;
+      this._version++;
+    } finally {
+      if (this._gen === gen) this._building = false;
+    }
+  }
+
+  /**
+   * Incremental update after a note is saved. Re-extracts the note's outgoing
+   * links from its (already-plaintext) content and patches both maps in O(links).
+   * No-op until the graph is built - the lazy build picks the note up later.
+   */
+  onNoteSaved(id: string, content: string): void {
+    if (!this._built) return;
+    const next = extractNoteLinkTargets(content, id);
+    const prev = this._outgoing.get(id);
+
+    // Drop backlinks for targets no longer referenced
+    if (prev) {
+      for (const target of prev) {
+        if (!next.has(target)) this._incoming.get(target)?.delete(id);
+      }
+    }
+    // Add backlinks for newly referenced targets
+    for (const target of next) {
+      if (prev?.has(target)) continue;
+      let sources = this._incoming.get(target);
+      if (!sources) {
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- plain Set inside non-reactive map
+        sources = new Set<string>();
+        this._incoming.set(target, sources);
+      }
+      sources.add(id);
+    }
+
+    if (next.size === 0) this._outgoing.delete(id);
+    else this._outgoing.set(id, next);
+    this._version++;
+  }
+
+  /** Remove a note from the graph entirely (permanent delete / empty trash). */
+  onNoteRemoved(id: string): void {
+    if (!this._built) return;
+    // Edges where `id` is the source
+    const targets = this._outgoing.get(id);
+    if (targets) {
+      for (const target of targets) this._incoming.get(target)?.delete(id);
+      this._outgoing.delete(id);
+    }
+    // Edges where `id` is the target
+    const sources = this._incoming.get(id);
+    if (sources) {
+      for (const source of sources) this._outgoing.get(source)?.delete(id);
+      this._incoming.delete(id);
+    }
+    this._version++;
+  }
+
+  /** Wipe the graph (lock / logout / wholesale refresh). Cancels any in-flight build. */
+  clear(): void {
+    this._gen++; // cancel in-flight build commit
+    this._outgoing = new Map();
+    this._incoming = new Map();
+    this._built = false;
+    this._building = false;
+    this._version++;
+  }
+
+  // ── Reads ───────────────────────────────────────────────────────
+
+  /** Note ids this note links to (outgoing). Reactive. */
+  outgoingIds(id: string): string[] {
+    void this._version;
+    const set = this._outgoing.get(id);
+    return set ? Array.from(set) : [];
+  }
+
+  /** Note ids that link to this note (backlinks / incoming). Reactive. */
+  incomingIds(id: string): string[] {
+    void this._version;
+    const set = this._incoming.get(id);
+    return set ? Array.from(set) : [];
+  }
+}
+
+async function safeDecrypt(stored: string): Promise<string> {
+  if (!stored) return '';
+  try {
+    return await cryptoManager.decryptText(stored);
+  } catch {
+    return ''; // corrupted ciphertext - treat as no links
+  }
+}
+
+export const noteLinkGraph = new NoteLinkGraph();

--- a/apps/reborn-notes/src/lib/services/note-link-graph.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-graph.svelte.ts
@@ -22,7 +22,7 @@
  */
 import { noteStore } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
-import { extractNoteLinkTargets } from './note-link-utils';
+import { extractNoteLinkTargets, intersectIds } from './note-link-utils';
 
 const BATCH_SIZE = 100;
 
@@ -202,6 +202,14 @@ class NoteLinkGraph {
     void this._version;
     const set = this._incoming.get(id);
     return set ? Array.from(set) : [];
+  }
+
+  /**
+   * Ids linked in both directions - notes this note links to that also link
+   * back (incoming ∩ outgoing). Reactive (via the two reads it composes).
+   */
+  mutualIds(id: string): Set<string> {
+    return intersectIds(this.incomingIds(id), this.outgoingIds(id));
   }
 }
 

--- a/apps/reborn-notes/src/lib/services/note-link-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractNoteLinkTargets } from './note-link-utils';
+import { extractNoteLinkTargets, intersectIds } from './note-link-utils';
 
 const A = '550e8400-e29b-41d4-a716-446655440000';
 const B = '123e4567-e89b-12d3-a456-426614174000';
@@ -50,5 +50,33 @@ describe('extractNoteLinkTargets', () => {
   it('returns an empty set for empty or link-free content', () => {
     expect(extractNoteLinkTargets('').size).toBe(0);
     expect(extractNoteLinkTargets('Plain text, no links.').size).toBe(0);
+  });
+});
+
+describe('intersectIds (mutual links)', () => {
+  it('returns the ids present in both lists', () => {
+    expect(intersectIds([A, B, C], [B, C])).toEqual(new Set([B, C]));
+  });
+
+  it('returns an empty set when there is no overlap', () => {
+    expect(intersectIds([A], [B, C]).size).toBe(0);
+  });
+
+  it('is case-insensitive and lowercases the result', () => {
+    expect(intersectIds([A.toUpperCase()], [A])).toEqual(new Set([A]));
+    expect(intersectIds([A], [A.toUpperCase()])).toEqual(new Set([A]));
+  });
+
+  it('de-duplicates repeated ids in either input', () => {
+    expect([...intersectIds([A, A, B], [A, A])]).toEqual([A]);
+  });
+
+  it('returns an empty set when either side is empty', () => {
+    expect(intersectIds([], [A, B]).size).toBe(0);
+    expect(intersectIds([A, B], []).size).toBe(0);
+  });
+
+  it('accepts Set inputs (the graph passes id sets)', () => {
+    expect(intersectIds(new Set([A, B]), new Set([B, C]))).toEqual(new Set([B]));
   });
 });

--- a/apps/reborn-notes/src/lib/services/note-link-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-utils.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { extractNoteLinkTargets } from './note-link-utils';
+
+const A = '550e8400-e29b-41d4-a716-446655440000';
+const B = '123e4567-e89b-12d3-a456-426614174000';
+const C = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+
+describe('extractNoteLinkTargets', () => {
+  it('extracts a single internal link target', () => {
+    expect([...extractNoteLinkTargets(`See [Note A](note:${A}).`)]).toEqual([A]);
+  });
+
+  it('extracts multiple distinct targets', () => {
+    const content = `[A](note:${A}) and [B](note:${B}) and [C](note:${C})`;
+    expect(extractNoteLinkTargets(content)).toEqual(new Set([A, B, C]));
+  });
+
+  it('de-duplicates repeated links to the same note', () => {
+    const content = `[x](note:${A}) ... [y](note:${A})`;
+    expect([...extractNoteLinkTargets(content)]).toEqual([A]);
+  });
+
+  it('excludes the note itself (no self-backlink), case-insensitively', () => {
+    const content = `[self](note:${A}) [other](note:${B})`;
+    expect(extractNoteLinkTargets(content, A)).toEqual(new Set([B]));
+    // selfId given in a different case must still be excluded
+    expect(extractNoteLinkTargets(content, A.toUpperCase())).toEqual(new Set([B]));
+  });
+
+  it('is case-insensitive and lowercases the captured id', () => {
+    const upper = A.toUpperCase();
+    expect([...extractNoteLinkTargets(`[a](NOTE:${upper})`)]).toEqual([A]);
+  });
+
+  it('ignores external links and other URI schemes', () => {
+    const content = `[ext](https://example.com) [mail](mailto:a@b.c) [img](image:${A})`;
+    expect(extractNoteLinkTargets(content).size).toBe(0);
+  });
+
+  it('does not match a bare note: string that is not a markdown link', () => {
+    // No `](` prefix → not a link destination, must not be picked up.
+    expect(extractNoteLinkTargets(`reference note:${A} inline`).size).toBe(0);
+  });
+
+  it('ignores malformed UUIDs', () => {
+    expect(extractNoteLinkTargets(`[bad](note:not-a-uuid)`).size).toBe(0);
+    expect(extractNoteLinkTargets(`[short](note:550e8400-e29b-41d4-a716)`).size).toBe(0);
+  });
+
+  it('returns an empty set for empty or link-free content', () => {
+    expect(extractNoteLinkTargets('').size).toBe(0);
+    expect(extractNoteLinkTargets('Plain text, no links.').size).toBe(0);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/note-link-utils.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-utils.ts
@@ -24,3 +24,21 @@ export function extractNoteLinkTargets(content: string, selfId?: string): Set<st
   }
   return targets;
 }
+
+/**
+ * Ids present in BOTH lists - the mutual (bidirectional) links of a note: the
+ * notes it links to that also link back. Powers the "↔" badge in the panel.
+ *
+ * Case-insensitive (ids are lowercased before comparing and in the result), so
+ * it stays correct regardless of how a given id was cased upstream.
+ */
+export function intersectIds(a: Iterable<string>, b: Iterable<string>): Set<string> {
+  const other = new Set<string>();
+  for (const id of b) other.add(id.toLowerCase());
+  const both = new Set<string>();
+  for (const id of a) {
+    const low = id.toLowerCase();
+    if (other.has(low)) both.add(low);
+  }
+  return both;
+}

--- a/apps/reborn-notes/src/lib/services/note-link-utils.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure helpers for the note-to-note link graph. Kept free of runes / crypto /
+ * storage so the link-extraction logic (the bug-prone, Zero-Knowledge-sensitive
+ * part - it must never over-match) is trivially unit-testable.
+ */
+
+/** Capture the target UUID of every `[label](note:UUID)` markdown link. */
+const NOTE_LINK_TARGET_RE =
+  /\]\(note:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)/gi;
+
+/**
+ * Extract the set of note ids that `content` links to via the `note:` scheme,
+ * lowercased and excluding `selfId` (a note is never its own backlink).
+ */
+export function extractNoteLinkTargets(content: string, selfId?: string): Set<string> {
+  const targets = new Set<string>();
+  if (!content) return targets;
+  const self = selfId?.toLowerCase();
+  NOTE_LINK_TARGET_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = NOTE_LINK_TARGET_RE.exec(content)) !== null) {
+    const target = match[1].toLowerCase();
+    if (target !== self) targets.add(target);
+  }
+  return targets;
+}

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -18,6 +18,7 @@ import { cryptoManager } from '@reborn/crypto';
 import { get } from 'svelte/store';
 import { authStore } from '$lib/stores/auth.store';
 import { noteIndex } from '$lib/services/note-index.svelte';
+import { noteLinkGraph } from '$lib/services/note-link-graph.svelte';
 import {
   pushNote,
   pushNoteUpdate,
@@ -274,6 +275,7 @@ export async function createNote(
     updatedAt,
     tagIds: []
   });
+  noteLinkGraph.onNoteSaved(id, content);
   return id;
 }
 
@@ -312,6 +314,7 @@ export async function updateNote(
     title,
     updatedAt
   });
+  noteLinkGraph.onNoteSaved(id, content);
 }
 
 /** Rename note title only. */
@@ -500,6 +503,7 @@ export async function permanentlyDeleteNote(id: string): Promise<void> {
   await noteHistoryOperations.deleteAllForNote(id);
   await noteStore.delete(id);
   noteIndex.remove(id);
+  noteLinkGraph.onNoteRemoved(id);
   pushNoteDelete(id, true);
 }
 
@@ -517,6 +521,7 @@ export async function emptyTrash(): Promise<number> {
   // Remove from index cache
   for (const n of archived) {
     noteIndex.remove(n.id);
+    noteLinkGraph.onNoteRemoved(n.id);
   }
 
   // Push permanent deletes to server (fire-and-forget, skip never-synced notes)

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -28,6 +28,7 @@
   import NotePicker from '$lib/components/NotePicker.svelte';
 
   import VersionHistorySheet from '$lib/components/VersionHistorySheet.svelte';
+  import LinkedNotesSheet from '$lib/components/LinkedNotesSheet.svelte';
   import FolderTree from '$lib/components/sidebar/FolderTree.svelte';
   import { pendingNewFolderDraft } from '$lib/stores/new-folder-draft.store';
   import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
@@ -273,6 +274,19 @@
     }
   }
 
+  function toggleLinkedNotes() {
+    linkedNotesOpen = !linkedNotesOpen;
+    if (linkedNotesOpen && historyMode !== 'closed') {
+      closeHistory();
+    }
+  }
+
+  function handleDetailLinkedNotes() {
+    detailActionSheetOpen = false;
+    if (historyMode !== 'closed') closeHistory();
+    linkedNotesOpen = true;
+  }
+
   async function confirmDetailDelete() {
     if (!$activeNoteId) return;
     const id = $activeNoteId;
@@ -288,6 +302,16 @@
   let viewMode = $state<ViewMode>('edit');
   type HistoryMode = 'closed' | 'list' | 'diff';
   let historyMode = $state<HistoryMode>('closed');
+  let linkedNotesOpen = $state(false);
+
+  // The Linked notes panel is mutually exclusive with version history (both are
+  // right-side sheets) and resets when returning to the list, so opening another
+  // note never auto-reopens it.
+  $effect(() => {
+    if (historyMode !== 'closed' || $activeNoteId == null) {
+      linkedNotesOpen = false;
+    }
+  });
   let selectedVersion = $state<import('@reborn/types').NoteHistoryDecrypted | null>(null);
   let previousVersion = $state<import('@reborn/types').NoteHistoryDecrypted | null>(null);
   let historyViewMode = $state<'preview' | 'diff'>('preview');
@@ -1419,6 +1443,8 @@
               bind:viewMode
               {effectiveViewMode}
               bind:historyMode
+              linkedNotesActive={linkedNotesOpen}
+              ontogglelinkednotes={toggleLinkedNotes}
               onback={() => {
                 if (isMobile && mobileHistoryDepth > 0) {
                   history.back();
@@ -1672,6 +1698,8 @@
             bind:viewMode
             {effectiveViewMode}
             bind:historyMode
+            linkedNotesActive={linkedNotesOpen}
+            ontogglelinkednotes={toggleLinkedNotes}
             onback={() => activeNoteId.set(null)}
             onshowxray={() => {
               showEncryptionXRay = true;
@@ -1879,6 +1907,20 @@
   />
 {/if}
 
+{#if $activeNoteId}
+  <LinkedNotesSheet
+    noteId={$activeNoteId}
+    open={linkedNotesOpen}
+    onnavigate={(id) => {
+      void handleNoteLink(id);
+      if (isMobile) linkedNotesOpen = false;
+    }}
+    onclose={() => {
+      linkedNotesOpen = false;
+    }}
+  />
+{/if}
+
 <ConfirmDialog
   bind:open={restoreDialogOpen}
   title={$t('history.restore_title')}
@@ -1907,6 +1949,7 @@
   onshare={(note) => handleDetailShare(note)}
   ondelete={() => handleDetailDelete()}
   onhistory={handleDetailHistory}
+  onlinkednotes={handleDetailLinkedNotes}
   onshowxray={() => { showEncryptionXRay = true; }}
   onrestore={() => {}}
   onpermanentdelete={() => {}}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -638,7 +638,11 @@
     "incoming_empty": "Noch verweist keine Notiz hierher.",
     "outgoing_empty": "Diese Notiz hat keine ausgehenden Links.",
     "empty": "Noch keine verknüpften Notizen.",
-    "loading": "Verknüpfungen werden gesucht…"
+    "loading": "Verknüpfungen werden gesucht…",
+    "mutual": "In beide Richtungen verknüpft",
+    "missing": "Fehlende Notiz",
+    "incoming_count": "Eingehende Links: {count}",
+    "outgoing_count": "Ausgehende Links: {count}"
   },
   "history": {
     "title": "Versionsverlauf",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -631,6 +631,15 @@
     "edited": "Bearbeitet",
     "created": "Erstellt"
   },
+  "linked_notes": {
+    "title": "Verknüpfte Notizen",
+    "incoming": "Eingehende Links",
+    "outgoing": "Ausgehende Links",
+    "incoming_empty": "Noch verweist keine Notiz hierher.",
+    "outgoing_empty": "Diese Notiz hat keine ausgehenden Links.",
+    "empty": "Noch keine verknüpften Notizen.",
+    "loading": "Verknüpfungen werden gesucht…"
+  },
   "history": {
     "title": "Versionsverlauf",
     "close": "Verlauf schließen",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -638,7 +638,11 @@
     "incoming_empty": "No notes link here yet.",
     "outgoing_empty": "This note has no outgoing links.",
     "empty": "No linked notes yet.",
-    "loading": "Finding links…"
+    "loading": "Finding links…",
+    "mutual": "Linked both ways",
+    "missing": "Missing note",
+    "incoming_count": "Incoming links: {count}",
+    "outgoing_count": "Outgoing links: {count}"
   },
   "history": {
     "title": "Version history",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -631,6 +631,15 @@
     "edited": "Edited",
     "created": "Created"
   },
+  "linked_notes": {
+    "title": "Linked notes",
+    "incoming": "Incoming links",
+    "outgoing": "Outgoing links",
+    "incoming_empty": "No notes link here yet.",
+    "outgoing_empty": "This note has no outgoing links.",
+    "empty": "No linked notes yet.",
+    "loading": "Finding links…"
+  },
   "history": {
     "title": "Version history",
     "close": "Close history",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -638,7 +638,11 @@
     "incoming_empty": "Ninguna nota enlaza aquí todavía.",
     "outgoing_empty": "Esta nota no tiene enlaces salientes.",
     "empty": "Aún no hay notas enlazadas.",
-    "loading": "Buscando enlaces…"
+    "loading": "Buscando enlaces…",
+    "mutual": "Enlazada en ambos sentidos",
+    "missing": "Nota faltante",
+    "incoming_count": "Enlaces entrantes: {count}",
+    "outgoing_count": "Enlaces salientes: {count}"
   },
   "history": {
     "title": "Historial de versiones",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -631,6 +631,15 @@
     "edited": "Editada",
     "created": "Creada"
   },
+  "linked_notes": {
+    "title": "Notas enlazadas",
+    "incoming": "Enlaces entrantes",
+    "outgoing": "Enlaces salientes",
+    "incoming_empty": "Ninguna nota enlaza aquí todavía.",
+    "outgoing_empty": "Esta nota no tiene enlaces salientes.",
+    "empty": "Aún no hay notas enlazadas.",
+    "loading": "Buscando enlaces…"
+  },
   "history": {
     "title": "Historial de versiones",
     "close": "Cerrar historial",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -631,6 +631,15 @@
     "edited": "Modifiée",
     "created": "Créée"
   },
+  "linked_notes": {
+    "title": "Notes liées",
+    "incoming": "Liens entrants",
+    "outgoing": "Liens sortants",
+    "incoming_empty": "Aucune note ne pointe ici pour le moment.",
+    "outgoing_empty": "Cette note n'a aucun lien sortant.",
+    "empty": "Aucune note liée pour le moment.",
+    "loading": "Recherche des liens…"
+  },
   "history": {
     "title": "Historique des versions",
     "close": "Fermer l'historique",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -638,7 +638,11 @@
     "incoming_empty": "Aucune note ne pointe ici pour le moment.",
     "outgoing_empty": "Cette note n'a aucun lien sortant.",
     "empty": "Aucune note liée pour le moment.",
-    "loading": "Recherche des liens…"
+    "loading": "Recherche des liens…",
+    "mutual": "Lié dans les deux sens",
+    "missing": "Note introuvable",
+    "incoming_count": "Liens entrants : {count}",
+    "outgoing_count": "Liens sortants : {count}"
   },
   "history": {
     "title": "Historique des versions",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -631,6 +631,15 @@
     "edited": "Edytowano",
     "created": "Utworzono"
   },
+  "linked_notes": {
+    "title": "Powiązane notatki",
+    "incoming": "Linki przychodzące",
+    "outgoing": "Linki wychodzące",
+    "incoming_empty": "Żadna notatka tu nie linkuje.",
+    "outgoing_empty": "Ta notatka nie ma linków wychodzących.",
+    "empty": "Brak powiązanych notatek.",
+    "loading": "Szukam powiązań…"
+  },
   "history": {
     "title": "Historia wersji",
     "close": "Zamknij historię",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -638,7 +638,11 @@
     "incoming_empty": "Żadna notatka tu nie linkuje.",
     "outgoing_empty": "Ta notatka nie ma linków wychodzących.",
     "empty": "Brak powiązanych notatek.",
-    "loading": "Szukam powiązań…"
+    "loading": "Szukam powiązań…",
+    "mutual": "Połączone w obie strony",
+    "missing": "Brakująca notatka",
+    "incoming_count": "Linki przychodzące: {count}",
+    "outgoing_count": "Linki wychodzące: {count}"
   },
   "history": {
     "title": "Historia wersji",


### PR DESCRIPTION
## Summary

Adds a "Linked notes" panel to Reborn Notes showing, for the current note, both
**incoming links (backlinks)** and **outgoing links**, each click-to-navigate.
Inspired by Obsidian, but built around this app's stable `[label](note:UUID)`
link format and Zero-Knowledge model.

- **UX:** a slide-in **right side panel on desktop** / **bottom overlay on mobile**,
  mirroring the existing version-history sheet. Opened from a `Waypoints` toggle in
  the desktop header, or from the mobile note action sheet (no extra header crowding
  on small screens). Mutually exclusive with the history panel; resets when leaving
  the note. No context snippets (titles only), per request.
- **Lists:** backlinks + outgoing, titles resolved from `NoteIndex`, archived/trashed
  and unresolved notes filtered out, sorted by title, with counts and empty states.

### Key decisions (for review)

- **Backlinks come from an in-memory derived graph (`NoteLinkGraph`), not a persisted
  table.** A note-to-note link map is a correlation graph - exactly what the tag
  N-to-M design hides from the server. Persisting it (even encrypted, even as
  per-note backlink blobs) would leak the graph via write co-movement + ciphertext
  size, and a shared backlink record is a sync hotspot that loses concurrent edits.
  So the graph is **RAM-only, never persisted, never synced**, derived from
  already-decrypted content, and cleared on lock alongside `NoteIndex`. Single source
  of truth stays the note content itself; the graph self-heals on rebuild.
- **Built lazily + maintained incrementally.** First panel open triggers one streamed
  content scan (peak RAM ≈ one note, like content search); subsequent note saves patch
  the graph in O(links) with zero extra decryption (plaintext is already in hand at
  save time). Invalidated wholesale on sync/import via the existing `noteIndex`
  build/clear chokepoints.
- **Future scale lever (not in this PR):** if a very large vault ever makes the
  first-build scan noticeable, promote to storing each note's *outgoing* links inside
  its own `metadata_encrypted` (ZK-safe, owner-partitioned) and derive backlinks from
  those. Deferred behind a measured trigger; the current code is the foundation it
  would reuse.

## Test plan

Automated (all green locally): `extractNoteLinkTargets` unit tests (9), full
reborn-notes suite (818), `svelte-check` 0 errors, eslint 0 errors, i18n parity
(notes), production build.

Manual smoke:
1. Create note A linking to B (`[[` autocomplete or toolbar). Open B - panel shows A
   under Incoming links; open A - shows B under Outgoing links. Click navigates.
2. Desktop: `Waypoints` icon in the header toggles the panel. Mobile: kebab -> "Linked
   notes" opens the bottom sheet; tapping a result navigates and closes it.
3. Rename B - A's backlink entry shows the new title. Delete B - it drops from A's
   outgoing on next open.
4. Note with no links shows the empty state. Lock/unlock - panel rebuilds on next open.
5. Verify all 5 locales (EN/PL/DE/FR/ES) render the panel labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: UX + a11y polish (review round)

Follow-up commit refining the panel per review notes - no data-model change:

- **Mutual links** - a note present in both lists is badged "↔" (tooltip). Detection is a pure `intersectIds()` in `note-link-utils.ts` (unit-tested) plus `noteLinkGraph.mutualIds()`.
- **Rows** - leading dots removed; denser vertical padding; full-width rules replaced by inset dividers aligned to the title; `cursor-pointer` + visible `focus-visible` ring.
- **Long titles** - single-line ellipsis + `title` attribute (full name on hover).
- **A11y** - `role=list`/`listitem`, section headings tied to their lists via `aria-labelledby`, count badges carry an `aria-label` (`incoming_count` / `outgoing_count`). Focus trap + Escape come from the shared `Sheet` (bits-ui Dialog).
- **Broken links** - a target whose note no longer exists renders disabled/greyed with a tooltip (`linked_notes.missing`) instead of silently vanishing.

### Decisions (auto mode) - please confirm at review
1. Mutual detection is a pure `intersectIds(a, b)` (incoming ∩ outgoing) rather than a graph-reading `getMutualLinks(noteId)`, to keep `note-link-utils.ts` runes-/storage-free and trivially unit-testable; the graph adds a thin `mutualIds()` wrapper.
2. Only truly-missing targets (no `NoteIndex` entry) surface as broken; archived/trashed targets stay hidden so the panel never reveals that a linked note was trashed.
3. The `Sheet` close button keeps the shared component's built-in (sr-only) label and focus/Escape handling; localizing that label would touch `@reborn/ui` app-wide, so it is left as a follow-up rather than done in this panel PR.

### Smoke (this round)
- Note that links to and is linked from the same note -> "↔" badge on that row in both sections; hover shows tooltip.
- Long titles truncate to one line; hover shows the full title.
- Keyboard: Tab into panel -> rows show a focus ring; Enter navigates; Escape closes.
- Link a note then delete the target -> outgoing list shows a greyed, non-clickable "Missing note" row.
- pl/de/fr/es: badge tooltip, "Missing note" and count labels are localized.

### Update 2: visual refinements (second review pass)

Visual-only follow-up (commit `9d11415`), no data-model / graph-logic / i18n change:
- **Trailing slot** - every row reserves a fixed-width slot (`w-6`, rendered even when empty), so the "↔" badges form a clean column and the title's ellipsis can never run under the icon.
- **Gutter** - the slot ends 16px from the right edge, symmetric to the 16px left text inset; rows line up with the section header and count pills.
- **Dividers removed** - rows now separate by spacing (`space-y-0.5`) + an inset, rounded hover (`ul px-2` + `rounded-lg`) instead of full-bleed rules (Obsidian/Bear style), consistent in both sections.
- Mutual-badge a11y unchanged (icon `aria-hidden`, meaning on the row's `aria-label` + tooltip).

Note (graph hygiene, not the panel): the `dev-guidelines` / `dev-guidelines-kopia` and `session-expiry-*` / `notes-session-expiry-*` pairs are duplicate notes in the vault - the panel faithfully reflects the graph; cleanup belongs in the notes, not the UI.
