### PR TITLE
fix(notes): remap note links on portable cross-account import

### DIFF
--- a/apps/reborn-notes/src/lib/services/note-link-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-utils.spec.ts
@@ -4,6 +4,7 @@ import {
   escapeLinkLabel,
   extractNoteLinkTargets,
   intersectIds,
+  remapNoteLinks,
   simplifySelfNoteLinks
 } from './note-link-utils';
 
@@ -63,6 +64,59 @@ describe('extractNoteLinkTargets', () => {
   it('returns an empty set for empty or link-free content', () => {
     expect(extractNoteLinkTargets('').size).toBe(0);
     expect(extractNoteLinkTargets('Plain text, no links.').size).toBe(0);
+  });
+});
+
+describe('remapNoteLinks', () => {
+  const NEW_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const NEW_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  it('rewrites a link target to its new id, keeping the label', () => {
+    const map = new Map([[A, NEW_A]]);
+    expect(remapNoteLinks(`See [Note A](note:${A}).`, map)).toBe(`See [Note A](note:${NEW_A}).`);
+  });
+
+  it('preserves a #heading anchor while swapping the id', () => {
+    const map = new Map([[A, NEW_A]]);
+    expect(remapNoteLinks(`[Sec](note:${A}#section)`, map)).toBe(`[Sec](note:${NEW_A}#section)`);
+  });
+
+  it('remaps every link, each to its own new id', () => {
+    const map = new Map([
+      [A, NEW_A],
+      [B, NEW_B]
+    ]);
+    expect(remapNoteLinks(`[a](note:${A}) and [b](note:${B})`, map)).toBe(
+      `[a](note:${NEW_A}) and [b](note:${NEW_B})`
+    );
+  });
+
+  it('leaves a link whose target is not in the map untouched (dangling)', () => {
+    // B is not in the map - a link to a note outside the backup stays verbatim.
+    const map = new Map([[A, NEW_A]]);
+    expect(remapNoteLinks(`[a](note:${A}) [b](note:${B})`, map)).toBe(
+      `[a](note:${NEW_A}) [b](note:${B})`
+    );
+  });
+
+  it('is case-insensitive on the id (uppercase link, lowercase map key)', () => {
+    const map = new Map([[A, NEW_A]]);
+    expect(remapNoteLinks(`[a](note:${A.toUpperCase()})`, map)).toBe(`[a](note:${NEW_A})`);
+  });
+
+  it('does not touch a bare note: mention that is not a link destination', () => {
+    const map = new Map([[A, NEW_A]]);
+    expect(remapNoteLinks(`ref note:${A} inline`, map)).toBe(`ref note:${A} inline`);
+  });
+
+  it('ignores malformed UUIDs', () => {
+    const map = new Map([[A, NEW_A]]);
+    expect(remapNoteLinks(`[bad](note:not-a-uuid)`, map)).toBe(`[bad](note:not-a-uuid)`);
+  });
+
+  it('returns content unchanged for empty content or empty map', () => {
+    expect(remapNoteLinks('', new Map([[A, NEW_A]]))).toBe('');
+    expect(remapNoteLinks(`[a](note:${A})`, new Map())).toBe(`[a](note:${A})`);
   });
 });
 

--- a/apps/reborn-notes/src/lib/services/note-link-utils.ts
+++ b/apps/reborn-notes/src/lib/services/note-link-utils.ts
@@ -30,6 +30,38 @@ export function extractNoteLinkTargets(content: string, selfId?: string): Set<st
 }
 
 /**
+ * Same `[label](note:UUID#anchor)` shape as {@link NOTE_LINK_TARGET_RE}, but
+ * split into three capture groups - the `](note:` prefix, the bare UUID, and the
+ * trailing `#anchor)` (or bare `)`) - so {@link remapNoteLinks} can swap just the
+ * id and rebuild the link verbatim.
+ */
+const NOTE_LINK_REWRITE_RE =
+  /(\]\(note:)([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})((?:#[^)]*)?\))/gi;
+
+/**
+ * Rewrite the target of every `[label](note:OLD_UUID)` link to the new id from
+ * `idMap`, leaving the label and any `#heading` anchor untouched. A link whose
+ * target is absent from the map is returned verbatim - during a portable
+ * cross-account import that means a link to a note outside the backup stays as-is
+ * (it was already going to dangle) rather than having its surrounding markdown
+ * mangled.
+ *
+ * This is what keeps note-to-note links working after a portable backup import
+ * regenerates every note id (see `reencryptPortablePayload`): the importer
+ * pre-mints the new ids, then runs this over each note's body so every `note:`
+ * target follows its note to the new account. Lookups are case-insensitive on
+ * the id (UUIDs from `randomUUID` are lowercase, but a hand-edited link may not
+ * be), mirroring {@link extractNoteLinkTargets}.
+ */
+export function remapNoteLinks(content: string, idMap: ReadonlyMap<string, string>): string {
+  if (!content || idMap.size === 0) return content;
+  return content.replace(NOTE_LINK_REWRITE_RE, (whole, pre: string, id: string, rest: string) => {
+    const mapped = idMap.get(id) ?? idMap.get(id.toLowerCase());
+    return mapped ? `${pre}${mapped}${rest}` : whole;
+  });
+}
+
+/**
  * Ids present in BOTH lists - the mutual (bidirectional) links of a note: the
  * notes it links to that also link back. Powers the "↔" badge in the panel.
  *

--- a/apps/reborn-notes/src/lib/services/portable-backup-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/portable-backup-utils.spec.ts
@@ -297,6 +297,53 @@ describe('reencryptPortablePayload (import, re-encrypt with target account key)'
     expect(noteByTitle['Orphan'].folder_id).toBeUndefined();
   });
 
+  it("rewrites note-to-note links in content to the imported notes' new ids; leaves links outside the backup as-is", async () => {
+    // Real UUID-shaped ids so the `note:` link regex matches (links reference
+    // notes by UUID). The two notes cross-link; one also links a note that is
+    // NOT part of the backup.
+    const ALPHA = '550e8400-e29b-41d4-a716-446655440000';
+    const BETA = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    const OUTSIDE = '00000000-0000-4000-8000-0000000000ff';
+    const notes = [
+      await makeStoredNote(A, {
+        id: ALPHA,
+        title: 'Alpha',
+        content: `Link to [Beta](note:${BETA}), to [a section](note:${BETA}#intro), and to [gone](note:${OUTSIDE}).`
+      }),
+      await makeStoredNote(A, {
+        id: BETA,
+        title: 'Beta',
+        content: `Back to [Alpha](note:${ALPHA}).`
+      })
+    ];
+
+    const payload = await buildPortablePayload(A, notes, [], [], '2026-06-25T00:00:00.000Z');
+    const wire = await reencryptPortablePayload(B, payload, 'user-B', seqIds());
+
+    const noteByTitle: Record<string, Record<string, unknown>> = {};
+    for (const nn of wire.notes) noteByTitle[await B.decryptText(field(nn, 'title_encrypted'))] = nn;
+    const alphaId = String(noteByTitle['Alpha'].id);
+    const betaId = String(noteByTitle['Beta'].id);
+    const alphaContent = await B.decryptText(field(noteByTitle['Alpha'], 'content_encrypted'));
+    const betaContent = await B.decryptText(field(noteByTitle['Beta'], 'content_encrypted'));
+
+    // Ids are regenerated (the very thing that used to break the links)...
+    expect(alphaId).not.toBe(ALPHA);
+    expect(betaId).not.toBe(BETA);
+    // ...and every link to a note inside the backup now points at its new id,
+    // with the #heading anchor preserved.
+    expect(alphaContent).toContain(`[Beta](note:${betaId})`);
+    expect(alphaContent).toContain(`[a section](note:${betaId}#intro)`);
+    expect(betaContent).toContain(`[Alpha](note:${alphaId})`);
+    // The source ids are gone from the bodies entirely.
+    expect(alphaContent).not.toContain(ALPHA);
+    expect(alphaContent).not.toContain(BETA);
+    expect(betaContent).not.toContain(ALPHA);
+    // A link to a note that was not part of the backup is left verbatim - it
+    // would dangle either way, and we never mangle the surrounding Markdown.
+    expect(alphaContent).toContain(`[gone](note:${OUTSIDE})`);
+  });
+
   it('defaults pin/star/tags for a note with no metadata, and omits tag color when absent', async () => {
     const notes = [await makeStoredNote(A, { id: 'n1', title: 'Plain', content: '' })];
     const tags = [await makeStoredTag(A, { id: 't1', name: 'nocolor' })];

--- a/apps/reborn-notes/src/lib/services/portable-backup-utils.ts
+++ b/apps/reborn-notes/src/lib/services/portable-backup-utils.ts
@@ -1,9 +1,9 @@
 /**
  * Pure transforms for the portable encrypted backup (envelope version 3,
- * "plaintext-inside"). Kept in a light module - importing only types - so the
- * crypto round-trip can be unit-tested without pulling the full export/import
- * service (stores, JSZip, DOMPurify, ...). Mirrors the split used by
- * `export-import-trash-utils.ts`.
+ * "plaintext-inside"). Kept in a light module - importing only types and a pure
+ * sibling util (note-link rewriting) - so the crypto round-trip can be
+ * unit-tested without pulling the full export/import service (stores, JSZip,
+ * DOMPurify, ...). Mirrors the split used by `export-import-trash-utils.ts`.
  *
  * The crypto is injected via {@link PortableCrypto} (satisfied by
  * `cryptoManager`) so tests can simulate two distinct accounts - the whole
@@ -20,6 +20,7 @@ import type {
   FolderEncrypted,
   TagEncrypted
 } from '@reborn/types';
+import { remapNoteLinks } from './note-link-utils';
 
 /** Minimal crypto surface needed by the transforms (a subset of cryptoManager). */
 export interface PortableCrypto {
@@ -218,6 +219,13 @@ function defaultNewId(): string {
  * additive - genuinely new records owned by the target account. Dangling
  * references (a `folder_id` or tag ID whose target is not part of the backup)
  * are dropped rather than carried over as a now-meaningless ID.
+ *
+ * Because note ids change too, the `note:UUID` links embedded in each note's
+ * Markdown body are rewritten to the freshly-minted ids ({@link remapNoteLinks})
+ * so note-to-note links keep resolving after a cross-account import. A link to a
+ * note that is not part of the backup is left untouched - it would dangle either
+ * way, and rewriting only what we can resolve avoids mangling the surrounding
+ * Markdown.
  */
 export async function reencryptPortablePayload(
   crypto: PortableCrypto,
@@ -234,6 +242,13 @@ export async function reencryptPortablePayload(
   for (const f of data.folders ?? []) folderIdMap.set(f.id, newId());
   const tagIdMap = new Map<string, string>();
   for (const t of data.tags ?? []) tagIdMap.set(t.id, newId());
+  // Pre-assign note IDs too, so a `note:UUID` link can be remapped to its
+  // target's new ID even when the linked note appears later in the array (or
+  // links the other way). Minted after folders+tags to keep the assignment
+  // order folders -> tags -> notes that the spec's deterministic generator and
+  // the existing FK assertions rely on.
+  const noteIdMap = new Map<string, string>();
+  for (const n of data.notes ?? []) noteIdMap.set(n.id, newId());
 
   const folders = await Promise.all(
     (data.folders ?? []).map(async (f) => ({
@@ -277,11 +292,11 @@ export async function reencryptPortablePayload(
       };
       if (n.periodic) metadata.periodic = n.periodic;
       return {
-        id: newId(),
+        id: noteIdMap.get(n.id)!,
         user_id: userId,
         folder_id: n.folder_id ? (folderIdMap.get(n.folder_id) ?? undefined) : undefined,
         title_encrypted: await crypto.encryptText(n.title || 'Untitled'),
-        content_encrypted: await crypto.encryptText(n.content ?? ''),
+        content_encrypted: await crypto.encryptText(remapNoteLinks(n.content ?? '', noteIdMap)),
         metadata_encrypted: await crypto.encryptObject<NoteSensitiveMetadata>(metadata),
         is_archived: n.is_archived ?? false,
         created_at: n.created_at,


### PR DESCRIPTION
## Summary

Importing a **portable (v3) backup on a different account** broke internal note-to-note links (`[label](note:UUID)`) in note content. A portable import regenerates every entity's UUID (the server rejects a write to an id already owned by another account with `403`), and while folder/tag foreign keys were already remapped, the `note:UUID` links inside note bodies were not - so each link pointed at the source account's now-nonexistent id and stopped resolving.

The fix completes the existing remapping in `reencryptPortablePayload`:

- pre-mint new note ids into a map (mirroring how folders and tags are handled),
- rewrite each note body's `note:UUID` targets to the fresh ids before re-encrypting, via a new pure `remapNoteLinks` helper in `note-link-utils.ts`.

Labels and `#heading` anchors are preserved; a link to a note **outside** the backup is left verbatim (it would dangle either way, and we don't mangle the surrounding Markdown). Same-account v1/v2 imports keep their ids and are unaffected; the folder/Obsidian importer keeps its own link rewriting.

Why a fix and not just a warning: for a full backup (export always includes all notes) every internal link is resolvable, so the proper fix fully solves it - a "links will break" warning would contradict reality. The only residual case is a link to an already-deleted note, which dangled before export too.

**Zero Knowledge:** untouched - the rewrite runs on plaintext in memory before re-encryption with the target account key; the server never sees the note-to-note graph.

## Test plan

Automated (green locally):
- `note-link-utils.spec.ts` - new `remapNoteLinks` block (8 cases: remap, anchor preserved, multi-link, dangling left as-is, case-insensitive id, bare mention ignored, malformed UUID ignored, empty content/map).
- `portable-backup-utils.spec.ts` - new cross-account round-trip: links to notes in the backup follow them to their new ids (anchor kept); a link to a note not in the backup stays verbatim; source ids gone from bodies.
- Full reborn-notes suite: 956 passed. svelte-check 0/0. eslint clean.

Smoke (suggested):
1. Account A: create notes that link to each other (`[[` autocomplete), export a **Portable encrypted backup** (Settings -> Import & Export).
2. Account B: import that backup with the password.
3. Open an imported note in preview -> click an internal link -> it navigates to the linked imported note (no "note not found"). The Linked-notes panel shows backlinks/outgoing resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)