### PR TITLE
chore(seed): refresh demo data for store screenshots

### DIFF
--- a/packages/database/src/seed-data.ts
+++ b/packages/database/src/seed-data.ts
@@ -65,7 +65,7 @@ export interface NoteData {
 // ==================== DEMO USER ====================
 
 export const DEMO_USER = {
-  username: 'amigo',
+  username: 'demo',
   password: 'Demo1234!'
 };
 

--- a/packages/database/src/seed-data.ts
+++ b/packages/database/src/seed-data.ts
@@ -1,6 +1,10 @@
 /**
  * Demo data for seed script — PL/EN versions.
- * Used for screenshots and testing.
+ * Used for store/website screenshots and testing.
+ *
+ * Task due dates are RELATIVE (dueInDays) so a fresh seed always renders a
+ * healthy Overdue / Today / Tomorrow / Upcoming spread regardless of seed date.
+ * Note dates are relative too (createdDaysAgo).
  */
 
 export type Lang = 'pl' | 'en';
@@ -18,8 +22,12 @@ export interface TaskData {
   description?: Record<Lang, string>;
   isCompleted: boolean;
   isStarred: boolean;
-  dueDate?: string;
-  hasTime?: boolean;
+  /** Days from seed time until due (negative = overdue, 0 = today). Omit = no due date. */
+  dueInDays?: number;
+  /** Local 'HH:MM'; when set, the task has a specific time (has_time = true). */
+  dueTime?: string;
+  /** Days ago the task was completed; only used when isCompleted (default 0 = today). */
+  completedDaysAgo?: number;
   position: number;
   subtasks?: SubtaskData[];
 }
@@ -78,7 +86,7 @@ export const TASKS: TaskData[] = [
     title: { pl: 'Odnowić paszport', en: 'Renew passport' },
     isCompleted: false,
     isStarred: false,
-    dueDate: '2026-04-18',
+    dueInDays: 21,
     position: 0
   },
   {
@@ -86,7 +94,7 @@ export const TASKS: TaskData[] = [
     title: { pl: 'Kupić prezent na urodziny Oli', en: 'Buy birthday gift for Ola' },
     isCompleted: false,
     isStarred: true,
-    dueDate: '2026-04-12',
+    dueInDays: 3,
     position: 1
   },
   {
@@ -101,7 +109,7 @@ export const TASKS: TaskData[] = [
     title: { pl: 'Wymienić olej w samochodzie', en: 'Change car oil' },
     isCompleted: false,
     isStarred: false,
-    dueDate: '2026-04-25',
+    dueInDays: 12,
     position: 3
   },
   {
@@ -109,7 +117,7 @@ export const TASKS: TaskData[] = [
     title: { pl: 'Odebrać paczkę z paczkomatu', en: 'Pick up parcel from locker' },
     isCompleted: false,
     isStarred: false,
-    dueDate: '2026-04-05',
+    dueInDays: 1,
     position: 4
   },
   // --- Work ---
@@ -120,13 +128,13 @@ export const TASKS: TaskData[] = [
       en: 'Prepare quarterly presentation'
     },
     description: {
-      pl: 'Prezentacja wyników Q1 dla zespołu. Spotkanie w piątek o 10:00 w sali konferencyjnej B. Pamiętać o wykresach sprzedaży i porównaniu z poprzednim kwartałem.',
-      en: 'Q1 results presentation for the team. Meeting on Friday at 10:00 in conference room B. Remember to include sales charts and comparison with previous quarter.'
+      pl: 'Prezentacja wyników Q1 dla zespołu. Spotkanie w sali konferencyjnej B. Pamiętać o wykresach sprzedaży i porównaniu z poprzednim kwartałem.',
+      en: 'Q1 results presentation for the team. Meeting in conference room B. Remember to include sales charts and a comparison with the previous quarter.'
     },
     isCompleted: false,
     isStarred: true,
-    dueDate: '2026-04-10',
-    hasTime: true,
+    dueInDays: 2,
+    dueTime: '10:00',
     position: 0,
     subtasks: [
       {
@@ -157,7 +165,7 @@ export const TASKS: TaskData[] = [
     title: { pl: 'Odpowiedzieć na maila od klienta', en: 'Reply to client email' },
     isCompleted: false,
     isStarred: false,
-    dueDate: '2026-04-05',
+    dueInDays: -1,
     position: 1
   },
   {
@@ -172,7 +180,7 @@ export const TASKS: TaskData[] = [
     title: { pl: 'Zaktualizować dokumentację API', en: 'Update API documentation' },
     isCompleted: false,
     isStarred: false,
-    dueDate: '2026-04-15',
+    dueInDays: 5,
     position: 3
   },
   // --- Shopping ---
@@ -186,15 +194,17 @@ export const TASKS: TaskData[] = [
   {
     listKey: 'shopping',
     title: { pl: 'Nowy kabel USB-C', en: 'New USB-C cable' },
-    isCompleted: false,
+    isCompleted: true,
     isStarred: false,
+    completedDaysAgo: 1,
     position: 1
   },
   {
     listKey: 'shopping',
     title: { pl: 'Baterie do pilota', en: 'Batteries for remote' },
-    isCompleted: false,
+    isCompleted: true,
     isStarred: false,
+    completedDaysAgo: 0,
     position: 2
   }
 ];
@@ -205,7 +215,8 @@ export const FOLDERS: FolderData[] = [
   { key: 'personal', name: { pl: 'Osobiste', en: 'Personal' }, orderIndex: 0 },
   { key: 'work', name: { pl: 'Praca', en: 'Work' }, orderIndex: 1 },
   { key: 'learning', name: { pl: 'Nauka', en: 'Learning' }, orderIndex: 2 },
-  { key: 'articles', name: { pl: 'Artykuły', en: 'Articles' }, orderIndex: 3 }
+  { key: 'projects', name: { pl: 'Projekty', en: 'Projects' }, orderIndex: 3 },
+  { key: 'articles', name: { pl: 'Artykuły', en: 'Articles' }, orderIndex: 4 }
 ];
 
 // ==================== TAGS ====================
@@ -215,7 +226,8 @@ export const TAGS: TagData[] = [
   { key: 'travel', name: { pl: 'Podróże', en: 'Travel' }, color: '#3B82F6' },
   { key: 'ideas', name: { pl: 'Pomysły', en: 'Ideas' }, color: '#8B5CF6' },
   { key: 'growth', name: { pl: 'Rozwój', en: 'Growth' }, color: '#10B981' },
-  { key: 'privacy', name: { pl: 'Prywatność', en: 'Privacy' }, color: '#F59E0B' }
+  { key: 'privacy', name: { pl: 'Prywatność', en: 'Privacy' }, color: '#F59E0B' },
+  { key: 'dev', name: { pl: 'Programowanie', en: 'Dev' }, color: '#06B6D4' }
 ];
 
 // ==================== NOTES ====================
@@ -229,37 +241,41 @@ export const NOTES: NoteData[] = [
       pl: `# Cele na 2026
 
 ## Zdrowie
-- Biegać 3× w tygodniu (cel: 10 km bez przerwy)
-- Regularny sen — 23:00 → 7:00
+- Biegać 3 razy w tygodniu (cel: 10 km bez przerwy)
+- Regularny sen: 23:00 -> 7:00
+- Mniej kawy, więcej wody
 
 ## Rozwój
 - Ukończyć kurs TypeScript (do czerwca)
-- Przeczytać 12 książek (1/miesiąc)
+- Przeczytać 12 książek (1 na miesiąc)
+- Nauczyć się podstaw hiszpańskiego (poziom A2)
 
 ## Finanse
-- Odłożyć 20% wypłaty co miesiąc
-- Fundusz awaryjny: 3× miesięczne wydatki
+- Odkładać 20% wypłaty co miesiąc
+- Fundusz awaryjny: 3-krotność miesięcznych wydatków
 
 ## Podróże
-- Lizbona w maju
-- Weekend w górach — jesień`,
+- Lizbona w maju ✈️
+- Weekend w górach jesienią`,
       en: `# Goals for 2026
 
 ## Health
-- Run 3× per week (goal: 10 km non-stop)
-- Regular sleep — 11 PM → 7 AM
+- Run 3 times a week (goal: 10 km non-stop)
+- Regular sleep: 11 PM -> 7 AM
+- Less coffee, more water
 
 ## Growth
-- Complete TypeScript course (by June)
-- Read 12 books (1/month)
+- Finish the TypeScript course (by June)
+- Read 12 books (1 per month)
+- Learn the basics of Spanish (level A2)
 
 ## Finances
-- Save 20% of salary each month
-- Emergency fund: 3× monthly expenses
+- Save 20% of each paycheck
+- Emergency fund: 3x monthly expenses
 
 ## Travel
 - Lisbon in May ✈️
-- Mountain weekend — autumn`
+- Mountain weekend in autumn`
     },
     isPinned: true,
     isStarred: false,
@@ -267,48 +283,161 @@ export const NOTES: NoteData[] = [
     tagKeys: ['growth'],
     createdDaysAgo: 90
   },
+  {
+    folderKey: 'personal',
+    title: { pl: 'Plan podróży - Lizbona', en: 'Lisbon trip plan' },
+    content: {
+      pl: `# Plan podróży - Lizbona 🇵🇹
+
+Pięć dni w maju. Lot z Krakowa, nocleg w dzielnicy Alfama.
+
+## Plan dnia
+
+| Dzień | Plan |
+| --- | --- |
+| Pon | Przylot, spacer po Alfamie, kolacja z fado |
+| Wt | Belém: wieża, klasztor, pastéis de nata |
+| Śr | Sintra: pałac Pena i Quinta da Regaleira |
+| Czw | Tramwaj 28, dzielnica Bairro Alto |
+| Pt | Targ Time Out, zakupy, powrót |
+
+## Do spakowania
+- [x] Paszport i bilety
+- [x] Ładowarka i powerbank
+- [ ] Krem z filtrem
+- [ ] Wygodne buty
+- [ ] Adapter do gniazdek
+
+> Wskazówka: bilet Lisboa Card obejmuje komunikację miejską i wstęp do większości muzeów.
+
+Rezerwacje: [booking.com](https://www.booking.com)`,
+      en: `# Lisbon trip plan 🇵🇹
+
+Five days in May. Flight from Krakow, staying in the Alfama district.
+
+## Day plan
+
+| Day | Plan |
+| --- | --- |
+| Mon | Arrival, walk around Alfama, fado dinner |
+| Tue | Belém: tower, monastery, pastéis de nata |
+| Wed | Sintra: Pena Palace and Quinta da Regaleira |
+| Thu | Tram 28, Bairro Alto district |
+| Fri | Time Out Market, shopping, flight home |
+
+## Packing list
+- [x] Passport and tickets
+- [x] Charger and power bank
+- [ ] Sunscreen
+- [ ] Comfortable shoes
+- [ ] Plug adapter
+
+> Tip: the Lisboa Card covers public transport and entry to most museums.
+
+Bookings: [booking.com](https://www.booking.com)`
+    },
+    isPinned: true,
+    isStarred: true,
+    orderIndex: 1,
+    tagKeys: ['travel', 'important'],
+    createdDaysAgo: 7
+  },
+  {
+    folderKey: 'personal',
+    title: { pl: 'Przepis na ciasto marchewkowe', en: 'Carrot cake recipe' },
+    content: {
+      pl: `# Przepis na ciasto marchewkowe 🥕
+
+Wilgotne, korzenne, gotowe w godzinę.
+
+## Składniki
+- 3 średnie marchewki (starte)
+- 2 szklanki mąki
+- 1 szklanka cukru trzcinowego
+- 3 jajka
+- 1 szklanka oleju
+- 2 łyżeczki cynamonu
+- 1 łyżeczka sody oczyszczonej
+
+## Przygotowanie
+1. Rozgrzej piekarnik do 180°C.
+2. Wymieszaj suche składniki w dużej misce.
+3. Dodaj jajka i olej, połącz na gładką masę.
+4. Wmieszaj startą marchewkę.
+5. Przelej do formy i piecz 45 minut.
+
+> Sprawdź patyczkiem: jeśli wychodzi suchy, ciasto jest gotowe.`,
+      en: `# Carrot cake recipe 🥕
+
+Moist, spiced, ready in an hour.
+
+## Ingredients
+- 3 medium carrots (grated)
+- 2 cups flour
+- 1 cup cane sugar
+- 3 eggs
+- 1 cup oil
+- 2 tsp cinnamon
+- 1 tsp baking soda
+
+## Steps
+1. Preheat the oven to 180°C.
+2. Mix the dry ingredients in a large bowl.
+3. Add the eggs and oil, blend until smooth.
+4. Fold in the grated carrots.
+5. Pour into a tin and bake for 45 minutes.
+
+> Test with a toothpick: if it comes out dry, the cake is done.`
+    },
+    isPinned: false,
+    isStarred: false,
+    orderIndex: 2,
+    createdDaysAgo: 40
+  },
   // --- Work ---
   {
     folderKey: 'work',
-    title: { pl: 'Notatki ze spotkania — 2 kwietnia', en: 'Meeting notes — April 2nd' },
+    title: { pl: 'Notatki ze spotkania - 20 czerwca', en: 'Meeting notes - June 20' },
     content: {
-      pl: `# Spotkanie zespołu — 2.04.2026
+      pl: `# Spotkanie zespołu - 20 czerwca 2026
 
 ## Uczestnicy
 Anna, Kasia, Marek, Tomek
 
 ## Tematy
-1. **Status sprintu 14** — 8/12 story points zamknięte
-2. **Demo dla klienta** — przesunięte na 10.04
-3. **Nowy designer** — Marta dołącza od 14.04
+1. **Status sprintu 14** - zamknięte 8 z 12 story points
+2. **Demo dla klienta** - przesunięte na 26 czerwca
+3. **Nowy projektant** - Marta dołącza 1 lipca
 
 ## Akcje
+- [x] Anna: wysłać podsumowanie sprintu
 - [ ] Marek: przygotować środowisko testowe
 - [ ] Kasia: zaktualizować backlog sprintu 15
-- [ ] Tomek: review PR-ów do piątku
+- [ ] Tomek: przejrzeć PR-y do piątku
 
-Następne spotkanie: **9.04 o 10:00**`,
-      en: `# Team Meeting — April 2, 2026
+Następne spotkanie: **27 czerwca o 10:00**`,
+      en: `# Team meeting - June 20, 2026
 
 ## Attendees
 Anna, Kasia, Marek, Tomek
 
 ## Topics
-1. **Sprint 14 status** — 8/12 story points closed
-2. **Client demo** — moved to April 10
-3. **New designer** — Marta joins April 14
+1. **Sprint 14 status** - 8 of 12 story points closed
+2. **Client demo** - moved to June 26
+3. **New designer** - Marta joins July 1
 
 ## Actions
-- [ ] Marek: prepare test environment
-- [ ] Kasia: update sprint 15 backlog
+- [x] Anna: send the sprint summary
+- [ ] Marek: prepare the test environment
+- [ ] Kasia: update the sprint 15 backlog
 - [ ] Tomek: review PRs by Friday
 
-Next meeting: **April 9 at 10:00**`
+Next meeting: **June 27 at 10:00**`
     },
     isPinned: true,
     isStarred: false,
     orderIndex: 0,
-    createdDaysAgo: 3
+    createdDaysAgo: 5
   },
   {
     folderKey: 'work',
@@ -317,29 +446,29 @@ Next meeting: **April 9 at 10:00**`
       pl: `# Pomysły na nowe funkcje 💡
 
 ## Priorytet wysoki
-- **Eksport do PDF** — użytkownicy często proszą
-- **Wyszukiwanie pełnotekstowe** — kluczowe dla dużych zbiorów notatek
+- **Eksport do PDF** - często proszą o to użytkownicy
+- **Wyszukiwanie pełnotekstowe** - kluczowe przy dużych zbiorach notatek
 
 ## Priorytet średni
 - Widok kanban dla zadań
-- Wspólne listy zadań (shared lists)
-- Notyfikacje push o terminach
+- Współdzielone listy zadań
+- Powiadomienia push o terminach
 
 ## Do zbadania
 - Integracja z kalendarzem (CalDAV?)
-- Plugin do przeglądarki (quick capture)`,
-      en: `# New Feature Ideas 💡
+- Wtyczka do przeglądarki (szybkie zapisywanie)`,
+      en: `# New feature ideas 💡
 
-## High Priority
-- **PDF export** — frequently requested by users
-- **Full-text search** — critical for large note collections
+## High priority
+- **PDF export** - frequently requested by users
+- **Full-text search** - critical for large note collections
 
-## Medium Priority
+## Medium priority
 - Kanban view for tasks
 - Shared task lists
 - Push notifications for deadlines
 
-## To Research
+## To research
 - Calendar integration (CalDAV?)
 - Browser extension (quick capture)`
     },
@@ -352,50 +481,207 @@ Next meeting: **April 9 at 10:00**`
   // --- Learning ---
   {
     folderKey: 'learning',
-    title: { pl: 'Kurs TypeScript — notatki', en: 'TypeScript course — notes' },
+    title: { pl: 'Kurs TypeScript - notatki', en: 'TypeScript course - notes' },
     content: {
-      pl: `# TypeScript — notatki z kursu 📝
+      pl: `# TypeScript - notatki z kursu 📝
+
+## Generyki
+\`\`\`typescript
+function identity<T>(arg: T): T {
+  return arg;
+}
+
+const first = <T>(arr: T[]): T | undefined => arr[0];
+\`\`\`
+Generyki pozwalają pisać reużywalne funkcje bez utraty informacji o typach.
+
+## Typy narzędziowe
+- \`Partial<T>\` - wszystkie pola opcjonalne
+- \`Required<T>\` - wszystkie pola wymagane
+- \`Pick<T, K>\` - wybrane pola
+- \`Omit<T, K>\` - wszystko poza K
+
+## Unie rozłączne
+\`\`\`typescript
+type Result =
+  | { status: 'ok'; data: string }
+  | { status: 'error'; message: string };
+
+function handle(r: Result) {
+  if (r.status === 'ok') return r.data;
+  return r.message;
+}
+\`\`\`
+
+> Wspólne pole literalne (tutaj \`status\`) działa jak dyskryminator przy zawężaniu typów.`,
+      en: `# TypeScript - course notes 📝
 
 ## Generics
 \`\`\`typescript
 function identity<T>(arg: T): T {
   return arg;
 }
+
+const first = <T>(arr: T[]): T | undefined => arr[0];
 \`\`\`
-Generics pozwalają na tworzenie reużywalnych komponentów z zachowaniem typowania.
+Generics let you write reusable functions without losing type information.
 
-## Utility Types
-- \`Partial<T>\` — wszystkie pola opcjonalne
-- \`Required<T>\` — wszystkie pola wymagane
-- \`Pick<T, K>\` — wybiór pól
-- \`Omit<T, K>\` — pominięcie pól
+## Utility types
+- \`Partial<T>\` - all fields optional
+- \`Required<T>\` - all fields required
+- \`Pick<T, K>\` - select specific fields
+- \`Omit<T, K>\` - everything except K
 
-## Discriminated Unions
-Kluczowe dla pattern matchingu — używać wspólnego pola literalnego jako dyskryminatora.`,
-      en: `# TypeScript — Course Notes 📝
-
-## Generics
+## Discriminated unions
 \`\`\`typescript
-function identity<T>(arg: T): T {
-  return arg;
+type Result =
+  | { status: 'ok'; data: string }
+  | { status: 'error'; message: string };
+
+function handle(r: Result) {
+  if (r.status === 'ok') return r.data;
+  return r.message;
 }
 \`\`\`
-Generics allow creating reusable components while preserving type safety.
 
-## Utility Types
-- \`Partial<T>\` — all fields optional
-- \`Required<T>\` — all fields required
-- \`Pick<T, K>\` — select specific fields
-- \`Omit<T, K>\` — omit specific fields
-
-## Discriminated Unions
-Essential for pattern matching — use a shared literal field as the discriminator.`
+> A shared literal field (here \`status\`) acts as a discriminator when narrowing types.`
     },
     isPinned: true,
     isStarred: true,
     orderIndex: 0,
-    tagKeys: ['growth'],
+    tagKeys: ['growth', 'dev'],
     createdDaysAgo: 18
+  },
+  {
+    folderKey: 'learning',
+    title: { pl: 'Python - praca z danymi', en: 'Python - working with data' },
+    content: {
+      pl: `# Python - praca z danymi 🐍
+
+## Listy składane
+\`\`\`python
+numbers = [1, 2, 3, 4, 5, 6]
+evens = [n for n in numbers if n % 2 == 0]
+squares = {n: n * n for n in numbers}
+print(evens)    # [2, 4, 6]
+\`\`\`
+
+## Zliczanie z collections
+\`\`\`python
+from collections import Counter
+
+words = "jabłko banan jabłko wiśnia banan jabłko".split()
+counts = Counter(words)
+print(counts.most_common(2))  # [('jabłko', 3), ('banan', 2)]
+\`\`\`
+
+## Wskazówki
+- \`enumerate(seq)\` zamiast ręcznego licznika
+- \`zip(a, b)\` do równoległej iteracji
+- f-stringi do formatowania: \`f"suma: {total}"\``,
+      en: `# Python - working with data 🐍
+
+## List comprehensions
+\`\`\`python
+numbers = [1, 2, 3, 4, 5, 6]
+evens = [n for n in numbers if n % 2 == 0]
+squares = {n: n * n for n in numbers}
+print(evens)    # [2, 4, 6]
+\`\`\`
+
+## Counting with collections
+\`\`\`python
+from collections import Counter
+
+words = "apple banana apple cherry banana apple".split()
+counts = Counter(words)
+print(counts.most_common(2))  # [('apple', 3), ('banana', 2)]
+\`\`\`
+
+## Tips
+- \`enumerate(seq)\` instead of a manual counter
+- \`zip(a, b)\` for parallel iteration
+- f-strings for formatting: \`f"total: {total}"\``
+    },
+    isPinned: false,
+    isStarred: false,
+    orderIndex: 1,
+    tagKeys: ['dev'],
+    createdDaysAgo: 10
+  },
+  // --- Projects ---
+  {
+    folderKey: 'projects',
+    title: { pl: 'Runbook wdrożenia API', en: 'API deployment runbook' },
+    content: {
+      pl: `# Runbook wdrożenia API 🚀
+
+Kroki wdrożenia nowej wersji na produkcję.
+
+## Przed wdrożeniem
+- [x] Testy zielone na CI
+- [x] Migracje sprawdzone na stagingu
+- [ ] Wpis w changelogu
+
+## Deploy
+\`\`\`bash
+git pull --ff-only origin main
+pnpm install --frozen-lockfile
+pnpm db:migrate
+docker compose up -d --build
+\`\`\`
+
+## Fragment docker-compose
+\`\`\`yaml
+services:
+  api:
+    image: reborn/api:latest
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+\`\`\`
+
+> Uwaga: jeśli healthcheck nie przejdzie w 60 sekund, wycofaj się do poprzedniego obrazu.`,
+      en: `# API deployment runbook 🚀
+
+Steps for shipping a new version to production.
+
+## Before deploy
+- [x] Tests green on CI
+- [x] Migrations verified on staging
+- [ ] Changelog entry added
+
+## Deploy
+\`\`\`bash
+git pull --ff-only origin main
+pnpm install --frozen-lockfile
+pnpm db:migrate
+docker compose up -d --build
+\`\`\`
+
+## docker-compose snippet
+\`\`\`yaml
+services:
+  api:
+    image: reborn/api:latest
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+\`\`\`
+
+> Warning: if the healthcheck fails within 60 seconds, roll back to the previous image.`
+    },
+    isPinned: false,
+    isStarred: false,
+    orderIndex: 0,
+    tagKeys: ['dev', 'important'],
+    createdDaysAgo: 6
   },
   // --- Articles (from blog) ---
   {
@@ -407,118 +693,52 @@ Essential for pattern matching — use a shared literal field as the discriminat
     content: {
       pl: `# Dlaczego szyfrowanie Zero Knowledge ma znaczenie
 
-W świecie, w którym wycieki danych trafiają na nagłówki co tydzień, tradycyjne zabezpieczenia nie wystarczają.
+Wycieki danych trafiają na nagłówki niemal co tydzień. Tradycyjne zabezpieczenia już nie wystarczają.
 
-## Czym jest Zero Knowledge?
-
-Dostawca usługi ma **zerową wiedzę** o rzeczywistych danych. Informacje są szyfrowane na urządzeniu, zanim je opuszczą, a tylko Ty masz klucze do ich odszyfrowania.
+## Czym jest Zero Knowledge
+Dostawca usługi ma **zerową wiedzę** o Twoich danych. Wszystko jest szyfrowane na urządzeniu, zanim je opuści, a klucze masz tylko Ty.
 
 ## Jak to działa
-
-1. Generowany jest główny klucz szyfrujący na urządzeniu
-2. Klucz jest szyfrowany kluczem pochodnym od hasła (PBKDF2, 600K iteracji)
-3. Tylko zaszyfrowany klucz trafia na serwer — nigdy prawdziwy klucz
-4. Wszystkie dane szyfrowane AES-256-GCM przed wysłaniem
+1. Główny klucz szyfrujący powstaje na Twoim urządzeniu.
+2. Klucz jest opakowany kluczem pochodnym od hasła (PBKDF2, 600 000 iteracji).
+3. Na serwer trafia tylko zaszyfrowany klucz, nigdy ten prawdziwy.
+4. Wszystkie dane są szyfrowane AES-256-GCM przed wysłaniem.
 
 ## Dlaczego to ważne
-
-- **Wycieki danych nieszkodliwe** — atakujący znajdzie tylko zaszyfrowany szum
-- **Brak zagrożenia wewnętrznego** — zespół nie może odczytać danych użytkowników
-- **Brak tylnych drzwi** — nie da się oddać tego, czego nie ma
-- **Dane pod kontrolą użytkownika** — klucze nigdy nie opuszczają urządzenia
+- **Wycieki stają się nieszkodliwe** - atakujący widzi tylko szum.
+- **Brak zagrożenia wewnętrznego** - zespół nie odczyta Twoich danych.
+- **Brak tylnych drzwi** - nie da się wydać tego, czego się nie ma.
+- **Dane pod Twoją kontrolą** - klucze nie opuszczają urządzenia.
 
 ## Kompromis
+Bez hasła danych nie da się odzyskać. Kody odzyskiwania to jedyna droga awaryjna. To cecha, nie błąd.`,
+      en: `# Why Zero Knowledge encryption matters
 
-Brak możliwości odzyskania danych bez hasła. Kody odzyskiwania to jedyna droga awaryjna. To feature, nie bug.`,
-      en: `# Why Zero Knowledge Encryption Matters
+Data breaches make headlines almost every week. Traditional security is no longer enough.
 
-In a world where data breaches make headlines every week, traditional security isn't enough.
+## What Zero Knowledge means
+The service provider has **zero knowledge** of your data. Everything is encrypted on your device before it leaves, and only you hold the keys.
 
-## What is Zero Knowledge?
+## How it works
+1. A master encryption key is generated on your device.
+2. The key is wrapped with a password-derived key (PBKDF2, 600,000 iterations).
+3. Only the encrypted key reaches the server, never the real one.
+4. All data is encrypted with AES-256-GCM before transmission.
 
-The service provider has **zero knowledge** of your actual data. Information is encrypted on your device before it leaves, and only you hold the keys to decrypt it.
+## Why it matters
+- **Breaches become harmless** - attackers see only noise.
+- **No insider threat** - the team cannot read your data.
+- **No backdoors** - you cannot hand over what you do not have.
+- **You control your data** - keys never leave your device.
 
-## How It Works
-
-1. A master encryption key is generated on your device
-2. That key is encrypted with a password-derived key (PBKDF2, 600K iterations)
-3. Only the encrypted key is sent to the server — never the real key
-4. All data encrypted with AES-256-GCM before transmission
-
-## Why It Matters
-
-- **Data breaches become harmless** — attackers find only encrypted noise
-- **No insider threat** — the team cannot read user data
-- **No backdoors** — can't hand over what you don't have
-- **User-controlled data** — encryption keys never leave the device
-
-## The Trade-off
-
-Data cannot be recovered without the password. Recovery codes are the only fallback. It's a feature, not a bug.`
+## The trade-off
+Without your password, data cannot be recovered. Recovery codes are the only fallback. It is a feature, not a bug.`
     },
     isPinned: false,
     isStarred: true,
     orderIndex: 0,
     tagKeys: ['privacy'],
-    createdDaysAgo: 20
-  },
-  {
-    folderKey: 'articles',
-    title: { pl: 'Przedstawiamy Reborn Apps', en: 'Introducing Reborn Apps' },
-    content: {
-      pl: `# Przedstawiamy Reborn Apps
-
-**Reborn Apps** — narzędzia produktywności z E2E encryption, tworzone przez europejską fundację non-profit.
-
-## Problem
-
-Większość appek produktywności traktuje dane użytkowników jako swój produkt — analizuje nawyki, wyświetla reklamy, przechowuje wszystko w plaintext.
-
-Reborn Apps opiera się na zasadzie: **Twoje dane należą do Ciebie**.
-
-## Aplikacje
-
-### re/task
-Menedżer zadań: listy, podzadania, gwiazdki, zadania cykliczne, tryb offline-first, pełne E2E encryption.
-
-### re/notes
-Notatki: edytor Markdown, foldery, tagi, tryb offline-first, E2E encryption.
-
-## Wartości
-
-- **Open source** — kod na licencji AGPL-3.0
-- **Non-profit** — Fundacja Reborn, Polska
-- **Europejskie** — hosting w Niemczech, RODO
-- **Darmowe** — bez reklam, bez śledzenia`,
-      en: `# Introducing Reborn Apps
-
-**Reborn Apps** — productivity tools with E2E encryption, built by a European non-profit foundation.
-
-## The Problem
-
-Most productivity apps treat user data as their product — analyzing habits, serving ads, storing everything in plaintext.
-
-Reborn Apps is built on one principle: **Your data belongs to you**.
-
-## Apps
-
-### re/task
-Task manager: lists, subtasks, stars, recurring tasks, offline-first mode, full E2E encryption.
-
-### re/notes
-Notes: Markdown editor, folders, tags, offline-first mode, E2E encryption.
-
-## Values
-
-- **Open source** — AGPL-3.0 licensed
-- **Non-profit** — Reborn Foundation, Poland
-- **European** — hosted in Germany, GDPR compliant
-- **Free** — no ads, no tracking`
-    },
-    isPinned: true,
-    isStarred: false,
-    orderIndex: 1,
-    createdDaysAgo: 25
+    createdDaysAgo: 22
   },
   {
     folderKey: 'articles',
@@ -530,163 +750,60 @@ Notes: Markdown editor, folders, tags, offline-first mode, E2E encryption.
       pl: `# Przegląd bezpieczeństwa Reborn Apps
 
 ## Architektura Zero Knowledge
-
-Serwer **nigdy nie ma dostępu** do danych w postaci jawnej. Szyfrowanie i deszyfrowanie wyłącznie na urządzeniu użytkownika.
+Serwer **nigdy** nie widzi danych w postaci jawnej. Szyfrowanie i deszyfrowanie dzieją się wyłącznie na urządzeniu użytkownika.
 
 ### Co serwer widzi
-- Nazwa użytkownika, hash hasła (Argon2id), zaszyfrowany klucz główny
-- ID rekordów (UUID), znaczniki czasu, klucze obce
+- Nazwę użytkownika, hash hasła (Argon2id), zaszyfrowany klucz główny
+- Identyfikatory rekordów (UUID), znaczniki czasu, klucze obce
 
 ### Czego serwer nie widzi
-- Treść zadań, notatek, opisy, nazwy list/folderów/tagów
-- Status ukończenia, gwiazdki, terminy, powiązania tagów
-- Dane PII (poza nazwą użytkownika)
+- Treści zadań i notatek, opisów, nazw list, folderów i tagów
+- Statusu ukończenia, gwiazdek, terminów, powiązań z tagami
 
 ## Kryptografia
-
 | Cel | Algorytm |
-|-----|----------|
+| --- | --- |
 | Hash hasła | Argon2id (m=19456, t=3, p=1) |
-| Derywacja klucza | PBKDF2 600K iteracji, SHA-256 |
+| Pochodna klucza | PBKDF2, 600 000 iteracji, SHA-256 |
 | Szyfrowanie danych | AES-GCM 256-bit |
 | Tokeny | JWT HMAC-SHA256 z rotacją sekretów |
 
-## Zabezpieczenia
+## Dodatkowe zabezpieczenia
+- Brute-force: 5 prób, potem 15 minut blokady
+- Rotacja refresh tokenów ze śledzeniem rodziny
+- HSTS oraz CSP oparte na nonce
+- Walidacja Zod i sanityzacja DOMPurify`,
+      en: `# Reborn Apps security overview
 
-- Brute-force: 5 prób → 15 min lockout
-- Refresh token rotation z family tracking
-- HSTS + CSP nonce-based
-- Walidacja Zod + sanityzacja DOMPurify
-- Idempotentna synchronizacja offline`,
-      en: `# Reborn Apps Security Overview
-
-## Zero Knowledge Architecture
-
-The server **never has access** to plaintext data. All encryption and decryption happens exclusively on the user's device.
+## Zero Knowledge architecture
+The server **never** sees plaintext data. Encryption and decryption happen only on the user's device.
 
 ### What the server sees
 - Username, password hash (Argon2id), encrypted master key
 - Record IDs (UUID), timestamps, foreign keys
 
 ### What the server never sees
-- Task content, notes, descriptions, list/folder/tag names
+- Task and note content, descriptions, list, folder and tag names
 - Completion status, stars, due dates, tag associations
-- PII data (beyond username)
 
 ## Cryptography
-
 | Purpose | Algorithm |
-|---------|-----------|
+| --- | --- |
 | Password hash | Argon2id (m=19456, t=3, p=1) |
-| Key derivation | PBKDF2 600K iterations, SHA-256 |
+| Key derivation | PBKDF2, 600,000 iterations, SHA-256 |
 | Data encryption | AES-GCM 256-bit |
 | Tokens | JWT HMAC-SHA256 with secret rotation |
 
-## Security Measures
-
-- Brute-force: 5 attempts → 15 min lockout
+## Extra protections
+- Brute-force: 5 attempts, then a 15-minute lockout
 - Refresh token rotation with family tracking
-- HSTS + nonce-based CSP
-- Zod validation + DOMPurify sanitization
-- Idempotent offline sync`
+- HSTS and nonce-based CSP
+- Zod validation and DOMPurify sanitization`
     },
     isPinned: false,
     isStarred: false,
-    orderIndex: 2,
+    orderIndex: 1,
     tagKeys: ['privacy', 'important'],
     createdDaysAgo: 4
-  },
-  {
-    folderKey: 'articles',
-    title: {
-      pl: 'Self-hosting Reborn Apps z Docker Compose',
-      en: 'Self-hosting Reborn Apps with Docker Compose'
-    },
-    content: {
-      pl: `# Self-hosting Reborn Apps z Docker Compose
-
-Jak uruchomić własną instancję Reborn Apps na serwerze.
-
-## Wymagania
-
-- Docker i Docker Compose
-- Serwer z min. 2 GB RAM
-- Domena (opcjonalna, ale zalecana)
-
-## Szybki start
-
-\`\`\`bash
-git clone https://github.com/fundacja-reborn/reapps.git
-cd reborn-apps
-cp .env.example .env
-docker compose up -d
-\`\`\`
-
-Uruchomi: PostgreSQL + re/task + re/notes.
-
-## Konfiguracja (.env)
-
-- \`DATABASE_URL\` — connection string PostgreSQL
-- \`JWT_SECRET\` — sekret JWT
-- \`ARGON2_MEMORY\` — koszt pamięci hashowania haseł
-
-## HTTPS z reverse proxy
-
-\`\`\`bash
-docker compose -f docker-compose.yml \\
-  -f docker-compose.proxy.yml up -d
-\`\`\`
-
-## Dlaczego self-hosting?
-
-- **Pełna kontrola** nad danymi
-- **Własna domena**
-- **Wymogi regulacyjne** — wewnętrzne polityki
-- **To samo E2E encryption** — szyfrowanie działa identycznie`,
-      en: `# Self-hosting Reborn Apps with Docker Compose
-
-How to run your own Reborn Apps instance on a server.
-
-## Requirements
-
-- Docker and Docker Compose
-- Server with at least 2 GB RAM
-- Domain name (optional but recommended)
-
-## Quick Start
-
-\`\`\`bash
-git clone https://github.com/fundacja-reborn/reapps.git
-cd reborn-apps
-cp .env.example .env
-docker compose up -d
-\`\`\`
-
-Starts: PostgreSQL + re/task + re/notes.
-
-## Configuration (.env)
-
-- \`DATABASE_URL\` — PostgreSQL connection string
-- \`JWT_SECRET\` — JWT signing secret
-- \`ARGON2_MEMORY\` — password hashing memory cost
-
-## HTTPS with reverse proxy
-
-\`\`\`bash
-docker compose -f docker-compose.yml \\
-  -f docker-compose.proxy.yml up -d
-\`\`\`
-
-## Why self-host?
-
-- **Full control** over your data
-- **Custom domain**
-- **Regulatory requirements** — internal data policies
-- **Same E2E encryption** — encryption works identically`
-    },
-    isPinned: false,
-    isStarred: false,
-    orderIndex: 3,
-    createdDaysAgo: 30
   }
 ];

--- a/packages/database/src/seed-data.ts
+++ b/packages/database/src/seed-data.ts
@@ -1,5 +1,5 @@
 /**
- * Demo data for seed script — PL/EN versions.
+ * Demo data for seed script - PL/EN versions.
  * Used for store/website screenshots and testing.
  *
  * Task due dates are RELATIVE (dueInDays) so a fresh seed always renders a

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -6,11 +6,52 @@ import type {
   SubtaskSensitiveMetadata,
   NoteSensitiveMetadata
 } from '@reborn/types';
-import { DEMO_USER, TASK_LISTS, TASKS, FOLDERS, TAGS, NOTES, type Lang } from './seed-data.js';
+import {
+  DEMO_USER,
+  TASK_LISTS,
+  TASKS,
+  FOLDERS,
+  TAGS,
+  NOTES,
+  type Lang,
+  type TaskData
+} from './seed-data.js';
 
 const logger = createLogger('Database:Seed');
 
 // ==================== HELPERS ====================
+
+/**
+ * Resolve a task's relative due offset into the string the app stores.
+ * Date-only dues become `YYYY-MM-DD`; timed dues become a full ISO timestamp
+ * with `has_time = true`. Computed at seed time so screenshots always show a
+ * fresh Overdue / Today / Tomorrow / Upcoming spread.
+ */
+function computeDue(task: TaskData): { dueDate: string | null; hasTime: boolean } {
+  if (task.dueInDays === undefined) return { dueDate: null, hasTime: false };
+
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + task.dueInDays);
+
+  if (task.dueTime) {
+    const [h, m] = task.dueTime.split(':').map(Number);
+    d.setHours(h, m, 0, 0);
+    return { dueDate: d.toISOString(), hasTime: true };
+  }
+
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, '0');
+  const da = String(d.getDate()).padStart(2, '0');
+  return { dueDate: `${y}-${mo}-${da}`, hasTime: false };
+}
+
+/** ISO timestamp N days ago, for the completed_at field of finished tasks. */
+function computeCompletedAt(daysAgo: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return d.toISOString();
+}
 
 function parseLang(args: string[]): Lang {
   const langIdx = args.indexOf('--lang');
@@ -128,12 +169,14 @@ async function main(): Promise<void> {
       ? await crypto.encryptString(task.description[lang])
       : null;
 
+    const { dueDate, hasTime } = computeDue(task);
+
     const metadata: TaskSensitiveMetadata = {
       is_completed: task.isCompleted,
       is_starred: task.isStarred,
-      due_date: task.dueDate ?? null,
-      has_time: task.hasTime ?? false,
-      completed_at: null,
+      due_date: dueDate,
+      has_time: hasTime,
+      completed_at: task.isCompleted ? computeCompletedAt(task.completedDaysAgo ?? 0) : null,
       reminder_date: null,
       is_recurring: false,
       notification_sent: false

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -99,7 +99,7 @@ async function main(): Promise<void> {
   const lang = parseLang(args);
   const clearOnly = isClearOnly(args);
 
-  logger.info('=== Reborn Apps — Seed Script ===');
+  logger.info('=== Reborn Apps - Seed Script ===');
 
   // Step 1: Clear existing data
   await clearDatabase();


### PR DESCRIPTION
## Summary

Refreshes the demo seed (`packages/database/src/seed-data.ts`) used to fill re/task and re/notes with data for App Store / Play Store and website screenshots. Run with `pnpm db:seed` (PL) or `pnpm db:seed -- --lang en` (EN).

- **10 notes** across 5 folders (Personal, Work, Learning, Projects, Articles) and **6 tags**, PL + EN. Showcases code blocks in **TypeScript, Python and Bash/YAML**, plus tables, in-note task checkboxes, blockquotes, and a heading-rich article for the outline panel.
- **12 tasks** across 3 lists with a description, subtasks, stars, and a partly-completed shopping list.
- **Relative due dates**: `TaskData` now uses `dueInDays` / `dueTime` resolved at seed time, so every seed renders a fresh Overdue / Today / Tomorrow / Upcoming spread instead of fixed dates stuck in the past.
- `completed_at` is now set for finished tasks so the Completed view has content.

No schema or encryption-model changes - seed content only. Consumed only by `seed.ts` via `tsx`, not bundled into the package build. The human-readable spec in `reapps-docs/planning/demo-screenshot-data.md` was updated to match (separate local repo, not in this PR).

## Decisions (auto mode - for review)

- **Absolute -> relative due dates** (`dueDate` -> `dueInDays` + `dueTime`). Screenshots are re-taken periodically, so hard-coded dates rot; the only trade-off is exact-calendar reproducibility, irrelevant for demo data.
- **Skipped** recurring tasks, periodic notes and wiki-links/backlinks in the seed. Recurrence uses a template/instance model that is risky to fake; periodic notes need period anchors; wiki-links are stored by UUID so raw `[[...]]` text would not resolve. Flagged as optional follow-ups in the spec doc.

## Test plan

- `pnpm db:seed`, then log in as `amigo` / `Demo1234\!` (clear IndexedDB `Reborn_task_DB` / `Reborn_notes_DB` first - each seed uses a new master key).
- re/task: confirm Overdue / Today / Tomorrow / Upcoming / Starred / Completed views are populated; open "Prepare quarterly presentation" for the subtask + description detail view.
- re/notes: open the code-block notes (TypeScript / Python / runbook) for syntax highlighting; "Lisbon trip plan" for the table + checkboxes; the Zero Knowledge article for the outline panel.
- Re-run with `-- --lang en` and confirm the English variant.
- Local gate: `tsc --noEmit` on the package passes (exit 0); eslint clean (one pre-existing unrelated warning).