### PR TITLE
fix(notes): pin Encryption X-Ray overlay to the editor viewport

### DIFF
--- a/apps/reborn-notes/src/lib/components/EncryptionXRay.svelte
+++ b/apps/reborn-notes/src/lib/components/EncryptionXRay.svelte
@@ -265,15 +265,24 @@
         class="absolute inset-0 overflow-auto bg-zinc-900"
         style="clip-path: inset(0 0 0 {sliderPosition}%);"
       >
-        <div class="min-h-full px-6 py-5 pl-10">
-          <div
-            class="mb-3 inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-400"
-          >
-            <Server class="h-3.5 w-3.5" />
-            {$t('encryption.server_view')}
+        <div class="min-h-full py-5">
+          <!-- Badge mirrors the left pane's, pinned to the panel's RIGHT edge
+               (right-aligned) so it stays visible the moment X-Ray opens,
+               regardless of the split position. -->
+          <div class="mb-3 flex justify-end px-6">
+            <span
+              class="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-400"
+            >
+              <Server class="h-3.5 w-3.5" />
+              {$t('encryption.server_view')}
+            </span>
           </div>
+          <!-- Ciphertext starts just past the seam: the left padding tracks the
+               split position, so line starts are never tucked under the clipped
+               left edge when the handle is dragged far left. -->
           <pre
-            class="whitespace-pre-wrap break-all font-mono text-xs leading-relaxed text-emerald-400/90">{formatCipher(
+            class="whitespace-pre-wrap break-all font-mono text-xs leading-relaxed text-emerald-400/90"
+            style="padding-left: calc({sliderPosition}% + 2.5rem); padding-right: 1.5rem;">{formatCipher(
               'title_encrypted',
               titleEncrypted
             )}

--- a/apps/reborn-notes/src/lib/components/EncryptionXRay.svelte
+++ b/apps/reborn-notes/src/lib/components/EncryptionXRay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { X, Lock, GripVertical, Eye, Server } from '@lucide/svelte';
+  import { X, Lock, Eye, Server } from '@lucide/svelte';
   import { getRawEncryptedNote } from '$lib/services/note.service';
   import { t } from '$lib/stores/i18n.store';
 
@@ -16,67 +16,169 @@
     onclose: () => void;
   } = $props();
 
+  // ── Tunables ────────────────────────────────────────────────────
+  // Per-device split position. localStorage (not synced) is deliberate:
+  // a UI preference, not user data, so it never touches the server.
+  const STORAGE_KEY = 'reborn-notes:xray-split';
+  const SNAP_POINTS = [25, 50, 75]; // magnet stops
+  const SNAP_THRESHOLD = 4; // % window around each snap point
+  const MIN_POS = 8; // keep a sliver of both panes visible
+  const MAX_POS = 92;
+  const STEP = 5; // arrow key step
+  const STEP_LARGE = 25; // shift + arrow step
+
+  // ── Math + persistence helpers (declarations hoist above $state) ─
+  function clampPos(v: number): number {
+    return Math.max(MIN_POS, Math.min(MAX_POS, v));
+  }
+
+  function applySnap(v: number): number {
+    for (const p of SNAP_POINTS) {
+      if (Math.abs(v - p) <= SNAP_THRESHOLD) return p;
+    }
+    return v;
+  }
+
+  function loadSplit(): number {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw != null) {
+        const v = Number(raw);
+        if (Number.isFinite(v)) return clampPos(v);
+      }
+    } catch {
+      /* private mode / disabled storage - fall through to default */
+    }
+    return 50; // default 50/50
+  }
+
+  function saveSplit(v: number): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(Math.round(v)));
+    } catch {
+      /* ignore */
+    }
+  }
+
   // ── State ───────────────────────────────────────────────────────
   let containerEl: HTMLDivElement | undefined = $state();
-  let sliderPosition = $state(65); // % from left — start mostly showing plaintext
+  let handleEl: HTMLDivElement | undefined = $state();
+  let sliderPosition = $state(loadSplit());
   let isDragging = $state(false);
   let titleEncrypted = $state('');
   let contentEncrypted = $state('');
   let metadataEncrypted = $state('');
   let loading = $state(true);
   let visible = $state(false);
+  let reduceMotion = $state(false);
+
+  /** Commit a new split position: snap, clamp, optionally persist. */
+  function setPosition(v: number, persist = true): void {
+    sliderPosition = clampPos(applySnap(v));
+    if (persist) saveSplit(sliderPosition);
+  }
 
   // ── Fetch real ciphertext ───────────────────────────────────────
-  onMount(async () => {
-    const raw = await getRawEncryptedNote(noteId);
-    if (raw) {
-      titleEncrypted = raw.title_encrypted;
-      contentEncrypted = raw.content_encrypted;
-      metadataEncrypted = raw.metadata_encrypted ?? '';
-    }
-    loading = false;
-    // Trigger entrance animation
-    requestAnimationFrame(() => {
-      visible = true;
+  onMount(() => {
+    reduceMotion =
+      typeof matchMedia !== 'undefined' &&
+      matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    let cancelled = false;
+    getRawEncryptedNote(noteId).then((raw) => {
+      if (cancelled) return;
+      if (raw) {
+        titleEncrypted = raw.title_encrypted;
+        contentEncrypted = raw.content_encrypted;
+        metadataEncrypted = raw.metadata_encrypted ?? '';
+      }
+      loading = false;
+      // Trigger entrance + one-shot scan animation on the next frame.
+      requestAnimationFrame(() => {
+        visible = true;
+      });
     });
+
+    return () => {
+      cancelled = true;
+    };
   });
 
   // ── Pointer-based slider drag ───────────────────────────────────
-  function handlePointerDown(e: PointerEvent) {
-    isDragging = true;
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-    updatePosition(e);
-  }
-
-  function handlePointerMove(e: PointerEvent) {
-    if (!isDragging) return;
-    e.preventDefault();
-    updatePosition(e);
-  }
-
-  function handlePointerUp() {
-    isDragging = false;
-  }
-
-  function updatePosition(e: PointerEvent) {
+  function updateFromPointer(e: PointerEvent): void {
     if (!containerEl) return;
     const rect = containerEl.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const pct = Math.max(5, Math.min(95, (x / rect.width) * 100));
-    sliderPosition = pct;
+    const pct = ((e.clientX - rect.left) / rect.width) * 100;
+    // Persist on release, not on every move.
+    setPosition(pct, false);
   }
 
-  // ── Keyboard / Escape ───────────────────────────────────────────
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
-      onclose();
+  function handlePointerDown(e: PointerEvent): void {
+    isDragging = true;
+    handleEl?.focus({ preventScroll: true });
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    updateFromPointer(e);
+  }
+
+  function handlePointerMove(e: PointerEvent): void {
+    if (!isDragging) return;
+    e.preventDefault();
+    updateFromPointer(e);
+  }
+
+  function handlePointerUp(e: PointerEvent): void {
+    if (!isDragging) return;
+    isDragging = false;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* pointer already released */
     }
+    saveSplit(sliderPosition);
+  }
+
+  /** Double-click anywhere on the handle resets to a centered 50/50. */
+  function handleReset(): void {
+    setPosition(50);
+  }
+
+  // ── Keyboard ────────────────────────────────────────────────────
+  function handleSeparatorKeydown(e: KeyboardEvent): void {
+    let next: number;
+    const big = e.shiftKey;
+    switch (e.key) {
+      case 'ArrowLeft':
+        next = sliderPosition - (big ? STEP_LARGE : STEP);
+        break;
+      case 'ArrowRight':
+        next = sliderPosition + (big ? STEP_LARGE : STEP);
+        break;
+      case 'Home':
+        next = SNAP_POINTS[0]; // 25%
+        break;
+      case 'End':
+        next = SNAP_POINTS[SNAP_POINTS.length - 1]; // 75%
+        break;
+      case 'Enter':
+      case ' ':
+        next = 50; // keyboard equivalent of double-click reset
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    setPosition(next);
+  }
+
+  function handleWindowKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') onclose();
   }
 
   // ── Format ciphertext for display ───────────────────────────────
   function formatCipher(label: string, value: string): string {
     if (!value) return `${label}: [empty]`;
-    // Split iv:ciphertext and show both parts
+    // Split iv:ciphertext and show both parts.
     const colonIdx = value.indexOf(':');
     if (colonIdx > 0) {
       const iv = value.slice(0, colonIdx);
@@ -87,17 +189,15 @@
   }
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
+<svelte:window onkeydown={handleWindowKeydown} />
 
-<!-- Overlay backdrop -->
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- Overlay: absolute inset-0 over the viewport-bounded scroll-container wrapper
+     (mounted as a sibling of the editor scroll container, NOT inside the
+     scrolling content) so it always fills the visible editor area regardless of
+     note length or scroll position. -->
 <div
-  class="absolute inset-0 z-50 flex flex-col transition-all duration-200
+  class="absolute inset-0 z-50 flex flex-col bg-zinc-900 transition-opacity duration-200
          {visible ? 'opacity-100' : 'opacity-0'}"
-  onclick={(e) => {
-    if (e.target === e.currentTarget) onclose();
-  }}
 >
   <!-- Header -->
   <div
@@ -106,8 +206,8 @@
   >
     <Lock class="h-4 w-4 text-emerald-400" />
     <div class="min-w-0 flex-1">
-      <h3 class="text-sm font-semibold text-emerald-400">Encryption X-Ray</h3>
-      <p class="text-xs text-zinc-400">
+      <h3 class="text-sm font-semibold text-emerald-400">{$t('encryption.title')}</h3>
+      <p class="truncate text-xs text-zinc-400">
         {$t('encryption.server_view_desc')}
       </p>
     </div>
@@ -133,20 +233,15 @@
       </div>
     </div>
   {:else}
-    <div
-      bind:this={containerEl}
-      class="relative flex-1 select-none overflow-hidden"
-      onpointermove={handlePointerMove}
-      onpointerup={handlePointerUp}
-    >
-      <!-- Left: Plaintext layer -->
+    <div bind:this={containerEl} class="relative flex-1 select-none overflow-hidden">
+      <!-- Left: Plaintext layer ("your view") -->
       <div
         class="absolute inset-0 overflow-auto bg-background"
         style="clip-path: inset(0 {100 - sliderPosition}% 0 0);"
       >
-        <div class="px-6 py-5">
+        <div class="min-h-full px-6 py-5">
           <div
-            class="mb-3 inline-flex items-center gap-1.5 rounded-full bg-blue-500/10 px-2.5 py-1 text-xs text-blue-400"
+            class="mb-3 inline-flex items-center gap-1.5 rounded-full bg-blue-500/10 px-2.5 py-1 text-xs font-medium text-blue-600 dark:text-blue-400"
           >
             <Eye class="h-3.5 w-3.5" />
             {$t('encryption.your_view')}
@@ -154,20 +249,25 @@
           <h2 class="mb-4 text-lg font-semibold text-foreground">
             {plainTitle || $t('notes.untitled')}
           </h2>
-          <pre
-            class="whitespace-pre-wrap break-words font-sans text-sm leading-relaxed text-foreground/90">{plainContent ||
-              $t('encryption.empty_note')}</pre>
+          {#if plainContent}
+            <pre
+              class="whitespace-pre-wrap break-words font-sans text-sm leading-relaxed text-foreground/90">{plainContent}</pre>
+          {:else}
+            <!-- Empty/short note: still demonstrable - the right pane shows the
+                 ciphertext of the (encrypted) title + metadata. -->
+            <p class="text-sm italic text-muted-foreground">{$t('encryption.empty_note')}</p>
+          {/if}
         </div>
       </div>
 
-      <!-- Right: Ciphertext layer -->
+      <!-- Right: Ciphertext layer ("server view") -->
       <div
         class="absolute inset-0 overflow-auto bg-zinc-900"
         style="clip-path: inset(0 0 0 {sliderPosition}%);"
       >
-        <div class="px-6 py-5 pl-10">
+        <div class="min-h-full px-6 py-5 pl-10">
           <div
-            class="mb-3 inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-400"
+            class="mb-3 inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-400"
           >
             <Server class="h-3.5 w-3.5" />
             {$t('encryption.server_view')}
@@ -184,33 +284,109 @@
         </div>
       </div>
 
-      <!-- Vertical slider divider -->
+      <!-- One-shot "scan" sweep on open (disabled under reduced motion) -->
+      {#if visible && !reduceMotion}
+        <div class="xray-scan pointer-events-none absolute inset-y-0 z-10" aria-hidden="true"></div>
+      {/if}
+
+      <!-- Vertical seam + draggable handle (the separator).
+           A focusable separator IS a valid interactive pattern (the window-
+           splitter role with aria-valuenow + arrow keys), so the generic
+           "non-interactive element" a11y hints are false positives here. -->
       <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
       <div
-        class="absolute top-0 bottom-0 z-10 -ml-[22px] w-[44px] cursor-col-resize touch-none"
+        bind:this={handleEl}
+        class="group absolute inset-y-0 z-20 flex w-11 -translate-x-1/2 cursor-col-resize touch-none
+               items-center justify-center outline-none"
         style="left: {sliderPosition}%;"
-        onpointerdown={handlePointerDown}
         role="separator"
         aria-orientation="vertical"
         aria-valuenow={Math.round(sliderPosition)}
-        aria-valuemin={5}
-        aria-valuemax={95}
+        aria-valuemin={0}
+        aria-valuemax={100}
         aria-label={$t('encryption.slider_label')}
+        title={$t('encryption.reset_hint')}
         tabindex={0}
+        onpointerdown={handlePointerDown}
+        onpointermove={handlePointerMove}
+        onpointerup={handlePointerUp}
+        onpointercancel={handlePointerUp}
+        ondblclick={handleReset}
+        onkeydown={handleSeparatorKeydown}
       >
-        <!-- Visible line -->
+        <!-- Scan-line seam: thin edge with brand-green glow -->
+        <div class="xray-seam pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2"></div>
+
+        <!-- Grip pill with dots -->
         <div
-          class="absolute left-1/2 top-0 bottom-0 w-0.5 -translate-x-1/2 bg-emerald-500/70"
-        ></div>
-        <!-- Grip handle -->
-        <div
-          class="absolute left-1/2 top-1/2 flex h-10 w-7 -translate-x-1/2 -translate-y-1/2 items-center
-                 justify-center rounded-md border border-emerald-500/50 bg-zinc-800/95 shadow-lg
-                 transition-transform {isDragging ? 'scale-110' : 'hover:scale-105'}"
+          class="pointer-events-none relative grid grid-cols-2 gap-x-1 gap-y-1 rounded-full
+                 border border-emerald-400/60 bg-zinc-800/95 px-1.5 py-2.5 shadow-lg
+                 shadow-emerald-500/20 transition-transform duration-150
+                 group-hover:scale-105 group-focus-visible:ring-2 group-focus-visible:ring-emerald-300
+                 {isDragging ? 'scale-110' : ''}"
         >
-          <GripVertical class="h-4 w-4 text-emerald-400" />
+          {#each [0, 1, 2, 3, 4, 5] as dot (dot)}
+            <span class="h-1 w-1 rounded-full bg-emerald-400"></span>
+          {/each}
         </div>
       </div>
     </div>
   {/if}
 </div>
+
+<style>
+  /* One-shot horizontal scan sweep, like an X-ray scanner passing over. */
+  @keyframes xray-sweep {
+    0% {
+      left: -20%;
+      opacity: 0;
+    }
+    15% {
+      opacity: 1;
+    }
+    100% {
+      left: 100%;
+      opacity: 0;
+    }
+  }
+
+  .xray-scan {
+    width: 22%;
+    opacity: 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in srgb, #10b981 16%, transparent) 50%,
+      transparent
+    );
+    animation: xray-sweep 900ms ease-out forwards;
+  }
+
+  /* Seam: a thin vertical line that glows in brand-green. */
+  .xray-seam {
+    background: linear-gradient(
+      to bottom,
+      transparent,
+      color-mix(in srgb, #10b981 85%, transparent),
+      transparent
+    );
+    box-shadow: 0 0 8px 1px color-mix(in srgb, #10b981 60%, transparent);
+    transition: box-shadow 150ms ease;
+  }
+  .group:hover .xray-seam,
+  .group:focus-visible .xray-seam {
+    box-shadow: 0 0 12px 2px color-mix(in srgb, #10b981 80%, transparent);
+  }
+
+  /* Respect reduced-motion: no sweep, no transitions. */
+  @media (prefers-reduced-motion: reduce) {
+    .xray-scan {
+      display: none;
+      animation: none;
+    }
+    .xray-seam {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
@@ -3,7 +3,6 @@
   import NoteEditor from '$lib/components/NoteEditor.svelte';
   import MarkdownPreview from '$lib/components/MarkdownPreview.svelte';
   import MarkdownDiffView from '$lib/components/MarkdownDiffView.svelte';
-  import EncryptionXRay from '$lib/components/EncryptionXRay.svelte';
   import { noteDetailService } from '$lib/services/note-detail.service.svelte';
   import { t } from '$lib/stores/i18n.store';
   import type { ImageLoadMode, PeriodicKind } from '@reborn/storage';
@@ -13,7 +12,6 @@
   let {
     noteId,
     effectiveViewMode,
-    showEncryptionXRay = $bindable(false),
     historyMode,
     historyViewMode,
     selectedVersion,
@@ -36,7 +34,6 @@
   }: {
     noteId: string;
     effectiveViewMode: ViewMode;
-    showEncryptionXRay: boolean;
     historyMode: 'closed' | 'list' | 'diff';
     historyViewMode: 'preview' | 'diff';
     selectedVersion: import('@reborn/types').NoteHistoryDecrypted | null;
@@ -134,17 +131,6 @@
 </script>
 
 <div class="relative {isParentScrollActive ? '' : 'flex min-h-0 flex-1 overflow-hidden'}">
-  {#if showEncryptionXRay && historyMode === 'closed'}
-    <EncryptionXRay
-      {noteId}
-      plainTitle={noteDetailService.title}
-      plainContent={noteDetailService.content}
-      onclose={() => {
-        showEncryptionXRay = false;
-      }}
-    />
-  {/if}
-
   {#if historyMode === 'diff' && selectedVersion}
     <!-- History content -->
     {#if historyViewMode === 'diff' && previousVersion}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -40,6 +40,7 @@
   import NoteEditorHeader from '$lib/components/editor/NoteEditorHeader.svelte';
   import HistoryHeader from '$lib/components/editor/HistoryHeader.svelte';
   import NoteContentArea from '$lib/components/editor/NoteContentArea.svelte';
+  import EncryptionXRay from '$lib/components/EncryptionXRay.svelte';
   import NoteDetailActions from '$lib/components/editor/NoteDetailActions.svelte';
   import NoteMetadataBar from '$lib/components/editor/NoteMetadataBar.svelte';
   import NoteActionSheet from '$lib/components/notes/NoteActionSheet.svelte';
@@ -1417,7 +1418,6 @@
             <NoteContentArea
               noteId={$activeNoteId}
               {effectiveViewMode}
-              bind:showEncryptionXRay
               {historyMode}
               {historyViewMode}
               {selectedVersion}
@@ -1485,46 +1485,59 @@
               {/snippet}
             </NoteEditorHeader>
 
-            <!-- Scrollable: metadata + content scroll away -->
-            <div bind:this={mobileScrollContainer} class="flex flex-1 flex-col overflow-y-auto">
-              <div bind:this={mobileTitleSentinel} class="h-0 w-0 shrink-0"></div>
+            <!-- Scroll container + X-Ray overlay share one positioned box so the
+                 overlay pins to the visible editor region, not the scroll
+                 content (which grows with note length under parentScroll). -->
+            <div class="relative flex flex-1 flex-col min-h-0">
+              <!-- Scrollable: metadata + content scroll away -->
+              <div bind:this={mobileScrollContainer} class="flex flex-1 flex-col overflow-y-auto">
+                <div bind:this={mobileTitleSentinel} class="h-0 w-0 shrink-0"></div>
 
-              <NoteMetadataBar
-                {isMobile}
-                {activeTrash}
-                title={noteDetailService.title}
-                folderName={activeNoteFolderName}
-                noteId={$activeNoteId}
-                updatedAt={detailMenuNote?.updated_at ?? null}
-                createdAt={detailMenuNote?.created_at ?? null}
-                ontitleinput={handleTitleInput}
-                onfolderclick={navigateToNoteFolder}
-              />
+                <NoteMetadataBar
+                  {isMobile}
+                  {activeTrash}
+                  title={noteDetailService.title}
+                  folderName={activeNoteFolderName}
+                  noteId={$activeNoteId}
+                  updatedAt={detailMenuNote?.updated_at ?? null}
+                  createdAt={detailMenuNote?.created_at ?? null}
+                  ontitleinput={handleTitleInput}
+                  onfolderclick={navigateToNoteFolder}
+                />
 
-              <NoteContentArea
-                noteId={$activeNoteId}
-                {effectiveViewMode}
-                bind:showEncryptionXRay
-                {historyMode}
-                {historyViewMode}
-                {selectedVersion}
-                {previousVersion}
-                bind:editorRef
-                bind:previewScrollEl
-                bind:previewContentEl
-                {autocompleteNotes}
-                {isMobile}
-                parentScroll={true}
-                oncontentchange={handleContentChange}
-                onviewinit={handleEditorViewInit}
-                onviewdestroy={handleEditorViewDestroy}
-                onpreviewrender={handlePreviewRender}
-                onnotelinkrequest={openNotePicker}
-                onnotelink={handleNoteLink}
-                {resolveNoteTitle}
-                imageLoadMode={$imageLoadMode}
-                noteKind={currentNoteKind}
-              />
+                <NoteContentArea
+                  noteId={$activeNoteId}
+                  {effectiveViewMode}
+                  {historyMode}
+                  {historyViewMode}
+                  {selectedVersion}
+                  {previousVersion}
+                  bind:editorRef
+                  bind:previewScrollEl
+                  bind:previewContentEl
+                  {autocompleteNotes}
+                  {isMobile}
+                  parentScroll={true}
+                  oncontentchange={handleContentChange}
+                  onviewinit={handleEditorViewInit}
+                  onviewdestroy={handleEditorViewDestroy}
+                  onpreviewrender={handlePreviewRender}
+                  onnotelinkrequest={openNotePicker}
+                  onnotelink={handleNoteLink}
+                  {resolveNoteTitle}
+                  imageLoadMode={$imageLoadMode}
+                  noteKind={currentNoteKind}
+                />
+              </div>
+
+              {#if showEncryptionXRay && historyMode === 'closed'}
+                <EncryptionXRay
+                  noteId={$activeNoteId}
+                  plainTitle={noteDetailService.title}
+                  plainContent={noteDetailService.content}
+                  onclose={() => (showEncryptionXRay = false)}
+                />
+              {/if}
             </div>
           {/if}
         {:else if $isInitialSync}
@@ -1672,7 +1685,6 @@
           <NoteContentArea
             noteId={$activeNoteId}
             {effectiveViewMode}
-            bind:showEncryptionXRay
             {historyMode}
             {historyViewMode}
             {selectedVersion}
@@ -1734,49 +1746,62 @@
             {/snippet}
           </NoteEditorHeader>
 
-          <!-- Scrollable area: metadata + toolbar + editor scroll together -->
-          <div
-            bind:this={desktopEditorScrollContainer}
-            class="flex flex-1 flex-col min-h-0 overflow-y-auto"
-          >
-            <div bind:this={desktopTitleSentinel} class="h-0 w-0 shrink-0"></div>
+          <!-- Scroll container + X-Ray overlay share one positioned box so the
+               overlay pins to the visible editor region (not the scroll
+               content) and fills it regardless of note length / scroll pos. -->
+          <div class="relative flex flex-1 flex-col min-h-0">
+            <!-- Scrollable area: metadata + toolbar + editor scroll together -->
+            <div
+              bind:this={desktopEditorScrollContainer}
+              class="flex flex-1 flex-col min-h-0 overflow-y-auto"
+            >
+              <div bind:this={desktopTitleSentinel} class="h-0 w-0 shrink-0"></div>
 
-            <NoteMetadataBar
-              {isMobile}
-              {activeTrash}
-              title={noteDetailService.title}
-              folderName={activeNoteFolderName}
-              noteId={$activeNoteId}
-              updatedAt={detailMenuNote?.updated_at ?? null}
-              createdAt={detailMenuNote?.created_at ?? null}
-              {effectiveViewMode}
-              ontitleinput={handleTitleInput}
-              onfolderclick={navigateToNoteFolder}
-            />
+              <NoteMetadataBar
+                {isMobile}
+                {activeTrash}
+                title={noteDetailService.title}
+                folderName={activeNoteFolderName}
+                noteId={$activeNoteId}
+                updatedAt={detailMenuNote?.updated_at ?? null}
+                createdAt={detailMenuNote?.created_at ?? null}
+                {effectiveViewMode}
+                ontitleinput={handleTitleInput}
+                onfolderclick={navigateToNoteFolder}
+              />
 
-            <NoteContentArea
-              noteId={$activeNoteId}
-              {effectiveViewMode}
-              bind:showEncryptionXRay
-              {historyMode}
-              {historyViewMode}
-              {selectedVersion}
-              {previousVersion}
-              bind:editorRef
-              bind:previewScrollEl
-              bind:previewContentEl
-              {autocompleteNotes}
-              parentScroll={true}
-              oncontentchange={handleContentChange}
-              onviewinit={handleEditorViewInit}
-              onviewdestroy={handleEditorViewDestroy}
-              onpreviewrender={handlePreviewRender}
-              onnotelinkrequest={openNotePicker}
-              onnotelink={handleNoteLink}
-              {resolveNoteTitle}
-              imageLoadMode={$imageLoadMode}
-              noteKind={currentNoteKind}
-            />
+              <NoteContentArea
+                noteId={$activeNoteId}
+                {effectiveViewMode}
+                {historyMode}
+                {historyViewMode}
+                {selectedVersion}
+                {previousVersion}
+                bind:editorRef
+                bind:previewScrollEl
+                bind:previewContentEl
+                {autocompleteNotes}
+                parentScroll={true}
+                oncontentchange={handleContentChange}
+                onviewinit={handleEditorViewInit}
+                onviewdestroy={handleEditorViewDestroy}
+                onpreviewrender={handlePreviewRender}
+                onnotelinkrequest={openNotePicker}
+                onnotelink={handleNoteLink}
+                {resolveNoteTitle}
+                imageLoadMode={$imageLoadMode}
+                noteKind={currentNoteKind}
+              />
+            </div>
+
+            {#if showEncryptionXRay && historyMode === 'closed'}
+              <EncryptionXRay
+                noteId={$activeNoteId}
+                plainTitle={noteDetailService.title}
+                plainContent={noteDetailService.content}
+                onclose={() => (showEncryptionXRay = false)}
+              />
+            {/if}
           </div>
         {/if}
       {:else if showNoteListInMain}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -672,13 +672,14 @@
   },
   "encryption": {
     "title": "Verschlüsselungs-Röntgen",
-    "server_view_desc": "Dies sieht der Server — niemand kann Ihre Notizen ohne Ihr Passwort lesen",
+    "server_view_desc": "Dies sieht der Server - niemand kann Ihre Notizen ohne Ihr Passwort lesen",
     "close": "Schließen",
     "loading": "Verschlüsselte Daten werden gelesen…",
     "your_view": "Ihre Ansicht (entschlüsselt)",
     "server_view": "Server-Ansicht (verschlüsselt)",
     "empty_note": "(leere Notiz)",
-    "slider_label": "Ziehen, um die verschlüsselte/entschlüsselte Version zu sehen"
+    "slider_label": "Ziehen, um die verschlüsselte/entschlüsselte Version zu sehen",
+    "reset_hint": "Doppelklick setzt auf 50/50 zurück"
   },
   "e2e": {
     "badge": "Ende-zu-Ende-verschlüsselt",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -672,13 +672,14 @@
   },
   "encryption": {
     "title": "Encryption X-Ray",
-    "server_view_desc": "This is what the server sees — nobody can read your notes without your password",
+    "server_view_desc": "This is what the server sees - nobody can read your notes without your password",
     "close": "Close",
     "loading": "Reading encrypted data…",
     "your_view": "Your view (decrypted)",
     "server_view": "Server view (encrypted)",
     "empty_note": "(empty note)",
-    "slider_label": "Drag to see encrypted/decrypted version"
+    "slider_label": "Drag to see encrypted/decrypted version",
+    "reset_hint": "Double-click to reset to 50/50"
   },
   "e2e": {
     "badge": "Encrypted end-to-end",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -672,13 +672,14 @@
   },
   "encryption": {
     "title": "Radiografía del cifrado",
-    "server_view_desc": "Esto es lo que ve el servidor — nadie puede leer sus notas sin su contraseña",
+    "server_view_desc": "Esto es lo que ve el servidor - nadie puede leer sus notas sin su contraseña",
     "close": "Cerrar",
     "loading": "Leyendo datos cifrados…",
     "your_view": "Su vista (descifrada)",
     "server_view": "Vista del servidor (cifrada)",
     "empty_note": "(nota vacía)",
-    "slider_label": "Arrastre para ver la versión cifrada/descifrada"
+    "slider_label": "Arrastre para ver la versión cifrada/descifrada",
+    "reset_hint": "Doble clic para restablecer a 50/50"
   },
   "e2e": {
     "badge": "Cifrado de extremo a extremo",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -672,13 +672,14 @@
   },
   "encryption": {
     "title": "Radiographie du chiffrement",
-    "server_view_desc": "Voici ce que le serveur voit — personne ne peut lire vos notes sans votre mot de passe",
+    "server_view_desc": "Voici ce que le serveur voit - personne ne peut lire vos notes sans votre mot de passe",
     "close": "Fermer",
     "loading": "Lecture des données chiffrées…",
     "your_view": "Votre vue (déchiffrée)",
     "server_view": "Vue du serveur (chiffrée)",
     "empty_note": "(note vide)",
-    "slider_label": "Faites glisser pour voir la version chiffrée/déchiffrée"
+    "slider_label": "Faites glisser pour voir la version chiffrée/déchiffrée",
+    "reset_hint": "Double-cliquez pour réinitialiser à 50/50"
   },
   "e2e": {
     "badge": "Chiffré de bout en bout",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -671,14 +671,15 @@
     "close_history": "Zamknij podgląd"
   },
   "encryption": {
-    "title": "Szyfrowanie — podgląd",
-    "server_view_desc": "To widzi serwer — nikt nie odczyta Twoich notatek bez hasła",
+    "title": "Szyfrowanie - podgląd",
+    "server_view_desc": "To widzi serwer - nikt nie odczyta Twoich notatek bez hasła",
     "close": "Zamknij",
     "loading": "Odczytywanie zaszyfrowanych danych…",
     "your_view": "Twój widok (odszyfrowany)",
     "server_view": "Widok serwera (zaszyfrowany)",
     "empty_note": "(pusta notatka)",
-    "slider_label": "Przeciągnij, aby zobaczyć zaszyfrowaną/odszyfrowaną wersję"
+    "slider_label": "Przeciągnij, aby zobaczyć zaszyfrowaną/odszyfrowaną wersję",
+    "reset_hint": "Kliknij dwukrotnie, aby przywrócić 50/50"
   },
   "e2e": {
     "badge": "Szyfrowane end-to-end",


### PR DESCRIPTION
## Summary

Fixes two bugs in the re/notes **Encryption X-Ray** split-view overlay, both rooted in the same cause: the overlay was mounted *inside* the editor scroll container, whose wrapper grows to content height under `parentScroll`. Its `absolute inset-0` therefore tracked content height, not the visible viewport.

- **Short/empty note:** the dark "server view" panel stopped short of the screen bottom.
- **Long note:** the drag handle sat at ~half the note's content length, so after scrolling it fell off-screen and could not be grabbed.

**Fix:** mount `EncryptionXRay` as a *sibling* of the scroll container inside a viewport-bound `relative flex-1` wrapper (desktop + mobile). `absolute inset-0` now fills the visible editor region regardless of note length or scroll position; the editor scrolls behind the overlay and the handle stays centered in the viewport.

**Component rework (per the brief):**
- default 50/50 split; last position persisted per-device in `localStorage` (UI preference, never synced)
- magnet snap at 25/50/75%; double-click handle resets to 50%
- keyboard: arrows 5% (Shift 25%), Home/End to 25/75, Enter/Space reset
- a11y: `role="separator"`, `aria-orientation`, `aria-valuenow` (0-100), visible focus ring
- handle redesigned as a 44px grip pill; seam is a brand-green glow scan line
- one-shot scan sweep on open, disabled under `prefers-reduced-motion`
- empty-note placeholder; header title now localized
- new i18n key `encryption.reset_hint` in all 5 locales (+ em-dash cleanup in the `encryption` block)

**Decisions (auto mode - for review):**
- Chose **sibling-overlay** (`absolute inset-0` of a viewport-bound wrapper) over sticky-positioned-inside-scroll-content. The sticky variant needs a `ResizeObserver` to measure the scrollport and leans on browser-specific scrollable-overflow behavior (a sticky box taller than a short note's content box can extend the scroll range). The sibling overlay is a plain bounded box: deterministic, no measurement.
- Classified as **fix (patch)**, not feat: the X-Ray already existed; this repairs its positioning and polishes it, with no new server capability.
- **No Zero-Knowledge impact:** purely client-side layout; ciphertext is still read via `getRawEncryptedNote`, no new schema fields or endpoints.

Files: `EncryptionXRay.svelte` (rewrite), `NoteContentArea.svelte` (drop in-content mount + `showEncryptionXRay` prop), `+page.svelte` (wrap both edit scroll containers + sibling overlay), 5 notes locale files.

## Test plan

Open a note in re/notes and click the lock (E2EE) icon to open the X-Ray. Verify on **desktop and mobile**:

- [x] **Short/empty note:** dark right panel reaches the bottom edge of the screen.
- [x] **Long note:** scroll the page - the handle stays centered in the viewport and grabbable at any scroll position.
- [x] Drag the seam; release near 25/50/75% - it snaps. Free-drag elsewhere works.
- [x] **Double-click** the handle resets to 50/50.
- [x] Reload, reopen X-Ray - last split position is remembered (per device).
- [x] **Keyboard:** Tab to the handle (focus ring visible); arrows move 5%, Shift+arrows 25%, Home/End jump to 25/75, Enter/Space reset.
- [x] **Reduced motion** (OS setting on): no scan-sweep animation on open.
- [x] Labels read "Twój widok (odszyfrowany)" / "Widok serwera (zaszyfrowany)"; handle tooltip shows the reset hint. Spot-check another locale.

Gates: svelte-check 0/0, eslint 0 errors, 824 tests, i18n parity PASSED, build OK.