### PR TITLE
docs(readme): announce upcoming native mobile apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 ---
 
+> 📱 **Coming soon - native mobile apps.** Native apps are coming to the App Store and Google Play - re/notes first, with re/task following shortly after. The same end-to-end encrypted notes and tasks as dedicated apps, built from this same open-source code. Track progress on the [changelog and roadmap](https://reapps.eu/changelog/).
+
 **Reborn Apps** is a suite of two Progressive Web Apps built with a **Zero Knowledge architecture** - all user data is encrypted on your device before it ever reaches the server. The server stores only ciphertext and cannot read your tasks, notes, or metadata.
 
 Built by [Reborn Foundation](https://reborn.org.pl) (Poland), a European non-profit. Hosted on Hetzner Cloud (Germany). No tracking, no ads, no email required.


### PR DESCRIPTION
## Summary

Adds a **"Coming soon" banner** near the top of the README (right under the header), mirroring the website's roadmap note: native re/notes and re/task apps are coming to the App Store and Google Play, built from this same open-source code. Links to the [changelog and roadmap](https://reapps.eu/changelog/).

Copy is taken verbatim from the site's `upcoming-native-apps` roadmap item, so the README and website stay consistent. Matches the README's existing blockquote-callout style (plain `>` + emoji + bold lead); docs-only, no em-dash.

## Test plan

- [ ] Render the README on GitHub: the banner shows as the first body block, reads clearly, and the changelog link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)