### PR TITLE
fix(whats-new): scope last-seen baseline per app

### DIFF
--- a/apps/reborn-notes/src/lib/services/whats-new.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/whats-new.service.spec.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Regression cover for the per-app "What's new" baseline.
+ *
+ * The bug: Task and Notes shared one localStorage key on the same origin, so
+ * whichever app loaded first advanced the baseline and suppressed the other
+ * app's dialog - even though release notes are filtered per app. The fix scopes
+ * the key per app and migrates the legacy shared key. These tests pin down the
+ * migration, the cross-app-safe cleanup (legacy kept until BOTH apps own a
+ * baseline), and the unchanged new-user / no-content / already-seen behaviour.
+ *
+ * i18n is mocked: a local compareVersions (trivial, separately tested in the
+ * package) keeps the test deterministic and off the live manifest, while
+ * hasUnseenReleaseNotes is a spy so each test controls "does this app have
+ * content in the gap".
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$lib/stores/whats-new.svelte', () => ({ openWhatsNew: vi.fn() }));
+vi.mock('@reborn/utils', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+vi.mock('@reborn/i18n', () => ({
+  // Mirror of the package's pure x.y.z compare - kept inline so the service test
+  // depends on neither the built package nor the live release manifest.
+  compareVersions: (a: string, b: string) => {
+    const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+    const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+    const len = Math.max(pa.length, pb.length);
+    for (let i = 0; i < len; i++) {
+      const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+      if (d !== 0) return d > 0 ? 1 : -1;
+    }
+    return 0;
+  },
+  hasUnseenReleaseNotes: vi.fn()
+}));
+
+const LEGACY_KEY = 'whats_new_last_seen';
+const NOTES_KEY = 'whats_new_last_seen_notes';
+const TASK_KEY = 'whats_new_last_seen_task';
+const CURRENT = '0.38.0';
+const PREVIOUS = '0.37.0';
+
+// Re-import per test: the module's `shown` latch and the per-app key resolution
+// must start fresh each time.
+async function load() {
+  const svc = await import('./whats-new.service');
+  const i18n = await import('@reborn/i18n');
+  const store = await import('$lib/stores/whats-new.svelte');
+  return {
+    maybeShowWhatsNew: svc.maybeShowWhatsNew,
+    hasUnseen: vi.mocked(i18n.hasUnseenReleaseNotes),
+    openWhatsNew: vi.mocked(store.openWhatsNew)
+  };
+}
+
+describe('maybeShowWhatsNew - per-app baseline', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.stubGlobal('__APP_VERSION__', CURRENT);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('new user (no baseline at all): records a silent baseline, no dialog', async () => {
+    const { maybeShowWhatsNew, openWhatsNew } = await load();
+
+    maybeShowWhatsNew('notes', 'web');
+
+    expect(openWhatsNew).not.toHaveBeenCalled();
+    expect(localStorage.getItem(NOTES_KEY)).toBe(CURRENT);
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it('migrates the legacy shared key so the fix release still opens the dialog', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS);
+    const { maybeShowWhatsNew, openWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(true);
+
+    maybeShowWhatsNew('notes', 'web');
+
+    expect(hasUnseen).toHaveBeenCalledWith({
+      app: 'notes',
+      platform: 'web',
+      lastSeenVersion: PREVIOUS,
+      currentVersion: CURRENT
+    });
+    expect(openWhatsNew).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(NOTES_KEY)).toBe(CURRENT);
+  });
+
+  it('keeps the legacy key until the other app has migrated too', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS); // task has NOT migrated yet
+    const { maybeShowWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(true);
+
+    maybeShowWhatsNew('notes', 'web');
+
+    // Task still needs the legacy value to migrate, so it must survive.
+    expect(localStorage.getItem(LEGACY_KEY)).toBe(PREVIOUS);
+    expect(localStorage.getItem(NOTES_KEY)).toBe(CURRENT);
+  });
+
+  it('drops the legacy key once both apps own a baseline', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS);
+    localStorage.setItem(TASK_KEY, CURRENT); // task already migrated
+    const { maybeShowWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(true);
+
+    maybeShowWhatsNew('notes', 'web');
+
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+    expect(localStorage.getItem(NOTES_KEY)).toBe(CURRENT);
+    expect(localStorage.getItem(TASK_KEY)).toBe(CURRENT);
+  });
+
+  it('no content for this app in the gap: advances baseline silently, no dialog', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS);
+    const { maybeShowWhatsNew, openWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(false);
+
+    maybeShowWhatsNew('notes', 'web');
+
+    expect(openWhatsNew).not.toHaveBeenCalled();
+    expect(localStorage.getItem(NOTES_KEY)).toBe(CURRENT);
+  });
+
+  it('already up to date: no dialog, no version check, baseline unchanged', async () => {
+    localStorage.setItem(NOTES_KEY, CURRENT);
+    const { maybeShowWhatsNew, openWhatsNew, hasUnseen } = await load();
+
+    maybeShowWhatsNew('notes', 'web');
+
+    expect(openWhatsNew).not.toHaveBeenCalled();
+    expect(hasUnseen).not.toHaveBeenCalled();
+    expect(localStorage.getItem(NOTES_KEY)).toBe(CURRENT);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/whats-new.service.ts
+++ b/apps/reborn-notes/src/lib/services/whats-new.service.ts
@@ -12,6 +12,11 @@
  * opens at most once per update and is never burned while the app is still
  * locked - we simply get called again after unlock.
  *
+ * The baseline is scoped per app: Task and Notes share a browser origin, so a
+ * single shared key let whichever app loaded first advance it and suppress the
+ * other app's dialog even when each had its own notes. The pre-per-app key is
+ * migrated on first read and dropped once both apps hold their own baseline.
+ *
  * First run on a device records a baseline silently - new users are not greeted
  * with a changelog. Content is bundled and the check is local: the server never
  * learns the client version or what was viewed (guideline 62 zero-telemetry).
@@ -23,7 +28,16 @@ import { createLogger } from '@reborn/utils';
 import { openWhatsNew } from '$lib/stores/whats-new.svelte';
 
 const logger = createLogger('notes:whats-new');
-const LAST_SEEN_KEY = 'whats_new_last_seen';
+
+// Pre-per-app shared key (Task + Notes used the same one on this origin).
+const LEGACY_KEY = 'whats_new_last_seen';
+// Per-app baseline key, e.g. "whats_new_last_seen_notes".
+const baselineKey = (app: ReleaseApp) => `whats_new_last_seen_${app}`;
+// Apps sharing this browser origin. Used only to decide when the legacy shared
+// key can be safely dropped: once every app holds its own baseline, none still
+// needs the legacy value to migrate. Keep in sync with ReleaseApp - an extra
+// entry only delays cleanup, a missing one risks dropping the key too early.
+const ORIGIN_APPS: ReleaseApp[] = ['notes', 'task'];
 
 // Latched only once we have actually opened the dialog (not on a no-op check),
 // so re-running the gate after an unlock in the same page load never re-pops a
@@ -35,22 +49,32 @@ export function maybeShowWhatsNew(app: ReleaseApp, platform: ReleasePlatform): v
   if (!browser || shown) return;
 
   const current = __APP_VERSION__;
+  const key = baselineKey(app);
 
   let lastSeen: string | null;
   try {
-    lastSeen = localStorage.getItem(LAST_SEEN_KEY);
+    lastSeen = localStorage.getItem(key);
+    // Migrate the pre-per-app shared baseline on first read after the rename, so
+    // the release shipping this fix still surfaces each app's own notes instead
+    // of being swallowed by a fresh "first run" baseline.
+    if (lastSeen === null) lastSeen = localStorage.getItem(LEGACY_KEY);
   } catch {
     return; // localStorage unavailable - harmless to re-check later
   }
 
   // First run on this device: record a baseline, don't greet new users.
   if (!lastSeen) {
-    safeSet(current);
+    safeSet(key, current);
     return;
   }
 
-  // Nothing newer than what the user has already seen.
-  if (compareVersions(current, lastSeen) <= 0) return;
+  // Nothing newer than what the user has already seen. Still persist the
+  // (possibly migrated) baseline into the per-app key, so the legacy fallback is
+  // not re-read every load and cleanup can proceed.
+  if (compareVersions(current, lastSeen) <= 0) {
+    safeSet(key, lastSeen);
+    return;
+  }
 
   if (hasUnseenReleaseNotes({ app, platform, lastSeenVersion: lastSeen, currentVersion: current })) {
     shown = true; // latch only on a real open
@@ -58,12 +82,19 @@ export function maybeShowWhatsNew(app: ReleaseApp, platform: ReleasePlatform): v
     openWhatsNew();
   }
   // Advance the baseline so this stays a once-per-update event across loads.
-  safeSet(current);
+  safeSet(key, current);
 }
 
-function safeSet(version: string): void {
+function safeSet(key: string, version: string): void {
   try {
-    localStorage.setItem(LAST_SEEN_KEY, version);
+    localStorage.setItem(key, version);
+    // Drop the legacy shared key only once every origin app holds its own
+    // baseline - removing it sooner would deny the other app the value it needs
+    // to migrate. Until then the orphan is harmless (one short string), and for
+    // a user who only ever opens one app it correctly lingers for the other.
+    if (ORIGIN_APPS.every((a) => localStorage.getItem(baselineKey(a)) !== null)) {
+      localStorage.removeItem(LEGACY_KEY);
+    }
   } catch {
     /* ignore */
   }

--- a/apps/reborn-notes/src/lib/test-stubs/app-environment.ts
+++ b/apps/reborn-notes/src/lib/test-stubs/app-environment.ts
@@ -1,0 +1,9 @@
+/**
+ * Test stub for SvelteKit's `$app/environment`.
+ *
+ * The notes vitest config is standalone (no sveltekit plugin), so `$app/*`
+ * specifiers are otherwise unresolvable. This lets specs import modules that
+ * pull in `$app/environment`; specs that need `browser === true` override it
+ * with `vi.mock('$app/environment', () => ({ browser: true }))`.
+ */
+export const browser = false;

--- a/apps/reborn-notes/vitest.config.ts
+++ b/apps/reborn-notes/vitest.config.ts
@@ -9,9 +9,14 @@ export default defineConfig({
   // Resolve SvelteKit's `$lib` alias so specs can import real (unmocked)
   // `$lib/...` modules - e.g. `$lib/utils/native-client`. Existing specs that
   // `vi.mock('$lib/...')` are unaffected (the mock still matches the specifier).
+  // `$app/environment` maps to a stub (no sveltekit plugin here to provide it);
+  // specs needing `browser === true` still override it via `vi.mock`.
   resolve: {
     alias: {
-      $lib: fileURLToPath(new URL('./src/lib', import.meta.url))
+      $lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
+      '$app/environment': fileURLToPath(
+        new URL('./src/lib/test-stubs/app-environment.ts', import.meta.url)
+      )
     }
   },
   test: {

--- a/apps/reborn-task/src/lib/services/whats-new.service.spec.ts
+++ b/apps/reborn-task/src/lib/services/whats-new.service.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Regression cover for the per-app "What's new" baseline.
+ *
+ * The bug: Task and Notes shared one localStorage key on the same origin, so
+ * whichever app loaded first advanced the baseline and suppressed the other
+ * app's dialog - even though release notes are filtered per app. The fix scopes
+ * the key per app and migrates the legacy shared key. These tests pin down the
+ * migration, the cross-app-safe cleanup (legacy kept until BOTH apps own a
+ * baseline), and the unchanged new-user / no-content / already-seen behaviour.
+ *
+ * i18n is mocked: a local compareVersions (trivial, separately tested in the
+ * package) keeps the test deterministic and off the live manifest, while
+ * hasUnseenReleaseNotes is a spy so each test controls "does this app have
+ * content in the gap".
+ */
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$lib/stores/whats-new.svelte', () => ({ openWhatsNew: vi.fn() }));
+vi.mock('@reborn/utils', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+vi.mock('@reborn/i18n', () => ({
+  // Mirror of the package's pure x.y.z compare - kept inline so the service test
+  // depends on neither the built package nor the live release manifest.
+  compareVersions: (a: string, b: string) => {
+    const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+    const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+    const len = Math.max(pa.length, pb.length);
+    for (let i = 0; i < len; i++) {
+      const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+      if (d !== 0) return d > 0 ? 1 : -1;
+    }
+    return 0;
+  },
+  hasUnseenReleaseNotes: vi.fn()
+}));
+
+const LEGACY_KEY = 'whats_new_last_seen';
+const TASK_KEY = 'whats_new_last_seen_task';
+const NOTES_KEY = 'whats_new_last_seen_notes';
+const CURRENT = '0.38.0';
+const PREVIOUS = '0.37.0';
+
+// Re-import per test: the module's `shown` latch and the per-app key resolution
+// must start fresh each time.
+async function load() {
+  const svc = await import('./whats-new.service');
+  const i18n = await import('@reborn/i18n');
+  const store = await import('$lib/stores/whats-new.svelte');
+  return {
+    maybeShowWhatsNew: svc.maybeShowWhatsNew,
+    hasUnseen: vi.mocked(i18n.hasUnseenReleaseNotes),
+    openWhatsNew: vi.mocked(store.openWhatsNew)
+  };
+}
+
+describe('maybeShowWhatsNew - per-app baseline', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.stubGlobal('__APP_VERSION__', CURRENT);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('new user (no baseline at all): records a silent baseline, no dialog', async () => {
+    const { maybeShowWhatsNew, openWhatsNew } = await load();
+
+    maybeShowWhatsNew('task', 'web');
+
+    expect(openWhatsNew).not.toHaveBeenCalled();
+    expect(localStorage.getItem(TASK_KEY)).toBe(CURRENT);
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it('migrates the legacy shared key so the fix release still opens the dialog', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS);
+    const { maybeShowWhatsNew, openWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(true);
+
+    maybeShowWhatsNew('task', 'web');
+
+    expect(hasUnseen).toHaveBeenCalledWith({
+      app: 'task',
+      platform: 'web',
+      lastSeenVersion: PREVIOUS,
+      currentVersion: CURRENT
+    });
+    expect(openWhatsNew).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(TASK_KEY)).toBe(CURRENT);
+  });
+
+  it('keeps the legacy key until the other app has migrated too', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS); // notes has NOT migrated yet
+    const { maybeShowWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(true);
+
+    maybeShowWhatsNew('task', 'web');
+
+    // Notes still needs the legacy value to migrate, so it must survive.
+    expect(localStorage.getItem(LEGACY_KEY)).toBe(PREVIOUS);
+    expect(localStorage.getItem(TASK_KEY)).toBe(CURRENT);
+  });
+
+  it('drops the legacy key once both apps own a baseline', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS);
+    localStorage.setItem(NOTES_KEY, CURRENT); // notes already migrated
+    const { maybeShowWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(true);
+
+    maybeShowWhatsNew('task', 'web');
+
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+    expect(localStorage.getItem(TASK_KEY)).toBe(CURRENT);
+    expect(localStorage.getItem(NOTES_KEY)).toBe(CURRENT);
+  });
+
+  it('no content for this app in the gap: advances baseline silently, no dialog', async () => {
+    localStorage.setItem(LEGACY_KEY, PREVIOUS);
+    const { maybeShowWhatsNew, openWhatsNew, hasUnseen } = await load();
+    hasUnseen.mockReturnValue(false);
+
+    maybeShowWhatsNew('task', 'web');
+
+    expect(openWhatsNew).not.toHaveBeenCalled();
+    expect(localStorage.getItem(TASK_KEY)).toBe(CURRENT);
+  });
+
+  it('already up to date: no dialog, no version check, baseline unchanged', async () => {
+    localStorage.setItem(TASK_KEY, CURRENT);
+    const { maybeShowWhatsNew, openWhatsNew, hasUnseen } = await load();
+
+    maybeShowWhatsNew('task', 'web');
+
+    expect(openWhatsNew).not.toHaveBeenCalled();
+    expect(hasUnseen).not.toHaveBeenCalled();
+    expect(localStorage.getItem(TASK_KEY)).toBe(CURRENT);
+  });
+});

--- a/apps/reborn-task/src/lib/services/whats-new.service.ts
+++ b/apps/reborn-task/src/lib/services/whats-new.service.ts
@@ -12,6 +12,11 @@
  * opens at most once per update and is never burned while the app is still
  * locked - we simply get called again after unlock.
  *
+ * The baseline is scoped per app: Task and Notes share a browser origin, so a
+ * single shared key let whichever app loaded first advance it and suppress the
+ * other app's dialog even when each had its own notes. The pre-per-app key is
+ * migrated on first read and dropped once both apps hold their own baseline.
+ *
  * First run on a device records a baseline silently - new users are not greeted
  * with a changelog. Content is bundled and the check is local: the server never
  * learns the client version or what was viewed (guideline 62 zero-telemetry).
@@ -23,7 +28,16 @@ import { createLogger } from '@reborn/utils';
 import { openWhatsNew } from '$lib/stores/whats-new.svelte';
 
 const logger = createLogger('task:whats-new');
-const LAST_SEEN_KEY = 'whats_new_last_seen';
+
+// Pre-per-app shared key (Task + Notes used the same one on this origin).
+const LEGACY_KEY = 'whats_new_last_seen';
+// Per-app baseline key, e.g. "whats_new_last_seen_task".
+const baselineKey = (app: ReleaseApp) => `whats_new_last_seen_${app}`;
+// Apps sharing this browser origin. Used only to decide when the legacy shared
+// key can be safely dropped: once every app holds its own baseline, none still
+// needs the legacy value to migrate. Keep in sync with ReleaseApp - an extra
+// entry only delays cleanup, a missing one risks dropping the key too early.
+const ORIGIN_APPS: ReleaseApp[] = ['notes', 'task'];
 
 // Latched only once we have actually opened the dialog (not on a no-op check),
 // so re-running the gate after an unlock in the same page load never re-pops a
@@ -35,22 +49,32 @@ export function maybeShowWhatsNew(app: ReleaseApp, platform: ReleasePlatform): v
   if (!browser || shown) return;
 
   const current = __APP_VERSION__;
+  const key = baselineKey(app);
 
   let lastSeen: string | null;
   try {
-    lastSeen = localStorage.getItem(LAST_SEEN_KEY);
+    lastSeen = localStorage.getItem(key);
+    // Migrate the pre-per-app shared baseline on first read after the rename, so
+    // the release shipping this fix still surfaces each app's own notes instead
+    // of being swallowed by a fresh "first run" baseline.
+    if (lastSeen === null) lastSeen = localStorage.getItem(LEGACY_KEY);
   } catch {
     return; // localStorage unavailable - harmless to re-check later
   }
 
   // First run on this device: record a baseline, don't greet new users.
   if (!lastSeen) {
-    safeSet(current);
+    safeSet(key, current);
     return;
   }
 
-  // Nothing newer than what the user has already seen.
-  if (compareVersions(current, lastSeen) <= 0) return;
+  // Nothing newer than what the user has already seen. Still persist the
+  // (possibly migrated) baseline into the per-app key, so the legacy fallback is
+  // not re-read every load and cleanup can proceed.
+  if (compareVersions(current, lastSeen) <= 0) {
+    safeSet(key, lastSeen);
+    return;
+  }
 
   if (hasUnseenReleaseNotes({ app, platform, lastSeenVersion: lastSeen, currentVersion: current })) {
     shown = true; // latch only on a real open
@@ -58,12 +82,19 @@ export function maybeShowWhatsNew(app: ReleaseApp, platform: ReleasePlatform): v
     openWhatsNew();
   }
   // Advance the baseline so this stays a once-per-update event across loads.
-  safeSet(current);
+  safeSet(key, current);
 }
 
-function safeSet(version: string): void {
+function safeSet(key: string, version: string): void {
   try {
-    localStorage.setItem(LAST_SEEN_KEY, version);
+    localStorage.setItem(key, version);
+    // Drop the legacy shared key only once every origin app holds its own
+    // baseline - removing it sooner would deny the other app the value it needs
+    // to migrate. Until then the orphan is harmless (one short string), and for
+    // a user who only ever opens one app it correctly lingers for the other.
+    if (ORIGIN_APPS.every((a) => localStorage.getItem(baselineKey(a)) !== null)) {
+      localStorage.removeItem(LEGACY_KEY);
+    }
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary

Task and Notes are served from the same origin, so the "What's new" auto-open service shared a single `localStorage` key (`whats_new_last_seen`). Whichever app loaded first advanced the baseline to the current version, so the other app's startup check exited early (`current <= lastSeen`) **before** it ever evaluated its own release notes - even though notes are filtered per app and each app has its own set. Result: after a release the dialog appeared in only one of the two apps.

**Fix:** scope the baseline key per app (`whats_new_last_seen_<app>`) so each app tracks its own and opens independently.

- **Migration:** the pre-per-app shared key is read as a fallback on first access, so the release shipping this fix still surfaces each app's own notes instead of being swallowed by a fresh "first run" baseline.
- **Cross-app-safe cleanup:** the legacy key is dropped only once *both* apps own a baseline (`ORIGIN_APPS.every(...)`); removing it sooner would deny the other app the value it needs to migrate. A user who only ever opens one app keeps the (harmless) legacy key for the day they open the other.

No change to the Zero-Knowledge model, schema, sync or crypto - this is purely a client-side localStorage key.

## Test plan

Regression specs added to both apps (`apps/*/src/lib/services/whats-new.service.spec.ts`): migration opens the dialog, legacy key survives until both apps migrate then is dropped, and the unchanged new-user / no-content / already-seen paths. Local gate green: `lint`, `check` (svelte-check 0/0), `test` (task + notes, incl. the 12 new cases), `build` - all on Node 24.

Smoke (browser):
- In DevTools, set `localStorage['whats_new_last_seen_task']` to an older version (e.g. `0.36.0`) and reload Task → "What's new" opens. Repeat for `_notes` in Notes.
- **Core fix:** with both apps on the same origin, view the dialog in Task, then open Notes → the dialog still opens in Notes (previously suppressed).
- New user (clear all `whats_new_last_seen*` keys) → no dialog, baseline recorded silently.
- Settings → Information → "What's new" still opens the dialog manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)