### PR TITLE
fix(notes): show authored label for internal links in Preview

### DIFF
--- a/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
+++ b/apps/reborn-notes/src/lib/components/MarkdownPreview.svelte
@@ -74,7 +74,6 @@
     onTocDelete,
     tocStale = false,
     onrender,
-    resolveNoteTitle,
     onHeadingLinkCopy,
     headingLinkLabel
   }: {
@@ -141,8 +140,6 @@
      * rebuild line-anchor caches in the scroll-sync.
      */
     onrender?: () => void;
-    /** Resolves current title for a note UUID (for auto-update display text) */
-    resolveNoteTitle?: (noteId: string) => string | undefined;
     /**
      * Owner-editable preview only. When provided, each rendered heading gets a
      * hover-revealed "copy link to heading" button; the click reports the
@@ -309,15 +306,12 @@
     const tableWrapped = raw
       .replace(/<table>/g, '<div class="table-wrap"><table>')
       .replace(/<\/table>/g, '</table></div>');
-    if (!resolveNoteTitle) return tableWrapped;
-    return tableWrapped.replace(
-      /<a ([^>]*?)href="note:([0-9a-f-]{36})(#[^"]*)?"([^>]*?)>([^<]*)<\/a>/gi,
-      (_match, pre, noteId, frag, post, _text) => {
-        const currentTitle = resolveNoteTitle(noteId);
-        const displayText = currentTitle ?? _text;
-        return `<a ${pre}href="note:${noteId}${frag ?? ''}"${post}>${displayText}</a>`;
-      }
-    );
+    // Note links render with their authored label, exactly as written - same as
+    // Live Preview, the shared snapshot and exported Markdown. We deliberately do
+    // NOT swap the label for the target note's current title: that clobbered
+    // custom labels and heading-anchor link text (`[localhost](note:UUID#slug)`
+    // showed the note title instead). The authored label is the source of truth.
+    return tableWrapped;
   });
 
   // After {@html html} commits to the DOM, stamp top-level children with

--- a/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteContentArea.svelte
@@ -33,8 +33,7 @@
     onviewdestroy,
     onpreviewrender,
     onnotelinkrequest,
-    onnotelink,
-    resolveNoteTitle
+    onnotelink
   }: {
     noteId: string;
     effectiveViewMode: ViewMode;
@@ -65,7 +64,6 @@
     onpreviewrender?: () => void;
     onnotelinkrequest: () => void;
     onnotelink: (noteId: string, anchor?: string) => void;
-    resolveNoteTitle: (noteId: string) => string | undefined;
   } = $props();
 
   // Split view always uses independent scrolls per pane — sticky+100dvh inside a
@@ -234,7 +232,6 @@
               onHeadingLinkCopy={handleHeadingLinkCopy}
               headingLinkLabel={$t('editor.copy_heading_link')}
               {tocStale}
-              {resolveNoteTitle}
               {imageLoadMode}
               {loadAllImagesHint}
               {settingsLinkLabel}
@@ -257,7 +254,6 @@
             onHeadingLinkCopy={handleHeadingLinkCopy}
             headingLinkLabel={$t('editor.copy_heading_link')}
             {tocStale}
-            {resolveNoteTitle}
             {imageLoadMode}
             {loadAllImagesHint}
             {settingsLinkLabel}

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -5,7 +5,7 @@
  * Cleared on lock/logout. Rebuilt after sync.
  * ~2 MB for 10K notes (vs ~50 MB full decrypt with content).
  *
- * Consumers: NoteList, NotePicker, autocomplete [[, resolveNoteTitle(), search sidebar.
+ * Consumers: NoteList, NotePicker, autocomplete [[, search sidebar.
  *
  * Replaces the old NoteTitleIndex — now stores all metadata needed for list rendering:
  * title, folderId, isPinned, isStarred, isArchived, createdAt, updatedAt, tagIds.
@@ -179,12 +179,6 @@ class NoteIndex {
       .filter(([, e]) => !e.isArchived)
       .sort((a, b) => b[1].updatedAt.localeCompare(a[1].updatedAt))
       .map(([id, e]) => ({ id, title: e.title }));
-  }
-
-  /** Get a single title by id. Reactive. */
-  getTitle(id: string): string | undefined {
-    void this._version;
-    return this._map.get(id)?.title;
   }
 
   /** Get a single entry by id. Reactive. */

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -970,10 +970,6 @@
     activeNoteId.set(noteId);
   }
 
-  function resolveNoteTitle(noteId: string): string | undefined {
-    return noteIndex.getTitle(noteId);
-  }
-
   // ── Note link picker ─────────────────────────────────────────────
   let notePickerOpen = $state(false);
   let notePickerNotes = $state<{ id: string; title: string }[]>([]);
@@ -1645,7 +1641,6 @@
               onpreviewrender={handlePreviewRender}
               onnotelinkrequest={openNotePicker}
               onnotelink={handleNoteLink}
-              {resolveNoteTitle}
               imageLoadMode={$imageLoadMode}
               noteKind={currentNoteKind}
             />
@@ -1739,7 +1734,6 @@
                   onpreviewrender={handlePreviewRender}
                   onnotelinkrequest={openNotePicker}
                   onnotelink={handleNoteLink}
-                  {resolveNoteTitle}
                   imageLoadMode={$imageLoadMode}
                   noteKind={currentNoteKind}
                 />
@@ -1914,7 +1908,6 @@
             onpreviewrender={handlePreviewRender}
             onnotelinkrequest={openNotePicker}
             onnotelink={handleNoteLink}
-            {resolveNoteTitle}
             imageLoadMode={$imageLoadMode}
             noteKind={currentNoteKind}
           />
@@ -2009,7 +2002,6 @@
                 onpreviewrender={handlePreviewRender}
                 onnotelinkrequest={openNotePicker}
                 onnotelink={handleNoteLink}
-                {resolveNoteTitle}
                 imageLoadMode={$imageLoadMode}
                 noteKind={currentNoteKind}
               />


### PR DESCRIPTION
## Summary

Preview mode rendered internal note links (`[label](note:UUID)`) with the target note's *current title* instead of the authored label, via an "auto-update title" rewrite in `MarkdownPreview`. This clobbered custom labels and heading-anchor link text: `[localhost - smoke test](note:UUID#heading-slug)` showed the note's title, and several links to the same note collapsed to identical text.

Live Preview, the shared snapshot and exported Markdown already render the authored label, so only Preview diverged. This PR makes Preview render the authored label too - what you save is what you see.

**Behaviour change (PO-approved):** this intentionally drops the documented rename-tracking, where a renamed note refreshed its label in Preview. Under plain `[label](note:UUID)` markdown there is no alias separator, so "track the title on rename" and "keep my custom label" are mutually exclusive; the authored label is now the single source of truth, consistent with every other view. If title-tracking is wanted back, the right shape is an Obsidian-style source rewrite on rename (separate feature).

Also removes the now-dead plumbing: the `resolveNoteTitle` prop chain (`MarkdownPreview` -> `NoteContentArea` -> `+page`) and `NoteIndex.getTitle`, which was its sole caller.

## Test plan

- [ ] Open a note with internal links carrying custom labels, e.g. `[localhost - smoke test](note:UUID#some-heading)` and `[my alias](note:UUID)`.
- [ ] Switch to **Preview**: each link shows its **authored label** (not the target note's title), matching **Edit / Live Preview**.
- [ ] Multiple links to the *same* note with different labels stay visually distinct.
- [ ] Clicking a link still navigates to the note (and scrolls to the `#heading` when present).
- [ ] Split view and version-history preview show authored labels too.
- [ ] Shared snapshot / PDF export unchanged (already showed authored labels).

Gate: `nx run reborn-notes:lint check test` all green - lint 0 errors, check 0 errors/0 warnings, 931 tests pass.