### PR TITLE
refactor(notes): lazy on-demand version history (stage 2a)

### DIFF
--- a/apps/reborn-notes/src/lib/components/VersionHistorySheet.svelte
+++ b/apps/reborn-notes/src/lib/components/VersionHistorySheet.svelte
@@ -34,6 +34,10 @@
     // saveVersionSnapshot has built-in deduplication — skips if content unchanged.
     await noteDetailService.flushPendingSave();
     await NoteService.saveVersionSnapshot(id);
+    // Lazily pull server-side versions (best-effort, online-only). History is no
+    // longer backfilled during sync; this is where other devices' snapshots land.
+    // Offline or any failure degrades gracefully to the local history below.
+    await NoteService.syncNoteVersionsFromServer(id);
     versions = await NoteService.getNoteHistoryDecrypted(id);
     loading = false;
   }

--- a/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
@@ -47,8 +47,6 @@
         return Check;
       case 'syncing':
         return RefreshCw;
-      case 'syncing_history':
-        return RefreshCw;
       case 'offline':
         return WifiOff;
       case 'error':
@@ -72,10 +70,6 @@
         return 'text-muted-foreground';
       case 'syncing':
         return 'text-primary';
-      case 'syncing_history':
-        // Muted, not primary: the notes are already synced and on screen; this
-        // is just the background history tidy-up.
-        return 'text-muted-foreground';
       case 'offline':
         return 'text-muted-foreground';
       case 'error':
@@ -99,8 +93,6 @@
         return $t('sync_status.synced');
       case 'syncing':
         return $t('sync_status.syncing');
-      case 'syncing_history':
-        return $t('sync_status.syncing_history');
       case 'offline':
         return $t('sync_status.offline');
       case 'error':
@@ -129,11 +121,7 @@
   }
 
   let Icon = $derived(getIcon($syncStatus.status));
-  let spinning = $derived(
-    $syncStatus.status === 'syncing' ||
-      $syncStatus.status === 'syncing_history' ||
-      manualSyncing
-  );
+  let spinning = $derived($syncStatus.status === 'syncing' || manualSyncing);
   let isClickable = $derived(
     $syncStatus.status !== 'offline' &&
       $syncStatus.status !== 'syncing' &&

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -15,8 +15,10 @@ import {
 } from '@reborn/storage';
 import { MAX_NOTE_VERSIONS, type NoteStoredLocal, type NoteDecrypted, type NoteHistoryEntry, type NoteHistoryDecrypted, type NoteSensitiveMetadata, type PeriodicNoteMetadata } from '@reborn/types';
 import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
 import { get } from 'svelte/store';
 import { authStore } from '$lib/stores/auth.store';
+import { checkOnline } from '$lib/stores/connectivity.store';
 import { noteIndex } from '$lib/services/note-index.svelte';
 import { noteLinkGraph } from '$lib/services/note-link-graph.svelte';
 import { noteNavHistory } from '$lib/services/note-nav-history.svelte';
@@ -25,8 +27,11 @@ import {
   pushNoteUpdate,
   pushNoteDelete,
   pushNoteRestore,
-  pushNoteVersion
+  pushNoteVersion,
+  pullNoteVersionsForNote
 } from './notes-sync.service';
+
+const logger = createLogger('Note-Service');
 
 export type SortBy = 'updated_at' | 'created_at' | 'title';
 
@@ -587,6 +592,33 @@ export async function saveVersionSnapshot(noteId: string): Promise<void> {
 /** Get version history for a note — raw encrypted entries (newest first). */
 export async function getNoteHistory(noteId: string): Promise<NoteHistoryEntry[]> {
   return noteHistoryQueries.getForNote(noteId);
+}
+
+/**
+ * Best-effort: pull this note's server-side version history into local IndexedDB.
+ *
+ * Called on demand when the history panel opens - versions are no longer
+ * backfilled during sync (that bulk cold-start cost is gone; see guideline 36).
+ * Online-only and fully graceful: offline or any failure leaves the local
+ * history untouched, so the panel still renders whatever snapshots exist locally.
+ *
+ * Merge safety: server entries carry their own id, so saveMany upserts them by id
+ * (a synced local snapshot becomes sync_status:'synced') while a not-yet-pushed
+ * local PENDING snapshot (its own UUID, unknown to the server) is never clobbered.
+ * pruneVersions then bounds the merged set to the newest MAX_NOTE_VERSIONS - the
+ * current snapshot has the newest created_at, so it survives.
+ *
+ * ZK: same ciphertext from the same endpoint as the old backfill, decrypted
+ * client-side by getNoteHistoryDecrypted - no change to the server-visibility model.
+ */
+export async function syncNoteVersionsFromServer(noteId: string): Promise<void> {
+  if (!checkOnline()) return;
+  try {
+    await pullNoteVersionsForNote(noteId);
+    await noteHistoryOperations.pruneVersions(noteId, MAX_NOTE_VERSIONS);
+  } catch (err) {
+    logger.debug('On-demand version history sync failed - falling back to local history', err);
+  }
 }
 
 /** Get version history decrypted on-demand (for UI display). */

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -334,84 +334,70 @@ describe('notes-sync - regression (offline data loss)', () => {
     // (Matches a call `Promise.allSettled(`, not the word in a comment.)
     expect(fn).not.toMatch(/Promise\.allSettled\s*\(/);
 
-    // The tail version push and the pull-side version fetch share the cap too.
+    // The tail version push still shares the cap. The bulk pull-side version
+    // fetch is gone - history is fetched per-note on demand in stage 2a.
     const versionsFn = src.slice(src.indexOf('async function pushPendingVersions'));
     expect(versionsFn.slice(0, 900)).toMatch(/settleInBatches\(\s*pending\b/);
-    const pullVersions = src.slice(src.indexOf('async function pullNoteVersions'));
-    expect(pullVersions.slice(0, 400)).toMatch(/settleInBatches\(\s*noteIds\b/);
     // The bespoke pull-versions batch constant is gone (unified onto the helper).
     expect(src).not.toMatch(/PULL_VERSIONS_BATCH_SIZE/);
   });
 
-  it('pulls versions only for notes pullNotes actually changed, not all notes (native GET storm)', () => {
-    // Native CapacitorHttp does ~1 GET/note for versions; pulling versions for
-    // EVERY note on EVERY sync dominated native sync time (e.g. 122 notes ×
-    // ~700ms). A note's server-side version list grows only when the note is
-    // edited (which bumps its sync_version), so an unchanged note cannot have
-    // new versions. pullNotes therefore reports the ids it wrote and the
-    // orchestrator pulls versions for only those. Cold start still backfills:
-    // every note is new → "changed". Guards the optimization from regressing
-    // back to the all-notes pull.
-    const src = readSource('./notes-sync.service.ts');
-
-    // pullNotes reports the changed set instead of returning void.
-    expect(src).toMatch(/async function pullNotes\(\): Promise<string\[\]>/);
-    const pullNotes = src.slice(
-      src.indexOf('async function pullNotes'),
-      src.indexOf('// ── Push helpers')
-    );
-    // Main write path returns the id; skip paths return null; result filtered.
-    expect(pullNotes).toMatch(/return n\.id;/);
-    expect(pullNotes).toMatch(/return null;/);
-    expect(pullNotes).toMatch(/return changedResults\.filter\(/);
-
-    // The orchestrator feeds pullNotes' result into pullNoteVersions - it must
-    // NOT re-derive the version target from a fresh getAll() of every note.
-    const orchestrator = src.slice(
-      src.indexOf('async function runPullFromServer'),
-      src.indexOf('async function pullFolders')
-    );
-    expect(orchestrator).toMatch(/const changedNoteIds = await pullNotes\(/);
-    expect(orchestrator).toMatch(/pullNoteVersions\(changedNoteIds\)/);
-    // The old all-notes version pull is gone.
-    expect(orchestrator).not.toMatch(/pullNoteVersions\(noteIds\)/);
-    expect(orchestrator).not.toMatch(/noteStore\.getAll\(\) as NoteEncrypted/);
-  });
-
-  it('runs the version backfill off the critical path (notes paint before history)', () => {
-    // Cold start treats every note as "changed", so pullNoteVersions does 1
-    // GET/note over the slow native bridge (~31s for 503 notes). Awaiting it
-    // held the freshly-pulled notes off-screen for the whole backfill (callers
-    // refresh the stores only after pullFromServer resolves). It must run as a
-    // background task and report through the isSyncingHistory phase so the footer
-    // can distinguish "Syncing history…" from a blocking "Syncing…". See
-    // guideline 36.
+  it('orchestrator no longer backfills version history (lazy on-demand path)', () => {
+    // Stage 2a: the bulk cold-start version backfill is gone from the pull
+    // critical path (it cost 1 GET/note, ~31s native for 503 notes). History is
+    // now fetched on demand when the panel opens (note.service
+    // syncNoteVersionsFromServer), so the orchestrator must not pull versions or
+    // drive the removed isSyncingHistory phase. See guideline 36.
     const src = readSource('./notes-sync.service.ts');
     const orchestrator = src.slice(
       src.indexOf('async function runPullFromServer'),
       src.indexOf('async function pullFolders')
     );
-    // Fire-and-forget, never awaited.
-    expect(orchestrator).toMatch(/void\s+pullNoteVersions\(changedNoteIds\)/);
-    expect(orchestrator).not.toMatch(/await\s+pullNoteVersions/);
-    // The background phase is raised and (ref-counted) lowered for the footer.
-    expect(orchestrator).toMatch(/isSyncingHistory\.set\(true\)/);
-    expect(orchestrator).toMatch(/isSyncingHistory\.set\(false\)/);
+    expect(orchestrator).not.toMatch(/pullNoteVersions/);
+    expect(orchestrator).not.toMatch(/isSyncingHistory/);
+    expect(orchestrator).not.toMatch(/historyBackfillsInFlight/);
+    // pullNotes is still called (its changed-id result is unused in 2a, kept for 2b).
+    expect(orchestrator).toMatch(/await pullNotes\(/);
   });
 
-  it('backfills versions with one batched write per note (no per-row save → WebView OOM)', () => {
-    // History rows carry content_encrypted (large); on a cold start the backfill
-    // touches every note. Writing them one save() at a time repeats the per-row
-    // transaction churn that OOM'd the Android WebView on the notes path (reg 16,
-    // PR #353). One saveMany() per note keeps each note's versions on a single
-    // transaction.
-    const src = readSource('./notes-sync.service.ts');
-    const pullVersions = src.slice(
-      src.indexOf('async function pullNoteVersions'),
-      src.indexOf('async function pushPendingVersions')
+  it('on-demand history sync fetches per note, batches the write, and prunes', () => {
+    // The single-note fetch helper survives (the bulk many-id variant is gone)
+    // and keeps the batched write: saveMany is one transaction per note, avoiding
+    // the per-row churn that OOM'd the Android WebView on the notes path (PR #353).
+    const syncSrc = readSource('./notes-sync.service.ts');
+    expect(syncSrc).toMatch(
+      /export async function pullNoteVersionsForNote\(noteId: string\)/
     );
-    expect(pullVersions).toMatch(/noteHistoryStore\.saveMany\(/);
-    expect(pullVersions).not.toMatch(/noteHistoryStore\.save\(/);
+    const helper = syncSrc.slice(
+      syncSrc.indexOf('export async function pullNoteVersionsForNote'),
+      syncSrc.indexOf('async function pushPendingVersions')
+    );
+    expect(helper).toMatch(/noteHistoryStore\.saveMany\(/);
+    expect(helper).not.toMatch(/noteHistoryStore\.save\(/);
+
+    // note.service wraps it as an online-only, best-effort sync that prunes to
+    // the version cap and degrades gracefully (offline → local history).
+    const noteSrc = readSource('./note.service.ts');
+    const fn = noteSrc.slice(
+      noteSrc.indexOf('export async function syncNoteVersionsFromServer'),
+      noteSrc.indexOf('export async function getNoteHistoryDecrypted')
+    );
+    expect(fn).toMatch(/checkOnline\(/);
+    expect(fn).toMatch(/pullNoteVersionsForNote\(/);
+    expect(fn).toMatch(/pruneVersions\(/);
+  });
+
+  it('version history panel syncs from server before reading local history', () => {
+    // VersionHistorySheet.loadHistory must fetch server versions (on demand)
+    // BEFORE decrypting/reading local history, so the panel reflects other
+    // devices' snapshots when online and falls back to local when offline.
+    const sheet = readSource('../components/VersionHistorySheet.svelte');
+    const loadHistory = sheet.slice(sheet.indexOf('async function loadHistory'));
+    const syncIdx = loadHistory.search(/syncNoteVersionsFromServer\s*\(/);
+    const readIdx = loadHistory.search(/getNoteHistoryDecrypted\s*\(/);
+    expect(syncIdx).toBeGreaterThan(-1);
+    expect(readIdx).toBeGreaterThan(-1);
+    expect(syncIdx).toBeLessThan(readIdx);
   });
 
   it('archived-pending retry joins the per-entity chain so the cap is real', () => {

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -40,7 +40,6 @@ import { authStore } from '$lib/stores/auth.store';
 import { createLogger } from '@reborn/utils';
 import {
   isSyncing,
-  isSyncingHistory,
   syncError,
   lastSyncedAt,
   isInitialSync,
@@ -171,13 +170,6 @@ export async function pullFromServer(): Promise<boolean> {
   return coalescedPull();
 }
 
-// In-flight version backfills. Pulls are single-flighted (coalescedPull), but a
-// pull RESOLVES before its background backfill finishes (that is the point), so a
-// later pull can start a second backfill while the first is still running. Clear
-// the `isSyncingHistory` phase only when the last one settles, otherwise the
-// footer would flash "Synced" mid-backfill.
-let historyBackfillsInFlight = 0;
-
 async function runPullFromServer(): Promise<boolean> {
   if (!isAuthenticated()) return false;
 
@@ -234,47 +226,22 @@ async function runPullFromServer(): Promise<boolean> {
         success = false;
       })
     ]);
-    // Notes after folders/tags (they reference them). pullNotes returns the IDs
-    // it actually wrote (new, or server sync_version newer) - the only notes
-    // whose server-side version history can have grown since the last sync.
-    const changedNoteIds = await pullNotes().catch((e) => {
+    // Notes after folders/tags (they reference them). pullNotes still reports the
+    // ids it actually wrote (new, or server sync_version newer); the result is
+    // unused here in stage 2a and kept for the paginated delta sync in 2b.
+    //
+    // Version history is no longer backfilled during sync. It used to pull 1
+    // GET/note for every changed note, and on a cold start (every note is "new")
+    // that dominated native CapacitorHttp sync time (~31s for 503 notes) - stage
+    // 1 moved it to a background task, stage 2a removes it entirely. History is
+    // now fetched on demand when the panel opens (note.service
+    // `syncNoteVersionsFromServer`), which is the only place a user looks at it.
+    // See guideline 36.
+    await pullNotes().catch((e) => {
       reportSyncError(e);
       logger.error('Pull notes failed:', e);
       success = false;
-      return [] as string[];
     });
-
-    // Pull versions only for changed notes, not all of them. A note's version
-    // list grows only when the note is edited (which bumps its sync_version), so
-    // an unchanged note cannot have new server-side versions. Cold start treats
-    // every note as new → full backfill. This removes the per-note GET storm
-    // (1 request/note/sync) that dominated native CapacitorHttp sync time. The
-    // tradeoff (a snapshot created without a sync_version bump - e.g. opening the
-    // history panel - may lag on other devices until the note's next edit) is
-    // acceptable: that content equals the live note and each device regenerates
-    // its own such snapshot locally. History is non-critical. See guideline 36.
-    // History backfill is non-critical and, on a cold start (every note is
-    // "new"), the dominant cost: 1 GET/note over the slow native CapacitorHttp
-    // bridge (~31s for 503 notes). It MUST NOT gate showing the notes - callers
-    // run refreshStoresAfterPull() once this function resolves, so awaiting the
-    // backfill kept the already-pulled notes off-screen for its whole duration.
-    // Run it as a background task and surface it through the dedicated
-    // `isSyncingHistory` phase ("Syncing history…" in the footer). lastSyncedAt
-    // below marks the notes pull as done, independent of this best-effort
-    // backfill. See guideline 36.
-    if (changedNoteIds.length > 0) {
-      historyBackfillsInFlight++;
-      isSyncingHistory.set(true);
-      void pullNoteVersions(changedNoteIds)
-        .catch((e) => {
-          reportSyncError(e);
-          logger.error('Pull note versions failed:', e);
-          // Non-critical - don't set success=false
-        })
-        .finally(() => {
-          if (--historyBackfillsInFlight === 0) isSyncingHistory.set(false);
-        });
-    }
 
     if (success) {
       logger.info('Pull sync completed');
@@ -664,8 +631,8 @@ async function pullNotes(): Promise<string[]> {
         }
       }
 
-      // This note's server state advanced (new, or newer sync_version) → its
-      // version list may have grown. Return its id for the targeted version pull.
+      // This note's server state advanced (new, or newer sync_version). Reported
+      // for stage 2b's delta sync; unused now that history loads on demand.
       return n.id;
     })
   );
@@ -718,8 +685,9 @@ async function pullNotes(): Promise<string[]> {
     logger.debug(`Removed ${orphanNoteIds.length} locally-synced notes no longer on server`);
   }
 
-  // Notes whose server state advanced this pull - the only ones whose
-  // server-side version history can have grown. Drives the targeted version pull.
+  // Notes whose server state advanced this pull. Reported for stage 2b's
+  // paginated delta sync; the caller currently ignores the result (version
+  // history is fetched on demand when the panel opens). See guideline 36.
   return changedResults.filter((id): id is string => id !== null);
 }
 
@@ -1629,37 +1597,39 @@ export function pushNoteVersion(entry: NoteHistoryEntry): void {
   });
 }
 
-/** Pull versions for all notes from server and upsert locally (batched, max SYNC_BATCH_SIZE concurrent). */
-async function pullNoteVersions(noteIds: string[]): Promise<void> {
-  await settleInBatches(noteIds, async (noteId) => {
-    const res = await authFetch(`${API_BASE}/notes/${noteId}/versions`);
-    if (!res.ok) return;
-    const { data } = await res.json();
-    if (!Array.isArray(data)) return;
+/**
+ * Fetch one note's server-side version history and upsert it locally in a single
+ * batched write. Backs the on-demand history path (note.service
+ * `syncNoteVersionsFromServer` → VersionHistorySheet): history is pulled when the
+ * panel opens, not backfilled during sync. The bulk cold-start backfill this
+ * replaced (1 GET/note, ~31s native for 503 notes) is gone. See guideline 36.
+ */
+export async function pullNoteVersionsForNote(noteId: string): Promise<void> {
+  const res = await authFetch(`${API_BASE}/notes/${noteId}/versions`);
+  if (!res.ok) return;
+  const { data } = await res.json();
+  if (!Array.isArray(data)) return;
 
-    // One batched write per note, not save()-per-row. History rows carry
-    // content_encrypted (large), and on a cold start this runs for every note -
-    // the same per-row transaction churn that OOM'd the Android WebView on the
-    // notes path (reg 16, PR #353). saveMany keeps each note's versions on a
-    // single transaction.
-    const entries: NoteHistoryEntry[] = (
-      data as Array<{
-        id: string;
-        note_id: string;
-        title_encrypted: string;
-        content_encrypted: string;
-        created_at: string;
-      }>
-    ).map((v) => ({
-      id: v.id,
-      note_id: v.note_id,
-      title_encrypted: v.title_encrypted,
-      content_encrypted: v.content_encrypted,
-      sync_status: 'synced',
-      created_at: v.created_at
-    }));
-    if (entries.length > 0) await noteHistoryStore.saveMany(entries);
-  });
+  // One batched write per note, not save()-per-row. History rows carry
+  // content_encrypted (large); saveMany keeps them on a single transaction (the
+  // per-row churn OOM'd the Android WebView on the notes path, PR #353).
+  const entries: NoteHistoryEntry[] = (
+    data as Array<{
+      id: string;
+      note_id: string;
+      title_encrypted: string;
+      content_encrypted: string;
+      created_at: string;
+    }>
+  ).map((v) => ({
+    id: v.id,
+    note_id: v.note_id,
+    title_encrypted: v.title_encrypted,
+    content_encrypted: v.content_encrypted,
+    sync_status: 'synced',
+    created_at: v.created_at
+  }));
+  if (entries.length > 0) await noteHistoryStore.saveMany(entries);
 }
 
 /** Push all pending (unsynced) note versions to server. */

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -14,11 +14,6 @@ import {
 export type SyncStatusType =
   | 'synced'
   | 'syncing'
-  // Notes are in IndexedDB and on screen; only the non-critical version-history
-  // backfill is still running in the background (a cold start does 1 GET/note).
-  // A distinct phase so the footer reads "Syncing history…" rather than a
-  // blocking "Syncing…" or a premature "Synced". See notes-sync.service.
-  | 'syncing_history'
   | 'offline'
   | 'error'
   // One or more records were permanently rejected by the server (a 4xx the
@@ -75,13 +70,6 @@ if (browser && connectivityStore) {
 // ── Sync progress (set by sync service) ─────────────────────────
 
 export const isSyncing = writable(false);
-// Background, non-critical phase: the notes are already pulled and visible, but
-// the version-history backfill (1 GET/note on a cold start - the dominant native
-// sync cost) is still running. Kept separate from `isSyncing` so it never gates
-// showing the notes; surfaced as the 'syncing_history' status. Ref-counted in
-// notes-sync.service (overlapping pulls), so it only clears when the LAST
-// backfill finishes.
-export const isSyncingHistory = writable(false);
 export const syncError = writable(false);
 export const sessionExpired = writable(false);
 // True in local-only / no-account mode. Set by the auth store (one-way, like
@@ -155,8 +143,7 @@ export const syncStatus = derived(
     pendingCount,
     errorCount,
     lastSyncedAt,
-    localOnly,
-    isSyncingHistory
+    localOnly
   ],
   ([
     $isOnline,
@@ -166,8 +153,7 @@ export const syncStatus = derived(
     $pendingCount,
     $errorCount,
     $lastSyncedAt,
-    $localOnly,
-    $isSyncingHistory
+    $localOnly
   ]): SyncStatusState => {
     let status: SyncStatusType;
 
@@ -188,11 +174,6 @@ export const syncStatus = derived(
       status = 'error';
     } else if ($pendingCount > 0) {
       status = 'pending';
-    } else if ($isSyncingHistory) {
-      // Notes are done and visible; only the background history backfill remains.
-      // Ranks below pending/error (those need user attention) but above the
-      // settled states so the footer keeps signalling the backfill is working.
-      status = 'syncing_history';
     } else if ($lastSyncedAt === null) {
       status = 'needs_sync';
     } else {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -717,7 +717,6 @@
     "local_only": "Nur lokal",
     "synced": "Synchronisiert",
     "syncing": "Notizen werden synchronisiert…",
-    "syncing_history": "Verlauf wird synchronisiert…",
     "offline": "Offline",
     "error": "Synchronisierungsfehler",
     "pending": "{count} ausstehend",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -717,7 +717,6 @@
     "local_only": "Local only",
     "synced": "Synced",
     "syncing": "Syncing notes…",
-    "syncing_history": "Syncing history…",
     "offline": "Offline",
     "error": "Sync error",
     "pending": "{count} pending",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -717,7 +717,6 @@
     "local_only": "Solo local",
     "synced": "Sincronizado",
     "syncing": "Sincronizando notas…",
-    "syncing_history": "Sincronizando el historial…",
     "offline": "Sin conexión",
     "error": "Error de sincronización",
     "pending": "{count} pendiente(s)",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -717,7 +717,6 @@
     "local_only": "Local uniquement",
     "synced": "Synchronisé",
     "syncing": "Synchronisation des notes…",
-    "syncing_history": "Synchronisation de l'historique…",
     "offline": "Hors ligne",
     "error": "Erreur de synchronisation",
     "pending": "{count} en attente",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -717,7 +717,6 @@
     "local_only": "Tylko lokalnie",
     "synced": "Zsynchronizowane",
     "syncing": "Synchronizacja notatek…",
-    "syncing_history": "Synchronizacja historii…",
     "offline": "Offline",
     "error": "Błąd synchronizacji",
     "pending": "{count} oczekujących",


### PR DESCRIPTION
## Summary

Stage 2a of the native cold-start sync scaling plan (stage 1 = #354, merged). Version history is **no longer backfilled during sync** - even in the background, as stage 1 left it. It is fetched from the server **only when the history panel opens**, removing the ~31s native cold-start cost entirely and the now-dead `isSyncingHistory` phase.

- **Orchestrator (`runPullFromServer`):** drops the background `pullNoteVersions` block, the `isSyncingHistory` phase, and the `historyBackfillsInFlight` ref-count. `pullNotes()` still returns `string[]` (changed ids), kept for stage 2b's delta sync; the orchestrator now ignores its result.
- **On-demand path:** new `NoteService.syncNoteVersionsFromServer` (online-only, best-effort, prunes to `MAX_NOTE_VERSIONS`, degrades to local history on offline/error), called from `VersionHistorySheet.loadHistory` before reading local history. Core fetch extracted to `pullNoteVersionsForNote` (single-note GET + `saveMany`) from the removed bulk `pullNoteVersions(noteIds)`.
- **Merge stays safe:** server versions upsert by id (`saveMany`); a not-yet-pushed local PENDING snapshot (own UUID) is never clobbered; prune keeps the newest 10 (current snapshot has the newest `created_at`).
- **Stage-1 cleanup:** removes `isSyncingHistory` writable, the `'syncing_history'` status (`SyncStatusType` + derived `syncStatus`, back to 8 deps), its four `SyncStatusFooter` branches, and the `sync_status.syncing_history` i18n key in all 5 locales. `sync_status.syncing` ("Syncing notes…") stays.

The 2a/2b split and the lazy-vs-background decision were accepted in the prior plan-mode session. Stage 2b (paginated delta sync, Filary 1+3) stays a separate PR with its own plan gate. Docs updated in reapps-docs (guideline 36 rules 15+17, planning, TODO/TODO-history).

**Zero-Knowledge:** unchanged - same ciphertext from the same endpoint (`GET /api/notes/{id}/versions`), decrypted client-side as before. No schema/API/server-visibility change.

## Test plan

Local gate (CI mirror), all green:
- vitest reborn-notes: **980/980**
- svelte-check (app type gate): **0 errors / 0 warnings**
- eslint (changed files): clean
- i18n parity (notes namespace): pass
- single-file `svelte.compile` (VersionHistorySheet + SyncStatusFooter): ok

Smoke (Michał, after native rebuild):
- Fresh Android login, ~503-note account → notes appear fast, **no "Syncing history…" phase**; footer goes "Syncing notes…" → "Synced".
- History panel **online** → versions load on demand (brief spinner). **Offline** → local history shown gracefully (no hard error).
- Edit a note + open history → current snapshot present; restore a version → works.
- iOS / warm sync → no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)