### PR TITLE
chore(native): show native + backend version in Notes settings

### DIFF
--- a/apps/reborn-notes/src/lib/utils/app-version.spec.ts
+++ b/apps/reborn-notes/src/lib/utils/app-version.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { parseBackendVersion } from './app-version';
+
+describe('parseBackendVersion', () => {
+  it('reads the version from a well-formed app-config body', () => {
+    expect(parseBackendVersion({ success: true, data: { version: '0.40.0' } })).toBe('0.40.0');
+  });
+
+  it('ignores sibling fields (native thresholds)', () => {
+    const body = {
+      success: true,
+      data: { version: '1.2.3', native: { android: { min_build: 5 }, ios: {} } }
+    };
+    expect(parseBackendVersion(body)).toBe('1.2.3');
+  });
+
+  it('returns null when version is missing', () => {
+    expect(parseBackendVersion({ success: true, data: { native: {} } })).toBeNull();
+  });
+
+  it('returns null for an empty-string version', () => {
+    expect(parseBackendVersion({ data: { version: '' } })).toBeNull();
+  });
+
+  it('returns null for a non-string version', () => {
+    expect(parseBackendVersion({ data: { version: 40 } })).toBeNull();
+  });
+
+  it('fails soft on unusable shapes', () => {
+    expect(parseBackendVersion(null)).toBeNull();
+    expect(parseBackendVersion(undefined)).toBeNull();
+    expect(parseBackendVersion('nope')).toBeNull();
+    expect(parseBackendVersion({})).toBeNull();
+    expect(parseBackendVersion({ data: null })).toBeNull();
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/app-version.ts
+++ b/apps/reborn-notes/src/lib/utils/app-version.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure parse of the live backend version from the /api/app-config response body
+ * (Settings "About" version display, guideline 38 "Wersje w aplikacji
+ * natywnej"). Deliberately free of SvelteKit/Capacitor imports so it unit-tests
+ * without the app environment - the native-gated runtime half (App.getInfo plus
+ * the fetch) lives in native-version-info.ts, mirroring the app-update.ts /
+ * native-app-update.ts split.
+ *
+ * Returns null for any unusable shape: an old client must keep rendering its own
+ * version even if a future server changes the response.
+ */
+export function parseBackendVersion(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const data = (body as Record<string, unknown>).data;
+  if (typeof data !== 'object' || data === null) return null;
+  const version = (data as Record<string, unknown>).version;
+  return typeof version === 'string' && version.length > 0 ? version : null;
+}

--- a/apps/reborn-notes/src/lib/utils/native-version-info.ts
+++ b/apps/reborn-notes/src/lib/utils/native-version-info.ts
@@ -1,0 +1,61 @@
+import { createLogger } from '@reborn/utils';
+import { API_BASE } from '$lib/utils/api-base';
+import { parseBackendVersion } from '$lib/utils/app-version';
+
+// No top-level side effects (logger included) - this module is imported by the
+// settings page but must stay fully treeshakeable from the web bundle (same
+// rule as native-app-update / native-master-key-vault). The __REBORN_NATIVE__
+// guard lets the bundler drop the body (and the dynamic @capacitor/app import)
+// from the web build entirely.
+
+export interface NativeVersionInfo {
+  /** Native shell marketing version, e.g. "1.0.0" (App.getInfo().version). */
+  appVersion: string;
+  /** Native build number, e.g. "1" (App.getInfo().build). */
+  appBuild: string;
+  /**
+   * Live backend monorepo version from /api/app-config, or null when the
+   * server is unreachable (offline). The frozen bundled-frontend version is
+   * __APP_VERSION__, read directly in the component - the gap between the two
+   * is the drift the user is meant to see (guideline 38).
+   */
+  backendVersion: string | null;
+}
+
+async function fetchBackendVersion(): Promise<string | null> {
+  try {
+    const res = await fetch(`${API_BASE}/app-config`);
+    if (!res.ok) return null;
+    return parseBackendVersion(await res.json());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Version detail for the native Settings "About" block (guideline 38 "Wersje w
+ * aplikacji natywnej"). Returns the store-installed native version plus the
+ * live backend version; the component pairs the backend version with the frozen
+ * __APP_VERSION__ so the user sees how far the bundled client has drifted from
+ * the server.
+ *
+ * Web returns null (the single __APP_VERSION__ line already tells the whole
+ * story there). Fail-soft: a failed backend fetch leaves backendVersion null
+ * but the native version still renders; only a missing App plugin yields null.
+ * Never throws.
+ */
+export async function getNativeVersionInfo(): Promise<NativeVersionInfo | null> {
+  if (!__REBORN_NATIVE__) return null;
+  try {
+    const { App } = await import('@capacitor/app');
+    const info = await App.getInfo();
+    return {
+      appVersion: info.version,
+      appBuild: info.build,
+      backendVersion: await fetchBackendVersion()
+    };
+  } catch (err) {
+    createLogger('notes:version-info').debug('native version info failed (fail-soft)', err);
+    return null;
+  }
+}

--- a/apps/reborn-notes/src/routes/api/app-config/+server.ts
+++ b/apps/reborn-notes/src/routes/api/app-config/+server.ts
@@ -2,6 +2,8 @@ import { json } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 
+declare const __APP_VERSION__: string;
+
 /**
  * Public, unauthenticated app metadata for NATIVE clients (Faza 5, plan D5).
  *
@@ -12,6 +14,13 @@ import type { RequestHandler } from './$types';
  * header, no telemetry - consistent with the no-PII posture. The trade-off is
  * accepted: the server cannot observe the client-version distribution before
  * raising a threshold. Web clients never call this endpoint.
+ *
+ * `version` is the live backend monorepo version (same value as
+ * /api/health.version). Native Settings shows it next to the frozen bundled
+ * frontend version so the user can see how far the store build has drifted
+ * from the server (guideline 38 "Wersje w aplikacji natywnej"). Serving it
+ * here lets the native client read thresholds and backend version in one
+ * round-trip. Still zero client telemetry - it is a plain GET.
  *
  * Env (all optional; 0 / unset = no enforcement):
  *   NATIVE_MIN_BUILD_ANDROID / NATIVE_MIN_BUILD_IOS
@@ -42,6 +51,7 @@ export const GET: RequestHandler = () =>
 	json({
 		success: true,
 		data: {
+			version: __APP_VERSION__,
 			native: {
 				android: platformConfig('ANDROID'),
 				ios: platformConfig('IOS')

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -28,6 +28,10 @@
     CalendarDays
   } from '@lucide/svelte';
   import { goto } from '$lib/utils/navigation';
+  import {
+    getNativeVersionInfo,
+    type NativeVersionInfo
+  } from '$lib/utils/native-version-info';
   import { t } from '$lib/stores/i18n.store';
   import { locale } from '$lib/stores/i18n.store';
   import { cn, GithubMark } from '@reborn/ui';
@@ -52,10 +56,17 @@
 
   let storageInfoExpanded = $state(false);
 
+  // Native-only: store-installed version + live backend version (drift detail).
+  // Null on web - the single __APP_VERSION__ line stays unchanged there.
+  let versionInfo = $state<NativeVersionInfo | null>(null);
+
   onMount(() => {
     if ($authStore.isAuthenticated) {
       void refreshQuota();
     }
+    void getNativeVersionInfo().then((info) => {
+      versionInfo = info;
+    });
   });
 
   function formatBytes(bytes: number): string {
@@ -488,10 +499,28 @@
             <Info class="h-5 w-5 text-muted-foreground shrink-0" />
             <div class="flex-1 min-w-0">
               <div class="font-medium">{$t('settings_page.about.name')}</div>
-              <div class="text-sm text-muted-foreground">
-                {$t('settings_page.about.version')}
-                {__APP_VERSION__}
-              </div>
+              {#if versionInfo}
+                <!-- Native: store-installed version, then the frozen bundled
+                     frontend vs the live backend so the drift is visible. -->
+                <div class="text-sm text-muted-foreground">
+                  {$t('settings_page.about.version')}
+                  {$t('settings_page.about.native_app_version', {
+                    values: { version: versionInfo.appVersion, build: versionInfo.appBuild }
+                  })}
+                </div>
+                <div class="text-xs text-muted-foreground">
+                  {$t('settings_page.about.frontend_version')}
+                  {__APP_VERSION__}
+                  <span aria-hidden="true" class="px-0.5">·</span>
+                  {$t('settings_page.about.backend_version')}
+                  {versionInfo.backendVersion ?? '-'}
+                </div>
+              {:else}
+                <div class="text-sm text-muted-foreground">
+                  {$t('settings_page.about.version')}
+                  {__APP_VERSION__}
+                </div>
+              {/if}
             </div>
           </div>
           <div class={itemClasses}>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -927,6 +927,9 @@
       "name": "re/notes",
       "desc": "E2E-verschlüsselte, Offline-First-Notizen",
       "version": "Version",
+      "native_app_version": "{version} (Build {build})",
+      "frontend_version": "Frontend",
+      "backend_version": "Backend",
       "license": "Lizenz",
       "open_task": "re/task öffnen",
       "open_notes": "re/notes öffnen"

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -927,6 +927,9 @@
       "name": "re/notes",
       "desc": "E2E encrypted, offline-first notes",
       "version": "Version",
+      "native_app_version": "{version} (build {build})",
+      "frontend_version": "Frontend",
+      "backend_version": "Backend",
       "license": "License",
       "open_task": "Open re/task",
       "open_notes": "Open re/notes"

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -927,6 +927,9 @@
       "name": "re/notes",
       "desc": "Notas cifradas E2E, offline-first",
       "version": "Versión",
+      "native_app_version": "{version} (compilación {build})",
+      "frontend_version": "Frontend",
+      "backend_version": "Backend",
       "license": "Licencia",
       "open_task": "Abrir re/task",
       "open_notes": "Abrir re/notes"

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -927,6 +927,9 @@
       "name": "re/notes",
       "desc": "Notes chiffrées E2E, offline-first",
       "version": "Version",
+      "native_app_version": "{version} (build {build})",
+      "frontend_version": "Frontend",
+      "backend_version": "Backend",
       "license": "Licence",
       "open_task": "Ouvrir re/task",
       "open_notes": "Ouvrir re/notes"

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -927,6 +927,9 @@
       "name": "re/notes",
       "desc": "Notatki z szyfrowaniem E2E, offline-first",
       "version": "Wersja",
+      "native_app_version": "{version} (build {build})",
+      "frontend_version": "Frontend",
+      "backend_version": "Backend",
       "license": "Licencja",
       "open_task": "Otwórz re/task",
       "open_notes": "Otwórz re/notes"


### PR DESCRIPTION
## Summary

On web a single `__APP_VERSION__` line tells the whole story (frontend == backend, same deploy). Native shells freeze the frontend bundle inside the store binary, so **three versions diverge**: the native shell version, the frozen bundled frontend (`__APP_VERSION__` at build time), and the live backend (deployed independently, often). Notes Settings → About now shows all three **on native** so the frontend↔backend drift is visible at a glance. Web is unchanged.

Native display:
```
Version 1.0.0 (build 1)            ← App.getInfo(), store-installed
Frontend 0.34.1 · Backend 0.40.0   ← frozen bundle vs live server ("-" offline)
```

Full model + rationale: guideline 38 "Wersje w aplikacji natywnej", guideline 62 §1.

### Decisions (pre-approved with Michał)
- **Show all three, not two** - the frozen-frontend vs backend gap is the signal; both sit on the monorepo version axis and compare directly (the native marketing version is a different axis).
- **Backend source: add `version` to `GET /api/app-config`** (native already fetches it for the min-version gate → one round-trip). Same value `/api/health` already returns.
- **Labels: Frontend / Backend.**

### Properties
- **Web byte-identical** - the native path is `__REBORN_NATIVE__`-gated and tree-shaken from the web client *and* server bundles (verified: no `@capacitor/app` / `app-config` refs in `output/client`). `versionInfo` is null on web → identical single line.
- **Zero telemetry preserved** - backend version is a plain GET; the client still sends nothing about itself (consistent with the min-version gate). Version is app metadata, not user data → no ZK surface. `version` exposed via app-config was already public via `/api/health`.
- Pure parser (`parseBackendVersion`, `app-version.ts`) split from the runtime half (`native-version-info.ts`) so it unit-tests without SvelteKit aliases, mirroring `app-update.ts` / `native-app-update.ts`.

## Test plan

Automated (green locally):
- `node scripts/check-i18n-parity.mjs --namespace=notes` - 5/5 parity, 3 new keys
- `nx run-many -t lint check test -p reborn-notes` - lint ✓, svelte-check 0/0, 830 tests (+6)
- `nx run-many -t lint typecheck test build -p @reborn/i18n` ✓
- `nx build reborn-notes` ✓ + DCE grep (no native refs in web client/server)

Native smoke (Michał, both platforms):
- `App.getInfo()` → headline shows `1.0.0 (build 1)`
- Frontend line shows the bundled `__APP_VERSION__`; Backend shows the server version (localprod)
- Cut the network → Backend shows `-`, native version still renders
- Web (PWA): About still shows the single `Version X.Y.Z` line, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)