### PR TITLE
feat(notes): show outline toggle in the mobile note header

### DIFF
--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -233,8 +233,9 @@
       {/each}
     </div>
 
-    <!-- Outline toggle (desktop only - on mobile it's in kebab menu) -->
-    {#if !isMobile && ontoggleoutline}
+    <!-- Outline toggle - shown on mobile too (frequent action); the kebab action
+         menu still offers it as well. h-7 w-7 matches the mobile lock/kebab. -->
+    {#if ontoggleoutline}
       <button
         type="button"
         onclick={ontoggleoutline}


### PR DESCRIPTION
## Summary

The document outline panel (new in v0.36.0) was reachable on mobile only through the note action sheet. Outline is a frequent navigation action, especially on phones, so this surfaces it as a first-class icon in the mobile note header too, accepting a little less title width during scroll. The "..." action sheet still offers it as well (no removal, per request).

One-line change: the outline header toggle was gated behind `\!isMobile`. `toggleOutline` and the right-side `OutlineSheet` already work on mobile (the panel closes after navigating); only the header button was hidden. `h-7 w-7` matches the mobile lock/kebab buttons.

This lands before the v0.36.0 release is re-cut, so the outline feature ships with the mobile header icon included.

## Test plan

- On a phone / narrow viewport, open a note with headings: the outline icon (list-tree) shows in the header next to the kebab; tapping it opens the outline panel; tapping a heading scrolls the note and closes the panel.
- The "..." action sheet still lists Outline.
- Desktop header unchanged.
- CI: lint + check + test + build green.