### PR TITLE
fix(settings): localize task file picker, drop notes folder-sync dupe

### DIFF
--- a/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/import-export/+page.svelte
@@ -14,16 +14,13 @@
     Upload,
     FolderArchive,
     FolderInput,
-    FolderSync,
     FileJson,
     FileText,
     KeyRound,
     Eye,
     EyeOff,
-    AlertTriangle,
-    ChevronRight
+    AlertTriangle
   } from '@lucide/svelte';
-  import { resolve } from '$app/paths';
   import { t } from '$lib/stores/i18n.store';
   import { foldersStore } from '$lib/stores/folders.store';
   import { tagsStore } from '$lib/stores/tags.store';
@@ -780,23 +777,6 @@
             <ImportResultSummary result={folderImportResult} class="mt-3" />
           {/if}
         </div>
-
-        <!-- Live folder sync moved to its own settings page (multi-folder) -->
-        <a
-          href={resolve('/settings/folder-sync')}
-          class="flex items-center gap-3 rounded-lg border bg-muted/30 p-4 transition-colors hover:bg-accent/50"
-        >
-          <FolderSync class="h-4 w-4 shrink-0 text-muted-foreground" />
-          <div class="min-w-0 flex-1">
-            <p class="text-sm font-medium">
-              {$t('settings_page.export_import.folder_sync_title')}
-            </p>
-            <p class="text-xs text-muted-foreground">
-              {$t('settings_page.export_import.folder_sync_hub_desc')}
-            </p>
-          </div>
-          <ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
-        </a>
 
         <!-- Import JSON backup -->
         <div class="p-4 rounded-lg border bg-muted/30">

--- a/apps/reborn-task/src/lib/services/import-summary-i18n.regression.spec.ts
+++ b/apps/reborn-task/src/lib/services/import-summary-i18n.regression.spec.ts
@@ -11,9 +11,11 @@ import { resolve } from 'path';
  * list) that showed Polish to every locale. The decrypted-export warning block
  * (title, body, "export anyway"/"cancel" buttons) plus the export and import
  * button loading labels (each a `{$t('common.loading') || 'Polish...'}` fallback)
- * had the same problem. This locks all of those via source assertions, with no
- * runtime import of the page's heavy dependency graph. Mirrors
- * `data-import.regression.spec.ts`. See guideline 44.
+ * had the same problem. The bare file `<input>` was a third leak: it rendered
+ * browser-locale chrome ("Wybierz plik"), now hidden behind a localized button.
+ * This locks all of those via source assertions, with no runtime import of the
+ * page's heavy dependency graph. Mirrors `data-import.regression.spec.ts`. See
+ * guideline 44.
  */
 function readSource(relative: string): string {
 	return readFileSync(resolve(__dirname, relative), 'utf-8');
@@ -57,6 +59,16 @@ describe('reborn-task export & import action labels - i18n (regression)', () => 
 	it('localizes the export and import loading labels', () => {
 		expect(page).toMatch(/import_export\.exporting'/);
 		expect(page).toMatch(/import_export\.importing'/);
+	});
+
+	it('hides the native file input behind a localized picker button', () => {
+		// A bare <input type="file"> renders browser-locale chrome ("Wybierz plik"
+		// / "Nie wybrano pliku"); hide it (sr-only) and drive selection from a
+		// localized Button + filename label instead, so no Polish leaks via the OS.
+		expect(page).toMatch(/type="file"[\s\S]{0,200}?class="sr-only"/);
+		expect(page).toMatch(/import_export\.import_select_file'/);
+		expect(page).toMatch(/import_export\.import_no_file'/);
+		expect(page).not.toMatch(/file:bg-background/); // old native-button styling
 	});
 
 	it('drops every hardcoded `|| Polish` fallback on loading labels', () => {

--- a/apps/reborn-task/src/routes/settings/import-export/+page.svelte
+++ b/apps/reborn-task/src/routes/settings/import-export/+page.svelte
@@ -409,17 +409,20 @@
 				{/if}
 
 				<div class="flex flex-col sm:flex-row gap-3">
-					<div class="flex-1">
+					<div class="flex flex-1 items-center gap-3 min-w-0">
 						<input
 							bind:this={fileInput}
 							type="file"
 							accept=".json"
 							onchange={handleFileChange}
-							class="block w-full text-sm text-muted-foreground
-								file:mr-4 file:py-2 file:px-4 file:rounded-md file:border file:border-input
-								file:text-sm file:font-medium file:bg-background file:text-foreground
-								hover:file:bg-muted cursor-pointer"
+							class="sr-only"
 						/>
+						<Button variant="outline" onclick={() => fileInput?.click()} class="shrink-0">
+							{$t('settings.import_export.import_select_file')}
+						</Button>
+						<span class="truncate text-sm text-muted-foreground">
+							{importFile ? importFile.name : $t('settings.import_export.import_no_file')}
+						</span>
 					</div>
 					<Button
 						onclick={handleImport}

--- a/packages/i18n/src/translations/tasks/de/settings.json
+++ b/packages/i18n/src/translations/tasks/de/settings.json
@@ -299,6 +299,7 @@
     "import_section_title": "Aus Datei importieren",
     "import_section_description": "Importieren Sie Daten aus einer JSON-Datei, die aus dieser App exportiert wurde. Neue Eintr\u00e4ge werden hinzugef\u00fcgt; bestehende aktualisiert, wenn die importierte Version neuer ist.",
     "import_select_file": "JSON-Datei ausw\u00e4hlen",
+    "import_no_file": "Keine Datei ausgew\u00e4hlt",
     "import_button": "Importieren",
     "import_success": "Import abgeschlossen: {lists} Listen, {tasks} Aufgaben, {subtasks} Teilaufgaben",
     "import_skipped_note": "{count} Elemente übersprungen (neuere lokale Versionen).",

--- a/packages/i18n/src/translations/tasks/en/settings.json
+++ b/packages/i18n/src/translations/tasks/en/settings.json
@@ -299,6 +299,7 @@
     "import_section_title": "Import from File",
     "import_section_description": "Import data from a JSON file exported from this app. New items will be added; existing ones updated if the imported version is newer.",
     "import_select_file": "Select JSON file",
+    "import_no_file": "No file selected",
     "import_button": "Import",
     "import_success": "Import complete: {lists} lists, {tasks} tasks, {subtasks} subtasks",
     "import_skipped_note": "Skipped {count} items (newer local versions).",

--- a/packages/i18n/src/translations/tasks/es/settings.json
+++ b/packages/i18n/src/translations/tasks/es/settings.json
@@ -299,6 +299,7 @@
     "import_section_title": "Importar desde archivo",
     "import_section_description": "Importe datos desde un archivo JSON exportado de esta aplicación. Los nuevos elementos se añadirán; los existentes se actualizarán si la versión importada es más reciente.",
     "import_select_file": "Seleccionar archivo JSON",
+    "import_no_file": "Ningún archivo seleccionado",
     "import_button": "Importar",
     "import_success": "Importación completa: {lists} listas, {tasks} tareas, {subtasks} subtareas",
     "import_skipped_note": "{count} elementos omitidos (versiones locales más recientes).",

--- a/packages/i18n/src/translations/tasks/fr/settings.json
+++ b/packages/i18n/src/translations/tasks/fr/settings.json
@@ -299,6 +299,7 @@
     "import_section_title": "Importer depuis un fichier",
     "import_section_description": "Importez les donn\u00e9es d'un fichier JSON export\u00e9 depuis cette application. Les nouveaux \u00e9l\u00e9ments seront ajout\u00e9s ; les \u00e9l\u00e9ments existants seront mis \u00e0 jour si la version import\u00e9e est plus r\u00e9cente.",
     "import_select_file": "S\u00e9lectionner un fichier JSON",
+    "import_no_file": "Aucun fichier s\u00e9lectionn\u00e9",
     "import_button": "Importer",
     "import_skipped_note": "{count} éléments ignorés (versions locales plus récentes).",
     "import_errors_title": "Erreurs d'import ({count}) :",

--- a/packages/i18n/src/translations/tasks/pl/settings.json
+++ b/packages/i18n/src/translations/tasks/pl/settings.json
@@ -299,6 +299,7 @@
     "import_section_title": "Import z pliku",
     "import_section_description": "Importuj dane z pliku JSON wyeksportowanego z tej aplikacji. Nowe elementy zostaną dodane; istniejące zaktualizowane (jeśli importowana wersja jest nowsza).",
     "import_select_file": "Wybierz plik JSON",
+    "import_no_file": "Nie wybrano pliku",
     "import_button": "Importuj",
     "import_success": "Import zakończony: {lists} list, {tasks} zadań, {subtasks} podzadań",
     "import_skipped_note": "Pominięto {count} elementów (nowsze lokalne wersje).",


### PR DESCRIPTION
## Summary

Two import-export settings cleanups from screenshots, one per app:

**re/task - localize the file picker** (`8a30fc5`)
The import file selector was a bare `<input type="file">`, so the browser rendered its own chrome ("Wybierz plik" / "Nie wybrano pliku") in the *browser's* language, not the app's - Polish leaked to every non-PL user. Now the native input is hidden (`sr-only`) and selection is driven from a localized `Button` (existing `import_select_file`) plus a filename label that falls back to a new `import_no_file` key. New key across the 5 task locales; parity passes.

**re/notes - drop the duplicate Folder sync entry** (`6e63c39`)
Folder sync has its own dedicated settings page (`/settings/folder-sync`), already linked from the main settings list. The leftover entry on the import-export page was redundant, so it is removed (along with the now-unused `FolderSync` / `ChevronRight` / `resolve` imports). The shared i18n keys stay - the main settings list still references them. The feature stays reachable; nothing orphaned.

The two commits are independent (different apps, no shared files) - squash is fine, or use a merge-commit to keep both as separate changelog entries.

## Test plan

- `nx run-many -t check -p reborn-task reborn-notes` - svelte-check 0 errors / 0 warnings (both)
- `nx run reborn-task:test` - 81 passed (regression spec asserts the native input is hidden + picker localized)
- `nx run-many -t test -p reborn-task reborn-notes` - task 81, notes 947
- `nx run-many -t lint -p reborn-task reborn-notes` - 0 errors (both)
- `nx run-many -t build -p reborn-task reborn-notes` - success (both)
- `node scripts/check-i18n-parity.mjs` - PASSED
- Smoke (re/task, non-PL locale): Settings -> Import & Export; the file picker shows "Select JSON file" + "No file selected" in the active language, and a chosen filename appears beside the button.
- Smoke (re/notes): Settings -> Import & Export no longer lists "Folder sync"; it is still reachable from the main Settings list.