### PR TITLE
fix(notes): batch initial-sync writes to stop Android WebView OOM

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -614,6 +614,31 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(window).toMatch(/return null;/);
   });
 
+  it('pullNotes batches note writes via saveMany, never per-note save (Android OOM)', () => {
+    // Regression for the first-sync crash on a large account (503 notes, many
+    // long): noteStore.save() runs refreshItems() - a full getAll() over the
+    // entire notes table (every content_encrypted blob) - on every call. Firing
+    // one per note (503 concurrent) made memory grow ~O(n²) and OOM-killed the
+    // in-process Android System WebView at ~40 s; iOS WKWebView (out of process)
+    // absorbed the same spike. The pull must collect the writes and flush them
+    // with a single saveMany() (one transaction, one refresh). See guideline 36.
+    const src = readSource('./notes-sync.service.ts');
+    const pullNotes = src.slice(
+      src.indexOf('async function pullNotes'),
+      src.indexOf('// ── Push helpers')
+    );
+    // Strip line comments so the assertions check actual calls, not the
+    // explanatory comment that names the old `noteStore.save()` trap on purpose.
+    const code = pullNotes.replace(/\/\/.*$/gm, '');
+    // Writes go through the batched primitive...
+    expect(code).toMatch(/noteStore\.saveMany\(/);
+    // ...and never per-note save() in the pull loop (the O(n²) refresh trap).
+    expect(code).not.toMatch(/noteStore\.save\(/);
+    // Tag-association writes are likewise bounded, not a 503-wide burst.
+    expect(code).toMatch(/settleInBatches\(\s*tagAdds\b/);
+    expect(code).toMatch(/settleInBatches\(\s*tagRemoves\b/);
+  });
+
   it('post-pull reconciler runs in +layout.svelte runSync and onMount paths', () => {
     const layout = readSource('../../routes/+layout.svelte');
     expect(layout).toMatch(/from '\$lib\/services\/shadow-index-reconciler\.service'/);

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -508,6 +508,19 @@ async function pullNotes(): Promise<string[]> {
   if (!res.ok) throw new Error(`GET /api/notes: ${res.status}`);
   const { data } = await res.json();
 
+  // Collect all writes here and flush them in one batch below, instead of issuing
+  // them per-note inside the map. Each `noteStore.save()` runs refreshItems() - a
+  // full getAll() over the whole notes table (every content_encrypted blob) - so
+  // firing 503 of them concurrently made first-sync memory grow ~O(n²) and
+  // OOM-killed the in-process Android System WebView at ~40 s. (iOS WKWebView
+  // renders out of process with a far higher ceiling, so it absorbed the same
+  // spike in ~10 s.) saveMany() does one transaction + one refresh; the UI is
+  // rebuilt by refreshStoresAfterPull() afterwards regardless, so the per-note
+  // refresh was redundant work on top of being the memory bomb. See guideline 36.
+  const notesToWrite: NoteStoredLocal[] = [];
+  const tagAdds: Array<{ noteId: string; tagId: string }> = [];
+  const tagRemoves: Array<{ noteId: string; tagId: string }> = [];
+
   const changedResults = await Promise.all(
     (
       data as Array<{
@@ -557,7 +570,7 @@ async function pullNotes(): Promise<string[]> {
           logger.info(
             `Reconciling archive state for note ${n.id}: local=${localNote.is_archived} server=${serverArchived}`
           );
-          await noteStore.save({ ...localNote, is_archived: serverArchived });
+          notesToWrite.push({ ...localNote, is_archived: serverArchived });
         }
 
         // Reconciliation: see pullFolders() for rationale. Covers notes whose edits
@@ -571,7 +584,7 @@ async function pullNotes(): Promise<string[]> {
             (localNote.folder_id ?? null) !== (n.folder_id ?? null))
         ) {
           logger.warn(`Reconciling orphaned note edit ${n.id} - marking pending`);
-          await noteStore.save({ ...localNote, sync_status: 'pending' });
+          notesToWrite.push({ ...localNote, sync_status: 'pending' });
         }
         return null;
       }
@@ -613,25 +626,19 @@ async function pullNotes(): Promise<string[]> {
         created_at: n.created_at,
         updated_at: n.updated_at
       };
-      await noteStore.save(note);
+      notesToWrite.push(note);
 
-      // Rebuild local note-tag associations from metadata_encrypted
+      // Rebuild local note-tag associations from metadata_encrypted. Collect the
+      // deltas here (read-only) and apply them in a bounded sweep below, off the
+      // per-note hot path - noteTagStore.save()/delete() each refresh that store too.
       if (metaTagIds.length > 0) {
         const currentTagIds = await noteTagQueries.getTagsForNote(n.id);
-        const toAdd = metaTagIds.filter((id: string) => !currentTagIds.includes(id));
-        const toRemove = currentTagIds.filter((id: string) => !metaTagIds.includes(id));
-        await Promise.all([
-          ...toAdd.map((tagId: string) =>
-            noteTagOperations
-              .addTagToNote(n.id, tagId)
-              .catch((e) => logger.warn('Failed to add tag to note', e))
-          ),
-          ...toRemove.map((tagId: string) =>
-            noteTagOperations
-              .removeTagFromNote(n.id, tagId)
-              .catch((e) => logger.warn('Failed to remove tag from note', e))
-          )
-        ]);
+        for (const tagId of metaTagIds) {
+          if (!currentTagIds.includes(tagId)) tagAdds.push({ noteId: n.id, tagId });
+        }
+        for (const tagId of currentTagIds) {
+          if (!metaTagIds.includes(tagId)) tagRemoves.push({ noteId: n.id, tagId });
+        }
       }
 
       // This note's server state advanced (new, or newer sync_version) → its
@@ -639,6 +646,39 @@ async function pullNotes(): Promise<string[]> {
       return n.id;
     })
   );
+
+  // Flush every note upsert / reconciliation in a single transaction (one
+  // refreshItems for the whole pull, not one per note). saveMany runs the same
+  // pre-save encryption guard per record as save(); a record that fails it is
+  // counted and skipped rather than aborting the whole sync.
+  if (notesToWrite.length > 0) {
+    const result = await noteStore.saveMany(notesToWrite);
+    if (result.failed > 0) {
+      logger.warn(
+        `pullNotes: ${result.failed}/${notesToWrite.length} note writes failed in batch`,
+        { errors: result.errors.slice(0, 3) }
+      );
+    }
+  }
+
+  // Apply tag-association deltas in bounded batches. addTagToNote/removeTagFromNote
+  // each refresh the (small) noteTags store; settleInBatches keeps that off a
+  // 503-wide burst. Disjoint pairs across notes, so global add-then-remove order
+  // is safe (a note never has the same tagId queued for both add and remove).
+  if (tagAdds.length > 0) {
+    await settleInBatches(tagAdds, ({ noteId, tagId }) =>
+      noteTagOperations
+        .addTagToNote(noteId, tagId)
+        .catch((e) => logger.warn('Failed to add tag to note', e))
+    );
+  }
+  if (tagRemoves.length > 0) {
+    await settleInBatches(tagRemoves, ({ noteId, tagId }) =>
+      noteTagOperations
+        .removeTagFromNote(noteId, tagId)
+        .catch((e) => logger.warn('Failed to remove tag from note', e))
+    );
+  }
 
   // Remove local notes that no longer exist on the server (permanently deleted on another device).
   // We use include_archived=true above, so the server returns soft-deleted notes too.


### PR DESCRIPTION
## Summary

On Android emulators (Pixel 7, API 34 and 36), the **first** sync after login of a large account (test account: 503 notes, many long) span the sync spinner with notes hidden and then **silently closed the app at ~40s**. Reopening showed the notes and synced in ~15s. iOS (iPhone 17) synced the same account in ~10s with no crash.

**Root cause - O(n^2) memory under unbounded concurrency.** `pullNotes()` issued `noteStore.save(note)` per note inside a `Promise.all` over the whole server response. `IndexedDBStore.save()` runs `refreshItems()` -> `getAll()` over the *entire* notes table (every `content_encrypted` blob) after every `put`, so ~503 concurrent saves re-materialised the growing table ~503 times -> memory ~O(n^2). Android's System WebView renders **in the app process** (manifest has no `largeHeap`), so it blew the heap ceiling and the OS killed the process. iOS WKWebView renders **out of process** with a far higher budget, so it absorbed the same spike. The **second sync works** because the `sync_version` guard skips the upserts entirely (zero saves) - which pinpointed the writes as the cost.

**Fix.** Collect every upsert/reconciliation into a buffer and flush it with a single `noteStore.saveMany()` (one transaction, one refresh). The UI is rebuilt by `refreshStoresAfterPull()` regardless, so the per-note refresh was redundant on top of being the memory bomb. First sync becomes O(n), like the working second sync. Note/tag association deltas are collected during decode and applied via `settleInBatches` after the bulk write.

**Zero-Knowledge: untouched.** Only the local IndexedDB write *strategy* changed (buffer + `saveMany` vs `save` in a loop). No schema / API / encryption-model / server-visibility change; the pre-save encryption guard still runs per record inside `saveMany` (a record that fails it is counted and skipped rather than aborting the whole sync). Reconciliation behaviour is preserved exactly, including the archive+content double-write (last write wins).

### Decisions (auto mode - for review)

- **`saveMany` over a mere concurrency cap** - capping `Promise.all` would lower peak memory but keep O(n^2) total work (each save still reloads the growing table); `saveMany` removes the O(n^2) at the source and is an existing, proven primitive (task app, folder/list stores).
- **Scope = `pullNotes` only** - `pullFolders`/`pullTags`/`pullSavedSearches` share the pattern but have small rows (no `content_encrypted`); their O(n^2) is negligible and was not the reported crash. Converting them is a cheap P3 follow-up (logged in reapps-docs).
- **Decode-phase `Promise.all` left unbounded on purpose** - with the writes moved out it is O(n) (get + small metadata decrypt); the working second sync proves O(n) fits the default Android heap on the same emulator.
- **`largeHeap` deliberately not added** - a discouraged band-aid; the code fix is sufficient and proven (the O(n) second sync runs without it). Documented as a lever for a future much larger account.

## Test plan

Automated (green locally):
- `vitest` reborn-notes: **978 pass**, incl. a new source-level regression test (`pullNotes batches note writes via saveMany, never per-note save`) and all 29 existing pull-path tests (the `return n.id;` / `return null;` / `changedResults.filter(` patterns are preserved).
- `svelte-check`: 0 errors / 0 warnings.
- `eslint`: clean.

Smoke (needs an Android native rebuild + `cap sync`):
- Fresh login of the 503-note account on Pixel 7 (API 34 and 36): first sync now completes to "Synced" without the ~40s crash; notes appear.
- iOS (iPhone 17): unchanged, still ~10s, no regression.
- Multi-device sanity: edit a note on device B -> pull on device A still reconciles (version bump, archive/restore, orphaned-edit re-mark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)