### PR TITLE
feat(notes): in-note search with match navigation

### DIFF
--- a/apps/reborn-notes/src/app.css
+++ b/apps/reborn-notes/src/app.css
@@ -47,6 +47,12 @@
   background-color: var(--rn-find-active-bg);
   color: var(--rn-find-active-fg);
 }
+/* Matches inside Live Preview block widgets (TOC / table / code), painted by the
+   editor's widget highlighter. Same base palette as above; active emphasis stays
+   on the editable-text mark, so widget hits use the base colour only. */
+::highlight(note-search-wgt) {
+  background-color: var(--rn-find-bg);
+}
 
 /* Notes uses Roboto as primary font */
 @theme inline {

--- a/apps/reborn-notes/src/app.css
+++ b/apps/reborn-notes/src/app.css
@@ -16,6 +16,12 @@
   --tag-mix: 13%;
   --tag-fg-mix: 100%;
   --tag-border-mix: 33%;
+  /* In-note search (find) highlight palette — shared by the CodeMirror editor
+     (.cm-note-search-match) and the rendered preview's CSS Custom Highlight API
+     ranges (::highlight rules below). */
+  --rn-find-bg: rgba(250, 204, 21, 0.4);
+  --rn-find-active-bg: #f59e0b;
+  --rn-find-active-fg: #1c1917;
 }
 .dark {
   --accent: oklch(0.371 0 0);
@@ -26,6 +32,20 @@
   --tag-mix: 18%;
   --tag-fg-mix: 55%;
   --tag-border-mix: 25%;
+  --rn-find-bg: rgba(250, 204, 21, 0.32);
+  --rn-find-active-bg: #f59e0b;
+  --rn-find-active-fg: #1c1917;
+}
+
+/* Rendered-preview find highlights, painted via the CSS Custom Highlight API in
+   lib/utils/note-search-dom.ts. Custom props inherit to the highlighted text, so
+   ::highlight() resolves the same palette the editor uses. */
+::highlight(note-search) {
+  background-color: var(--rn-find-bg);
+}
+::highlight(note-search-active) {
+  background-color: var(--rn-find-active-bg);
+  color: var(--rn-find-active-fg);
 }
 
 /* Notes uses Roboto as primary font */

--- a/apps/reborn-notes/src/app.css
+++ b/apps/reborn-notes/src/app.css
@@ -48,10 +48,14 @@
   color: var(--rn-find-active-fg);
 }
 /* Matches inside Live Preview block widgets (TOC / table / code), painted by the
-   editor's widget highlighter. Same base palette as above; active emphasis stays
-   on the editable-text mark, so widget hits use the base colour only. */
+   editor's widget highlighter. Same palette as the text marks: base for all hits,
+   the strong variant for the active match when it can be located unambiguously. */
 ::highlight(note-search-wgt) {
   background-color: var(--rn-find-bg);
+}
+::highlight(note-search-wgt-active) {
+  background-color: var(--rn-find-active-bg);
+  color: var(--rn-find-active-fg);
 }
 
 /* Notes uses Roboto as primary font */

--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { EditorView, keymap, placeholder as placeholderExt } from '@codemirror/view';
-  import { EditorState, Compartment } from '@codemirror/state';
+  import { EditorState, Compartment, Prec } from '@codemirror/state';
   import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
   import {
     syntaxHighlighting,
@@ -520,7 +520,12 @@
             : []
         ),
         noteLinkDecoration,
-        noteSearchExtension,
+        // Highest precedence so the search mark becomes the INNERMOST span (CM6
+        // nests higher-precedence decorations deeper) and its background paints
+        // ON TOP of Live Preview's own inline marks — e.g. `cm-lp-code`, whose
+        // grey background would otherwise occlude the highlight on a match that
+        // lands inside inline code.
+        Prec.highest(noteSearchExtension),
         stripBulletAnchorListener,
         EditorView.domEventHandlers({
           click(e) {

--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -11,6 +11,7 @@
   import { oneDark } from '@codemirror/theme-one-dark';
   import { noteLinkAutocomplete, type NoteLinkItem } from '$lib/editor/note-link-autocomplete';
   import { noteLinkDecoration } from '$lib/editor/note-link-decoration';
+  import { noteSearchExtension } from '$lib/editor/note-search';
   import { listIndent, listOutdent } from '$lib/editor/list-keymap';
   import {
     BULLET_ANCHOR,
@@ -519,6 +520,7 @@
             : []
         ),
         noteLinkDecoration,
+        noteSearchExtension,
         stripBulletAnchorListener,
         EditorView.domEventHandlers({
           click(e) {
@@ -1199,6 +1201,18 @@
     text-decoration: underline dashed;
     text-underline-offset: 3px;
     border-radius: 2px;
+  }
+
+  /* In-note search (find) highlights — driven by editor/note-search.ts. Colors
+     share the --rn-find-* vars defined globally on the note page so the editor
+     and the rendered preview's ::highlight() styles stay in sync. */
+  :global(.cm-host .cm-note-search-match) {
+    background-color: var(--rn-find-bg, rgba(250, 204, 21, 0.4));
+    border-radius: 2px;
+  }
+  :global(.cm-host .cm-note-search-match-active) {
+    background-color: var(--rn-find-active-bg, #f59e0b);
+    color: var(--rn-find-active-fg, #1c1917);
   }
 
   .toolbar-btn {

--- a/apps/reborn-notes/src/lib/components/editor/NoteDetailActions.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteDetailActions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     MoreHorizontal,
+    Search,
     Pin,
     PinOff,
     Star,
@@ -31,6 +32,7 @@
   let {
     note,
     onmenuopen,
+    onsearch,
     onpin,
     onstar,
     onmove,
@@ -48,6 +50,8 @@
     note: NoteListItem | null;
     /** Mobile: opens parent-provided NoteActionSheet */
     onmenuopen: () => void;
+    /** Opens the in-note search bar (Ctrl/Cmd+F equivalent). */
+    onsearch: () => void;
     onpin: () => void;
     onstar: () => void;
     onmove: (folderId: string | null, e?: Event) => void;
@@ -117,7 +121,14 @@
             </button>
           {/snippet}
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" class="min-w-40">
+        <DropdownMenuContent align="end" class="min-w-44">
+          <!-- Find -->
+          <DropdownMenuItem onclick={onsearch}>
+            <Search class="h-3.5 w-3.5" />
+            {$t('note_search.open')}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <!-- Organize -->
           <DropdownMenuItem onclick={onpin}>
             {#if note.is_pinned}
               <PinOff class="h-3.5 w-3.5" />
@@ -140,11 +151,14 @@
             <FolderInput class="h-3.5 w-3.5" />
             {$t('notes.move_to_folder')}
           </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <!-- Content tools (conditional on the note having headings / a TOC block) -->
           {#if tocMenuMode === 'insert'}
             <DropdownMenuItem onclick={onTocApply}>
               <ListPlus class="h-3.5 w-3.5" />
               {$t('toc.insert')}
             </DropdownMenuItem>
+            <DropdownMenuSeparator />
           {:else if tocMenuMode === 'manage'}
             <DropdownMenuItem onclick={onTocApply}>
               <RefreshCw class="h-3.5 w-3.5" />
@@ -161,15 +175,9 @@
               <ListX class="h-3.5 w-3.5" />
               {$t('toc.remove')}
             </DropdownMenuItem>
+            <DropdownMenuSeparator />
           {/if}
-          <DropdownMenuItem onclick={onexport}>
-            <Download class="h-3.5 w-3.5" />
-            {$t('notes.export_markdown')}
-          </DropdownMenuItem>
-          <DropdownMenuItem onclick={onexportpdf}>
-            <FileText class="h-3.5 w-3.5" />
-            {$t('notes.export_pdf')}
-          </DropdownMenuItem>
+          <!-- Share / export -->
           <DropdownMenuItem onclick={oncopylink}>
             <Link2 class="h-3.5 w-3.5" />
             {$t('notes.copy_note_link')}
@@ -180,11 +188,22 @@
               {$t('share.note.menu_label')}
             </DropdownMenuItem>
           {/if}
+          <DropdownMenuItem onclick={onexport}>
+            <Download class="h-3.5 w-3.5" />
+            {$t('notes.export_markdown')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onclick={onexportpdf}>
+            <FileText class="h-3.5 w-3.5" />
+            {$t('notes.export_pdf')}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <!-- Info -->
           <DropdownMenuItem onclick={onshowxray}>
             <ScanEye class="h-3.5 w-3.5" />
             {$t('encryption.title')}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
+          <!-- Destructive -->
           <DropdownMenuItem
             class="text-destructive focus:text-destructive"
             onclick={ondelete}

--- a/apps/reborn-notes/src/lib/components/editor/NoteSearchBar.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteSearchBar.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import { Search, ChevronUp, ChevronDown, X, CaseSensitive } from '@lucide/svelte';
+  import { t } from '$lib/stores/i18n.store';
+
+  let {
+    query,
+    caseSensitive,
+    total,
+    current,
+    capped = false,
+    isMobile = false,
+    focusSignal = 0,
+    oninput,
+    ontogglecase,
+    onnext,
+    onprev,
+    onclose
+  }: {
+    /** Current search query (controlled by the parent). */
+    query: string;
+    /** Whether matching is case-sensitive. */
+    caseSensitive: boolean;
+    /** Total number of matches in the active surface. */
+    total: number;
+    /** 1-based index of the active match, or 0 when there are none. */
+    current: number;
+    /** Whether `total` hit the match cap (renders as `N+`). */
+    capped?: boolean;
+    isMobile?: boolean;
+    /** Bumped by the parent to (re)focus + select the input (e.g. Ctrl/Cmd+F again). */
+    focusSignal?: number;
+    oninput: (value: string) => void;
+    ontogglecase: () => void;
+    onnext: () => void;
+    onprev: () => void;
+    onclose: () => void;
+  } = $props();
+
+  let inputEl = $state<HTMLInputElement | null>(null);
+
+  const hasQuery = $derived(query.length > 0);
+  const noResults = $derived(hasQuery && total === 0);
+  const countText = $derived(`${current}/${total}${capped ? '+' : ''}`);
+  // Localized, screen-reader-friendly status (the visible counter is compact).
+  const statusText = $derived(
+    noResults
+      ? $t('note_search.no_results')
+      : hasQuery
+        ? $t('note_search.position', { values: { current, total: `${total}${capped ? '+' : ''}` } })
+        : ''
+  );
+
+  // Focus + select on mount and whenever the parent bumps focusSignal.
+  $effect(() => {
+    void focusSignal;
+    const el = inputEl;
+    if (!el) return;
+    el.focus();
+    el.select();
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (e.shiftKey) onprev();
+      else onnext();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onclose();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      onnext();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      onprev();
+    }
+  }
+</script>
+
+<div
+  role="search"
+  class="flex items-center gap-1 border bg-popover text-popover-foreground shadow-md
+    {isMobile
+    ? 'w-full gap-1.5 border-x-0 border-t-0 px-2 py-1.5'
+    : 'rounded-lg px-1.5 py-1'}"
+>
+  <Search class="ml-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+
+  <input
+    bind:this={inputEl}
+    type="text"
+    value={query}
+    oninput={(e) => oninput(e.currentTarget.value)}
+    onkeydown={handleKeydown}
+    placeholder={$t('note_search.placeholder')}
+    aria-label={$t('note_search.placeholder')}
+    spellcheck="false"
+    autocapitalize="off"
+    autocorrect="off"
+    class="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground
+      {isMobile ? '' : 'w-44'}"
+  />
+
+  <!-- Match counter (visible compact + localized status for assistive tech) -->
+  <span class="shrink-0 px-1 text-xs tabular-nums {noResults ? 'text-destructive' : 'text-muted-foreground'}">
+    {#if hasQuery}
+      <span aria-hidden="true">{noResults ? $t('note_search.no_results') : countText}</span>
+    {/if}
+    <span class="sr-only" role="status" aria-live="polite">{statusText}</span>
+  </span>
+
+  <!-- Case-sensitive toggle -->
+  <button
+    type="button"
+    onclick={ontogglecase}
+    aria-pressed={caseSensitive}
+    title={$t('note_search.match_case')}
+    aria-label={$t('note_search.match_case')}
+    class="flex shrink-0 items-center justify-center rounded transition-colors
+      {isMobile ? 'h-8 w-8' : 'h-7 w-7'}
+      {caseSensitive
+      ? 'bg-accent text-accent-foreground'
+      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+  >
+    <CaseSensitive class="h-4 w-4" />
+  </button>
+
+  <div class="mx-0.5 h-5 w-px shrink-0 bg-border" role="separator"></div>
+
+  <!-- Previous / next match -->
+  <button
+    type="button"
+    onclick={onprev}
+    disabled={total === 0}
+    title={$t('note_search.previous')}
+    aria-label={$t('note_search.previous')}
+    class="flex shrink-0 items-center justify-center rounded text-muted-foreground transition-colors
+      hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40
+      {isMobile ? 'h-8 w-8' : 'h-7 w-7'}"
+  >
+    <ChevronUp class="h-4 w-4" />
+  </button>
+  <button
+    type="button"
+    onclick={onnext}
+    disabled={total === 0}
+    title={$t('note_search.next')}
+    aria-label={$t('note_search.next')}
+    class="flex shrink-0 items-center justify-center rounded text-muted-foreground transition-colors
+      hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40
+      {isMobile ? 'h-8 w-8' : 'h-7 w-7'}"
+  >
+    <ChevronDown class="h-4 w-4" />
+  </button>
+
+  <div class="mx-0.5 h-5 w-px shrink-0 bg-border" role="separator"></div>
+
+  <!-- Close -->
+  <button
+    type="button"
+    onclick={onclose}
+    title={$t('note_search.close')}
+    aria-label={$t('note_search.close')}
+    class="flex shrink-0 items-center justify-center rounded text-muted-foreground transition-colors
+      hover:bg-accent hover:text-accent-foreground
+      {isMobile ? 'h-8 w-8' : 'h-7 w-7'}"
+  >
+    <X class="h-4 w-4" />
+  </button>
+</div>

--- a/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    Search,
     Pin,
     PinOff,
     Star,
@@ -28,6 +29,7 @@
     open = $bindable(false),
     note,
     isTrash = false,
+    onsearch,
     onpin,
     onstar,
     onmove,
@@ -50,6 +52,8 @@
     open: boolean;
     note: NoteListItem | null;
     isTrash?: boolean;
+    /** Opens the in-note search bar. Only wired in the open-note context. */
+    onsearch?: () => void;
     onpin: (id: string) => void;
     onstar: (id: string) => void;
     onmove: (id: string) => void;
@@ -79,14 +83,23 @@
     /** Remove the managed TOC block. */
     onTocRemove?: () => void;
   } = $props();
+
+  // Whether the "navigate/structure this note" group has anything to show, so
+  // its leading separator isn't rendered for list-item sheets (which pass none).
+  const hasContentTools = $derived(
+    !!onoutline || !!onlinkednotes || !!onhistory || tocMenuMode !== 'hidden'
+  );
 </script>
 
 <Sheet bind:open>
-  <SheetContent side="bottom" class="h-auto">
-    <SheetHeader class="text-left">
+  <!-- Capped height + scrollable body so a long menu fits a short screen; the
+       header (and the sheet's absolute close button) stay pinned while only the
+       action list scrolls. -->
+  <SheetContent side="bottom" class="flex max-h-[85dvh] flex-col">
+    <SheetHeader class="shrink-0 pr-8 text-left">
       <SheetTitle class="line-clamp-2 text-left">{note?.title || $t('notes.untitled')}</SheetTitle>
     </SheetHeader>
-    <div class="mt-4 space-y-1">
+    <div class="flex-1 space-y-1 overflow-y-auto">
       {#if isTrash}
         <Button
           variant="ghost"
@@ -105,6 +118,22 @@
           {$t('notes.delete_permanently')}
         </Button>
       {:else}
+        <!-- Find -->
+        {#if onsearch}
+          <Button
+            variant="ghost"
+            class="w-full justify-start"
+            onclick={() => {
+              open = false;
+              onsearch?.();
+            }}
+          >
+            <Search class="mr-2 h-4 w-4" />
+            {$t('note_search.open')}
+          </Button>
+          <div class="my-1 h-px bg-border" role="separator"></div>
+        {/if}
+        <!-- Organize -->
         <Button
           variant="ghost"
           class="w-full justify-start"
@@ -139,66 +168,93 @@
           <FolderInput class="mr-2 h-4 w-4" />
           {$t('notes.move_to_folder')}
         </Button>
-        {#if tocMenuMode === 'insert'}
-          <Button
-            variant="ghost"
-            class="w-full justify-start"
-            onclick={() => {
-              open = false;
-              onTocApply?.();
-            }}
-          >
-            <ListPlus class="mr-2 h-4 w-4" />
-            {$t('toc.insert')}
-          </Button>
-        {:else if tocMenuMode === 'manage'}
-          <Button
-            variant="ghost"
-            class="w-full justify-start"
-            onclick={() => {
-              open = false;
-              onTocApply?.();
-            }}
-          >
-            <RefreshCw class="mr-2 h-4 w-4" />
-            {$t('toc.refresh')}
-            {#if tocStale}
-              <span
-                class="ml-auto inline-block h-1.5 w-1.5 rounded-full bg-amber-500"
-                aria-hidden="true"
-              ></span>
-            {/if}
-          </Button>
-          <Button
-            variant="ghost"
-            class="w-full justify-start"
-            onclick={() => {
-              open = false;
-              onTocRemove?.();
-            }}
-          >
-            <ListX class="mr-2 h-4 w-4" />
-            {$t('toc.remove')}
-          </Button>
+        <!-- Navigate / structure this note -->
+        {#if hasContentTools}
+          <div class="my-1 h-px bg-border" role="separator"></div>
+          {#if onoutline}
+            <Button
+              variant="ghost"
+              class="w-full justify-start"
+              onclick={() => {
+                open = false;
+                onoutline?.();
+              }}
+            >
+              <ListTree class="mr-2 h-4 w-4" />
+              {$t('outline.title')}
+            </Button>
+          {/if}
+          {#if tocMenuMode === 'insert'}
+            <Button
+              variant="ghost"
+              class="w-full justify-start"
+              onclick={() => {
+                open = false;
+                onTocApply?.();
+              }}
+            >
+              <ListPlus class="mr-2 h-4 w-4" />
+              {$t('toc.insert')}
+            </Button>
+          {:else if tocMenuMode === 'manage'}
+            <Button
+              variant="ghost"
+              class="w-full justify-start"
+              onclick={() => {
+                open = false;
+                onTocApply?.();
+              }}
+            >
+              <RefreshCw class="mr-2 h-4 w-4" />
+              {$t('toc.refresh')}
+              {#if tocStale}
+                <span
+                  class="ml-auto inline-block h-1.5 w-1.5 rounded-full bg-amber-500"
+                  aria-hidden="true"
+                ></span>
+              {/if}
+            </Button>
+            <Button
+              variant="ghost"
+              class="w-full justify-start"
+              onclick={() => {
+                open = false;
+                onTocRemove?.();
+              }}
+            >
+              <ListX class="mr-2 h-4 w-4" />
+              {$t('toc.remove')}
+            </Button>
+          {/if}
+          {#if onlinkednotes}
+            <Button
+              variant="ghost"
+              class="w-full justify-start"
+              onclick={() => {
+                open = false;
+                onlinkednotes?.();
+              }}
+            >
+              <Waypoints class="mr-2 h-4 w-4" />
+              {$t('linked_notes.title')}
+            </Button>
+          {/if}
+          {#if onhistory}
+            <Button
+              variant="ghost"
+              class="w-full justify-start"
+              onclick={() => {
+                open = false;
+                onhistory?.();
+              }}
+            >
+              <Clock class="mr-2 h-4 w-4" />
+              {$t('history.title')}
+            </Button>
+          {/if}
         {/if}
-        <Button
-          variant="ghost"
-          class="w-full justify-start"
-          onclick={() => note && onexport(note)}
-        >
-          <Download class="mr-2 h-4 w-4" />
-          {$t('notes.export_markdown')}
-        </Button>
-        {#if onexportpdf}
-          <Button
-            variant="ghost"
-            class="w-full justify-start"
-            onclick={() => note && onexportpdf?.(note)}
-          >
-            <FileText class="mr-2 h-4 w-4" />
-            {$t('notes.export_pdf')}
-          </Button>
-        {/if}
+        <!-- Share / export -->
+        <div class="my-1 h-px bg-border" role="separator"></div>
         <Button
           variant="ghost"
           class="w-full justify-start"
@@ -222,46 +278,27 @@
             {$t('share.note.menu_label')}
           </Button>
         {/if}
-        {#if onhistory}
+        <Button
+          variant="ghost"
+          class="w-full justify-start"
+          onclick={() => note && onexport(note)}
+        >
+          <Download class="mr-2 h-4 w-4" />
+          {$t('notes.export_markdown')}
+        </Button>
+        {#if onexportpdf}
           <Button
             variant="ghost"
             class="w-full justify-start"
-            onclick={() => {
-              open = false;
-              onhistory?.();
-            }}
+            onclick={() => note && onexportpdf?.(note)}
           >
-            <Clock class="mr-2 h-4 w-4" />
-            {$t('history.title')}
+            <FileText class="mr-2 h-4 w-4" />
+            {$t('notes.export_pdf')}
           </Button>
         {/if}
-        {#if onoutline}
-          <Button
-            variant="ghost"
-            class="w-full justify-start"
-            onclick={() => {
-              open = false;
-              onoutline?.();
-            }}
-          >
-            <ListTree class="mr-2 h-4 w-4" />
-            {$t('outline.title')}
-          </Button>
-        {/if}
-        {#if onlinkednotes}
-          <Button
-            variant="ghost"
-            class="w-full justify-start"
-            onclick={() => {
-              open = false;
-              onlinkednotes?.();
-            }}
-          >
-            <Waypoints class="mr-2 h-4 w-4" />
-            {$t('linked_notes.title')}
-          </Button>
-        {/if}
+        <!-- Info -->
         {#if onshowxray}
+          <div class="my-1 h-px bg-border" role="separator"></div>
           <Button
             variant="ghost"
             class="w-full justify-start"
@@ -274,6 +311,8 @@
             {$t('encryption.title')}
           </Button>
         {/if}
+        <!-- Destructive -->
+        <div class="my-1 h-px bg-border" role="separator"></div>
         <Button
           variant="ghost"
           class="w-full justify-start text-destructive hover:text-destructive"

--- a/apps/reborn-notes/src/lib/editor/note-search.ts
+++ b/apps/reborn-notes/src/lib/editor/note-search.ts
@@ -1,17 +1,55 @@
 /**
  * CodeMirror backend for the in-note "find in note" feature.
  *
- * Renders match highlights as mark decorations driven by a single
- * {@link setNoteSearch} effect: the host (the note page) computes matches with
- * the shared {@link findMatches} and dispatches them here. The field is inert
- * until the first effect, so it is safe to include in the editor unconditionally.
+ * Two layers, both driven by a single {@link setNoteSearch} effect the host (the
+ * note page) dispatches after computing matches with the shared
+ * {@link findMatches}:
+ *
+ *  1. **Mark decorations** over editable text - the common case. Higher
+ *     precedence than Live Preview's inline marks so the highlight background
+ *     paints over `cm-lp-code` etc. (see NoteEditor's `Prec.highest`).
+ *  2. **A widget highlighter** ({@link noteSearchWidgetPlugin}) that colours
+ *     matches inside Live Preview block widgets (TOC / table / fenced code).
+ *     Those widgets `Decoration.replace` their source with generated DOM, so the
+ *     mark layer has no text to attach to inside them; the plugin paints their
+ *     DOM via the CSS Custom Highlight API instead. The host filters out source
+ *     ranges the widgets render away (e.g. TOC `#slug`s) before dispatching, so
+ *     the count stays aligned with what is visible.
+ *
+ * Both layers are inert until the first effect, so the extension is safe to
+ * include in the editor unconditionally.
  */
-import { EditorView, Decoration, type DecorationSet } from '@codemirror/view';
+import {
+  EditorView,
+  Decoration,
+  ViewPlugin,
+  type DecorationSet,
+  type ViewUpdate,
+  type PluginValue
+} from '@codemirror/view';
 import { StateField, StateEffect, RangeSetBuilder, type Extension } from '@codemirror/state';
 import type { SearchMatch } from '$lib/utils/note-search-core';
+import { NOTE_SEARCH_MATCH_CAP } from '$lib/utils/note-search-core';
+import {
+  findDomMatchRanges,
+  paintWidgetHighlights,
+  clearWidgetHighlights
+} from '$lib/utils/note-search-dom';
 
-/** Effect carrying the current match set + active index, or `null` to clear. */
-export const setNoteSearch = StateEffect.define<{ matches: SearchMatch[]; active: number } | null>();
+/** Current in-note search state shared by both editor layers. */
+export interface NoteSearchState {
+  /** Matches as document offsets (already filtered to what is visible). */
+  matches: SearchMatch[];
+  /** Index of the active match into {@link matches}, or -1. */
+  active: number;
+  /** The raw query - the widget highlighter re-searches widget DOM with it. */
+  query: string;
+  /** Case sensitivity, kept in sync with the query for widget re-search. */
+  caseSensitive: boolean;
+}
+
+/** Effect carrying the current search state, or `null` to clear. */
+export const setNoteSearch = StateEffect.define<NoteSearchState | null>();
 
 const matchDeco = Decoration.mark({ class: 'cm-note-search-match' });
 const activeDeco = Decoration.mark({ class: 'cm-note-search-match cm-note-search-match-active' });
@@ -26,31 +64,100 @@ function buildDecorations(matches: SearchMatch[], active: number): DecorationSet
   return builder.finish();
 }
 
-const noteSearchField = StateField.define<DecorationSet>({
+/** Map a state's match offsets through a set of document changes. */
+function mapState(state: NoteSearchState, changes: ViewUpdate['changes']): NoteSearchState {
+  const matches: SearchMatch[] = [];
+  for (const m of state.matches) {
+    const from = changes.mapPos(m.from);
+    const to = changes.mapPos(m.to);
+    if (to > from) matches.push({ from, to });
+  }
+  return { ...state, matches };
+}
+
+const noteSearchField = StateField.define<NoteSearchState | null>({
   create() {
-    return Decoration.none;
+    return null;
   },
-  update(deco, tr) {
+  update(state, tr) {
     // Keep highlights aligned through edits until the host recomputes, so they
     // don't visibly jump while the user types in the editor with search open.
-    deco = deco.map(tr.changes);
+    if (state && tr.docChanged) state = mapState(state, tr.changes);
     for (const effect of tr.effects) {
-      if (effect.is(setNoteSearch)) {
-        deco = effect.value
-          ? buildDecorations(effect.value.matches, effect.value.active)
-          : Decoration.none;
-      }
+      if (effect.is(setNoteSearch)) state = effect.value;
     }
-    return deco;
+    return state;
   },
-  provide: (field) => EditorView.decorations.from(field)
+  provide: (field) =>
+    EditorView.decorations.from(field, (state) =>
+      state ? buildDecorations(state.matches, state.active) : Decoration.none
+    )
 });
 
+// Live Preview block widgets whose source is replaced by generated DOM. The
+// mark layer can't highlight inside them; the widget highlighter searches their
+// rendered text directly. (Image widgets carry no searchable text, so they are
+// intentionally omitted.)
+const WIDGET_SELECTOR = '.cm-lp-toc, .cm-lp-table-wrap, .cm-lp-codeblock-outer';
+
 /**
- * CM6 extension that renders in-note search highlights. Inert until the host
- * dispatches {@link setNoteSearch}; include it unconditionally in the editor.
+ * ViewPlugin that paints in-note search matches inside Live Preview block
+ * widgets. It re-scans the visible widget DOM whenever the search state, the
+ * document, or the viewport changes (new widgets scroll in), deferring the DOM
+ * read/write to a measure pass so the widget markup is laid out. In raw editor
+ * mode no widgets exist, so the scan finds nothing and the layer stays clear.
  */
-export const noteSearchExtension: Extension = [noteSearchField];
+class NoteSearchWidgetHighlighter implements PluginValue {
+  constructor(view: EditorView) {
+    this.schedule(view);
+  }
+
+  update(update: ViewUpdate): void {
+    const searchChanged = update.transactions.some((tr) =>
+      tr.effects.some((e) => e.is(setNoteSearch))
+    );
+    if (update.docChanged || update.viewportChanged || update.geometryChanged || searchChanged) {
+      this.schedule(update.view);
+    }
+  }
+
+  private schedule(view: EditorView): void {
+    // `key: this` coalesces repeated requests in the same frame into one scan.
+    view.requestMeasure({
+      key: this,
+      read: () => this.collect(view),
+      write: (ranges) => paintWidgetHighlights(ranges)
+    });
+  }
+
+  private collect(view: EditorView): Range[] {
+    const state = view.state.field(noteSearchField, false);
+    if (!state || !state.query) return [];
+    const roots = view.contentDOM.querySelectorAll<HTMLElement>(WIDGET_SELECTOR);
+    if (!roots.length) return [];
+    const ranges: Range[] = [];
+    for (const root of roots) {
+      for (const range of findDomMatchRanges(root, state.query, state.caseSensitive)) {
+        ranges.push(range);
+        if (ranges.length >= NOTE_SEARCH_MATCH_CAP) return ranges;
+      }
+    }
+    return ranges;
+  }
+
+  destroy(): void {
+    clearWidgetHighlights();
+  }
+}
+
+const noteSearchWidgetPlugin = ViewPlugin.fromClass(NoteSearchWidgetHighlighter);
+
+/**
+ * CM6 extension that renders in-note search highlights (text marks + Live
+ * Preview widget highlights). Inert until the host dispatches
+ * {@link setNoteSearch}; include it unconditionally in the editor.
+ */
+export const noteSearchExtension: Extension = [noteSearchField, noteSearchWidgetPlugin];
 
 /** Scroll the editor so `match` is centered, without moving the caret/selection. */
 export function scrollCmMatchIntoView(view: EditorView, match: SearchMatch): void {

--- a/apps/reborn-notes/src/lib/editor/note-search.ts
+++ b/apps/reborn-notes/src/lib/editor/note-search.ts
@@ -1,0 +1,58 @@
+/**
+ * CodeMirror backend for the in-note "find in note" feature.
+ *
+ * Renders match highlights as mark decorations driven by a single
+ * {@link setNoteSearch} effect: the host (the note page) computes matches with
+ * the shared {@link findMatches} and dispatches them here. The field is inert
+ * until the first effect, so it is safe to include in the editor unconditionally.
+ */
+import { EditorView, Decoration, type DecorationSet } from '@codemirror/view';
+import { StateField, StateEffect, RangeSetBuilder, type Extension } from '@codemirror/state';
+import type { SearchMatch } from '$lib/utils/note-search-core';
+
+/** Effect carrying the current match set + active index, or `null` to clear. */
+export const setNoteSearch = StateEffect.define<{ matches: SearchMatch[]; active: number } | null>();
+
+const matchDeco = Decoration.mark({ class: 'cm-note-search-match' });
+const activeDeco = Decoration.mark({ class: 'cm-note-search-match cm-note-search-match-active' });
+
+function buildDecorations(matches: SearchMatch[], active: number): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  for (let i = 0; i < matches.length; i++) {
+    const { from, to } = matches[i];
+    if (to <= from) continue; // mark decorations must be non-empty
+    builder.add(from, to, i === active ? activeDeco : matchDeco);
+  }
+  return builder.finish();
+}
+
+const noteSearchField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none;
+  },
+  update(deco, tr) {
+    // Keep highlights aligned through edits until the host recomputes, so they
+    // don't visibly jump while the user types in the editor with search open.
+    deco = deco.map(tr.changes);
+    for (const effect of tr.effects) {
+      if (effect.is(setNoteSearch)) {
+        deco = effect.value
+          ? buildDecorations(effect.value.matches, effect.value.active)
+          : Decoration.none;
+      }
+    }
+    return deco;
+  },
+  provide: (field) => EditorView.decorations.from(field)
+});
+
+/**
+ * CM6 extension that renders in-note search highlights. Inert until the host
+ * dispatches {@link setNoteSearch}; include it unconditionally in the editor.
+ */
+export const noteSearchExtension: Extension = [noteSearchField];
+
+/** Scroll the editor so `match` is centered, without moving the caret/selection. */
+export function scrollCmMatchIntoView(view: EditorView, match: SearchMatch): void {
+  view.dispatch({ effects: EditorView.scrollIntoView(match.from, { y: 'center' }) });
+}

--- a/apps/reborn-notes/src/lib/editor/note-search.ts
+++ b/apps/reborn-notes/src/lib/editor/note-search.ts
@@ -28,8 +28,10 @@ import {
   type PluginValue
 } from '@codemirror/view';
 import { StateField, StateEffect, RangeSetBuilder, type Extension } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
 import type { SearchMatch } from '$lib/utils/note-search-core';
 import { NOTE_SEARCH_MATCH_CAP } from '$lib/utils/note-search-core';
+import { findTocBlockRange } from '$lib/utils/toc';
 import {
   findDomMatchRanges,
   paintWidgetHighlights,
@@ -100,12 +102,57 @@ const noteSearchField = StateField.define<NoteSearchState | null>({
 // intentionally omitted.)
 const WIDGET_SELECTOR = '.cm-lp-toc, .cm-lp-table-wrap, .cm-lp-codeblock-outer';
 
+interface SourceRange {
+  from: number;
+  to: number;
+}
+
+/** What {@link NoteSearchWidgetHighlighter.collect} paints: base hits + one active. */
+interface WidgetPaint {
+  base: Range[];
+  active: Range | null;
+}
+
+/**
+ * Source ranges of the replaced block widgets currently in view - the managed
+ * TOC block plus every `Table` / `FencedCode` node in the visible viewport.
+ * These match exactly the blocks `decorations.ts` swaps for widgets, and let the
+ * highlighter map the active source match onto a widget's DOM hit. The syntax
+ * tree is walked only over `visibleRanges`, and the TOC's whole-doc regex runs
+ * only when a TOC widget is actually present, to keep the per-frame scan cheap.
+ */
+function widgetSourceRanges(view: EditorView, hasTocRoot: boolean): SourceRange[] {
+  const ranges: SourceRange[] = [];
+  if (hasTocRoot) {
+    const toc = findTocBlockRange(view.state.doc.toString());
+    if (toc) ranges.push(toc);
+  }
+  const tree = syntaxTree(view.state);
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter(node) {
+        if (node.name === 'Table' || node.name === 'FencedCode') {
+          ranges.push({ from: node.from, to: node.to });
+        }
+      }
+    });
+  }
+  return ranges;
+}
+
 /**
  * ViewPlugin that paints in-note search matches inside Live Preview block
  * widgets. It re-scans the visible widget DOM whenever the search state, the
  * document, or the viewport changes (new widgets scroll in), deferring the DOM
  * read/write to a measure pass so the widget markup is laid out. In raw editor
  * mode no widgets exist, so the scan finds nothing and the layer stays clear.
+ *
+ * The active match gets the strong (orange) highlight too, but only when it can
+ * be located UNAMBIGUOUSLY: a widget's in-range source matches must align 1:1
+ * with its DOM hits (both in document order). On any mismatch the widget falls
+ * back to base-only, so a pathological query can never colour the wrong entry.
  */
 class NoteSearchWidgetHighlighter implements PluginValue {
   constructor(view: EditorView) {
@@ -123,26 +170,60 @@ class NoteSearchWidgetHighlighter implements PluginValue {
 
   private schedule(view: EditorView): void {
     // `key: this` coalesces repeated requests in the same frame into one scan.
-    view.requestMeasure({
+    view.requestMeasure<WidgetPaint>({
       key: this,
       read: () => this.collect(view),
-      write: (ranges) => paintWidgetHighlights(ranges)
+      write: ({ base, active }) => paintWidgetHighlights(base, active)
     });
   }
 
-  private collect(view: EditorView): Range[] {
+  private collect(view: EditorView): WidgetPaint {
+    const empty: WidgetPaint = { base: [], active: null };
     const state = view.state.field(noteSearchField, false);
-    if (!state || !state.query) return [];
+    if (!state || !state.query) return empty;
     const roots = view.contentDOM.querySelectorAll<HTMLElement>(WIDGET_SELECTOR);
-    if (!roots.length) return [];
-    const ranges: Range[] = [];
+    if (!roots.length) return empty;
+
+    const activeMatch = state.active >= 0 ? state.matches[state.active] : null;
+    const hasTocRoot =
+      !!activeMatch && Array.from(roots).some((r) => r.classList.contains('cm-lp-toc'));
+    const wranges = activeMatch ? widgetSourceRanges(view, hasTocRoot) : [];
+
+    const base: Range[] = [];
+    let active: Range | null = null;
+    let count = 0;
+
     for (const root of roots) {
-      for (const range of findDomMatchRanges(root, state.query, state.caseSensitive)) {
-        ranges.push(range);
-        if (ranges.length >= NOTE_SEARCH_MATCH_CAP) return ranges;
+      const hits = findDomMatchRanges(root, state.query, state.caseSensitive);
+      if (!hits.length) continue;
+
+      // Try to locate the active match's DOM hit inside this widget (see class
+      // doc): map the root to its source range, then align in-range source
+      // matches with DOM hits 1:1. Any ambiguity ⇒ this widget is base-only.
+      let activeIdx = -1;
+      if (activeMatch) {
+        let pos = -1;
+        try {
+          pos = view.posAtDOM(root);
+        } catch {
+          pos = -1;
+        }
+        const wr = pos >= 0 ? wranges.find((r) => pos >= r.from && pos <= r.to) : undefined;
+        if (wr && activeMatch.from >= wr.from && activeMatch.from < wr.to) {
+          const inRange = state.matches.filter((m) => m.from >= wr.from && m.from < wr.to);
+          if (inRange.length === hits.length) {
+            activeIdx = inRange.findIndex((m) => m.from === activeMatch.from);
+          }
+        }
+      }
+
+      for (let i = 0; i < hits.length; i++) {
+        if (i === activeIdx) active = hits[i];
+        else base.push(hits[i]);
+        if (++count >= NOTE_SEARCH_MATCH_CAP) return { base, active };
       }
     }
-    return ranges;
+    return { base, active };
   }
 
   destroy(): void {

--- a/apps/reborn-notes/src/lib/utils/note-search-core.test.ts
+++ b/apps/reborn-notes/src/lib/utils/note-search-core.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { findMatches, NOTE_SEARCH_MATCH_CAP } from './note-search-core';
+
+describe('findMatches', () => {
+  it('returns empty for an empty query', () => {
+    expect(findMatches('hello world', '', false)).toEqual([]);
+  });
+
+  it('finds all non-overlapping matches with correct offsets', () => {
+    expect(findMatches('abcabc', 'bc', false)).toEqual([
+      { from: 1, to: 3 },
+      { from: 4, to: 6 }
+    ]);
+  });
+
+  it('does not produce overlapping matches', () => {
+    // "aa" in "aaaa" -> positions 0 and 2, not 0,1,2
+    expect(findMatches('aaaa', 'aa', false)).toEqual([
+      { from: 0, to: 2 },
+      { from: 2, to: 4 }
+    ]);
+  });
+
+  it('is case-insensitive by default', () => {
+    expect(findMatches('Foo FOO foo', 'foo', false)).toEqual([
+      { from: 0, to: 3 },
+      { from: 4, to: 7 },
+      { from: 8, to: 11 }
+    ]);
+  });
+
+  it('respects case-sensitive mode', () => {
+    expect(findMatches('Foo FOO foo', 'foo', true)).toEqual([{ from: 8, to: 11 }]);
+  });
+
+  it('treats regex metacharacters as literal text', () => {
+    expect(findMatches('a.b a.b axb', 'a.b', false)).toEqual([
+      { from: 0, to: 3 },
+      { from: 4, to: 7 }
+    ]);
+    expect(findMatches('price (5) and (6)', '(5)', false)).toEqual([{ from: 6, to: 9 }]);
+  });
+
+  it('caps the number of returned matches', () => {
+    const text = 'x'.repeat(NOTE_SEARCH_MATCH_CAP + 50);
+    expect(findMatches(text, 'x', false)).toHaveLength(NOTE_SEARCH_MATCH_CAP);
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/note-search-core.test.ts
+++ b/apps/reborn-notes/src/lib/utils/note-search-core.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { findMatches, NOTE_SEARCH_MATCH_CAP } from './note-search-core';
+import { findMatches, excludeMatchesInSpans, NOTE_SEARCH_MATCH_CAP } from './note-search-core';
 
 describe('findMatches', () => {
   it('returns empty for an empty query', () => {
@@ -44,5 +44,38 @@ describe('findMatches', () => {
   it('caps the number of returned matches', () => {
     const text = 'x'.repeat(NOTE_SEARCH_MATCH_CAP + 50);
     expect(findMatches(text, 'x', false)).toHaveLength(NOTE_SEARCH_MATCH_CAP);
+  });
+});
+
+describe('excludeMatchesInSpans', () => {
+  const m = (from: number, to: number) => ({ from, to });
+
+  it('returns the input unchanged when there are no spans', () => {
+    const matches = [m(0, 3), m(5, 8)];
+    expect(excludeMatchesInSpans(matches, [])).toBe(matches);
+  });
+
+  it('drops matches that overlap an excluded span', () => {
+    const matches = [m(0, 3), m(10, 13), m(20, 23)];
+    // span [8,15) overlaps the middle match only
+    expect(excludeMatchesInSpans(matches, [{ from: 8, to: 15 }])).toEqual([m(0, 3), m(20, 23)]);
+  });
+
+  it('drops a match that is only partially inside a span', () => {
+    // match [4,7) overlaps span [6,10) at one character → dropped
+    expect(excludeMatchesInSpans([m(4, 7)], [{ from: 6, to: 10 }])).toEqual([]);
+  });
+
+  it('keeps matches that merely touch a span boundary (half-open)', () => {
+    // match [0,5) ends exactly where span [5,9) starts → no overlap
+    expect(excludeMatchesInSpans([m(0, 5)], [{ from: 5, to: 9 }])).toEqual([m(0, 5)]);
+  });
+
+  it('drops a match overlapping any of several spans', () => {
+    const spans = [
+      { from: 0, to: 4 },
+      { from: 20, to: 24 }
+    ];
+    expect(excludeMatchesInSpans([m(2, 5), m(10, 12), m(22, 25)], spans)).toEqual([m(10, 12)]);
   });
 });

--- a/apps/reborn-notes/src/lib/utils/note-search-core.ts
+++ b/apps/reborn-notes/src/lib/utils/note-search-core.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared, surface-agnostic matcher for the in-note "find in note" feature.
+ *
+ * Both backends - the CodeMirror editor ({@link ../editor/note-search}) and the
+ * rendered Markdown preview ({@link ./note-search-dom}) - feed their text through
+ * {@link findMatches} so the search semantics (case folding, escaping, the match
+ * cap) stay identical no matter which view mode is active. Search runs entirely
+ * client-side over already-decrypted, in-memory content; nothing is sent to or
+ * logged on the server.
+ */
+
+export interface SearchMatch {
+  /** Start offset (inclusive) into the searched text. */
+  from: number;
+  /** End offset (exclusive) into the searched text. */
+  to: number;
+}
+
+/**
+ * Hard cap on highlighted matches. Keeps decoration/range building cheap on
+ * pathological queries (e.g. a single common letter in a large note). When the
+ * cap is hit the caller surfaces the count as "capped" (e.g. `2000+`).
+ */
+export const NOTE_SEARCH_MATCH_CAP = 2000;
+
+/** Escape a user string so it is matched literally inside a RegExp. */
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Find non-overlapping matches of `query` in `text`, case-insensitive unless
+ * `caseSensitive` is set.
+ *
+ * Matches against the ORIGINAL text via a RegExp rather than lower-casing both
+ * sides: `String.prototype.toLowerCase()` can change length under Unicode case
+ * folding (e.g. `İ`), which would shift offsets and misalign CodeMirror
+ * decorations / DOM ranges. A regex match reports indices into the original
+ * string, so offsets always line up. Returns at most
+ * {@link NOTE_SEARCH_MATCH_CAP} matches.
+ */
+export function findMatches(text: string, query: string, caseSensitive: boolean): SearchMatch[] {
+  if (!query) return [];
+  let re: RegExp;
+  try {
+    re = new RegExp(escapeRegExp(query), caseSensitive ? 'g' : 'gi');
+  } catch {
+    return [];
+  }
+  const matches: SearchMatch[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    // A non-empty query can't yield a zero-length match, but advancing past a
+    // zero-length lastIndex anyway guards against an infinite loop if that
+    // invariant ever changes.
+    if (m.index === re.lastIndex) re.lastIndex++;
+    matches.push({ from: m.index, to: m.index + m[0].length });
+    if (matches.length >= NOTE_SEARCH_MATCH_CAP) break;
+  }
+  return matches;
+}

--- a/apps/reborn-notes/src/lib/utils/note-search-core.ts
+++ b/apps/reborn-notes/src/lib/utils/note-search-core.ts
@@ -59,3 +59,27 @@ export function findMatches(text: string, query: string, caseSensitive: boolean)
   }
   return matches;
 }
+
+/** A half-open `[from, to)` source span. */
+export interface SearchSpan {
+  from: number;
+  to: number;
+}
+
+/**
+ * Drop matches that overlap any span in `excluded`.
+ *
+ * Used in Live Preview to hide matches that fall in source ranges the editor
+ * renders away (e.g. the `#slug` inside a managed TOC's `](#slug)` link target -
+ * a kebab-case dup of the heading the reader never sees). Filtering keeps the
+ * match count and prev/next navigation aligned with what is actually visible, so
+ * the user never lands on an "invisible" hit. A match overlaps a span when their
+ * half-open ranges intersect (`from < span.to && to > span.from`).
+ */
+export function excludeMatchesInSpans(
+  matches: SearchMatch[],
+  excluded: SearchSpan[]
+): SearchMatch[] {
+  if (!excluded.length) return matches;
+  return matches.filter((m) => !excluded.some((s) => m.from < s.to && m.to > s.from));
+}

--- a/apps/reborn-notes/src/lib/utils/note-search-dom.ts
+++ b/apps/reborn-notes/src/lib/utils/note-search-dom.ts
@@ -1,0 +1,145 @@
+/**
+ * Rendered-preview (DOM) backend for the in-note "find in note" feature.
+ *
+ * Highlights matches in the rendered Markdown without mutating its DOM, using
+ * the CSS Custom Highlight API (`CSS.highlights` + `Highlight` ranges). Not
+ * touching the DOM matters: the preview re-renders via `{@html}` on every edit /
+ * checkbox toggle, and injected wrapper elements would be wiped (and would fight
+ * the renderer). The host recomputes ranges after each render instead.
+ *
+ * The preview is searched as RENDERED text, so a query matches what the reader
+ * sees (e.g. `bold`), not the Markdown source (`**bold**`) - the editor backend
+ * covers source search. Ranges may span inline element boundaries (bold/links).
+ */
+import { findMatches, NOTE_SEARCH_MATCH_CAP } from './note-search-core';
+
+const HL_ALL = 'note-search';
+const HL_ACTIVE = 'note-search-active';
+
+/** Whether the browser supports the CSS Custom Highlight API (painting). */
+export function supportsHighlightApi(): boolean {
+  return typeof CSS !== 'undefined' && 'highlights' in CSS && typeof Highlight !== 'undefined';
+}
+
+interface NodeOffset {
+  node: Text;
+  /** Index in the concatenated text where this node's data begins. */
+  start: number;
+}
+
+/**
+ * Build DOM Ranges for every match of `query` in `root`'s rendered text.
+ *
+ * Concatenates all text nodes (with a per-node start-offset map), runs the
+ * shared {@link findMatches} over the joined string, then maps each global
+ * offset back to its `(textNode, offset)` via binary search - so a match that
+ * crosses inline boundaries still yields one continuous Range. Capped at
+ * {@link NOTE_SEARCH_MATCH_CAP}.
+ */
+export function findDomMatchRanges(
+  root: HTMLElement | null,
+  query: string,
+  caseSensitive: boolean
+): Range[] {
+  if (!query || !root) return [];
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const offsets: NodeOffset[] = [];
+  let full = '';
+  let current: Node | null;
+  while ((current = walker.nextNode())) {
+    const textNode = current as Text;
+    if (!textNode.data) continue;
+    offsets.push({ node: textNode, start: full.length });
+    full += textNode.data;
+  }
+  if (!offsets.length) return [];
+
+  const matches = findMatches(full, query, caseSensitive);
+
+  // Map a global offset into the concatenated text back to its text node.
+  const locate = (globalIdx: number): { node: Text; offset: number } => {
+    let lo = 0;
+    let hi = offsets.length - 1;
+    let ans = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (offsets[mid].start <= globalIdx) {
+        ans = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return { node: offsets[ans].node, offset: globalIdx - offsets[ans].start };
+  };
+
+  const ranges: Range[] = [];
+  for (const m of matches) {
+    const s = locate(m.from);
+    const e = locate(m.to);
+    try {
+      const range = document.createRange();
+      range.setStart(s.node, Math.min(s.offset, s.node.length));
+      range.setEnd(e.node, Math.min(e.offset, e.node.length));
+      ranges.push(range);
+    } catch {
+      /* Skip ranges the DOM rejects (e.g. node detached mid-render). */
+    }
+    if (ranges.length >= NOTE_SEARCH_MATCH_CAP) break;
+  }
+  return ranges;
+}
+
+/**
+ * Paint `ranges` as the base highlight and the `active`-th as the strong
+ * highlight. The active range is kept OUT of the base set so the two
+ * `::highlight()` styles don't blend where they'd overlap. No-op without API
+ * support (matches still navigate/scroll; only the paint is skipped).
+ */
+export function paintDomHighlights(ranges: Range[], active: number): void {
+  if (!supportsHighlightApi()) return;
+  const base = new Highlight();
+  let activeRange: Range | null = null;
+  ranges.forEach((range, i) => {
+    if (i === active) activeRange = range;
+    else base.add(range);
+  });
+  CSS.highlights.set(HL_ALL, base);
+  if (activeRange) {
+    const strong = new Highlight();
+    strong.add(activeRange);
+    CSS.highlights.set(HL_ACTIVE, strong);
+  } else {
+    CSS.highlights.delete(HL_ACTIVE);
+  }
+}
+
+/** Remove both in-note search highlights from the registry. */
+export function clearDomHighlights(): void {
+  if (!supportsHighlightApi()) return;
+  CSS.highlights.delete(HL_ALL);
+  CSS.highlights.delete(HL_ACTIVE);
+}
+
+/**
+ * Scroll `scrollEl` so `range` is centered. Falls back to the match's parent
+ * element when the scroll container is unknown or the range has no box yet
+ * (e.g. zero-size during a re-render).
+ */
+export function scrollDomRangeIntoView(scrollEl: HTMLElement | null, range: Range): void {
+  const fallback = () =>
+    range.startContainer.parentElement?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  if (!scrollEl) {
+    fallback();
+    return;
+  }
+  const cr = range.getBoundingClientRect();
+  if (cr.height === 0 && cr.width === 0) {
+    fallback();
+    return;
+  }
+  const sr = scrollEl.getBoundingClientRect();
+  const delta = cr.top - sr.top - (scrollEl.clientHeight / 2 - cr.height / 2);
+  scrollEl.scrollBy({ top: delta, behavior: 'smooth' });
+}

--- a/apps/reborn-notes/src/lib/utils/note-search-dom.ts
+++ b/apps/reborn-notes/src/lib/utils/note-search-dom.ts
@@ -15,6 +15,15 @@ import { findMatches, NOTE_SEARCH_MATCH_CAP } from './note-search-core';
 
 const HL_ALL = 'note-search';
 const HL_ACTIVE = 'note-search-active';
+/**
+ * Separate highlight name for matches painted INSIDE Live Preview block widgets
+ * (TOC / table / code) by the CodeMirror editor's widget highlighter. Kept
+ * distinct from {@link HL_ALL} so the editor's `clearDomHighlights()` (run on
+ * every editor-mode repaint) can wipe the rendered-preview highlights without
+ * touching the widget ones, and vice versa - the two backends never stomp each
+ * other even though both write to the document-global `CSS.highlights`.
+ */
+const HL_WIDGET = 'note-search-wgt';
 
 /** Whether the browser supports the CSS Custom Highlight API (painting). */
 export function supportsHighlightApi(): boolean {
@@ -120,6 +129,32 @@ export function clearDomHighlights(): void {
   if (!supportsHighlightApi()) return;
   CSS.highlights.delete(HL_ALL);
   CSS.highlights.delete(HL_ACTIVE);
+}
+
+/**
+ * Paint `ranges` (matches found inside Live Preview block widgets) under the
+ * dedicated {@link HL_WIDGET} name. Empty input clears the layer. These ranges
+ * live in the editor's widget DOM, which CodeMirror's mark decorations can't
+ * reach (the source is replaced by generated DOM); the CSS Custom Highlight API
+ * is the only way to colour them without mutating widget markup. Active-match
+ * emphasis stays on visible editor text (the `cm-note-search-match-active` mark);
+ * widget hits render as the base highlight only.
+ */
+export function paintWidgetHighlights(ranges: Range[]): void {
+  if (!supportsHighlightApi()) return;
+  if (!ranges.length) {
+    CSS.highlights.delete(HL_WIDGET);
+    return;
+  }
+  const hl = new Highlight();
+  for (const range of ranges) hl.add(range);
+  CSS.highlights.set(HL_WIDGET, hl);
+}
+
+/** Remove the Live Preview widget search highlight from the registry. */
+export function clearWidgetHighlights(): void {
+  if (!supportsHighlightApi()) return;
+  CSS.highlights.delete(HL_WIDGET);
 }
 
 /**

--- a/apps/reborn-notes/src/lib/utils/note-search-dom.ts
+++ b/apps/reborn-notes/src/lib/utils/note-search-dom.ts
@@ -24,6 +24,8 @@ const HL_ACTIVE = 'note-search-active';
  * other even though both write to the document-global `CSS.highlights`.
  */
 const HL_WIDGET = 'note-search-wgt';
+/** Active-match variant of {@link HL_WIDGET} (the strong/orange emphasis). */
+const HL_WIDGET_ACTIVE = 'note-search-wgt-active';
 
 /** Whether the browser supports the CSS Custom Highlight API (painting). */
 export function supportsHighlightApi(): boolean {
@@ -132,29 +134,37 @@ export function clearDomHighlights(): void {
 }
 
 /**
- * Paint `ranges` (matches found inside Live Preview block widgets) under the
- * dedicated {@link HL_WIDGET} name. Empty input clears the layer. These ranges
- * live in the editor's widget DOM, which CodeMirror's mark decorations can't
- * reach (the source is replaced by generated DOM); the CSS Custom Highlight API
- * is the only way to colour them without mutating widget markup. Active-match
- * emphasis stays on visible editor text (the `cm-note-search-match-active` mark);
- * widget hits render as the base highlight only.
+ * Paint matches found inside Live Preview block widgets: `base` under the
+ * {@link HL_WIDGET} name and the `active` range (if any) under
+ * {@link HL_WIDGET_ACTIVE}. These ranges live in the editor's widget DOM, which
+ * CodeMirror's mark decorations can't reach (the source is replaced by generated
+ * DOM); the CSS Custom Highlight API is the only way to colour them without
+ * mutating widget markup. The active range is kept OUT of `base` by the caller so
+ * the two `::highlight()` styles don't blend. Empty input clears each layer.
  */
-export function paintWidgetHighlights(ranges: Range[]): void {
+export function paintWidgetHighlights(base: Range[], active: Range | null): void {
   if (!supportsHighlightApi()) return;
-  if (!ranges.length) {
+  if (base.length) {
+    const hl = new Highlight();
+    for (const range of base) hl.add(range);
+    CSS.highlights.set(HL_WIDGET, hl);
+  } else {
     CSS.highlights.delete(HL_WIDGET);
-    return;
   }
-  const hl = new Highlight();
-  for (const range of ranges) hl.add(range);
-  CSS.highlights.set(HL_WIDGET, hl);
+  if (active) {
+    const hl = new Highlight();
+    hl.add(active);
+    CSS.highlights.set(HL_WIDGET_ACTIVE, hl);
+  } else {
+    CSS.highlights.delete(HL_WIDGET_ACTIVE);
+  }
 }
 
-/** Remove the Live Preview widget search highlight from the registry. */
+/** Remove both Live Preview widget search highlights from the registry. */
 export function clearWidgetHighlights(): void {
   if (!supportsHighlightApi()) return;
   CSS.highlights.delete(HL_WIDGET);
+  CSS.highlights.delete(HL_WIDGET_ACTIVE);
 }
 
 /**

--- a/apps/reborn-notes/src/lib/utils/toc-hidden-spans.test.ts
+++ b/apps/reborn-notes/src/lib/utils/toc-hidden-spans.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { tocHiddenSpans, TOC_OPEN, TOC_CLOSE } from './toc';
+import { findMatches, excludeMatchesInSpans } from './note-search-core';
+
+// A realistic managed TOC block (markers + bold title + nested link list).
+const toc = [
+  TOC_OPEN,
+  '',
+  '**Table of contents**',
+  '',
+  '- [Heading anchors](#heading-anchors)',
+  '  - [Nested anchor](#nested-anchor)',
+  '',
+  TOC_CLOSE
+].join('\n');
+
+describe('tocHiddenSpans', () => {
+  it('returns [] when there is no managed block', () => {
+    expect(tocHiddenSpans('# just a note\n\nbody text')).toEqual([]);
+  });
+
+  it('covers the comment markers and `](#slug)` targets, not the labels', () => {
+    const content = `intro\n\n${toc}\n\nbody`;
+    const spans = tocHiddenSpans(content);
+    const covers = (needle: string) => {
+      const at = content.indexOf(needle);
+      return spans.some((s) => at >= s.from && at < s.to);
+    };
+    expect(covers(TOC_OPEN)).toBe(true);
+    expect(covers(TOC_CLOSE)).toBe(true);
+    expect(covers('#heading-anchors')).toBe(true);
+    expect(covers('#nested-anchor')).toBe(true);
+    // The visible label text (before the `](`) stays outside the hidden spans.
+    expect(covers('Heading anchors]')).toBe(false);
+  });
+
+  it('drops a slug match but keeps body and label matches (Live Preview count)', () => {
+    const content = `intro anchors\n\n${toc}\n\nbody`;
+    const all = findMatches(content, 'anchors', false);
+    const visible = excludeMatchesInSpans(all, tocHiddenSpans(content));
+    // "anchors" appears in the body, the label, and the slug → 3 raw matches;
+    // the slug occurrence is filtered out → 2 visible.
+    expect(all).toHaveLength(3);
+    expect(visible).toHaveLength(2);
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/toc.ts
+++ b/apps/reborn-notes/src/lib/utils/toc.ts
@@ -84,6 +84,36 @@ export function findTocBlockRange(content: string): { from: number; to: number }
 }
 
 /**
+ * Source spans inside the managed TOC block that Live Preview renders away, so
+ * an in-note search can drop matches the reader never sees:
+ *
+ *  - the `<!-- toc -->` / `<!-- /toc -->` comment markers, and
+ *  - each `](#slug)` link target - the slug is a kebab-case DUP of the heading
+ *    text, so a query that matches a heading also matches its slug, which would
+ *    otherwise inflate the count with a hit that has no visible counterpart (the
+ *    rendered entry shows only the label; the slug lives in the anchor's href).
+ *
+ * Returned spans are absolute `[from, to)` offsets into `content`. The visible
+ * title and entry labels are deliberately NOT listed - matches there stay.
+ * Returns `[]` when there is no managed block.
+ */
+export function tocHiddenSpans(content: string): { from: number; to: number }[] {
+  const block = findTocBlockRange(content);
+  if (!block) return [];
+  const slice = content.slice(block.from, block.to);
+  const spans: { from: number; to: number }[] = [];
+  const push = (re: RegExp) => {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(slice)) !== null) {
+      spans.push({ from: block.from + m.index, to: block.from + m.index + m[0].length });
+    }
+  };
+  push(/<!--[\s\S]*?-->/g); // open/close markers
+  push(/\]\(#[^)]*\)/g); // `](#slug)` link targets
+  return spans;
+}
+
+/**
  * Escape the characters that would break a Markdown link label. The backslash
  * (Markdown's escape char) MUST be in the set, otherwise a literal `\` in the
  * heading text would "consume" a following bracket escape and close the label

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -67,6 +67,7 @@
   import {
     appSettings,
     imageLoadMode,
+    editorMode,
     editorModeIntroSeen,
     periodicNotesSettings
   } from '$lib/stores/app-settings.store';
@@ -90,11 +91,16 @@
   import { createScrollSync } from '$lib/utils/scroll-sync';
   import { scrollToHeading } from '$lib/utils/heading-scroll';
   import type { DocHeading } from '$lib/utils/heading-outline';
-  import { applyToc, removeToc, hasToc, isTocStale } from '$lib/utils/toc';
+  import { applyToc, removeToc, hasToc, isTocStale, tocHiddenSpans } from '$lib/utils/toc';
   import { createEditorAdapter, createPreviewAdapter } from '$lib/utils/line-adapter';
   import { requireActiveSession } from '$lib/utils/require-active-session';
   import type { EditorView } from '@codemirror/view';
-  import { findMatches, NOTE_SEARCH_MATCH_CAP, type SearchMatch } from '$lib/utils/note-search-core';
+  import {
+    findMatches,
+    excludeMatchesInSpans,
+    NOTE_SEARCH_MATCH_CAP,
+    type SearchMatch
+  } from '$lib/utils/note-search-core';
   import { setNoteSearch, scrollCmMatchIntoView } from '$lib/editor/note-search';
   import {
     findDomMatchRanges,
@@ -1423,7 +1429,15 @@
       cmMatches = [];
     } else {
       const text = noteDetailService.content; // offsets line up with the CM doc
-      cmMatches = query ? findMatches(text, query, caseSensitive) : [];
+      let matches = query ? findMatches(text, query, caseSensitive) : [];
+      // Live Preview renders a managed TOC as a widget showing only entry labels;
+      // its `#slug` link targets (kebab dups of the headings) are never visible,
+      // so drop matches there to keep the count/navigation aligned with what the
+      // reader sees. Raw editor mode shows the slugs verbatim, so keep them.
+      if (effectiveViewMode === 'edit' && $editorMode === 'live' && matches.length) {
+        matches = excludeMatchesInSpans(matches, tocHiddenSpans(text));
+      }
+      cmMatches = matches;
       domMatches = [];
     }
   });
@@ -1453,7 +1467,11 @@
       const matches = cmMatches;
       clearDomHighlights();
       editorView?.dispatch({
-        effects: setNoteSearch.of(matches.length ? { matches, active } : null)
+        effects: setNoteSearch.of(
+          matches.length
+            ? { matches, active, query: searchQuery, caseSensitive: searchCaseSensitive }
+            : null
+        )
       });
     }
   });

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -43,6 +43,7 @@
   import NoteContentArea from '$lib/components/editor/NoteContentArea.svelte';
   import EncryptionXRay from '$lib/components/EncryptionXRay.svelte';
   import NoteDetailActions from '$lib/components/editor/NoteDetailActions.svelte';
+  import NoteSearchBar from '$lib/components/editor/NoteSearchBar.svelte';
   import NoteMetadataBar from '$lib/components/editor/NoteMetadataBar.svelte';
   import NoteActionSheet from '$lib/components/notes/NoteActionSheet.svelte';
   import ShareNoteDialog from '$lib/components/notes/ShareNoteDialog.svelte';
@@ -93,6 +94,14 @@
   import { createEditorAdapter, createPreviewAdapter } from '$lib/utils/line-adapter';
   import { requireActiveSession } from '$lib/utils/require-active-session';
   import type { EditorView } from '@codemirror/view';
+  import { findMatches, NOTE_SEARCH_MATCH_CAP, type SearchMatch } from '$lib/utils/note-search-core';
+  import { setNoteSearch, scrollCmMatchIntoView } from '$lib/editor/note-search';
+  import {
+    findDomMatchRanges,
+    paintDomHighlights,
+    clearDomHighlights,
+    scrollDomRangeIntoView
+  } from '$lib/utils/note-search-dom';
 
   type ViewMode = 'edit' | 'split' | 'preview';
 
@@ -1322,6 +1331,156 @@
     editorView = null;
   }
 
+  // ── In-note search (find in note) ─────────────────────────────────
+  // Client-side find over the OPEN note. One bar drives two backends by view
+  // mode: the CodeMirror editor (edit/split) via mark decorations, and the
+  // rendered preview (preview) via the CSS Custom Highlight API. Everything runs
+  // in the browser over already-decrypted, in-memory content — nothing is sent
+  // to or logged on the server (Zero Knowledge preserved).
+  let searchOpen = $state(false);
+  let searchQuery = $state('');
+  let searchCaseSensitive = $state(false);
+  let searchActiveIndex = $state(-1); // 0-based; -1 when there are no matches
+  let searchFocusSignal = $state(0); // bumped to (re)focus + select the bar input
+  let cmMatches = $state<SearchMatch[]>([]);
+  let domMatches = $state<Range[]>([]);
+  // Scroll to the active match only on explicit navigation / query change — never
+  // on a plain content edit, so typing with search open doesn't yank the viewport.
+  let pendingSearchScroll = $state(false);
+
+  const searchTotal = $derived(
+    effectiveViewMode === 'preview' ? domMatches.length : cmMatches.length
+  );
+  const searchCapped = $derived(searchTotal >= NOTE_SEARCH_MATCH_CAP);
+  const searchCurrent = $derived(
+    searchActiveIndex >= 0 && searchTotal > 0 ? searchActiveIndex + 1 : 0
+  );
+
+  function openNoteSearch() {
+    if (!searchOpen) {
+      // Seed from a non-empty single-line editor selection (find-bar convention).
+      const view = editorView;
+      if (view) {
+        const sel = view.state.selection.main;
+        if (!sel.empty) {
+          const picked = view.state.sliceDoc(sel.from, sel.to);
+          if (picked && !picked.includes('\n') && picked.length <= 200) searchQuery = picked;
+        }
+      }
+      searchActiveIndex = searchQuery ? 0 : -1;
+      searchOpen = true;
+    }
+    // Re-triggering Ctrl/Cmd+F on an open bar just refocuses + selects the input.
+    pendingSearchScroll = true;
+    searchFocusSignal++;
+  }
+
+  function closeNoteSearch() {
+    if (!searchOpen) return;
+    searchOpen = false;
+    pendingSearchScroll = false;
+    cmMatches = [];
+    domMatches = [];
+    clearDomHighlights();
+    editorView?.dispatch({ effects: setNoteSearch.of(null) });
+    // Return focus to the editor so typing resumes where the user left off.
+    if (effectiveViewMode !== 'preview') editorView?.focus();
+  }
+
+  function handleSearchInput(value: string) {
+    searchQuery = value;
+    searchActiveIndex = value ? 0 : -1; // a new query jumps to the first match
+    pendingSearchScroll = true;
+  }
+
+  function toggleSearchCase() {
+    searchCaseSensitive = !searchCaseSensitive;
+    searchActiveIndex = searchQuery ? 0 : -1;
+    pendingSearchScroll = true;
+    searchFocusSignal++;
+  }
+
+  function stepSearch(delta: 1 | -1) {
+    if (searchTotal === 0) return;
+    const base = searchActiveIndex < 0 ? 0 : searchActiveIndex;
+    searchActiveIndex = (base + delta + searchTotal) % searchTotal;
+    pendingSearchScroll = true;
+  }
+
+  // Recompute matches for the ACTIVE surface as the query / doc / preview change.
+  // Writes only the match arrays (never activeIndex) to avoid a reactive loop.
+  $effect(() => {
+    if (!searchOpen || $activeNoteId == null || historyMode !== 'closed') {
+      cmMatches = [];
+      domMatches = [];
+      return;
+    }
+    const query = searchQuery;
+    const caseSensitive = searchCaseSensitive;
+    if (effectiveViewMode === 'preview') {
+      void previewRenderTick; // re-run after each preview re-render
+      domMatches = findDomMatchRanges(previewContentEl, query, caseSensitive);
+      cmMatches = [];
+    } else {
+      const text = noteDetailService.content; // offsets line up with the CM doc
+      cmMatches = query ? findMatches(text, query, caseSensitive) : [];
+      domMatches = [];
+    }
+  });
+
+  // Keep activeIndex valid as the match set changes (clamp on shrink, preserve
+  // otherwise). Writes inside untrack so it never re-triggers itself.
+  $effect(() => {
+    const total = effectiveViewMode === 'preview' ? domMatches.length : cmMatches.length;
+    untrack(() => {
+      if (total === 0) {
+        if (searchActiveIndex !== -1) searchActiveIndex = -1;
+      } else if (searchActiveIndex < 0 || searchActiveIndex >= total) {
+        searchActiveIndex = 0;
+      }
+    });
+  });
+
+  // Paint highlights on the active surface and clear the other one.
+  $effect(() => {
+    const mode = effectiveViewMode;
+    const active = searchActiveIndex;
+    if (mode === 'preview') {
+      const ranges = domMatches;
+      editorView?.dispatch({ effects: setNoteSearch.of(null) });
+      paintDomHighlights(ranges, active);
+    } else {
+      const matches = cmMatches;
+      clearDomHighlights();
+      editorView?.dispatch({
+        effects: setNoteSearch.of(matches.length ? { matches, active } : null)
+      });
+    }
+  });
+
+  // Scroll the active match into view, but only when navigation / a query change
+  // asked for it (pendingSearchScroll) — not on every recompute.
+  $effect(() => {
+    const mode = effectiveViewMode;
+    const matches = mode === 'preview' ? domMatches : cmMatches;
+    const active = searchActiveIndex;
+    if (!pendingSearchScroll) return;
+    if (active < 0 || active >= matches.length) return;
+    if (mode === 'preview') {
+      scrollDomRangeIntoView(previewSyncScrollEl, matches[active] as Range);
+    } else if (editorView) {
+      scrollCmMatchIntoView(editorView, matches[active] as SearchMatch);
+    }
+    pendingSearchScroll = false;
+  });
+
+  // Close search when leaving the note or entering version history / trash diff.
+  $effect(() => {
+    if ($activeNoteId == null || historyMode !== 'closed') {
+      if (searchOpen) closeNoteSearch();
+    }
+  });
+
   // ── Folder breadcrumb navigation ──────────────────────────────────
   // The section-change $effect above clears `activeFolderId` for any non-periodic
   // transition. So we set the target id AFTER tick() - once that clearing pass
@@ -1478,6 +1637,16 @@
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
       activeSection = 'search';
+      return;
+    }
+    // Ctrl/Cmd+F — in-note find. Overrides the browser's page find while a note
+    // is open (mirrors Google Docs / Notion / VS Code). Live note view only,
+    // never in version history or trash.
+    if ((e.metaKey || e.ctrlKey) && (e.key === 'f' || e.key === 'F') && !e.shiftKey && !e.altKey) {
+      if ($activeNoteId != null && historyMode === 'closed' && !activeTrash) {
+        e.preventDefault();
+        openNoteSearch();
+      }
       return;
     }
     // Alt+Left / Alt+Right - Back / Forward between visited notes. Ignored when
@@ -1806,6 +1975,7 @@
                 <NoteDetailActions
                   note={detailMenuNote}
                   onmenuopen={() => (detailActionSheetOpen = true)}
+                  onsearch={openNoteSearch}
                   onpin={handleDetailPin}
                   onstar={handleDetailStar}
                   onmove={handleDetailMoveDesktop}
@@ -1862,6 +2032,25 @@
                   noteKind={currentNoteKind}
                 />
               </div>
+
+              {#if searchOpen}
+                <div class="absolute inset-x-0 top-0 z-30">
+                  <NoteSearchBar
+                    isMobile
+                    query={searchQuery}
+                    caseSensitive={searchCaseSensitive}
+                    total={searchTotal}
+                    current={searchCurrent}
+                    capped={searchCapped}
+                    focusSignal={searchFocusSignal}
+                    oninput={handleSearchInput}
+                    ontogglecase={toggleSearchCase}
+                    onnext={() => stepSearch(1)}
+                    onprev={() => stepSearch(-1)}
+                    onclose={closeNoteSearch}
+                  />
+                </div>
+              {/if}
 
               {#if showEncryptionXRay && historyMode === 'closed'}
                 <EncryptionXRay
@@ -2073,6 +2262,7 @@
               <NoteDetailActions
                 note={detailMenuNote}
                 onmenuopen={() => (detailActionSheetOpen = true)}
+                onsearch={openNoteSearch}
                 onpin={handleDetailPin}
                 onstar={handleDetailStar}
                 onmove={handleDetailMoveDesktop}
@@ -2136,6 +2326,24 @@
                 noteKind={currentNoteKind}
               />
             </div>
+
+            {#if searchOpen}
+              <div class="absolute right-3 top-3 z-30">
+                <NoteSearchBar
+                  query={searchQuery}
+                  caseSensitive={searchCaseSensitive}
+                  total={searchTotal}
+                  current={searchCurrent}
+                  capped={searchCapped}
+                  focusSignal={searchFocusSignal}
+                  oninput={handleSearchInput}
+                  ontogglecase={toggleSearchCase}
+                  onnext={() => stepSearch(1)}
+                  onprev={() => stepSearch(-1)}
+                  onclose={closeNoteSearch}
+                />
+              </div>
+            {/if}
 
             {#if showEncryptionXRay && historyMode === 'closed'}
               <EncryptionXRay
@@ -2320,6 +2528,7 @@
 <NoteActionSheet
   bind:open={detailActionSheetOpen}
   note={detailMenuNote}
+  onsearch={openNoteSearch}
   onpin={() => handleDetailPin()}
   onstar={() => handleDetailStar()}
   onmove={() => handleDetailOpenMoveMobile()}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -650,6 +650,16 @@
     "back": "Vorherige Notiz",
     "forward": "Nächste Notiz"
   },
+  "note_search": {
+    "open": "In Notiz suchen",
+    "placeholder": "In Notiz suchen…",
+    "previous": "Vorheriger Treffer",
+    "next": "Nächster Treffer",
+    "close": "Suche schließen",
+    "match_case": "Groß-/Kleinschreibung beachten",
+    "no_results": "Keine Treffer",
+    "position": "{current} von {total}"
+  },
   "outline": {
     "title": "Gliederung",
     "empty": "Diese Notiz hat noch keine Überschriften."

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -650,6 +650,16 @@
     "back": "Previous note",
     "forward": "Next note"
   },
+  "note_search": {
+    "open": "Search in note",
+    "placeholder": "Search in note…",
+    "previous": "Previous match",
+    "next": "Next match",
+    "close": "Close search",
+    "match_case": "Match case",
+    "no_results": "No results",
+    "position": "{current} of {total}"
+  },
   "outline": {
     "title": "Outline",
     "empty": "No headings in this note yet."

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -650,6 +650,16 @@
     "back": "Nota anterior",
     "forward": "Nota siguiente"
   },
+  "note_search": {
+    "open": "Buscar en la nota",
+    "placeholder": "Buscar en la nota…",
+    "previous": "Coincidencia anterior",
+    "next": "Coincidencia siguiente",
+    "close": "Cerrar búsqueda",
+    "match_case": "Distinguir mayúsculas y minúsculas",
+    "no_results": "Sin resultados",
+    "position": "{current} de {total}"
+  },
   "outline": {
     "title": "Esquema",
     "empty": "Esta nota aún no tiene encabezados."

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -650,6 +650,16 @@
     "back": "Note précédente",
     "forward": "Note suivante"
   },
+  "note_search": {
+    "open": "Rechercher dans la note",
+    "placeholder": "Rechercher dans la note…",
+    "previous": "Résultat précédent",
+    "next": "Résultat suivant",
+    "close": "Fermer la recherche",
+    "match_case": "Respecter la casse",
+    "no_results": "Aucun résultat",
+    "position": "{current} sur {total}"
+  },
   "outline": {
     "title": "Plan",
     "empty": "Cette note n'a pas encore de titres."

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -650,6 +650,16 @@
     "back": "Poprzednia notatka",
     "forward": "Następna notatka"
   },
+  "note_search": {
+    "open": "Szukaj w notatce",
+    "placeholder": "Szukaj w notatce…",
+    "previous": "Poprzednie dopasowanie",
+    "next": "Następne dopasowanie",
+    "close": "Zamknij wyszukiwanie",
+    "match_case": "Uwzględnij wielkość liter",
+    "no_results": "Brak wyników",
+    "position": "{current} z {total}"
+  },
   "outline": {
     "title": "Konspekt",
     "empty": "Ta notatka nie ma jeszcze nagłówków."


### PR DESCRIPTION
## Summary

Adds find-in-note for Reborn Notes, requested from the note kebab menu.

- **Search bar** with a live match counter (`3/12`), prev/next navigation, a case-sensitivity toggle (`Aa`), and close. Opens from the kebab ("Search in note") and, on desktop, via **Ctrl/Cmd+F** (overrides the browser page-find while a note is open, like Google Docs / Notion / VS Code).
- **All view modes**: highlights in the CodeMirror editor (edit/split) via mark decorations, and in the rendered preview via the CSS Custom Highlight API. Both backends share one matcher so semantics are identical; offsets stay aligned (regex over original text, no lowercasing).
- **Keyboard**: Enter / Down next, Shift+Enter / Up previous, Esc closes and returns focus to the editor.
- **Kebab cleanup** (also requested): reordered into best-practice groups with dividers - Search first, destructive Delete isolated last - consistent across the desktop dropdown and the mobile action sheet. The mobile sheet is now scrollable with a pinned header + close so the longer menu fits short screens (the desktop dropdown already caps its height via the base component).
- **Zero Knowledge**: search runs fully client-side over already-decrypted, in-memory content - nothing is sent to or logged on the server. No schema / sync / crypto changes.

Design decisions (for review):
- Two backends behind one bar (CM decorations + DOM Custom Highlight API) rather than one approach, so search works in every mode the kebab is available in.
- No new dependency: built on the existing `@codemirror/*` packages + the browser Highlight API (broadly supported; painting degrades gracefully where absent, count/scroll still work).
- New i18n namespace `note_search.*` added to all 5 locales.

## Test plan

Open a note with repeated words across paragraphs, headings, bold/links.
- [x] Ctrl/Cmd+F opens the bar (desktop); kebab -> "Search in note" opens it (desktop + mobile).
- [x] Typing shows the count; matches highlight; the current match is emphasized.
- [x] Enter / Shift+Enter and the Down/Up buttons scroll through matches and wrap around.
- [x] `Aa` toggles case sensitivity; count updates.
- [ ] Esc closes and returns focus to the editor.
- [ ] Switch edit -> preview (and split): search still highlights and navigates in the rendered preview.
- [ ] Dark mode: highlight and active-match colors are legible.
- [ ] Mobile: bar is full-width at the top; the action sheet scrolls with header + close pinned on a short screen.
- [ ] Kebab order reads cleanly with Search on top and Delete isolated at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)