### PR TITLE
feat(notes): paginated delta sync with determinate progress

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -29,7 +29,7 @@
   import { tagsStore } from '$lib/stores/tags.store';
   import { SidebarTrigger } from '@reborn/ui/sidebar';
   import { t } from '$lib/stores/i18n.store';
-  import { sessionExpired, isInitialSync } from '$lib/stores/sync-status.store';
+  import { sessionExpired, isInitialSync, syncProgress } from '$lib/stores/sync-status.store';
   import { requireActiveSession } from '$lib/utils/require-active-session';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
   import ConfirmDialog from './shared/ConfirmDialog.svelte';
@@ -1025,6 +1025,13 @@
             <p class="text-sm text-muted-foreground">{$t('auth.session.empty_no_data')}</p>
           {:else if $isInitialSync}
             <p class="text-sm text-muted-foreground">{$t('sync_status.initial.title')}</p>
+            {#if $syncProgress && $syncProgress.total > 0}
+              <p class="mt-1 text-xs text-muted-foreground/70">
+                {$t('sync_status.syncing_progress', {
+                  values: { done: $syncProgress.done, total: $syncProgress.total }
+                })}
+              </p>
+            {/if}
           {:else}
             <p class="text-sm text-muted-foreground">{$t('notes.no_notes_short')}</p>
             <button

--- a/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
@@ -14,8 +14,13 @@
     AlertTriangle,
     HardDrive
   } from '@lucide/svelte';
-  import { syncStatus, type SyncStatusType } from '$lib/stores/sync-status.store';
-  import { pullFromServer, pushPendingItems, refreshStoresAfterPull } from '$lib/services/notes-sync.service';
+  import { syncStatus, syncProgress, type SyncStatusType } from '$lib/stores/sync-status.store';
+  import {
+    pullFromServer,
+    pushPendingItems,
+    refreshStoresAfterPull,
+    requestFullReconcileNextPull
+  } from '$lib/services/notes-sync.service';
   import { t } from '$lib/stores/i18n.store';
 
   let manualSyncing = $state(false);
@@ -31,6 +36,9 @@
 
     manualSyncing = true;
     try {
+      // Manual sync is an explicit "make me current" - force a full id reconcile
+      // (all_ids) so permanent deletes from other devices are caught now.
+      requestFullReconcileNextPull();
       await pushPendingItems();
       const synced = await pullFromServer();
       if (synced) {
@@ -91,8 +99,14 @@
     switch (status) {
       case 'synced':
         return $t('sync_status.synced');
-      case 'syncing':
-        return $t('sync_status.syncing');
+      case 'syncing': {
+        // Determinate counter while the notes phase is paginating; plain label
+        // otherwise (warm sync with no pages to count).
+        const p = $syncProgress;
+        return p && p.total > 0
+          ? $t('sync_status.syncing_progress', { values: { done: p.done, total: p.total } })
+          : $t('sync_status.syncing');
+      }
       case 'offline':
         return $t('sync_status.offline');
       case 'error':
@@ -121,6 +135,9 @@
   }
 
   let Icon = $derived(getIcon($syncStatus.status));
+  // Reactive to $syncProgress: getLabel reads it in the 'syncing' case, so the
+  // counter ("Syncing notes… 320/2000") updates as pages land.
+  let label = $derived(getLabel($syncStatus.status));
   let spinning = $derived($syncStatus.status === 'syncing' || manualSyncing);
   let isClickable = $derived(
     $syncStatus.status !== 'offline' &&
@@ -153,10 +170,10 @@
       class="flex items-center gap-1.5 min-w-0 w-full rounded-md px-1 py-1 md:py-0.5 text-sm md:text-xs transition-colors
              hover:bg-sidebar-accent disabled:pointer-events-none disabled:opacity-70
              {getColorClass($syncStatus.status)}"
-      title={isClickable ? $t('sync_status.click_to_sync') : getLabel($syncStatus.status)}
+      title={isClickable ? $t('sync_status.click_to_sync') : label}
     >
       <Icon class="h-4 w-4 md:h-3.5 md:w-3.5 shrink-0 {spinning ? 'animate-spin' : ''}" />
-      <span class="truncate">{getLabel($syncStatus.status)}</span>
+      <span class="truncate">{label}</span>
       {#if timeStr && $syncStatus.status === 'synced'}
         <span class="ml-auto shrink-0 text-[10px] text-muted-foreground/60">{timeStr}</span>
       {/if}

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -11,7 +11,7 @@
  * title, folderId, isPinned, isStarred, isArchived, createdAt, updatedAt, tagIds.
  * Full content is NEVER stored here — loaded on demand by note-detail.service.
  */
-import { noteStore, noteTagStore } from '@reborn/storage';
+import { noteStore, noteTagStore, noteTagQueries } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
 import { decryptTitleOnly } from './note.service';
 import { noteLinkGraph } from './note-link-graph.svelte';
@@ -133,6 +133,47 @@ class NoteIndex {
       this._version++;
     } finally {
       this._building = false;
+    }
+  }
+
+  /**
+   * Incrementally add/update specific notes by id: point-read just those rows
+   * (noteStore.getMany) and decrypt them, instead of build()'s full
+   * getAll()+decrypt of every note. Backs the paginated pull's per-page reveal -
+   * each page lands in the index without an O(n) rebuild per page (which would
+   * re-deserialize the whole notes table every page = the O(n²) trap PR #353
+   * removed). Tags are read from the (already-applied) note-tag relations, so
+   * call this AFTER the page's tag deltas are written. Same crypto guard as
+   * build(): a row that fails to decrypt is skipped; a later full rebuild
+   * (refreshStoresAfterPull) reconciles it.
+   */
+  async upsertFromStore(ids: string[]): Promise<void> {
+    if (!cryptoManager.isInitialized() || ids.length === 0) return;
+    const encrypted = await noteStore.getMany(ids);
+    let changed = false;
+    for (const enc of encrypted) {
+      try {
+        const e = await decryptTitleOnly(enc);
+        const tagIds = await noteTagQueries.getTagsForNote(e.id);
+        this._map.set(e.id, {
+          title: e.title,
+          folderId: e.folderId,
+          isPinned: e.isPinned,
+          isStarred: e.isStarred,
+          isArchived: e.isArchived,
+          createdAt: e.createdAt,
+          updatedAt: e.updatedAt,
+          tagIds
+        });
+        changed = true;
+      } catch {
+        // Skip undecryptable row; the post-pull full rebuild reconciles it.
+      }
+    }
+    if (changed) {
+      this._version++;
+      // Titles/folders may have changed; invalidate the lazy link graph.
+      noteLinkGraph.clear();
     }
   }
 

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -177,10 +177,21 @@ class NoteIndex {
     }
   }
 
-  /** Clear and rebuild (after sync). */
+  /**
+   * Rebuild from IndexedDB (after sync / import). ATOMIC: delegates to build(),
+   * which fills a fresh local Map and swaps it into `this._map` only at the very
+   * end. It must NOT pre-clear the map: build() yields to the event loop between
+   * decrypt batches (setTimeout(0)), so a pre-clear would leave the index
+   * observably EMPTY for the whole rebuild. That empty window lands right after
+   * a cold-login pull sets lastSyncedAt ("Synced") and clears isSyncing - the
+   * one moment both look "done" - and any index read in it (e.g.
+   * findExistingPeriodicNote) sees zero notes and wrongly concludes "absent",
+   * duplicating the periodic note the pull just delivered. Keeping the old,
+   * complete map live until the swap closes that window. Stale entries (notes
+   * deleted on the server) are dropped by the swap, since build() reads the
+   * current getAll(). See guideline 57.
+   */
   async rebuild(): Promise<void> {
-    this._map.clear();
-    this._version++;
     await this.build();
   }
 

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -721,3 +721,123 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(method).toMatch(/if\s*\(\s*!note\s*\)\s*return/);
   });
 });
+
+describe('notes-sync - paginated delta sync (stage 2b)', () => {
+  function pullNotesSrc(): string {
+    const src = readSource('./notes-sync.service.ts');
+    return src.slice(
+      src.indexOf('async function pullNotes'),
+      src.indexOf('async function writeNotesPage')
+    );
+  }
+  function writeNotesPageSrc(): string {
+    const src = readSource('./notes-sync.service.ts');
+    return src.slice(
+      src.indexOf('async function writeNotesPage'),
+      src.indexOf('// ── Push helpers')
+    );
+  }
+
+  it('pullNotes pages through the server in a cursor loop', () => {
+    const code = pullNotesSrc().replace(/\/\/.*$/gm, '');
+    // A do/while loop driven by the server's has_more / next_cursor.
+    expect(code).toMatch(/do\s*\{/);
+    expect(code).toMatch(/while\s*\(\s*cursor\s*\)/);
+    expect(code).toMatch(/has_more/);
+    expect(code).toMatch(/next_cursor/);
+    // The request carries the page limit + cursor.
+    expect(code).toMatch(/limit/);
+    expect(code).toMatch(/params\.set\(\s*['"]cursor['"]/);
+  });
+
+  it('each page is written via saveMany (bounded to a page) and revealed via the index', () => {
+    // saveMany lives in the per-page writer; the O(n²) per-note save() trap stays
+    // out of both functions.
+    const writer = writeNotesPageSrc().replace(/\/\/.*$/gm, '');
+    expect(writer).toMatch(/noteStore\.saveMany\(/);
+    expect(writer).not.toMatch(/noteStore\.save\(/);
+    // The loop reveals each page incrementally without a full rebuild per page.
+    const loop = pullNotesSrc().replace(/\/\/.*$/gm, '');
+    expect(loop).toMatch(/noteIndex\.upsertFromStore\(/);
+    expect(loop).toMatch(/notesStore\.refresh\(/);
+    expect(loop).not.toMatch(/noteIndex\.rebuild\(/);
+  });
+
+  it('orphan-delete uses the authoritative all_ids only, never page contents', () => {
+    const code = pullNotesSrc().replace(/\/\/.*$/gm, '');
+    // Deletion is gated on the full id set and skipped when it is absent.
+    expect(code).toMatch(/if\s*\(\s*allIds\s*\)/);
+    expect(code).toMatch(/!serverIds\.has\(/);
+    expect(code).toMatch(/noteStore\.deleteMany\(/);
+    // The old "diff against the response body" orphan path must be gone - in
+    // delta mode the body is only the changed notes, so it is NOT authoritative.
+    expect(code).not.toMatch(/serverNoteIds/);
+  });
+
+  it('reads the delta watermark behind a count() guard and advances it after the pull', () => {
+    const code = pullNotesSrc().replace(/\/\/.*$/gm, '');
+    // Ignore a stale watermark when IDB holds no notes (wiped but localStorage
+    // survived) -> full pull.
+    expect(code).toMatch(/noteStore\.count\(/);
+    expect(code).toMatch(/readWatermark\(/);
+    expect(code).toMatch(/writeWatermark\(/);
+    // The reset helper is exported for the logout path.
+    const full = readSource('./notes-sync.service.ts');
+    expect(full).toMatch(/export function clearNotesDeltaWatermark\(/);
+  });
+
+  it('drives a determinate progress store, cleared in a finally', () => {
+    const code = pullNotesSrc();
+    expect(code).toMatch(/syncProgress\.set\(\s*\{/); // {done, total}
+    expect(code).toMatch(/syncProgress\.set\(\s*null\s*\)/);
+    // Orchestrator also clears it as a safety net.
+    const run = readSource('./notes-sync.service.ts');
+    const runPull = run.slice(
+      run.indexOf('async function runPullFromServer'),
+      run.indexOf('async function pullFolders')
+    );
+    expect(runPull).toMatch(/syncProgress\.set\(\s*null\s*\)/);
+  });
+
+  it('requests all_ids only on a reconcile pull (variant B gating)', () => {
+    const code = pullNotesSrc().replace(/\/\/.*$/gm, '');
+    // reconcile decision comes from the session flag, and only the first page
+    // asks for it.
+    expect(code).toMatch(/const reconcile = !reconciledThisSession/);
+    expect(code).toMatch(/reconcile\s*\)\s*params\.set\(\s*['"]reconcile['"]/);
+    const full = readSource('./notes-sync.service.ts');
+    expect(full).toMatch(/export function requestFullReconcileNextPull\(/);
+  });
+
+  it('manual sync and online-recovery force a full reconcile', () => {
+    const footer = readSource('../components/sync/SyncStatusFooter.svelte');
+    expect(footer).toMatch(/requestFullReconcileNextPull\(\)/);
+    const store = readSource('../stores/sync-status.store.ts');
+    expect(store).toMatch(/requestFullReconcileNextPull/);
+  });
+
+  it('logout clears the delta watermark', () => {
+    const authStore = readSource('../stores/auth.store.ts');
+    expect(authStore).toMatch(/clearNotesDeltaWatermark\(\)/);
+  });
+
+  it('degrades safely against an old server with no page envelope', () => {
+    const code = pullNotesSrc().replace(/\/\/.*$/gm, '');
+    // When the server returns no `page`, the loop must not crash and must only
+    // treat the body as the full id set when there was no `since` (a true bulk).
+    expect(code).toMatch(/!pageInfo/);
+    expect(code).toMatch(/pageInfo\?\.has_more/);
+  });
+
+  it('noteIndex.upsertFromStore updates in-memory by id, not via a full getAll rebuild', () => {
+    const src = readSource('./note-index.svelte.ts');
+    const method = src.slice(
+      src.indexOf('async upsertFromStore'),
+      src.indexOf('/** Clear and rebuild')
+    );
+    expect(method).toMatch(/noteStore\.getMany\(/);
+    expect(method).toMatch(/this\._map\.set\(/);
+    // Must NOT fall back to the full-table getAll() that build() uses.
+    expect(method).not.toMatch(/noteStore\.getAll\(/);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -43,6 +43,7 @@ import {
   syncError,
   lastSyncedAt,
   isInitialSync,
+  syncProgress,
   refreshPendingCount
 } from '$lib/stores/sync-status.store';
 import { authFetch } from '$lib/utils/auth-fetch';
@@ -255,6 +256,10 @@ async function runPullFromServer(): Promise<boolean> {
     success = false;
   } finally {
     isSyncing.set(false);
+    // Safety net: pullNotes clears its own progress in a finally, but if it
+    // threw before that (e.g. the count()/watermark read), make sure the footer
+    // counter never wedges.
+    syncProgress.set(null);
     // Drop the first-load placeholder if this pull failed (e.g. offline): the
     // success path leaves it for refreshStoresAfterPull to clear once the stores
     // are hydrated. No-op when it was never set (periodic pulls).
@@ -490,13 +495,206 @@ async function pullSavedSearches(): Promise<void> {
   }
 }
 
+// Page size for the paginated delta pull. A few thousand notes / 200 = a few
+// dozen pages: few enough requests to keep native bridge overhead low, small
+// enough that no single transfer spikes the bridge's memory. See guideline 36.
+const NOTES_PAGE_SIZE = 200;
+
+type ServerNote = {
+  id: string;
+  folder_id?: string;
+  title_encrypted: string;
+  content_encrypted: string;
+  metadata_encrypted?: string;
+  is_archived?: boolean;
+  deleted_at?: string;
+  created_at: string;
+  updated_at: string;
+  sync_version?: number;
+};
+
+type ServerPage = {
+  has_more: boolean;
+  next_cursor: string | null;
+  total?: number;
+  all_ids?: string[];
+};
+
+// ── Delta-sync watermark (localStorage, per account) ─────────────
+// We persist max(updated_at) seen FROM THE SERVER so the next pull fetches only
+// the delta (?since). The value is a plaintext timestamp (updated_at is already
+// plaintext in the server-visibility model), so localStorage is fine; it is
+// keyed by userId and never leaves the device. Read is guarded by
+// noteStore.count() in pullNotes: if IndexedDB was wiped but localStorage
+// survived, the watermark is ignored and a full pull runs. Cleared on logout.
+const WATERMARK_PREFIX = 'notes_delta_since_';
+function readWatermark(userId: string): string | null {
+  try {
+    return localStorage.getItem(WATERMARK_PREFIX + userId);
+  } catch {
+    return null;
+  }
+}
+function writeWatermark(userId: string, iso: string): void {
+  try {
+    localStorage.setItem(WATERMARK_PREFIX + userId, iso);
+  } catch {
+    /* private mode / quota - delta just degrades to a full pull next time */
+  }
+}
+/** Drop every account's delta watermark. Called from the logout/clear path. */
+export function clearNotesDeltaWatermark(): void {
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k?.startsWith(WATERMARK_PREFIX)) keys.push(k);
+    }
+    for (const k of keys) localStorage.removeItem(k);
+  } catch {
+    /* ignore */
+  }
+}
+
+// Variant B orphan-delete gating: request the full id set (all_ids) only on the
+// first pull of this JS session, on manual sync, and on online-recovery - NOT on
+// every 5-min periodic pull (those stay pure deltas). A permanent delete from
+// another device then propagates on next app start / manual sync / reconnect,
+// which is benign (the trash/soft-delete state propagates via the delta itself).
+// This saves both the all_ids transfer and the local getAll() on idle syncs.
+let reconciledThisSession = false;
+export function requestFullReconcileNextPull(): void {
+  reconciledThisSession = false;
+}
+
+/**
+ * Paginated delta pull of notes (Filar 1). Loops keyset pages from the server,
+ * writing each page in one saveMany and revealing it in the list as it lands,
+ * then orphan-deletes via the authoritative all_ids and advances the watermark.
+ *
+ * Returns the ids whose server state advanced this pull (reported for callers /
+ * future use; history is fetched on demand, not from this list).
+ */
 async function pullNotes(): Promise<string[]> {
-  // See pullFolders() for rationale on the userId guard.
   const userId = get(authStore).userId;
   if (!userId) return [];
-  const res = await authFetch(`${API_BASE}/notes?include_archived=true`);
-  if (!res.ok) throw new Error(`GET /api/notes: ${res.status}`);
-  const { data } = await res.json();
+
+  // Variant B: only the first session pull / manual / online-recovery reconciles.
+  const reconcile = !reconciledThisSession;
+  // Ignore a stale watermark when IDB holds no notes (wiped but localStorage
+  // survived) - force a full pull so we don't skip unchanged notes we don't have.
+  const hasLocalNotes = (await noteStore.count()) > 0;
+  const since = hasLocalNotes ? readWatermark(userId) : null;
+
+  // Dynamic imports (same rationale as refreshStoresAfterPull): avoids a
+  // sync-service <-> note-index/notes-store import cycle. Cached by the bundler.
+  const { noteIndex } = await import('$lib/services/note-index.svelte');
+  const { notesStore } = await import('$lib/stores/notes.store');
+
+  const changed: string[] = [];
+  let cursor: string | null = null;
+  let firstPage = true;
+  let total = 0;
+  let done = 0;
+  // Authoritative full id set for orphan-delete. Stays null unless the server
+  // actually returns it (new server + reconcile) - we must NEVER orphan-delete
+  // from a partial delta page (that would wipe every unchanged note).
+  let allIds: Set<string> | null = null;
+  let maxUpdatedAt = since ?? '';
+
+  try {
+    do {
+      const params = new URLSearchParams({
+        include_archived: 'true',
+        limit: String(NOTES_PAGE_SIZE)
+      });
+      // `since` only on the first request; later pages carry the keyset cursor,
+      // which already sits past `since`.
+      if (firstPage && since) params.set('since', since);
+      if (cursor) params.set('cursor', cursor);
+      if (firstPage && reconcile) params.set('reconcile', 'true');
+
+      const res = await authFetch(`${API_BASE}/notes?${params.toString()}`);
+      if (!res.ok) throw new Error(`GET /api/notes: ${res.status}`);
+      const body = await res.json();
+      const data = (body.data ?? []) as ServerNote[];
+      const pageInfo = body.page as ServerPage | undefined;
+
+      if (firstPage) {
+        total = pageInfo?.total ?? data.length;
+        if (pageInfo?.all_ids) {
+          // New server + reconcile: trust the explicit full id set.
+          allIds = new Set(pageInfo.all_ids);
+        } else if (!pageInfo && !since) {
+          // Old server (no `page`) with no `since` returns the FULL set in `data`,
+          // so it is itself authoritative for orphan-delete. With a `since` we'd
+          // only get a delta, so we leave allIds null and skip orphan-delete.
+          allIds = new Set(data.map((n) => n.id));
+        }
+        syncProgress.set({ done: 0, total });
+      }
+
+      const { changed: pageChanged, maxUpdatedAt: pageMax } = await writeNotesPage(data, userId);
+      changed.push(...pageChanged);
+      if (pageMax > maxUpdatedAt) maxUpdatedAt = pageMax;
+      done += data.length;
+      syncProgress.set({ done, total: Math.max(total, done) });
+
+      // Incremental reveal: add this page to the in-memory index by id (point
+      // reads, no full rebuild) and repaint. writeNotesPage already applied the
+      // page's tag deltas, so getTagsForNote sees fresh relations.
+      if (pageChanged.length > 0) {
+        await noteIndex.upsertFromStore(pageChanged);
+        notesStore.refresh();
+      }
+      // Reveal progressively: drop the first-load placeholder once the first
+      // page is in memory, instead of waiting for the whole (multi-page) pull.
+      if (firstPage) isInitialSync.set(false);
+
+      cursor = pageInfo?.has_more ? (pageInfo.next_cursor ?? null) : null;
+      firstPage = false;
+    } while (cursor);
+  } finally {
+    syncProgress.set(null);
+  }
+
+  // Orphan-delete ONLY from the authoritative all_ids (never from page contents:
+  // a delta page holds just the changed notes). Skipped entirely when allIds is
+  // null (old server, or a non-reconcile periodic pull).
+  if (allIds) {
+    const serverIds = allIds;
+    const allLocalNotes = (await noteStore.getAll()) as NoteStoredLocal[];
+    const orphanNoteIds = allLocalNotes
+      .filter((n) => n.sync_status === 'synced' && !serverIds.has(n.id))
+      .map((n) => n.id);
+    if (orphanNoteIds.length > 0) {
+      await noteStore.deleteMany(orphanNoteIds);
+      logger.debug(`Removed ${orphanNoteIds.length} locally-synced notes no longer on server`);
+    }
+  }
+
+  // Advance the delta watermark (server-authoritative, monotonic). Next pull
+  // fetches only rows updated at/after this instant.
+  if (maxUpdatedAt && maxUpdatedAt !== since) writeWatermark(userId, maxUpdatedAt);
+  reconciledThisSession = true;
+
+  return changed;
+}
+
+/**
+ * Decode, reconcile and persist one page of server notes in a single batched
+ * write (one saveMany per page, not save()-per-note - the O(n²) refresh trap of
+ * PR #353, now bounded to a page). Applies the page's note-tag deltas too.
+ * Returns the ids that advanced plus the highest server updated_at in the page.
+ */
+async function writeNotesPage(
+  data: ServerNote[],
+  userId: string
+): Promise<{ changed: string[]; maxUpdatedAt: string }> {
+  // Highest server updated_at in this page (ISO strings sort chronologically).
+  // Computed over ALL rows, including ones the sync_version guard skips below -
+  // we still saw them at that timestamp, so the next ?since must cover them.
+  const maxUpdatedAt = data.reduce((m, n) => (n.updated_at > m ? n.updated_at : m), '');
 
   // Collect all writes here and flush them in one batch below, instead of issuing
   // them per-note inside the map. Each `noteStore.save()` runs refreshItems() - a
@@ -670,25 +868,10 @@ async function pullNotes(): Promise<string[]> {
     );
   }
 
-  // Remove local notes that no longer exist on the server (permanently deleted on another device).
-  // We use include_archived=true above, so the server returns soft-deleted notes too.
-  // If a note is missing from the response entirely, it was permanently deleted.
-  const serverNoteIds = new Set(
-    (data as Array<{ id: string }>).map((n) => n.id)
-  );
-  const allLocalNotes = (await noteStore.getAll()) as NoteStoredLocal[];
-  const orphanNoteIds = allLocalNotes
-    .filter((n) => n.sync_status === 'synced' && !serverNoteIds.has(n.id))
-    .map((n) => n.id);
-  if (orphanNoteIds.length > 0) {
-    await noteStore.deleteMany(orphanNoteIds);
-    logger.debug(`Removed ${orphanNoteIds.length} locally-synced notes no longer on server`);
-  }
-
-  // Notes whose server state advanced this pull. Reported for stage 2b's
-  // paginated delta sync; the caller currently ignores the result (version
-  // history is fetched on demand when the panel opens). See guideline 36.
-  return changedResults.filter((id): id is string => id !== null);
+  return {
+    changed: changedResults.filter((id): id is string => id !== null),
+    maxUpdatedAt
+  };
 }
 
 // ── Push helpers - IndexedDB → server ────────────────────────────

--- a/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression for the periodic-note duplicate introduced by the paginated delta
+ * sync (PR #356).
+ *
+ * `findExistingPeriodicNote` resolves against the in-memory `noteIndex`, which
+ * the paginated pull builds up one page at a time. The keyset order
+ * (`updated_at ASC`) puts today's freshly-touched periodic note on the LAST
+ * page, while the first-load placeholder drops after page 1 - so a click on the
+ * daily/weekly/monthly button during the pull window used to miss the note that
+ * was simply not paged in yet and create a duplicate of it.
+ *
+ * The fix gates `getOrCreateNote`: on an index miss WITH a pull in flight, wait
+ * for the pull to settle (index complete) and resolve once more before creating.
+ *
+ * Source-level, like notes-sync.regression.spec.ts: periodic-notes.service pulls
+ * in browser-only modules (cryptoManager, reactive stores) that are impractical
+ * to wire up in a Node test env. The wait primitive itself is unit-tested in
+ * store-wait.spec.ts.
+ */
+
+function readSource(relative: string): string {
+  return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+function getOrCreateNoteBody(): string {
+  const src = readSource('./periodic-notes.service.ts');
+  const start = src.indexOf('export async function getOrCreateNote');
+  expect(start).toBeGreaterThan(-1);
+  // getOrCreateNote is the last export in the file; slice to EOF is fine, but
+  // bound it defensively at the next top-level `export ` if one is ever added.
+  const after = src.slice(start + 1);
+  const nextExportIdx = after.indexOf('\nexport ');
+  const end = nextExportIdx > -1 ? start + 1 + nextExportIdx : src.length;
+  return src.slice(start, end);
+}
+
+describe('periodic notes - resolver/sync race (PR #356 regression)', () => {
+  it('imports the in-flight-sync flag and the wait primitive', () => {
+    const src = readSource('./periodic-notes.service.ts');
+    expect(src).toMatch(/import\s*\{\s*isSyncing\s*\}\s*from\s*'\$lib\/stores\/sync-status\.store'/);
+    expect(src).toMatch(/import\s*\{\s*whenFalsy\s*\}\s*from\s*'\$lib\/utils\/store-wait'/);
+  });
+
+  it('getOrCreateNote waits for an in-flight pull before creating, then re-resolves', () => {
+    const body = getOrCreateNoteBody();
+
+    // Must consult the in-flight flag and await the settle primitive.
+    expect(body).toMatch(/get\(\s*isSyncing\s*\)/);
+    expect(body).toMatch(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
+
+    // Ordering: initial resolve → gate (await whenFalsy) → re-resolve → create.
+    const firstResolve = body.indexOf('findExistingPeriodicNote');
+    const waitIdx = body.search(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
+    const secondResolve = body.indexOf('findExistingPeriodicNote', waitIdx);
+    const createIdx = body.indexOf('createNote(');
+
+    expect(firstResolve).toBeGreaterThan(-1);
+    expect(waitIdx).toBeGreaterThan(firstResolve);
+    // A second resolve happens AFTER the wait...
+    expect(secondResolve).toBeGreaterThan(waitIdx);
+    // ...and the actual create happens only after that re-resolve.
+    expect(createIdx).toBeGreaterThan(secondResolve);
+  });
+
+  it('the wait is gated on isSyncing so steady-state clicks never block', () => {
+    const body = getOrCreateNoteBody();
+    // The whenFalsy await must sit inside an `if (get(isSyncing))` block, not
+    // run unconditionally (which would couple every click to a store read +
+    // redundant re-resolve even when nothing is syncing).
+    const guardIdx = body.search(/if\s*\(\s*get\(\s*isSyncing\s*\)\s*\)/);
+    const waitIdx = body.search(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(waitIdx).toBeGreaterThan(guardIdx);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
@@ -21,9 +21,19 @@ import { resolve } from 'path';
  *      round-trip + push BEFORE pulling, so `isSyncing` is still false. Ensure a
  *      pull completes first via the single-flight `pullFromServer` (joins the
  *      imminent/in-flight pull, no extra round-trip), then re-resolve.
- * Only after both windows still miss do we create. The smoke repro was exactly
- * window 2: logging in and opening the daily note immediately, before the new
- * session's pull had paged today's note in.
+ * Only after both windows still miss do we create.
+ *
+ * THIRD window (the one the first two fixes missed; smoke 2026-06-28): the
+ * duplicate reproduced "directly after Synced", with isSyncing false AND
+ * lastSyncedAt non-null - so neither gate window was open. Root cause was not in
+ * the resolver at all but in `noteIndex.rebuild()`: it did `this._map.clear()`
+ * before an async `build()` that yields between decrypt batches, leaving the
+ * index observably EMPTY for the whole rebuild. `refreshStoresAfterPull` runs
+ * that rebuild immediately after the pull flips lastSyncedAt -> "Synced", so a
+ * periodic-note open in the gap saw zero notes and duplicated today's note. The
+ * structural fix is in note-index.svelte.ts: rebuild() must delegate to build()
+ * (which swaps a fresh Map in atomically) and never pre-clear. The two test
+ * blocks below pin BOTH layers - the resolver gate and the atomic rebuild.
  *
  * Source-level, like notes-sync.regression.spec.ts: periodic-notes.service pulls
  * in browser-only modules (cryptoManager, reactive stores) that are impractical
@@ -95,5 +105,42 @@ describe('periodic notes - resolver/sync race (PR #356 regression)', () => {
     expect(coldWait).toBeGreaterThan(firstResolve);
     expect(secondResolve).toBeGreaterThan(lastWait);
     expect(createIdx).toBeGreaterThan(secondResolve);
+  });
+});
+
+describe('noteIndex.rebuild - atomic swap (post-pull empty-window regression)', () => {
+  function rebuildBody(): string {
+    const src = readSource('./note-index.svelte.ts');
+    const start = src.indexOf('async rebuild(');
+    expect(start).toBeGreaterThan(-1);
+    // rebuild() is a short method; bound the slice at the next method's closing
+    // by taking up to the following `  /** ` doc-comment or `  clear(` sibling.
+    const after = src.slice(start);
+    const end = after.search(/\n\s{2}(?:\/\*\*|clear\(|update\()/);
+    return end > -1 ? after.slice(0, end) : after.slice(0, 400);
+  }
+
+  it('rebuild() delegates to build() and never pre-clears the live map', () => {
+    const body = rebuildBody();
+    // build() fills a fresh Map and swaps it into this._map only at the end, so
+    // the old complete map must stay readable until the swap. A pre-clear here
+    // (this._map.clear()) reopens the post-"Synced" empty window that duplicated
+    // periodic notes - it must be gone.
+    expect(body).toMatch(/await\s+this\.build\(\)/);
+    expect(body).not.toMatch(/this\._map\.clear\(\)/);
+  });
+
+  it('build() itself swaps a freshly-built map in atomically (single assignment)', () => {
+    const src = readSource('./note-index.svelte.ts');
+    const start = src.indexOf('async build(');
+    // Bound the slice at the next method (upsertFromStore) so we read exactly
+    // build()'s body, not a fixed char window that could clip the final swap.
+    const end = src.indexOf('async upsertFromStore(', start);
+    const body = src.slice(start, end > -1 ? end : start + 2400);
+    // The atomicity contract rebuild() relies on: build() works on a LOCAL `map`
+    // and publishes it with one `this._map = map`, rather than mutating this._map
+    // incrementally (which would expose partial state mid-build).
+    expect(body).toMatch(/const\s+map\s*=\s*new\s+Map/);
+    expect(body).toMatch(/this\._map\s*=\s*map/);
   });
 });

--- a/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
@@ -9,12 +9,21 @@ import { resolve } from 'path';
  * `findExistingPeriodicNote` resolves against the in-memory `noteIndex`, which
  * the paginated pull builds up one page at a time. The keyset order
  * (`updated_at ASC`) puts today's freshly-touched periodic note on the LAST
- * page, while the first-load placeholder drops after page 1 - so a click on the
- * daily/weekly/monthly button during the pull window used to miss the note that
+ * page, while the first-load placeholder drops after page 1 - so opening the
+ * daily/weekly/monthly note during the pull window used to miss the note that
  * was simply not paged in yet and create a duplicate of it.
  *
- * The fix gates `getOrCreateNote`: on an index miss WITH a pull in flight, wait
- * for the pull to settle (index complete) and resolve once more before creating.
+ * The fix gates `getOrCreateNote` over TWO windows:
+ *   1. A pull is in flight (`isSyncing`): wait for it to settle (the flag clears
+ *      in the pull's `finally`, after the last page is upserted), then re-resolve.
+ *   2. Cold login, pre-pull window (`lastSyncedAt === null`, not local-only, no
+ *      pull in flight yet but one imminent): the layout's runSync does a settings
+ *      round-trip + push BEFORE pulling, so `isSyncing` is still false. Ensure a
+ *      pull completes first via the single-flight `pullFromServer` (joins the
+ *      imminent/in-flight pull, no extra round-trip), then re-resolve.
+ * Only after both windows still miss do we create. The smoke repro was exactly
+ * window 2: logging in and opening the daily note immediately, before the new
+ * session's pull had paged today's note in.
  *
  * Source-level, like notes-sync.regression.spec.ts: periodic-notes.service pulls
  * in browser-only modules (cryptoManager, reactive stores) that are impractical
@@ -39,41 +48,52 @@ function getOrCreateNoteBody(): string {
 }
 
 describe('periodic notes - resolver/sync race (PR #356 regression)', () => {
-  it('imports the in-flight-sync flag and the wait primitive', () => {
+  it('imports the sync-state flags and the wait primitive', () => {
     const src = readSource('./periodic-notes.service.ts');
-    expect(src).toMatch(/import\s*\{\s*isSyncing\s*\}\s*from\s*'\$lib\/stores\/sync-status\.store'/);
+    // isSyncing (in-flight), lastSyncedAt + localOnly (cold pre-pull window).
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bisSyncing\b[^}]*\blastSyncedAt\b[^}]*\blocalOnly\b[^}]*\}\s*from\s*'\$lib\/stores\/sync-status\.store'/s
+    );
     expect(src).toMatch(/import\s*\{\s*whenFalsy\s*\}\s*from\s*'\$lib\/utils\/store-wait'/);
   });
 
-  it('getOrCreateNote waits for an in-flight pull before creating, then re-resolves', () => {
+  it('window 1: waits for an in-flight pull, gated on isSyncing so steady-state clicks never block', () => {
     const body = getOrCreateNoteBody();
-
-    // Must consult the in-flight flag and await the settle primitive.
-    expect(body).toMatch(/get\(\s*isSyncing\s*\)/);
-    expect(body).toMatch(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
-
-    // Ordering: initial resolve → gate (await whenFalsy) → re-resolve → create.
-    const firstResolve = body.indexOf('findExistingPeriodicNote');
-    const waitIdx = body.search(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
-    const secondResolve = body.indexOf('findExistingPeriodicNote', waitIdx);
-    const createIdx = body.indexOf('createNote(');
-
-    expect(firstResolve).toBeGreaterThan(-1);
-    expect(waitIdx).toBeGreaterThan(firstResolve);
-    // A second resolve happens AFTER the wait...
-    expect(secondResolve).toBeGreaterThan(waitIdx);
-    // ...and the actual create happens only after that re-resolve.
-    expect(createIdx).toBeGreaterThan(secondResolve);
-  });
-
-  it('the wait is gated on isSyncing so steady-state clicks never block', () => {
-    const body = getOrCreateNoteBody();
-    // The whenFalsy await must sit inside an `if (get(isSyncing))` block, not
-    // run unconditionally (which would couple every click to a store read +
-    // redundant re-resolve even when nothing is syncing).
+    // The whenFalsy await must sit inside an `if (get(isSyncing))` block, not run
+    // unconditionally (which would couple every click to a redundant re-resolve).
     const guardIdx = body.search(/if\s*\(\s*get\(\s*isSyncing\s*\)\s*\)/);
     const waitIdx = body.search(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
     expect(guardIdx).toBeGreaterThan(-1);
     expect(waitIdx).toBeGreaterThan(guardIdx);
+  });
+
+  it('window 2: on a cold first sync (lastSyncedAt null, not local-only) it awaits a pull before creating', () => {
+    const body = getOrCreateNoteBody();
+    // Must gate on the cold-first-sync condition...
+    expect(body).toMatch(/!get\(\s*localOnly\s*\)/);
+    expect(body).toMatch(/get\(\s*lastSyncedAt\s*\)\s*===\s*null/);
+    // ...and ensure a pull settles (single-flight join), not just probe a flag.
+    expect(body).toMatch(/await\s+import\(\s*'\$lib\/services\/notes-sync\.service'\s*\)/);
+    expect(body).toMatch(/await\s+pullFromServer\(\)/);
+  });
+
+  it('both windows re-resolve against the index AFTER settling and create only if still absent', () => {
+    const body = getOrCreateNoteBody();
+
+    const firstResolve = body.indexOf('findExistingPeriodicNote');
+    // The gate settles via either window before the second resolve.
+    const inFlightWait = body.search(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
+    const coldWait = body.search(/await\s+pullFromServer\(\)/);
+    const createIdx = body.indexOf('createNote(');
+    // The re-resolve sits after BOTH window awaits (it's guarded by a `settled`
+    // flag set in either branch), and before create.
+    const lastWait = Math.max(inFlightWait, coldWait);
+    const secondResolve = body.indexOf('findExistingPeriodicNote', lastWait);
+
+    expect(firstResolve).toBeGreaterThan(-1);
+    expect(inFlightWait).toBeGreaterThan(firstResolve);
+    expect(coldWait).toBeGreaterThan(firstResolve);
+    expect(secondResolve).toBeGreaterThan(lastWait);
+    expect(createIdx).toBeGreaterThan(secondResolve);
   });
 });

--- a/apps/reborn-notes/src/lib/services/periodic-notes.service.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-notes.service.ts
@@ -37,6 +37,8 @@ import {
 import { foldersStore } from '$lib/stores/folders.store';
 import { notesStore } from '$lib/stores/notes.store';
 import { noteIndex } from '$lib/services/note-index.svelte';
+import { isSyncing } from '$lib/stores/sync-status.store';
+import { whenFalsy } from '$lib/utils/store-wait';
 import { getSetting } from '$lib/utils/app-settings';
 import { appSettings } from '$lib/stores/app-settings.store';
 import { t as i18nT, locale as i18nLocale } from '$lib/stores/i18n.store';
@@ -327,6 +329,20 @@ export async function getOrCreateNote(
 
   const existing = await findExistingPeriodicNote(folderId, kind, anchorIso);
   if (existing) return { noteId: existing, created: false };
+
+  // No match in the in-memory index - but the index is built incrementally
+  // during the initial paginated pull, and the keyset order (updated_at ASC)
+  // puts today's freshly-touched periodic note on the LAST page. A miss while a
+  // pull is still in flight may just mean "not paged in yet", not "doesn't
+  // exist": creating now would duplicate a note that's about to arrive. Wait
+  // for the pull to settle (index complete), then resolve once more before
+  // committing to a new note. Steady-state (no pull running) this is a no-op.
+  // Post-sync dedup (detectAndNotifyPeriodicDuplicates) remains the backstop.
+  if (get(isSyncing)) {
+    await whenFalsy(isSyncing);
+    const afterSync = await findExistingPeriodicNote(folderId, kind, anchorIso);
+    if (afterSync) return { noteId: afterSync, created: false };
+  }
 
   const noteId = await createNote(title, '', folderId, {
     periodic: { kind, anchor: anchorIso }

--- a/apps/reborn-notes/src/lib/services/periodic-notes.service.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-notes.service.ts
@@ -37,7 +37,7 @@ import {
 import { foldersStore } from '$lib/stores/folders.store';
 import { notesStore } from '$lib/stores/notes.store';
 import { noteIndex } from '$lib/services/note-index.svelte';
-import { isSyncing } from '$lib/stores/sync-status.store';
+import { isSyncing, lastSyncedAt, localOnly } from '$lib/stores/sync-status.store';
 import { whenFalsy } from '$lib/utils/store-wait';
 import { getSetting } from '$lib/utils/app-settings';
 import { appSettings } from '$lib/stores/app-settings.store';
@@ -330,18 +330,45 @@ export async function getOrCreateNote(
   const existing = await findExistingPeriodicNote(folderId, kind, anchorIso);
   if (existing) return { noteId: existing, created: false };
 
-  // No match in the in-memory index - but the index is built incrementally
-  // during the initial paginated pull, and the keyset order (updated_at ASC)
-  // puts today's freshly-touched periodic note on the LAST page. A miss while a
-  // pull is still in flight may just mean "not paged in yet", not "doesn't
-  // exist": creating now would duplicate a note that's about to arrive. Wait
-  // for the pull to settle (index complete), then resolve once more before
-  // committing to a new note. Steady-state (no pull running) this is a no-op.
-  // Post-sync dedup (detectAndNotifyPeriodicDuplicates) remains the backstop.
+  // A miss in the in-memory index is not authoritative until the server's notes
+  // for this session are actually paged in. The index is built incrementally
+  // during the paginated pull, and the keyset order (updated_at ASC) puts today's
+  // freshly-touched periodic note on the LAST page - so a premature miss would
+  // duplicate a note that's about to arrive. Two windows to cover:
+  //
+  //   1. A pull is in flight (isSyncing): today's note may still be on an
+  //      un-paged page. isSyncing clears in the pull's `finally`, AFTER the last
+  //      page is upserted into the index, so waiting it out is sufficient.
+  //   2. Cold login, pre-pull window: the index was just (re)built from an empty
+  //      IndexedDB and no pull is in flight YET, but one is imminent - the
+  //      layout's runSync does a synced-settings round-trip + pushPendingItems
+  //      BEFORE it calls pullFromServer, and lastSyncedAt is still null. isSyncing
+  //      is false here, so window 1 misses it; we'd create a duplicate of the
+  //      note the pull is about to deliver. Ensure a pull completes first.
+  //      pullFromServer is single-flight, so this JOINS the imminent/in-flight
+  //      pull rather than adding a round-trip, and the index is populated
+  //      incrementally, so the re-resolve below sees today's note. lastSyncedAt
+  //      flips non-null after the first success, so steady-state opens skip this.
+  //
+  // Re-resolve after settling; create only if still absent. Post-sync dedup
+  // (detectAndNotifyPeriodicDuplicates) stays the backstop for any residue.
+  let settled = false;
   if (get(isSyncing)) {
     await whenFalsy(isSyncing);
-    const afterSync = await findExistingPeriodicNote(folderId, kind, anchorIso);
-    if (afterSync) return { noteId: afterSync, created: false };
+    settled = true;
+  } else if (!get(localOnly) && get(lastSyncedAt) === null) {
+    try {
+      const { pullFromServer } = await import('$lib/services/notes-sync.service');
+      await pullFromServer();
+    } catch {
+      // Offline / transient: fall through and create now; the post-sync dedup
+      // scan reconciles a rare duplicate once connectivity returns.
+    }
+    settled = true;
+  }
+  if (settled) {
+    const after = await findExistingPeriodicNote(folderId, kind, anchorIso);
+    if (after) return { noteId: after, created: false };
   }
 
   const noteId = await createNote(title, '', folderId, {

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -425,6 +425,10 @@ function createAuthStore() {
     try {
       const { clearAllUserData } = await import('@reborn/storage');
       await clearAllUserData();
+      // Drop the delta-sync watermark so the next login does a clean full pull
+      // (dynamic import avoids an auth.store <-> notes-sync.service cycle).
+      const { clearNotesDeltaWatermark } = await import('$lib/services/notes-sync.service');
+      clearNotesDeltaWatermark();
     } catch (err) {
       logger.error('Failed to clear IndexedDB on logout:', err);
     }

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -52,8 +52,16 @@ if (browser && connectivityStore) {
     const nowOnline = $c.status === 'online';
     if (nowOnline && !wasOnline) {
       import('$lib/services/notes-sync.service').then(
-        async ({ pullFromServer, pushPendingItems, refreshStoresAfterPull }) => {
+        async ({
+          pullFromServer,
+          pushPendingItems,
+          refreshStoresAfterPull,
+          requestFullReconcileNextPull
+        }) => {
           try {
+            // Coming back online: we may have missed deletes while offline, so
+            // force a full id reconcile (all_ids) on this pull, not a bare delta.
+            requestFullReconcileNextPull();
             await pushPendingItems();
             const synced = await pullFromServer();
             if (synced) await refreshStoresAfterPull();
@@ -70,6 +78,13 @@ if (browser && connectivityStore) {
 // ── Sync progress (set by sync service) ─────────────────────────
 
 export const isSyncing = writable(false);
+// Determinate progress for the notes phase of a pull (paginated delta sync):
+// {done, total} as pages land, or null when no pull is counting. Set by
+// notes-sync.service's pullNotes, cleared in runPullFromServer's finally. Read
+// by SyncStatusFooter and the first-load placeholder to show "Syncing notes…
+// 320/2000". A determinate counter is the key "is it frozen?" answer on a cold
+// sync of a few-thousand-note account on native.
+export const syncProgress = writable<{ done: number; total: number } | null>(null);
 export const syncError = writable(false);
 export const sessionExpired = writable(false);
 // True in local-only / no-account mode. Set by the auth store (one-way, like

--- a/apps/reborn-notes/src/lib/utils/store-wait.spec.ts
+++ b/apps/reborn-notes/src/lib/utils/store-wait.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { writable } from 'svelte/store';
+import { whenFalsy } from './store-wait';
+
+describe('whenFalsy', () => {
+  it('resolves immediately when the store is already falsy', async () => {
+    const s = writable(false);
+    let resolved = false;
+    await whenFalsy(s).then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(true);
+  });
+
+  it('waits for a truthy store to flip falsy', async () => {
+    const s = writable(true);
+    let resolved = false;
+    const p = whenFalsy(s).then(() => {
+      resolved = true;
+    });
+
+    // Still pending while truthy.
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    s.set(false);
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('ignores intermediate truthy churn and resolves only on the first falsy', async () => {
+    const s = writable<number>(1);
+    let resolveCount = 0;
+    const p = whenFalsy(s).then(() => {
+      resolveCount++;
+    });
+
+    s.set(2); // still truthy
+    s.set(3); // still truthy
+    await Promise.resolve();
+    expect(resolveCount).toBe(0);
+
+    s.set(0); // falsy
+    await p;
+    // Further changes must not re-fire (already unsubscribed).
+    s.set(5);
+    s.set(0);
+    await Promise.resolve();
+    expect(resolveCount).toBe(1);
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/store-wait.ts
+++ b/apps/reborn-notes/src/lib/utils/store-wait.ts
@@ -1,0 +1,28 @@
+import { get, type Readable } from 'svelte/store';
+
+/**
+ * Resolve once `store` holds a falsy value.
+ *
+ * Returns an already-resolved promise when the store is falsy right now, so the
+ * common (steady-state) path costs nothing. Otherwise subscribes and resolves
+ * on the first falsy emission, then unsubscribes.
+ *
+ * Used to gate a read on an in-flight async flag (e.g. `isSyncing`) without
+ * polling: "if a pull is running, wait for it to finish, then look again".
+ */
+export function whenFalsy<T>(store: Readable<T>): Promise<void> {
+  if (!get(store)) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const unsub = store.subscribe((value) => {
+      if (value || settled) return;
+      settled = true;
+      resolve();
+      // Defer the unsubscribe: on a synchronous falsy emission `unsub` may not
+      // be assigned yet. We never reach here on the initial subscribe call
+      // (the `get` guard above means the store is truthy at subscribe time),
+      // but the microtask hop keeps this correct for any store contract.
+      queueMicrotask(() => unsub());
+    });
+  });
+}

--- a/apps/reborn-notes/src/routes/api/notes/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/+server.ts
@@ -9,12 +9,78 @@ import { apiErrorResponse } from '$lib/server/api-error';
 
 const logger = createLogger('Notes-API-Notes');
 
+const DEFAULT_PAGE_LIMIT = 200;
+const MAX_PAGE_LIMIT = 500;
+
+type NoteRow = {
+  id: string;
+  folder_id: string | null;
+  title_encrypted: string;
+  content_encrypted: string;
+  excerpt_encrypted: string | null;
+  metadata_encrypted: string | null;
+  is_archived: boolean;
+  deleted_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  sync_version: number;
+};
+
+/** Wire shape for a single note. Identical for legacy and paginated responses. */
+function serializeNote(n: NoteRow) {
+  return {
+    id: n.id,
+    folder_id: n.folder_id,
+    title_encrypted: n.title_encrypted,
+    content_encrypted: n.content_encrypted,
+    excerpt_encrypted: n.excerpt_encrypted,
+    metadata_encrypted: n.metadata_encrypted ?? undefined,
+    is_archived: n.is_archived,
+    deleted_at: n.deleted_at?.toISOString() ?? null,
+    created_at: n.created_at.toISOString(),
+    updated_at: n.updated_at.toISOString(),
+    sync_version: n.sync_version
+  };
+}
+
 /**
- * GET /api/notes — fetch all notes for the authenticated user.
+ * Opaque keyset cursor over (updated_at, id). Both fields are already plaintext
+ * in the server-visibility model, so this introduces no new plaintext - it is
+ * just an encoding of the last row on a page. Not Prisma's `cursor:{id}`, which
+ * breaks when the cursor row was hard-deleted between pages (real in delta sync).
+ */
+function encodeCursor(updatedAt: Date, id: string): string {
+  return Buffer.from(JSON.stringify({ u: updatedAt.toISOString(), i: id })).toString('base64url');
+}
+function decodeCursor(raw: string): { updatedAt: Date; id: string } | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
+    if (typeof parsed?.u !== 'string' || typeof parsed?.i !== 'string') return null;
+    const updatedAt = new Date(parsed.u);
+    if (Number.isNaN(updatedAt.getTime())) return null;
+    return { updatedAt, id: parsed.i };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GET /api/notes — fetch notes for the authenticated user.
+ *
+ * Two modes, selected by whether the client sends pagination params:
+ *   • Legacy (no `limit`/`cursor`): returns the full matching set, no `page`
+ *     envelope. Keeps clients on older builds working unchanged (OTA paradox).
+ *   • Paginated delta: keyset pagination over (updated_at ASC, id ASC). Returns
+ *     one page + a `page` envelope { has_more, next_cursor, total?, all_ids? }.
+ *
  * Query params:
- *   folder_id  — filter by folder (use "null" for unorganised)
- *   include_archived=true — include trash
- *   since      — ISO timestamp: only notes updated after this date
+ *   folder_id            — filter by folder ("null" for unorganised)
+ *   include_archived=true — include trash (soft-deleted rows)
+ *   since                — ISO timestamp: delta lower bound (inclusive, >=)
+ *   cursor               — opaque keyset cursor (next page)
+ *   limit                — page size (default 200, max 500)
+ *   reconcile=true       — first page also returns all_ids (full id set) for
+ *                          orphan-delete of notes hard-deleted on another device
  */
 export const GET: RequestHandler = async ({ request, url }) => {
   try {
@@ -24,33 +90,82 @@ export const GET: RequestHandler = async ({ request, url }) => {
     const folderId = url.searchParams.get('folder_id');
     const includeArchived = url.searchParams.get('include_archived') === 'true';
     const since = url.searchParams.get('since');
+    const cursorRaw = url.searchParams.get('cursor');
+    const limitRaw = url.searchParams.get('limit');
+    const wantReconcile = url.searchParams.get('reconcile') === 'true';
+    const paginated = limitRaw !== null || cursorRaw !== null;
 
-    const where: Prisma.NoteWhereInput = { user_id: userId };
-    if (!includeArchived) where.deleted_at = null;
-    if (folderId === 'null') where.folder_id = null;
-    else if (folderId) where.folder_id = folderId;
-    if (since) where.updated_at = { gt: new Date(since) };
+    // Filter shared by the page query, the delta count and the all_ids scan.
+    const baseWhere: Prisma.NoteWhereInput = { user_id: userId };
+    if (!includeArchived) baseWhere.deleted_at = null;
+    if (folderId === 'null') baseWhere.folder_id = null;
+    else if (folderId) baseWhere.folder_id = folderId;
 
-    const notes = await prisma.note.findMany({
-      where,
-      orderBy: { updated_at: 'desc' }
-    });
+    // ── Legacy mode: old clients send neither limit nor cursor. ──────────
+    if (!paginated) {
+      const where: Prisma.NoteWhereInput = { ...baseWhere };
+      if (since) where.updated_at = { gt: new Date(since) };
+      const notes = await prisma.note.findMany({ where, orderBy: { updated_at: 'desc' } });
+      return json({ success: true, data: notes.map(serializeNote) });
+    }
 
-    const data = notes.map((n) => ({
-      id: n.id,
-      folder_id: n.folder_id,
-      title_encrypted: n.title_encrypted,
-      content_encrypted: n.content_encrypted,
-      excerpt_encrypted: n.excerpt_encrypted,
-      metadata_encrypted: n.metadata_encrypted ?? undefined,
-      is_archived: n.is_archived,
-      deleted_at: n.deleted_at?.toISOString() ?? null,
-      created_at: n.created_at.toISOString(),
-      updated_at: n.updated_at.toISOString(),
-      sync_version: n.sync_version
-    }));
+    // ── Paginated delta mode ────────────────────────────────────────────
+    const limit = Math.min(
+      Math.max(parseInt(limitRaw ?? '', 10) || DEFAULT_PAGE_LIMIT, 1),
+      MAX_PAGE_LIMIT
+    );
+    const cursor = cursorRaw ? decodeCursor(cursorRaw) : null;
+    if (cursorRaw && !cursor) {
+      return json({ success: false, error: 'Invalid cursor' }, { status: 400 });
+    }
 
-    return json({ success: true, data });
+    // The cursor (when present) is a strict keyset lower bound already past
+    // `since`, so it supersedes it. The first page (no cursor) applies `since`
+    // INCLUSIVELY (>=): boundary rows equal to the client watermark are re-sent
+    // and no-op'd by the client's sync_version guard, so a row written at the
+    // exact watermark instant is never missed.
+    const pageWhere: Prisma.NoteWhereInput = { ...baseWhere };
+    if (cursor) {
+      pageWhere.OR = [
+        { updated_at: { gt: cursor.updatedAt } },
+        { updated_at: cursor.updatedAt, id: { gt: cursor.id } }
+      ];
+    } else if (since) {
+      pageWhere.updated_at = { gte: new Date(since) };
+    }
+
+    // Peek one extra row to detect has_more without a second count.
+    const rows = (await prisma.note.findMany({
+      where: pageWhere,
+      orderBy: [{ updated_at: 'asc' }, { id: 'asc' }],
+      take: limit + 1
+    })) as NoteRow[];
+    const hasMore = rows.length > limit;
+    const pageRows = hasMore ? rows.slice(0, limit) : rows;
+    const last = pageRows[pageRows.length - 1];
+    const nextCursor = hasMore && last ? encodeCursor(last.updated_at, last.id) : null;
+
+    const page: {
+      has_more: boolean;
+      next_cursor: string | null;
+      total?: number;
+      all_ids?: string[];
+    } = { has_more: hasMore, next_cursor: nextCursor };
+
+    // First page only (no cursor): attach the delta total for a determinate
+    // progress counter, and - when asked - the FULL id set for orphan reconcile.
+    // all_ids ignores the since/cursor filter: it is every note row the user has.
+    if (!cursor) {
+      const deltaWhere: Prisma.NoteWhereInput = { ...baseWhere };
+      if (since) deltaWhere.updated_at = { gte: new Date(since) };
+      page.total = await prisma.note.count({ where: deltaWhere });
+      if (wantReconcile) {
+        const ids = await prisma.note.findMany({ where: baseWhere, select: { id: true } });
+        page.all_ids = ids.map((r) => r.id);
+      }
+    }
+
+    return json({ success: true, data: pageRows.map(serializeNote), page });
   } catch (err: unknown) {
     return apiErrorResponse(err, logger, 'GET /api/notes');
   }

--- a/apps/reborn-notes/src/routes/api/notes/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/notes/server.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  note: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    upsert: vi.fn(),
+    findUnique: vi.fn(),
+    findFirst: vi.fn()
+  },
+  folder: {
+    findFirst: vi.fn()
+  }
+};
+
+vi.mock('@reborn/database', () => ({ prisma: mockPrisma }));
+
+const mockGetUserFromToken = vi.fn();
+vi.mock('$lib/server/auth', () => ({
+  getUserFromToken: (...args: unknown[]) => mockGetUserFromToken(...args)
+}));
+
+vi.mock('@reborn/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+}));
+
+vi.mock('@reborn/types', () => ({
+  validateBody: vi.fn(),
+  schemas: { CreateNoteRequestSchema: {} }
+}));
+
+vi.mock('$lib/server/storage-quota', () => ({
+  checkQuota: vi.fn().mockResolvedValue({ allowed: true, used: 0, limit: 1000 })
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function noteRow(id: string, updatedAt: string) {
+  return {
+    id,
+    folder_id: null,
+    title_encrypted: 'iv:title',
+    content_encrypted: 'iv:content',
+    excerpt_encrypted: null,
+    metadata_encrypted: null,
+    is_archived: false,
+    deleted_at: null,
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    updated_at: new Date(updatedAt),
+    sync_version: 1
+  };
+}
+
+async function callGet(query: string) {
+  const { GET } = await import('./+server');
+  const url = new URL(`http://localhost/api/notes${query}`);
+  const event = {
+    request: new Request(url, { headers: { authorization: 'Bearer mock-token' } }),
+    url
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response = await (GET as any)(event);
+  const data = await response.json();
+  return { status: response.status, body: data };
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserFromToken.mockResolvedValue(USER_ID);
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('GET /api/notes - legacy (un-paginated) mode', () => {
+  it('returns the full set with no `page` envelope when no limit/cursor is sent', async () => {
+    mockPrisma.note.findMany.mockResolvedValue([
+      noteRow('a', '2026-02-01T00:00:00.000Z'),
+      noteRow('b', '2026-01-15T00:00:00.000Z')
+    ]);
+
+    const { status, body } = await callGet('?include_archived=true');
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(2);
+    // No pagination envelope - old clients read `data` and ignore the rest.
+    expect(body.page).toBeUndefined();
+    // Old behavior: newest-first, single findMany, no count for total.
+    const args = mockPrisma.note.findMany.mock.calls[0][0];
+    expect(args.orderBy).toEqual({ updated_at: 'desc' });
+    expect(mockPrisma.note.count).not.toHaveBeenCalled();
+  });
+
+  it('still honors `since` (gt) in legacy mode', async () => {
+    mockPrisma.note.findMany.mockResolvedValue([]);
+    await callGet('?include_archived=true&since=2026-02-01T00:00:00.000Z');
+    const args = mockPrisma.note.findMany.mock.calls[0][0];
+    expect(args.where.updated_at).toEqual({ gt: new Date('2026-02-01T00:00:00.000Z') });
+  });
+});
+
+describe('GET /api/notes - paginated delta mode', () => {
+  it('first page: keyset order, has_more via peek, next_cursor, total, no all_ids without reconcile', async () => {
+    // limit=2 with a peek of 3 rows -> has_more, page trimmed to 2.
+    mockPrisma.note.findMany.mockResolvedValue([
+      noteRow('a', '2026-01-01T00:00:00.000Z'),
+      noteRow('b', '2026-01-02T00:00:00.000Z'),
+      noteRow('c', '2026-01-03T00:00:00.000Z')
+    ]);
+    mockPrisma.note.count.mockResolvedValue(42);
+
+    const { status, body } = await callGet('?include_archived=true&limit=2');
+
+    expect(status).toBe(200);
+    expect(body.data).toHaveLength(2);
+    expect(body.page.has_more).toBe(true);
+    expect(typeof body.page.next_cursor).toBe('string');
+    expect(body.page.total).toBe(42);
+    expect(body.page.all_ids).toBeUndefined();
+
+    // Ascending keyset order + peek (take = limit + 1).
+    const pageArgs = mockPrisma.note.findMany.mock.calls[0][0];
+    expect(pageArgs.orderBy).toEqual([{ updated_at: 'asc' }, { id: 'asc' }]);
+    expect(pageArgs.take).toBe(3);
+  });
+
+  it('first page with reconcile=true returns all_ids (full id set, independent of the delta)', async () => {
+    mockPrisma.note.findMany.mockImplementation((args: { select?: { id: boolean } }) => {
+      if (args.select?.id) {
+        return Promise.resolve([{ id: 'a' }, { id: 'b' }, { id: 'x' }, { id: 'y' }]);
+      }
+      return Promise.resolve([noteRow('a', '2026-01-01T00:00:00.000Z')]);
+    });
+    mockPrisma.note.count.mockResolvedValue(1);
+
+    const { body } = await callGet('?include_archived=true&limit=200&reconcile=true');
+
+    expect(body.page.all_ids).toEqual(['a', 'b', 'x', 'y']);
+    expect(body.page.has_more).toBe(false);
+    // all_ids query carries no since/cursor filter - the whole user's id set.
+    const idsCall = mockPrisma.note.findMany.mock.calls.find((c) => c[0]?.select?.id);
+    expect(idsCall?.[0].where).toEqual({ user_id: USER_ID });
+  });
+
+  it('first page applies `since` INCLUSIVELY (gte) so a boundary row is never missed', async () => {
+    mockPrisma.note.findMany.mockResolvedValue([]);
+    mockPrisma.note.count.mockResolvedValue(0);
+    await callGet('?include_archived=true&limit=200&since=2026-02-01T00:00:00.000Z');
+    const pageArgs = mockPrisma.note.findMany.mock.calls[0][0];
+    expect(pageArgs.where.updated_at).toEqual({ gte: new Date('2026-02-01T00:00:00.000Z') });
+  });
+
+  it('cursor page uses a keyset OR predicate and omits total/all_ids', async () => {
+    mockPrisma.note.findMany.mockResolvedValue([noteRow('c', '2026-01-03T00:00:00.000Z')]);
+    // Build a valid cursor for (updated_at, id).
+    const cursor = Buffer.from(
+      JSON.stringify({ u: '2026-01-02T00:00:00.000Z', i: 'b' })
+    ).toString('base64url');
+
+    const { body } = await callGet(
+      `?include_archived=true&limit=200&reconcile=true&cursor=${cursor}`
+    );
+
+    expect(body.page.total).toBeUndefined();
+    expect(body.page.all_ids).toBeUndefined();
+    expect(mockPrisma.note.count).not.toHaveBeenCalled();
+    const pageArgs = mockPrisma.note.findMany.mock.calls[0][0];
+    expect(pageArgs.where.OR).toEqual([
+      { updated_at: { gt: new Date('2026-01-02T00:00:00.000Z') } },
+      { updated_at: new Date('2026-01-02T00:00:00.000Z'), id: { gt: 'b' } }
+    ]);
+  });
+
+  it('rejects a malformed cursor with 400', async () => {
+    const { status, body } = await callGet('?include_archived=true&cursor=not-a-valid-cursor!!');
+    expect(status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('clamps limit to the max page size', async () => {
+    mockPrisma.note.findMany.mockResolvedValue([]);
+    mockPrisma.note.count.mockResolvedValue(0);
+    await callGet('?include_archived=true&limit=99999');
+    const pageArgs = mockPrisma.note.findMany.mock.calls[0][0];
+    expect(pageArgs.take).toBe(501); // MAX_PAGE_LIMIT (500) + 1 peek
+  });
+});
+
+describe('GET /api/notes - auth', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockGetUserFromToken.mockResolvedValue(null);
+    const { status } = await callGet('?limit=200');
+    expect(status).toBe(401);
+  });
+});

--- a/packages/database/prisma/migrations/20260627000000_add_note_keyset_index/migration.sql
+++ b/packages/database/prisma/migrations/20260627000000_add_note_keyset_index/migration.sql
@@ -1,0 +1,4 @@
+-- CreateIndex
+-- Composite index backing keyset pagination of the notes delta pull
+-- (GET /api/notes ordered by (updated_at, id), scoped per user). See guideline 36.
+CREATE INDEX "Note_user_id_updated_at_id_idx" ON "Note"("user_id", "updated_at", "id");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -292,6 +292,10 @@ model Note {
   @@index([user_id, deleted_at])
   @@index([folder_id])
   @@index([updated_at])
+  // Keyset pagination for the delta pull (GET /api/notes): ORDER BY (updated_at, id)
+  // scoped to a user. The standalone updated_at index can't serve a per-user
+  // keyset scan; this composite does. See guideline 36 (paginated delta sync).
+  @@index([user_id, updated_at, id])
 }
 
 model Tag {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -717,6 +717,7 @@
     "local_only": "Nur lokal",
     "synced": "Synchronisiert",
     "syncing": "Notizen werden synchronisiert…",
+    "syncing_progress": "Notizen werden synchronisiert… {done}/{total}",
     "offline": "Offline",
     "error": "Synchronisierungsfehler",
     "pending": "{count} ausstehend",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -717,6 +717,7 @@
     "local_only": "Local only",
     "synced": "Synced",
     "syncing": "Syncing notes…",
+    "syncing_progress": "Syncing notes… {done}/{total}",
     "offline": "Offline",
     "error": "Sync error",
     "pending": "{count} pending",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -717,6 +717,7 @@
     "local_only": "Solo local",
     "synced": "Sincronizado",
     "syncing": "Sincronizando notas…",
+    "syncing_progress": "Sincronizando notas… {done}/{total}",
     "offline": "Sin conexión",
     "error": "Error de sincronización",
     "pending": "{count} pendiente(s)",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -717,6 +717,7 @@
     "local_only": "Local uniquement",
     "synced": "Synchronisé",
     "syncing": "Synchronisation des notes…",
+    "syncing_progress": "Synchronisation des notes… {done}/{total}",
     "offline": "Hors ligne",
     "error": "Erreur de synchronisation",
     "pending": "{count} en attente",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -717,6 +717,7 @@
     "local_only": "Tylko lokalnie",
     "synced": "Zsynchronizowane",
     "syncing": "Synchronizacja notatek…",
+    "syncing_progress": "Synchronizacja notatek… {done}/{total}",
     "offline": "Offline",
     "error": "Błąd synchronizacji",
     "pending": "{count} oczekujących",


### PR DESCRIPTION
## Summary

Replaces the single bulk `GET /api/notes` with a **keyset-paginated delta pull** (Filar 1) plus a **determinate "X/total" progress** counter (Filar 3). Targets accounts with a few thousand notes on native: the old single-transfer of the whole ciphertext base spiked the CapacitorHttp bridge and showed no progress; now the pull pages, warm sync is a delta, and the footer/placeholder show real progress.

Stage 2b of the notes-sync scaling plan (Etap 1 = #354, Etap 2a = #355). No Zero-Knowledge change.

### Server (`GET /api/notes`) - backward compatible
- **Legacy mode** (no `limit`/`cursor`): full set, no `page` envelope -> clients on older builds keep working (OTA paradox).
- **Paginated mode**: keyset over `(updated_at ASC, id ASC)`, peek for `has_more`, envelope `page { has_more, next_cursor, total?, all_ids? }`. `since` is **inclusive (>=)**; first page carries `total` + (when `reconcile=true`) the full `all_ids` set.
- Opaque base64url cursor over `(updated_at, id)` - **not** Prisma `cursor:{id}` (breaks when the cursor row was hard-deleted between pages).
- New `@@index([user_id, updated_at, id])` (migration `20260627000000_add_note_keyset_index`).

### Client
- `pullNotes` loops pages, `saveMany` per page (memory bounded to a page), reveals each page via `noteIndex.upsertFromStore` (point reads, **no full rebuild** - avoids the O(n^2) refresh trap from #353).
- Delta **watermark** (`max(updated_at)`) in `localStorage` per user, guarded by `noteStore.count()` so a wiped IDB forces a full pull; reset on logout.
- **Orphan-delete only from the authoritative `all_ids`**, never page contents; skipped when `all_ids` is absent (old server / non-reconcile pull).
- `all_ids` requested only on the first session pull, manual sync and online-recovery (**variant B**), keeping periodic syncs pure deltas.

### Key decisions (approved in plan)
- `all_ids` over tombstones (full reconcile, no schema/stream migration), gated by variant B to save idle bandwidth.
- Ascending keyset (mid-pagination edit is re-pulled, never skipped); `since` inclusive (no boundary miss).
- Watermark in localStorage + `count()` guard (eviction is origin-wide all-or-nothing).
- api-client `limit/offset` left out of scope - notes sync uses `authFetch`, not api-client.

## Test plan

Automated (green): reborn-notes **999/999** unit tests (incl. new `routes/api/notes/server.spec.ts`, 9), `notes-sync.regression.spec.ts` +10, svelte-check 0/0, eslint clean, i18n parity (notes) OK, single-file `svelte.compile` OK, `prisma validate` OK.

Deploy: run the migration (`pnpm db:migrate`) + `pnpm db:generate`. Server is backward compatible (an old client falls back to legacy mode), so order vs client rollout is not critical.

Smoke (please verify):
- **Cold start** (fresh login or after clearAllUserData) on a large account: notes appear progressively (200 at a time), footer shows "Syncing notes... X/total" counting up; no OOM on Android native.
- **Warm restart**: fast - only changed notes fetched (delta), not the whole base.
- **Cross-device edit**: edit a note on device B -> device A periodic/manual sync picks it up.
- **Permanent delete** a note on device B -> device A reflects it after manual sync / app restart / reconnect (variant B: not necessarily within the 5-min periodic).
- Manual sync button and offline->online recovery both still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)