### PR TITLE
chore(changelog): export Coming soon entries to /changelog

### DIFF
--- a/scripts/export-release-notes.mjs
+++ b/scripts/export-release-notes.mjs
@@ -4,7 +4,7 @@
 //
 // The in-app "What's new" dialog reads the dataset directly from @reborn/i18n;
 // the website cannot import that package (standalone Astro repo), so this script
-// flattens manifest + per-locale text into one self-contained file that gets
+// flattens manifest + upcoming + per-locale text into one self-contained file that gets
 // committed into reapps-www. One source of truth, two surfaces.
 //
 // Run at release time (after `pnpm release`), then commit the result in
@@ -43,6 +43,7 @@ function readJson(path) {
 }
 
 const manifest = readJson(join(RN_DIR, 'manifest.json'));
+const upcoming = readJson(join(RN_DIR, 'upcoming.json'));
 const text = Object.fromEntries(LOCALES.map((l) => [l, readJson(join(TEXT_DIR, `${l}.json`))]));
 
 // Fail loudly on any missing translation so a release never ships a half-empty
@@ -55,6 +56,12 @@ for (const release of manifest) {
       const entry = text[locale][item.id];
       if (typeof entry !== 'string' || entry.length === 0) missing.push(`${locale}:${item.id}`);
     }
+  }
+}
+for (const item of upcoming) {
+  for (const locale of LOCALES) {
+    const entry = text[locale][item.id];
+    if (typeof entry !== 'string' || entry.length === 0) missing.push(`${locale}:${item.id}`);
   }
 }
 if (missing.length) {
@@ -74,10 +81,21 @@ const releases = manifest.map((release) => ({
   }))
 }));
 
+// Coming-soon entries live off the version axis (no version/date/category):
+// rendered as a section atop the public changelog, mirroring what the in-app
+// dialog shows on web.
+const upcomingItems = upcoming.map((item) => ({
+  id: item.id,
+  apps: item.apps,
+  platforms: item.platforms,
+  text: Object.fromEntries(LOCALES.map((l) => [l, text[l][item.id]]))
+}));
+
 const output = {
   schema: 1,
   locales: LOCALES,
-  releases
+  releases,
+  upcoming: upcomingItems
 };
 
 const json = JSON.stringify(output, null, 2) + '\n';
@@ -89,6 +107,6 @@ if (toStdout) {
   writeFileSync(outPath, json, 'utf8');
   const itemCount = releases.reduce((n, r) => n + r.items.length, 0);
   console.log(
-    `[export-release-notes] Wrote ${releases.length} releases / ${itemCount} items (${LOCALES.length} locales) to ${outPath}`
+    `[export-release-notes] Wrote ${releases.length} releases / ${itemCount} items + ${upcomingItems.length} upcoming (${LOCALES.length} locales) to ${outPath}`
   );
 }


### PR DESCRIPTION
## Summary

Teaches `scripts/export-release-notes.mjs` to flatten `upcoming.json` into the portable JSON the public `/changelog` page (reapps-www) consumes, so the site can render a "Coming soon" section - the same upcoming entries the in-app What's new dialog already shows on web. Until now only `manifest` releases were exported and `upcoming` was dropped on the website side.

- Reads `upcoming.json`, applies the same missing-translation guard to upcoming ids as to releases, and adds `upcoming: [{ id, apps, platforms, text{5 locales} }]` to the output.
- The website side (render + i18n `coming_soon` + regenerated `release-notes.json`) lands in reapps-www (PR #5, branch `feat/changelog-page`).

Resolves the TODO flagged in guideline 68 ("Most prod -> www"): the dialog showed upcoming, the website did not.

## Test plan

- `node scripts/export-release-notes.mjs` -> wrote 33 releases / 44 items + 1 upcoming (5 locales); output validated (`upcoming` populated, latest 0.35.0).
- reapps-www `astro build` -> 31 pages built; `/changelog` renders the Coming soon section with platform badges.