### PR TITLE
feat(notes): back/forward navigation between linked notes

### DIFF
--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -7,6 +7,8 @@
     Waypoints,
     ListTree,
     ArrowLeft,
+    ChevronLeft,
+    ChevronRight,
     Lock,
     Loader2,
     CheckCircle2,
@@ -35,6 +37,12 @@
     ontogglelinkednotes,
     outlineActive = false,
     ontoggleoutline,
+    canGoBackNote = false,
+    canGoForwardNote = false,
+    backNoteTitle = '',
+    forwardNoteTitle = '',
+    onnotehistoryback,
+    onnotehistoryforward,
     onback,
     onshowxray,
     onrestore,
@@ -59,6 +67,18 @@
     outlineActive?: boolean;
     /** Toggle the Outline panel (desktop only - mobile uses the kebab menu). */
     ontoggleoutline?: () => void;
+    /** Note-navigation Back availability (drives the Back chevron's enabled state). */
+    canGoBackNote?: boolean;
+    /** Note-navigation Forward availability (drives the Forward chevron's enabled state). */
+    canGoForwardNote?: boolean;
+    /** Title of the note Back would open - shown in the chevron tooltip. */
+    backNoteTitle?: string;
+    /** Title of the note Forward would open - shown in the chevron tooltip. */
+    forwardNoteTitle?: string;
+    /** Go Back one note in the visit trail (desktop chevron). */
+    onnotehistoryback?: () => void;
+    /** Go Forward one note in the visit trail (desktop chevron). */
+    onnotehistoryforward?: () => void;
     onback: () => void;
     onshowxray: () => void;
     onrestore: () => void;
@@ -112,6 +132,40 @@
   >
     <ArrowLeft class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />
   </button>
+
+  <!-- Back / Forward through the note visit trail. Desktop only (mobile uses the
+       edge-swipe and the back-arrow chaining); shown once a trail exists. The
+       `<`/`>` chevrons read as history, distinct from the `←` close arrow. -->
+  {#if !isMobile && (canGoBackNote || canGoForwardNote)}
+    <div class="flex shrink-0 items-center">
+      <button
+        type="button"
+        onclick={onnotehistoryback}
+        disabled={!canGoBackNote}
+        class="flex h-8 w-8 items-center justify-center rounded-md text-foreground
+           hover:bg-accent transition-colors disabled:pointer-events-none disabled:opacity-40"
+        title={canGoBackNote && backNoteTitle
+          ? `${$t('note_nav.back')}: ${backNoteTitle} (Alt+←)`
+          : `${$t('note_nav.back')} (Alt+←)`}
+        aria-label={$t('note_nav.back')}
+      >
+        <ChevronLeft class="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onclick={onnotehistoryforward}
+        disabled={!canGoForwardNote}
+        class="flex h-8 w-8 items-center justify-center rounded-md text-foreground
+           hover:bg-accent transition-colors disabled:pointer-events-none disabled:opacity-40"
+        title={canGoForwardNote && forwardNoteTitle
+          ? `${$t('note_nav.forward')}: ${forwardNoteTitle} (Alt+→)`
+          : `${$t('note_nav.forward')} (Alt+→)`}
+        aria-label={$t('note_nav.forward')}
+      >
+        <ChevronRight class="h-4 w-4" />
+      </button>
+    </div>
+  {/if}
 
   <!-- Small title (shown when large title scrolls out of view) -->
   {#if title}

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -15,6 +15,7 @@ import { noteStore, noteTagStore } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
 import { decryptTitleOnly } from './note.service';
 import { noteLinkGraph } from './note-link-graph.svelte';
+import { noteNavHistory } from './note-nav-history.svelte';
 import type { NoteDecrypted } from '@reborn/types';
 import { evaluate, type QueryAST, type SearchContext, type SearchEntity } from '@reborn/utils';
 
@@ -147,6 +148,10 @@ class NoteIndex {
     this._map.clear();
     this._version++;
     noteLinkGraph.clear();
+    // Navigation trail is session-scoped: drop it on lock/logout so Back can't
+    // walk into another account's notes. NOT cleared on build() (unlock leaves
+    // it empty anyway; a post-import refresh should keep the trail intact).
+    noteNavHistory.clear();
   }
 
   // ── Incremental updates ────────────────────────────────────────

--- a/apps/reborn-notes/src/lib/services/note-nav-history-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/note-nav-history-utils.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptyTrail,
+  recordVisit,
+  stepBack,
+  stepForward,
+  removeFromTrail,
+  currentId,
+  backTargetId,
+  forwardTargetId,
+  MAX_TRAIL,
+  type NavTrail
+} from './note-nav-history-utils';
+
+/** Build a trail by recording a sequence of visits from empty. */
+function trailOf(...ids: string[]): NavTrail {
+  return ids.reduce((t, id) => recordVisit(t, id), emptyTrail());
+}
+
+describe('note-nav-history-utils', () => {
+  it('an empty trail has no current note and no Back/Forward', () => {
+    const t = emptyTrail();
+    expect(currentId(t)).toBeNull();
+    expect(backTargetId(t)).toBeNull();
+    expect(forwardTargetId(t)).toBeNull();
+  });
+
+  it('records visits and tracks the current note', () => {
+    const t = trailOf('a', 'b');
+    expect(currentId(t)).toBe('b');
+    expect(backTargetId(t)).toBe('a');
+    expect(forwardTargetId(t)).toBeNull();
+  });
+
+  it('ignores re-visiting the note already open', () => {
+    const t = recordVisit(trailOf('a'), 'a');
+    expect(t.entries).toEqual(['a']);
+    expect(backTargetId(t)).toBeNull();
+  });
+
+  it('walks Back and Forward along the trail', () => {
+    let t = trailOf('a', 'b', 'c');
+    t = stepBack(t);
+    expect(currentId(t)).toBe('b');
+    t = stepBack(t);
+    expect(currentId(t)).toBe('a');
+    expect(backTargetId(t)).toBeNull();
+    t = stepForward(t);
+    expect(currentId(t)).toBe('b');
+    expect(forwardTargetId(t)).toBe('c');
+  });
+
+  it('truncates the forward trail when a new note is visited after going Back', () => {
+    let t = trailOf('a', 'b', 'c');
+    t = stepBack(t); // at b, c ahead
+    t = recordVisit(t, 'd'); // rewrites the future
+    expect(t.entries).toEqual(['a', 'b', 'd']);
+    expect(currentId(t)).toBe('d');
+    expect(forwardTargetId(t)).toBeNull();
+  });
+
+  it('Back / Forward are no-ops at the ends', () => {
+    const t = trailOf('a');
+    expect(stepBack(t)).toBe(t);
+    expect(stepForward(t)).toBe(t);
+    expect(currentId(stepBack(t))).toBe('a');
+  });
+
+  it('removes every occurrence and keeps the cursor on the same note', () => {
+    const t = removeFromTrail(trailOf('a', 'b', 'c'), 'b'); // cursor was on c
+    expect(t.entries).toEqual(['a', 'c']);
+    expect(currentId(t)).toBe('c');
+    expect(backTargetId(t)).toBe('a');
+  });
+
+  it('removing the current note shifts the cursor back one step', () => {
+    const t = removeFromTrail(trailOf('a', 'b'), 'b'); // cursor was on b
+    expect(t.entries).toEqual(['a']);
+    expect(currentId(t)).toBe('a');
+    expect(forwardTargetId(t)).toBeNull();
+  });
+
+  it('removing a note not in the trail is a no-op', () => {
+    const t = trailOf('a', 'b');
+    expect(removeFromTrail(t, 'zzz')).toBe(t);
+  });
+
+  it('removing every entry empties the trail', () => {
+    const t = removeFromTrail(trailOf('a'), 'a');
+    expect(t.entries).toEqual([]);
+    expect(t.cursor).toBe(-1);
+    expect(currentId(t)).toBeNull();
+  });
+
+  it('caps the trail length, dropping the oldest entries', () => {
+    let t = emptyTrail();
+    for (let i = 0; i < MAX_TRAIL + 25; i++) t = recordVisit(t, `n${i}`);
+    expect(t.entries.length).toBe(MAX_TRAIL);
+    expect(currentId(t)).toBe(`n${MAX_TRAIL + 24}`); // newest kept
+    expect(t.entries[0]).toBe('n25'); // oldest 25 dropped
+  });
+
+  it('treats input trails as immutable (returns new objects)', () => {
+    const t0 = trailOf('a', 'b');
+    const t1 = recordVisit(t0, 'c');
+    expect(t0.entries).toEqual(['a', 'b']);
+    expect(t1.entries).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/note-nav-history-utils.ts
+++ b/apps/reborn-notes/src/lib/services/note-nav-history-utils.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure trail logic for note Back/Forward navigation - the stack + cursor math,
+ * free of runes/state so it is unit-testable (mirrors the note-link-utils ↔
+ * note-link-graph split). The reactive wrapper lives in
+ * `note-nav-history.svelte.ts`.
+ *
+ * A trail is a list of visited note ids (oldest → newest) plus a cursor index
+ * into it (-1 when empty). All operations are immutable: they return a new
+ * trail, never mutating the input.
+ */
+
+export interface NavTrail {
+  /** Visited note ids, oldest → newest. */
+  readonly entries: readonly string[];
+  /** Index of the current note within `entries` (-1 when empty). */
+  readonly cursor: number;
+}
+
+/** Cap the trail so a long session can't grow it without bound. */
+export const MAX_TRAIL = 100;
+
+export function emptyTrail(): NavTrail {
+  return { entries: [], cursor: -1 };
+}
+
+export function currentId(t: NavTrail): string | null {
+  return t.entries[t.cursor] ?? null;
+}
+
+/** Id Back would land on, or null if there is nothing behind the cursor. */
+export function backTargetId(t: NavTrail): string | null {
+  return t.cursor > 0 ? t.entries[t.cursor - 1] : null;
+}
+
+/** Id Forward would land on, or null if the cursor is at the newest entry. */
+export function forwardTargetId(t: NavTrail): string | null {
+  return t.cursor < t.entries.length - 1 ? t.entries[t.cursor + 1] : null;
+}
+
+/**
+ * Record a visit to `id`. Truncates any forward entries first (a new visit
+ * after going Back rewrites the future, like a browser), caps the length, and
+ * no-ops when `id` is already the current entry (re-opening the open note).
+ */
+export function recordVisit(t: NavTrail, id: string): NavTrail {
+  if (t.entries[t.cursor] === id) return t;
+  const kept = t.entries.slice(0, t.cursor + 1);
+  kept.push(id);
+  const overflow = kept.length - MAX_TRAIL;
+  const entries = overflow > 0 ? kept.slice(overflow) : kept;
+  return { entries, cursor: entries.length - 1 };
+}
+
+/** Move the cursor back one step (no-op at the start of the trail). */
+export function stepBack(t: NavTrail): NavTrail {
+  return backTargetId(t) === null ? t : { entries: t.entries, cursor: t.cursor - 1 };
+}
+
+/** Move the cursor forward one step (no-op at the newest entry). */
+export function stepForward(t: NavTrail): NavTrail {
+  return forwardTargetId(t) === null ? t : { entries: t.entries, cursor: t.cursor + 1 };
+}
+
+/**
+ * Drop every occurrence of `id` (note permanently deleted) and shift the cursor
+ * so it keeps pointing at the same logical note.
+ */
+export function removeFromTrail(t: NavTrail, id: string): NavTrail {
+  if (!t.entries.includes(id)) return t;
+  const removedUpToCursor = t.entries.slice(0, t.cursor + 1).filter((e) => e === id).length;
+  const entries = t.entries.filter((e) => e !== id);
+  const cursor = Math.max(-1, Math.min(t.cursor - removedUpToCursor, entries.length - 1));
+  return { entries, cursor };
+}

--- a/apps/reborn-notes/src/lib/services/note-nav-history.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-nav-history.svelte.ts
@@ -1,0 +1,126 @@
+/**
+ * NoteNavHistory - in-memory Back/Forward navigation stack for note visits.
+ *
+ * A browser-like history of opened notes: every time a note becomes the active
+ * note (picked from the list or followed through an internal `note:UUID` link)
+ * it is recorded; Back / Forward walk that trail. Powers the header chevrons,
+ * the Alt+Arrow shortcuts, and the mobile edge-swipe / back-arrow chaining.
+ *
+ * This is the reactive wrapper around the pure trail logic in
+ * `note-nav-history-utils.ts`. Following NoteLinkGraph, the trail itself is a
+ * plain (non-reactive) value and a `_version` signal is bumped on every change
+ * so reactive readers re-run; the pure logic stays unit-testable without runes.
+ *
+ * NB: this is NAVIGATION history (which notes you visited), distinct from the
+ * per-note VERSION history (`noteHistoryOperations`, `VersionHistorySheet`,
+ * `historyMode`). Hence the `Nav` in the name.
+ *
+ * Security / Zero-Knowledge:
+ *   - RAM-only. NEVER persisted to IndexedDB/localStorage/sessionStorage and
+ *     NEVER sent to the server. The trail is a list of note UUIDs (already
+ *     server-visible as foreign keys) plus per-note scroll offsets - no
+ *     plaintext content, no new correlation signal beyond what the server
+ *     already stores. Lifecycle mirrors NoteLinkGraph: cleared on lock/logout
+ *     (via `noteIndex.clear()`), pruned when a note is permanently removed.
+ *   - Not persisted by design: a visit trail is session navigation state, not
+ *     user data. It resets on reload, like a fresh browser tab's history.
+ */
+import {
+  emptyTrail,
+  recordVisit,
+  stepBack,
+  stepForward,
+  removeFromTrail,
+  currentId,
+  backTargetId,
+  forwardTargetId,
+  type NavTrail
+} from './note-nav-history-utils';
+
+class NoteNavHistory {
+  /** Plain (non-reactive) trail; `_version` signals changes to reactive readers. */
+  private _trail: NavTrail = emptyTrail();
+  /** Svelte 5 reactive version counter - consumers re-render on bump. */
+  private _version = $state(0);
+  /**
+   * Per-note scroll offset, so Back restores the reading position. Keyed by
+   * note id (not stack position) so a note revisited twice shares its
+   * last-known scroll. Non-reactive - read/written imperatively on navigation.
+   */
+  private _scroll = new Map<string, number>();
+
+  // ── Reads (reactive) ────────────────────────────────────────────
+
+  get current(): string | null {
+    void this._version;
+    return currentId(this._trail);
+  }
+
+  get backTargetId(): string | null {
+    void this._version;
+    return backTargetId(this._trail);
+  }
+
+  get forwardTargetId(): string | null {
+    void this._version;
+    return forwardTargetId(this._trail);
+  }
+
+  get canGoBack(): boolean {
+    return this.backTargetId !== null;
+  }
+
+  get canGoForward(): boolean {
+    return this.forwardTargetId !== null;
+  }
+
+  // ── Navigation ──────────────────────────────────────────────────
+
+  /** Record a visit to `id` (truncates forward entries, like a browser). */
+  visit(id: string): void {
+    this._trail = recordVisit(this._trail, id);
+    this._version++;
+  }
+
+  /** Move the cursor back one step; returns the now-current id (or null). */
+  back(): string | null {
+    this._trail = stepBack(this._trail);
+    this._version++;
+    return this.current;
+  }
+
+  /** Move the cursor forward one step; returns the now-current id (or null). */
+  forward(): string | null {
+    this._trail = stepForward(this._trail);
+    this._version++;
+    return this.current;
+  }
+
+  // ── Scroll memory ───────────────────────────────────────────────
+
+  saveScroll(id: string, top: number): void {
+    this._scroll.set(id, top);
+  }
+
+  getScroll(id: string): number {
+    return this._scroll.get(id) ?? 0;
+  }
+
+  // ── Maintenance ─────────────────────────────────────────────────
+
+  /** Drop every entry for `id` (note permanently deleted / emptied from trash). */
+  remove(id: string): void {
+    this._trail = removeFromTrail(this._trail, id);
+    this._scroll.delete(id);
+    this._version++;
+  }
+
+  /** Wipe the whole trail (lock / logout / vault refresh). */
+  clear(): void {
+    this._trail = emptyTrail();
+    this._scroll.clear();
+    this._version++;
+  }
+}
+
+export const noteNavHistory = new NoteNavHistory();

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -19,6 +19,7 @@ import { get } from 'svelte/store';
 import { authStore } from '$lib/stores/auth.store';
 import { noteIndex } from '$lib/services/note-index.svelte';
 import { noteLinkGraph } from '$lib/services/note-link-graph.svelte';
+import { noteNavHistory } from '$lib/services/note-nav-history.svelte';
 import {
   pushNote,
   pushNoteUpdate,
@@ -504,6 +505,7 @@ export async function permanentlyDeleteNote(id: string): Promise<void> {
   await noteStore.delete(id);
   noteIndex.remove(id);
   noteLinkGraph.onNoteRemoved(id);
+  noteNavHistory.remove(id);
   pushNoteDelete(id, true);
 }
 
@@ -522,6 +524,7 @@ export async function emptyTrash(): Promise<number> {
   for (const n of archived) {
     noteIndex.remove(n.id);
     noteLinkGraph.onNoteRemoved(n.id);
+    noteNavHistory.remove(n.id);
   }
 
   // Push permanent deletes to server (fire-and-forget, skip never-synced notes)

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -75,6 +75,7 @@
   import { t } from '$lib/stores/i18n.store';
   import { noteDetailService } from '$lib/services/note-detail.service.svelte';
   import { noteIndex } from '$lib/services/note-index.svelte';
+  import { noteNavHistory } from '$lib/services/note-nav-history.svelte';
   import { tagManager } from '$lib/services/tag-manager.svelte';
   import { toastStore } from '@reborn/ui';
   import {
@@ -507,7 +508,11 @@
     const dx = e.changedTouches[0].clientX - swipeStartX;
     const dy = Math.abs(e.changedTouches[0].clientY - swipeStartY);
     if (dx > 80 && dy < 50) {
-      if (isMobile && mobileHistoryDepth > 0) {
+      // Walk the note visit trail first (C→B→A); only once it's exhausted does
+      // the swipe fall through to closing the note / popping the mobile history.
+      if ($activeNoteId != null && noteNavHistory.canGoBack) {
+        goBackNote();
+      } else if (isMobile && mobileHistoryDepth > 0) {
         history.back();
       } else {
         await noteDetailService.flushAndSnapshot();
@@ -941,6 +946,77 @@
   // slug with its note id keeps a stale anchor from firing on an unrelated note.
   let pendingAnchor = $state<{ noteId: string; slug: string } | null>(null);
 
+  // ── Note navigation history (Back / Forward between notes) ───────
+  // Browser-like trail of visited notes. The recorder $effect (declared just
+  // above the scroll-reset effect) records every note that becomes active and
+  // captures the outgoing note's scroll; Back/Forward move the cursor and ask
+  // for a scroll restore. `suppressHistoryRecord` marks an activeNoteId change
+  // that came from Back/Forward itself, so it isn't recorded as a new visit.
+  let suppressHistoryRecord = false;
+  let prevHistoryNoteId: string | null = null;
+  let pendingScrollRestore = $state<{ noteId: string; top: number } | null>(null);
+
+  const backNoteTitle = $derived(
+    noteNavHistory.backTargetId ? (noteIndex.get(noteNavHistory.backTargetId)?.title ?? '') : ''
+  );
+  const forwardNoteTitle = $derived(
+    noteNavHistory.forwardTargetId
+      ? (noteIndex.get(noteNavHistory.forwardTargetId)?.title ?? '')
+      : ''
+  );
+
+  /** The scroll container that actually scrolls the open note, per view mode. */
+  function activeNoteScrollEl(): HTMLElement | null {
+    if (isMobile) return mobileScrollContainer ?? null;
+    if (effectiveViewMode === 'split') return previewScrollEl ?? null;
+    if (effectiveViewMode === 'edit') return editorView?.scrollDOM ?? desktopEditorScrollContainer ?? null;
+    return desktopEditorScrollContainer ?? null; // preview
+  }
+
+  /** Apply a pending Back/Forward scroll restore once the target note is laid out. */
+  function applyPendingScrollRestore() {
+    const target = pendingScrollRestore;
+    if (!target || target.noteId !== $activeNoteId) return;
+    const el = activeNoteScrollEl();
+    if (el) el.scrollTop = target.top;
+    pendingScrollRestore = null;
+  }
+
+  /** Step the navigation trail to a validated target and restore its scroll. */
+  async function navigateNavHistory(dir: 'back' | 'forward') {
+    const targetId = dir === 'back' ? noteNavHistory.backTargetId : noteNavHistory.forwardTargetId;
+    if (!targetId) return;
+    await noteDetailService.flushAndSnapshot();
+    const note = await notesStore.loadNote(targetId);
+    if (!note) {
+      toastStore.error($t('notes.note_not_found'));
+      noteNavHistory.remove(targetId); // broken entry - drop so it's skipped next time
+      return;
+    }
+    if (note.is_archived) {
+      toastStore.info($t('notes.note_in_trash'));
+      noteNavHistory.remove(targetId);
+      return;
+    }
+    // Commit the cursor move now that the target is known-good.
+    if (dir === 'back') noteNavHistory.back();
+    else noteNavHistory.forward();
+    suppressHistoryRecord = true;
+    pendingScrollRestore = { noteId: targetId, top: noteNavHistory.getScroll(targetId) };
+    activeNoteId.set(targetId);
+    // Preview/split restore via handlePreviewRender; edit-only has no render
+    // callback, so nudge a restore on the next frame as well (idempotent - the
+    // first apply clears the pending state).
+    tick().then(() => requestAnimationFrame(applyPendingScrollRestore));
+  }
+
+  function goBackNote() {
+    void navigateNavHistory('back');
+  }
+  function goForwardNote() {
+    void navigateNavHistory('forward');
+  }
+
   async function handleNoteLink(noteId: string, anchor?: string) {
     await noteDetailService.flushAndSnapshot();
     const note = await notesStore.loadNote(noteId);
@@ -1053,6 +1129,24 @@
     return isMobile ? mobileScrollContainer : desktopEditorScrollContainer;
   });
 
+  // Record note visits for Back/Forward navigation and capture the OUTGOING
+  // note's scroll position before the reset effect below zeroes it. Declared
+  // before that effect so it runs first on each $activeNoteId change. Reads
+  // refs/mode inside untrack so it depends only on $activeNoteId (mirrors the
+  // reset effect's reasoning).
+  $effect(() => {
+    const id = $activeNoteId;
+    untrack(() => {
+      if (prevHistoryNoteId != null) {
+        const el = activeNoteScrollEl();
+        if (el) noteNavHistory.saveScroll(prevHistoryNoteId, el.scrollTop);
+      }
+      if (id != null && !suppressHistoryRecord) noteNavHistory.visit(id);
+      suppressHistoryRecord = false;
+      prevHistoryNoteId = id;
+    });
+  });
+
   // Reset both the abstract anchor AND the parent scroll container's
   // scrollTop whenever we open a different note. NoteEditor/MarkdownPreview
   // are not remounted on note change (they just receive a new content prop),
@@ -1073,6 +1167,9 @@
       // note to its heading, and a competing scrollTop=0 (effect order is not
       // guaranteed) would land us back at the top.
       if (pendingAnchor?.noteId === navId && navId != null) return;
+      // Same deferral for a Back/Forward scroll restore - applyPendingScrollRestore
+      // sets the saved offset after render; zeroing here would fight it.
+      if (pendingScrollRestore?.noteId === navId && navId != null) return;
       if (desktopEditorScrollContainer) desktopEditorScrollContainer.scrollTop = 0;
       if (mobileScrollContainer) mobileScrollContainer.scrollTop = 0;
       if (previewScrollEl) previewScrollEl.scrollTop = 0;
@@ -1122,6 +1219,8 @@
   function handlePreviewRender() {
     scrollSync.refresh();
     previewRenderTick++;
+    // Restore a Back/Forward scroll position once the target note has rendered.
+    applyPendingScrollRestore();
     // Consume a pending cross-note heading anchor once its note has rendered.
     // Clear it on a note mismatch (a different note rendered first) so a stale
     // anchor never fires on an unrelated note.
@@ -1379,6 +1478,23 @@
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
       activeSection = 'search';
+      return;
+    }
+    // Alt+Left / Alt+Right - Back / Forward between visited notes. Ignored when
+    // focus is in the editor (there Alt+Arrow is CM6 word navigation) and only
+    // while a note is open. Other modifiers excluded so it can't shadow combos.
+    if (
+      e.altKey &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.shiftKey &&
+      (e.key === 'ArrowLeft' || e.key === 'ArrowRight') &&
+      $activeNoteId != null &&
+      !(e.target as HTMLElement | null)?.closest('.cm-editor')
+    ) {
+      e.preventDefault();
+      if (e.key === 'ArrowLeft') goBackNote();
+      else goForwardNote();
     }
   }}
 />
@@ -1655,8 +1771,16 @@
               ontogglelinkednotes={toggleLinkedNotes}
               outlineActive={outlineOpen}
               ontoggleoutline={toggleOutline}
+              canGoBackNote={noteNavHistory.canGoBack}
+              canGoForwardNote={noteNavHistory.canGoForward}
+              {backNoteTitle}
+              {forwardNoteTitle}
+              onnotehistoryback={goBackNote}
+              onnotehistoryforward={goForwardNote}
               onback={() => {
-                if (isMobile && mobileHistoryDepth > 0) {
+                if (noteNavHistory.canGoBack) {
+                  goBackNote();
+                } else if (isMobile && mobileHistoryDepth > 0) {
                   history.back();
                 } else {
                   activeNoteId.set(null);
@@ -1922,6 +2046,12 @@
             ontogglelinkednotes={toggleLinkedNotes}
             outlineActive={outlineOpen}
             ontoggleoutline={toggleOutline}
+            canGoBackNote={noteNavHistory.canGoBack}
+            canGoForwardNote={noteNavHistory.canGoForward}
+            {backNoteTitle}
+            {forwardNoteTitle}
+            onnotehistoryback={goBackNote}
+            onnotehistoryforward={goForwardNote}
             onback={() => activeNoteId.set(null)}
             onshowxray={() => {
               showEncryptionXRay = true;

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -646,6 +646,10 @@
     "incoming_count": "Eingehende Links: {count}",
     "outgoing_count": "Ausgehende Links: {count}"
   },
+  "note_nav": {
+    "back": "Vorherige Notiz",
+    "forward": "Nächste Notiz"
+  },
   "outline": {
     "title": "Gliederung",
     "empty": "Diese Notiz hat noch keine Überschriften."

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -646,6 +646,10 @@
     "incoming_count": "Incoming links: {count}",
     "outgoing_count": "Outgoing links: {count}"
   },
+  "note_nav": {
+    "back": "Previous note",
+    "forward": "Next note"
+  },
   "outline": {
     "title": "Outline",
     "empty": "No headings in this note yet."

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -646,6 +646,10 @@
     "incoming_count": "Enlaces entrantes: {count}",
     "outgoing_count": "Enlaces salientes: {count}"
   },
+  "note_nav": {
+    "back": "Nota anterior",
+    "forward": "Nota siguiente"
+  },
   "outline": {
     "title": "Esquema",
     "empty": "Esta nota aún no tiene encabezados."

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -646,6 +646,10 @@
     "incoming_count": "Liens entrants : {count}",
     "outgoing_count": "Liens sortants : {count}"
   },
+  "note_nav": {
+    "back": "Note précédente",
+    "forward": "Note suivante"
+  },
   "outline": {
     "title": "Plan",
     "empty": "Cette note n'a pas encore de titres."

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -646,6 +646,10 @@
     "incoming_count": "Linki przychodzące: {count}",
     "outgoing_count": "Linki wychodzące: {count}"
   },
+  "note_nav": {
+    "back": "Poprzednia notatka",
+    "forward": "Następna notatka"
+  },
   "outline": {
     "title": "Konspekt",
     "empty": "Ta notatka nie ma jeszcze nagłówków."


### PR DESCRIPTION
## Summary

Adds browser-like Back/Forward navigation between notes. After following internal `note:UUID` links (A->B->C), you can step back C->B->A and forward again - completing the internal-linking feature (the Linked-notes panel previously only offered manual, multi-click backlink hopping, losing scroll and direction).

Three surfaces (all requested):
- **Keyboard** `Alt+Left` / `Alt+Right`. Guarded against editor focus (in CodeMirror `Alt+Arrow` is word navigation), so it acts in reading/preview mode where links are followed; only active while a note is open.
- **Desktop header**: a `<` `>` chevron pair next to the close arrow (visually distinct from the `<-` close), shown once a trail exists, each disabled per availability, tooltip = target note title + shortcut.
- **Mobile**: the edge-swipe-back gesture and the header back-arrow walk the note trail first (C->B->A), then fall back to the existing close-to-list / `history.back()` behavior.

**Back restores scroll position** (decision: in v1) - you return to where you were reading in the previous note.

### Design / decisions
- Both decisions agreed up front: `Alt+Left/Right` over `Cmd+[`/`]`, and scroll-restore in v1. Opening a note from the list also counts as a history step (browser-like).
- **Architecture**: pure stack/cursor logic in `note-nav-history-utils.ts` (immutable `NavTrail`, unit-tested) behind a thin runes wrapper `note-nav-history.svelte.ts` (`noteNavHistory`, `_version` signal + scroll `Map`), mirroring the existing `note-link-utils` / `note-link-graph` split. Named `Nav` to distinguish from note *version* history.
- **Single chokepoint**: one `$effect` on `$activeNoteId` records visits and captures the outgoing note's scroll (instead of touching ~6 `activeNoteId.set` sites); Back/Forward are flagged so they aren't re-recorded.
- **Zero-Knowledge: unchanged.** The trail is a list of note UUIDs (already server-visible foreign keys) plus scroll offsets - RAM-only, never persisted or synced, no plaintext, no new correlation signal. Cleared on lock/logout, pruned on permanent delete; trashed/missing targets are skipped with a toast.
- **Deferred (P3)**: hardware Android back (Capacitor) and browser `popstate` on mobile-web do not yet walk the note trail (swipe + header arrow do) - would require pushState-per-jump or `backButton.setHandler`, kept out of v1 to avoid destabilizing the existing mobile-history trampoline.

## Test plan

Quality gates (green): `svelte-check` 0/0 (5511 files), `eslint` 0 errors, `vitest` +12 new `note-nav-history-utils` tests + 426 existing service tests pass, i18n parity PASSED (`note_nav.{back,forward}` x5 locales).

Smoke (please verify):
- [ ] Desktop: open note A, follow a link to B, then to C. Header shows `<`/`>`. Click `<` (or press `Alt+Left`) -> returns to B, then to A; `Alt+Right` goes forward.
- [ ] Scroll down in a long note, follow a link, press Back -> returns to the previous note at the same scroll offset.
- [ ] `Alt+Left` while editing (cursor in the editor) does NOT navigate - it moves the cursor by word (editor-focus guard). Use the chevrons there.
- [ ] Following a new link after going Back truncates the forward trail (forward chevron disables).
- [ ] Mobile: A->B->C via links, then edge-swipe right (or tap the header back arrow) -> C->B->A, and only after the trail is exhausted does it close to the list.
- [ ] Permanently delete a note that is in your trail, then Back/Forward past it -> it is skipped; a trashed target shows the "in trash" toast.
- [ ] Lock/logout then back in: the trail is empty (no cross-session leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)