### PR TITLE
fix(notes): show notes before version-history backfill on cold start

### DIFF
--- a/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
@@ -47,6 +47,8 @@
         return Check;
       case 'syncing':
         return RefreshCw;
+      case 'syncing_history':
+        return RefreshCw;
       case 'offline':
         return WifiOff;
       case 'error':
@@ -70,6 +72,10 @@
         return 'text-muted-foreground';
       case 'syncing':
         return 'text-primary';
+      case 'syncing_history':
+        // Muted, not primary: the notes are already synced and on screen; this
+        // is just the background history tidy-up.
+        return 'text-muted-foreground';
       case 'offline':
         return 'text-muted-foreground';
       case 'error':
@@ -93,6 +99,8 @@
         return $t('sync_status.synced');
       case 'syncing':
         return $t('sync_status.syncing');
+      case 'syncing_history':
+        return $t('sync_status.syncing_history');
       case 'offline':
         return $t('sync_status.offline');
       case 'error':
@@ -121,7 +129,11 @@
   }
 
   let Icon = $derived(getIcon($syncStatus.status));
-  let spinning = $derived($syncStatus.status === 'syncing' || manualSyncing);
+  let spinning = $derived(
+    $syncStatus.status === 'syncing' ||
+      $syncStatus.status === 'syncing_history' ||
+      manualSyncing
+  );
   let isClickable = $derived(
     $syncStatus.status !== 'offline' &&
       $syncStatus.status !== 'syncing' &&

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -378,6 +378,42 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(orchestrator).not.toMatch(/noteStore\.getAll\(\) as NoteEncrypted/);
   });
 
+  it('runs the version backfill off the critical path (notes paint before history)', () => {
+    // Cold start treats every note as "changed", so pullNoteVersions does 1
+    // GET/note over the slow native bridge (~31s for 503 notes). Awaiting it
+    // held the freshly-pulled notes off-screen for the whole backfill (callers
+    // refresh the stores only after pullFromServer resolves). It must run as a
+    // background task and report through the isSyncingHistory phase so the footer
+    // can distinguish "Syncing history…" from a blocking "Syncing…". See
+    // guideline 36.
+    const src = readSource('./notes-sync.service.ts');
+    const orchestrator = src.slice(
+      src.indexOf('async function runPullFromServer'),
+      src.indexOf('async function pullFolders')
+    );
+    // Fire-and-forget, never awaited.
+    expect(orchestrator).toMatch(/void\s+pullNoteVersions\(changedNoteIds\)/);
+    expect(orchestrator).not.toMatch(/await\s+pullNoteVersions/);
+    // The background phase is raised and (ref-counted) lowered for the footer.
+    expect(orchestrator).toMatch(/isSyncingHistory\.set\(true\)/);
+    expect(orchestrator).toMatch(/isSyncingHistory\.set\(false\)/);
+  });
+
+  it('backfills versions with one batched write per note (no per-row save → WebView OOM)', () => {
+    // History rows carry content_encrypted (large); on a cold start the backfill
+    // touches every note. Writing them one save() at a time repeats the per-row
+    // transaction churn that OOM'd the Android WebView on the notes path (reg 16,
+    // PR #353). One saveMany() per note keeps each note's versions on a single
+    // transaction.
+    const src = readSource('./notes-sync.service.ts');
+    const pullVersions = src.slice(
+      src.indexOf('async function pullNoteVersions'),
+      src.indexOf('async function pushPendingVersions')
+    );
+    expect(pullVersions).toMatch(/noteHistoryStore\.saveMany\(/);
+    expect(pullVersions).not.toMatch(/noteHistoryStore\.save\(/);
+  });
+
   it('archived-pending retry joins the per-entity chain so the cap is real', () => {
     // pushNoteUpdate/pushNoteDelete are fire-and-forget (void). If the sweep
     // didn't await something, settleInBatches would enqueue every archived note

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -40,6 +40,7 @@ import { authStore } from '$lib/stores/auth.store';
 import { createLogger } from '@reborn/utils';
 import {
   isSyncing,
+  isSyncingHistory,
   syncError,
   lastSyncedAt,
   isInitialSync,
@@ -170,6 +171,13 @@ export async function pullFromServer(): Promise<boolean> {
   return coalescedPull();
 }
 
+// In-flight version backfills. Pulls are single-flighted (coalescedPull), but a
+// pull RESOLVES before its background backfill finishes (that is the point), so a
+// later pull can start a second backfill while the first is still running. Clear
+// the `isSyncingHistory` phase only when the last one settles, otherwise the
+// footer would flash "Synced" mid-backfill.
+let historyBackfillsInFlight = 0;
+
 async function runPullFromServer(): Promise<boolean> {
   if (!isAuthenticated()) return false;
 
@@ -245,12 +253,27 @@ async function runPullFromServer(): Promise<boolean> {
     // history panel - may lag on other devices until the note's next edit) is
     // acceptable: that content equals the live note and each device regenerates
     // its own such snapshot locally. History is non-critical. See guideline 36.
+    // History backfill is non-critical and, on a cold start (every note is
+    // "new"), the dominant cost: 1 GET/note over the slow native CapacitorHttp
+    // bridge (~31s for 503 notes). It MUST NOT gate showing the notes - callers
+    // run refreshStoresAfterPull() once this function resolves, so awaiting the
+    // backfill kept the already-pulled notes off-screen for its whole duration.
+    // Run it as a background task and surface it through the dedicated
+    // `isSyncingHistory` phase ("Syncing history…" in the footer). lastSyncedAt
+    // below marks the notes pull as done, independent of this best-effort
+    // backfill. See guideline 36.
     if (changedNoteIds.length > 0) {
-      await pullNoteVersions(changedNoteIds).catch((e) => {
-        reportSyncError(e);
-        logger.error('Pull note versions failed:', e);
-        // Non-critical - don't set success=false
-      });
+      historyBackfillsInFlight++;
+      isSyncingHistory.set(true);
+      void pullNoteVersions(changedNoteIds)
+        .catch((e) => {
+          reportSyncError(e);
+          logger.error('Pull note versions failed:', e);
+          // Non-critical - don't set success=false
+        })
+        .finally(() => {
+          if (--historyBackfillsInFlight === 0) isSyncingHistory.set(false);
+        });
     }
 
     if (success) {
@@ -1614,22 +1637,28 @@ async function pullNoteVersions(noteIds: string[]): Promise<void> {
     const { data } = await res.json();
     if (!Array.isArray(data)) return;
 
-    for (const v of data as Array<{
-      id: string;
-      note_id: string;
-      title_encrypted: string;
-      content_encrypted: string;
-      created_at: string;
-    }>) {
-      await noteHistoryStore.save({
-        id: v.id,
-        note_id: v.note_id,
-        title_encrypted: v.title_encrypted,
-        content_encrypted: v.content_encrypted,
-        sync_status: 'synced',
-        created_at: v.created_at
-      });
-    }
+    // One batched write per note, not save()-per-row. History rows carry
+    // content_encrypted (large), and on a cold start this runs for every note -
+    // the same per-row transaction churn that OOM'd the Android WebView on the
+    // notes path (reg 16, PR #353). saveMany keeps each note's versions on a
+    // single transaction.
+    const entries: NoteHistoryEntry[] = (
+      data as Array<{
+        id: string;
+        note_id: string;
+        title_encrypted: string;
+        content_encrypted: string;
+        created_at: string;
+      }>
+    ).map((v) => ({
+      id: v.id,
+      note_id: v.note_id,
+      title_encrypted: v.title_encrypted,
+      content_encrypted: v.content_encrypted,
+      sync_status: 'synced',
+      created_at: v.created_at
+    }));
+    if (entries.length > 0) await noteHistoryStore.saveMany(entries);
   });
 }
 

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -14,6 +14,11 @@ import {
 export type SyncStatusType =
   | 'synced'
   | 'syncing'
+  // Notes are in IndexedDB and on screen; only the non-critical version-history
+  // backfill is still running in the background (a cold start does 1 GET/note).
+  // A distinct phase so the footer reads "Syncing history…" rather than a
+  // blocking "Syncing…" or a premature "Synced". See notes-sync.service.
+  | 'syncing_history'
   | 'offline'
   | 'error'
   // One or more records were permanently rejected by the server (a 4xx the
@@ -70,6 +75,13 @@ if (browser && connectivityStore) {
 // ── Sync progress (set by sync service) ─────────────────────────
 
 export const isSyncing = writable(false);
+// Background, non-critical phase: the notes are already pulled and visible, but
+// the version-history backfill (1 GET/note on a cold start - the dominant native
+// sync cost) is still running. Kept separate from `isSyncing` so it never gates
+// showing the notes; surfaced as the 'syncing_history' status. Ref-counted in
+// notes-sync.service (overlapping pulls), so it only clears when the LAST
+// backfill finishes.
+export const isSyncingHistory = writable(false);
 export const syncError = writable(false);
 export const sessionExpired = writable(false);
 // True in local-only / no-account mode. Set by the auth store (one-way, like
@@ -135,7 +147,17 @@ export async function refreshPendingCount(): Promise<number> {
 // ── Derived unified status ───────────────────────────────────────
 
 export const syncStatus = derived(
-  [isOnline, isSyncing, syncError, sessionExpired, pendingCount, errorCount, lastSyncedAt, localOnly],
+  [
+    isOnline,
+    isSyncing,
+    syncError,
+    sessionExpired,
+    pendingCount,
+    errorCount,
+    lastSyncedAt,
+    localOnly,
+    isSyncingHistory
+  ],
   ([
     $isOnline,
     $isSyncing,
@@ -144,7 +166,8 @@ export const syncStatus = derived(
     $pendingCount,
     $errorCount,
     $lastSyncedAt,
-    $localOnly
+    $localOnly,
+    $isSyncingHistory
   ]): SyncStatusState => {
     let status: SyncStatusType;
 
@@ -165,6 +188,11 @@ export const syncStatus = derived(
       status = 'error';
     } else if ($pendingCount > 0) {
       status = 'pending';
+    } else if ($isSyncingHistory) {
+      // Notes are done and visible; only the background history backfill remains.
+      // Ranks below pending/error (those need user attention) but above the
+      // settled states so the footer keeps signalling the backfill is working.
+      status = 'syncing_history';
     } else if ($lastSyncedAt === null) {
       status = 'needs_sync';
     } else {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -716,7 +716,8 @@
   "sync_status": {
     "local_only": "Nur lokal",
     "synced": "Synchronisiert",
-    "syncing": "Synchronisierung…",
+    "syncing": "Notizen werden synchronisiert…",
+    "syncing_history": "Verlauf wird synchronisiert…",
     "offline": "Offline",
     "error": "Synchronisierungsfehler",
     "pending": "{count} ausstehend",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -716,7 +716,8 @@
   "sync_status": {
     "local_only": "Local only",
     "synced": "Synced",
-    "syncing": "Syncing…",
+    "syncing": "Syncing notes…",
+    "syncing_history": "Syncing history…",
     "offline": "Offline",
     "error": "Sync error",
     "pending": "{count} pending",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -716,7 +716,8 @@
   "sync_status": {
     "local_only": "Solo local",
     "synced": "Sincronizado",
-    "syncing": "Sincronizando…",
+    "syncing": "Sincronizando notas…",
+    "syncing_history": "Sincronizando el historial…",
     "offline": "Sin conexión",
     "error": "Error de sincronización",
     "pending": "{count} pendiente(s)",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -716,7 +716,8 @@
   "sync_status": {
     "local_only": "Local uniquement",
     "synced": "Synchronisé",
-    "syncing": "Synchronisation…",
+    "syncing": "Synchronisation des notes…",
+    "syncing_history": "Synchronisation de l'historique…",
     "offline": "Hors ligne",
     "error": "Erreur de synchronisation",
     "pending": "{count} en attente",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -716,7 +716,8 @@
   "sync_status": {
     "local_only": "Tylko lokalnie",
     "synced": "Zsynchronizowane",
-    "syncing": "Synchronizacja…",
+    "syncing": "Synchronizacja notatek…",
+    "syncing_history": "Synchronizacja historii…",
     "offline": "Offline",
     "error": "Błąd synchronizacji",
     "pending": "{count} oczekujących",


### PR DESCRIPTION
## Summary

Stage 1 of the native cold-start sync plan (`planning/notes-sync-scale-and-progress.md`). On a native cold start a 503-note account showed nothing for ~47s. The pull splits into **notes** (~16s, written to IndexedDB) and a **non-critical version-history backfill** (~31s: every note is "new", so 1 `GET /notes/{id}/versions` per note over the slow Android CapacitorHttp bridge). `runPullFromServer` *awaited* the backfill, and callers paint the list via `refreshStoresAfterPull()` only after `pullFromServer()` resolves - so the ready-on-disk notes stayed off-screen for the whole backfill.

This change unblocks notes and makes the remaining work legible:

- **Background backfill, not awaited.** `void pullNoteVersions(...).finally(...)`; `pullFromServer()` resolves right after `pullNotes`, so callers paint at ~16s. No caller changes (the `await pullFromServer(); refreshStoresAfterPull()` pattern is preserved). `lastSyncedAt` marks the notes pull, independent of the best-effort backfill.
- **Phase-aware footer.** New `isSyncingHistory` writable → status `syncing_history` (ranked below pending/error, above synced). Footer: "Syncing notes…" → "Syncing history…" (muted) → "Synced".
- **`saveMany` in the backfill.** One batched write per note instead of `save()`-per-row - the same O(n²) refresh churn that OOM'd the Android WebView on the notes path (reg 16, #353); history rows carry large `content_encrypted`.
- **i18n.** New `sync_status.syncing_history` + relabel `sync_status.syncing` in 5 locales (parity green).

### Decisions for review

- **Stage 1 keeps the background backfill; it does NOT cut to lazy on-demand.** `VersionHistorySheet` reads versions **only from local IndexedDB** (no fetch-on-open), so cutting the backfill without adding on-demand fetch+decrypt+loading would break offline history right after login. Stage 1 = non-blocking background (offline history still works, notes unblocked); the **lazy cut is Stage 2** (paginated delta sync). This is faithful to the accepted direction, not a departure from "lazy".
- **Ref-count (`historyBackfillsInFlight`)** clears the phase only when the *last* backfill settles. Single-flight serializes pulls, but a pull resolves *before* its background tail, so a later pull can start a second backfill; without the ref-count the first `.finally` would flash "Synced" mid-backfill.
- **`reportSyncError` kept in the background catch** - verified it only calls `connectivityStore.markFailure()` on network errors and does **not** flip the global `syncError`, so a non-critical history failure never shows "Sync error" (`success`/`lastSyncedAt` untouched).
- **Relabel `syncing` → "Syncing notes…"** (not left generic) - clean phase progression; `isSyncing` only ever reflects the pull (never a push), so the label is accurate. Notes namespace only, rendered solely in `SyncStatusFooter`.

### Zero-Knowledge

Untouched - this is purely client-side ordering/strategy (when to paint, how to write versions to local IDB, what the footer shows). No schema, API contract, encryption-model, or server-visibility change. `pullNoteVersions` still stores raw ciphertext, zero decryption.

## Test plan

Quality gate (local): svelte-check 0/0 (5530); eslint clean; vitest reborn-notes 980 ✓ (incl. 2 new source-level regressions); i18n parity OK; i18n suite 27 ✓; single-file `svelte.compile()` of the footer OK. Full `nx build` skipped in sandbox (pnpm-provisioning EPERM) - svelte-check covers .ts+.svelte, CI runs the build.

Smoke (Michał, after native rebuild):

1. Fresh login on Android (Pixel 7 API 34/36) with the 503-note test account.
2. Notes should appear fast (~16s, not ~47s); footer shows "Syncing notes…" then "Syncing history…" (muted), then "Synced".
3. Open a note's history panel after "Synced" - versions are present (the background backfill landed).
4. iOS (iPhone 17) unchanged; warm sync unchanged (no changed notes → no backfill, footer goes straight to "Synced").