### PR TITLE
feat(notes): readable first-sync state and merge-duplicates modal

### DIFF
--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -35,7 +35,8 @@
     Heart,
     UserPlus,
     LogIn,
-    Lock
+    Lock,
+    Loader2
   } from '@lucide/svelte';
   import * as Tooltip from '@reborn/ui/components/tooltip';
   import * as DropdownMenu from '@reborn/ui/components/dropdown-menu';
@@ -59,6 +60,7 @@
     onNewNote,
     onsectionclick,
     onPeriodic,
+    pendingKind = null,
     horizontal = false,
     alwaysVisible = false
   }: {
@@ -68,6 +70,9 @@
     onsectionclick?: (section: Section) => void;
     /** Open or create the daily/weekly/monthly note for the current period. */
     onPeriodic?: (kind: PeriodicKind) => void;
+    /** Periodic kind currently resolving (waiting on the initial-sync pull): its
+     *  button shows a spinner instead of looking dead. See handlePeriodic. */
+    pendingKind?: PeriodicKind | null;
     /** Horizontal mode for mobile sheet header */
     horizontal?: boolean;
     /** Show icon rail regardless of breakpoint (for mobile master-detail layout) */
@@ -236,6 +241,7 @@
     {#each PERIODIC_BUTTONS as p (p.kind)}
       {@const sectionId = `periodic-${p.kind}` as const}
       {@const isActive = activeSection === sectionId}
+      {@const isPending = pendingKind === p.kind}
       <button
         type="button"
         onclick={() => onPeriodic?.(p.kind)}
@@ -245,9 +251,14 @@
           : 'text-muted-foreground hover:bg-sidebar-accent/60'}"
         aria-label={periodicTooltip(p.kind)}
         aria-current={isActive ? 'page' : undefined}
+        aria-busy={isPending}
         title={periodicTooltip(p.kind)}
       >
-        <p.icon class="h-5 w-5" />
+        {#if isPending}
+          <Loader2 class="h-5 w-5 animate-spin" />
+        {:else}
+          <p.icon class="h-5 w-5" />
+        {/if}
         <span class="text-[11px] leading-none">{periodicLabel(p.kind)}</span>
       </button>
     {/each}
@@ -409,6 +420,7 @@
     {#each PERIODIC_BUTTONS as p (p.kind)}
       {@const sectionId = `periodic-${p.kind}` as const}
       {@const isActive = activeSection === sectionId}
+      {@const isPending = pendingKind === p.kind}
       <Tooltip.Root>
         <Tooltip.Trigger>
           {#snippet child({ props })}
@@ -422,8 +434,13 @@
                 : 'text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
               aria-label={periodicTooltip(p.kind)}
               aria-current={isActive ? 'page' : undefined}
+              aria-busy={isPending}
             >
-              <p.icon class="h-6 w-6 md:h-5 md:w-5" />
+              {#if isPending}
+                <Loader2 class="h-6 w-6 md:h-5 md:w-5 animate-spin" />
+              {:else}
+                <p.icon class="h-6 w-6 md:h-5 md:w-5" />
+              {/if}
             </button>
           {/snippet}
         </Tooltip.Trigger>

--- a/apps/reborn-notes/src/lib/components/notes/PeriodicDuplicatesDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/PeriodicDuplicatesDialog.svelte
@@ -1,0 +1,48 @@
+<!--
+  @component
+  Confirmation modal offering to merge duplicate periodic notes. Opens when
+  `detectAndNotifyPeriodicDuplicates` (fire-and-forget after a pull) posts to the
+  `periodicDuplicatePrompt` store. Replaces the old auto-dismissing toast, which
+  vanished before the user could act on a semi-destructive merge (smoke #2 of
+  PR #356). Mounted once, globally, in +layout.svelte.
+-->
+<script lang="ts">
+  import ConfirmDialog from '../shared/ConfirmDialog.svelte';
+  import {
+    periodicDuplicatePrompt,
+    confirmMergePeriodicDuplicates,
+    dismissPeriodicDuplicatePrompt
+  } from '$lib/services/periodic-dedup.service';
+  import { t } from '$lib/stores/i18n.store';
+
+  let open = $state(false);
+  // Latched so the close animation keeps its text after the store clears.
+  let count = $state(0);
+
+  // `open` is a pure function of the store: opens on a posted prompt, closes when
+  // cleared (by confirm/dismiss).
+  $effect(() => {
+    const p = $periodicDuplicatePrompt;
+    if (p) count = p.extra;
+    open = p !== null;
+  });
+
+  // Closed via Escape / overlay click bypasses the action callbacks; treat that
+  // as a dismiss so `open` and the store stay consistent. notifiedKeys already
+  // guards against re-popping the same batch this session.
+  $effect(() => {
+    if (!open && $periodicDuplicatePrompt !== null) {
+      dismissPeriodicDuplicatePrompt();
+    }
+  });
+</script>
+
+<ConfirmDialog
+  bind:open
+  title={$t('notes.periodic.dedup.modal_title')}
+  description={$t('notes.periodic.dedup.modal_description', { values: { count } })}
+  confirmText={$t('notes.periodic.dedup.merge_action')}
+  cancelText={$t('notes.periodic.dedup.dismiss_action')}
+  onConfirm={confirmMergePeriodicDuplicates}
+  onCancel={dismissPeriodicDuplicatePrompt}
+/>

--- a/apps/reborn-notes/src/lib/components/sync/InitialSyncBanner.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/InitialSyncBanner.svelte
@@ -1,0 +1,116 @@
+<!--
+  @component
+  Non-blocking top banner shown during the very first sync after login, while
+  the local IndexedDB is being built from the server (paginated delta sync).
+
+  It does NOT block the app: notes stream into the list as pages land (#356
+  incremental reveal) and any already-loaded note is readable underneath. The
+  banner only makes the global "first sync in progress" state visible - lifting
+  the determinate counter out of the easily-missed sidebar footer - and explains
+  why a few index-dependent actions (the periodic-note buttons) briefly wait.
+
+  Mounted in +layout.svelte alongside SessionExpiredBanner, inside the measured
+  div that feeds --rn-banner-h, so the 100dvh page layouts make room for it.
+
+  Reads the stores directly (app-local component): `isInitialSync` gates it,
+  `syncProgress` switches it from indeterminate to a determinate bar. A 300ms
+  delay mirrors InitialSyncState's anti-flicker so a fast sync never flashes it.
+-->
+<script lang="ts">
+  import { Loader2 } from '@lucide/svelte';
+  import { isInitialSync, syncProgress } from '$lib/stores/sync-status.store';
+  import { t } from '$lib/stores/i18n.store';
+
+  // Anti-flicker: only render after 300ms of continuous initial-sync, so a
+  // fast (small-account) sync that settles sooner never flashes the banner.
+  let showAfterDelay = $state(false);
+  $effect(() => {
+    if (!$isInitialSync) {
+      showAfterDelay = false;
+      return;
+    }
+    const timer = setTimeout(() => {
+      showAfterDelay = true;
+    }, 300);
+    return () => clearTimeout(timer);
+  });
+
+  // Determinate once the notes phase reports a positive total; indeterminate
+  // (spinner + sliding bar) during the pre-pull window where syncProgress is null.
+  let determinate = $derived(($syncProgress?.total ?? 0) > 0);
+  let pct = $derived(
+    determinate ? Math.min(100, Math.round((($syncProgress!.done) / $syncProgress!.total) * 100)) : 0
+  );
+</script>
+
+{#if showAfterDelay && $isInitialSync}
+  <div
+    class="border-b border-primary/15 bg-primary/5"
+    role="status"
+    aria-live="polite"
+  >
+    <!-- pt: max() extends the banner under the iOS notch / Dynamic Island so the
+         content starts below it (env() is 0 elsewhere), mirroring SessionExpiredBanner. -->
+    <div class="px-4 pb-2 pt-[max(0.5rem,env(safe-area-inset-top,0px))]">
+      <div class="flex items-center gap-2.5">
+        <Loader2 class="h-4 w-4 shrink-0 animate-spin text-primary" aria-hidden="true" />
+        <div class="min-w-0 flex-1">
+          <div class="flex items-baseline justify-between gap-2">
+            <span class="truncate text-sm font-medium text-foreground">
+              {$t('sync_status.initial.building')}
+            </span>
+            {#if determinate}
+              <span class="shrink-0 text-xs tabular-nums text-muted-foreground">
+                {$t('sync_status.initial.count', {
+                  values: { done: $syncProgress!.done, total: $syncProgress!.total }
+                })}
+              </span>
+            {/if}
+          </div>
+          <!-- Progress track -->
+          <div
+            class="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-primary/15"
+            role="progressbar"
+            aria-label={$t('sync_status.initial.building')}
+            aria-valuemin={0}
+            aria-valuemax={determinate ? $syncProgress!.total : undefined}
+            aria-valuenow={determinate ? $syncProgress!.done : undefined}
+          >
+            {#if determinate}
+              <div
+                class="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
+                style="width: {pct}%"
+              ></div>
+            {:else}
+              <div class="rn-indeterminate h-full w-1/3 rounded-full bg-primary"></div>
+            {/if}
+          </div>
+        </div>
+      </div>
+      <!-- Reassurance: this is a one-time, post-login event. Hidden on the
+           narrowest screens to keep the banner a single compact line there. -->
+      <p class="mt-1.5 hidden pl-[1.625rem] text-xs text-muted-foreground sm:block">
+        {$t('sync_status.initial.building_hint')}
+      </p>
+    </div>
+  </div>
+{/if}
+
+<style>
+  @keyframes rn-indeterminate {
+    0% {
+      transform: translateX(-110%);
+    }
+    100% {
+      transform: translateX(310%);
+    }
+  }
+  .rn-indeterminate {
+    animation: rn-indeterminate 1.4s ease-in-out infinite;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .rn-indeterminate {
+      animation-duration: 2.6s;
+    }
+  }
+</style>

--- a/apps/reborn-notes/src/lib/components/sync/initial-sync-ux.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/components/sync/initial-sync-ux.regression.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Initial-sync UX (issue reported by Michał, smoke #2 of PR #356, 2026-06-28).
+ *
+ * During a cold-login sync the notes stream into the list incrementally (#356),
+ * but the periodic-note buttons (daily/weekly/monthly) gate on the in-flight
+ * pull (periodic-notes.service `getOrCreateNote`) to avoid creating a duplicate
+ * of a note that's still on an un-paged page. Before this change the gated click
+ * looked DEAD - no feedback while it waited. Variant B (chosen) keeps the
+ * incremental reveal and adds two non-blocking signals:
+ *   1. A top banner (InitialSyncBanner) with determinate progress, mounted in
+ *      +layout.svelte's measured banner stack so it feeds --rn-banner-h.
+ *   2. A spinner on the periodic button that is mid-resolve (IconNav.pendingKind,
+ *      driven by +page.svelte's periodicPendingKind around the await).
+ *
+ * Source-level guards (the repo's regression idiom): the renderer is awkward to
+ * mount in a Node env, so we pin the contracts that are easy to silently break.
+ */
+
+function readSource(relative: string): string {
+  return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+describe('initial-sync UX - banner + periodic pending (2026-06-28)', () => {
+  describe('InitialSyncBanner', () => {
+    const src = readSource('./InitialSyncBanner.svelte');
+
+    it('renders only while the FIRST sync is active, not on every sync', () => {
+      expect(src).toMatch(
+        /import\s*\{[^}]*\bisInitialSync\b[^}]*\bsyncProgress\b[^}]*\}\s*from\s*'\$lib\/stores\/sync-status\.store'/s
+      );
+      // isInitialSync (cleared by refreshStoresAfterPull) gates the banner; a warm
+      // periodic sync must NOT pop it. The 300ms delay is anti-flicker, not the gate.
+      expect(src).toMatch(/\{#if[^}]*\$isInitialSync[^}]*\}/);
+    });
+
+    it('switches to a determinate progressbar once a positive total is known', () => {
+      // Indeterminate (sliding bar) until syncProgress reports total > 0, then a
+      // real determinate progressbar - the key "is it frozen?" answer on native.
+      expect(src).toMatch(/syncProgress\?\.total/);
+      expect(src).toMatch(/role="progressbar"/);
+      expect(src).toMatch(/\$t\('sync_status\.initial\.building'\)/);
+    });
+  });
+
+  describe('+layout.svelte banner mount', () => {
+    const src = readSource('../../../routes/+layout.svelte');
+
+    it('mounts InitialSyncBanner INSIDE the measured div that feeds --rn-banner-h', () => {
+      expect(src).toMatch(
+        /import\s+InitialSyncBanner\s+from\s+'\$lib\/components\/sync\/InitialSyncBanner\.svelte'/
+      );
+      // The 100dvh page/settings layouts subtract --rn-banner-h. If the banner sits
+      // OUTSIDE the measured div, the var stays 0 and the banner overlaps content
+      // (IconNav avatar clipped off-screen). Pin: banner is within the measured div.
+      expect(src).toMatch(/--rn-banner-h:\s*\{bannerStackHeight\}px/);
+      const measuredStart = src.indexOf('bind:clientHeight={bannerStackHeight}');
+      expect(measuredStart).toBeGreaterThan(-1);
+      const measuredDiv = src.slice(measuredStart, src.indexOf('</div>', measuredStart));
+      expect(measuredDiv).toMatch(/<InitialSyncBanner\b/);
+    });
+  });
+
+  describe('IconNav periodic pending spinner', () => {
+    const src = readSource('../layout/IconNav.svelte');
+
+    it('accepts a pendingKind prop and imports the spinner icon', () => {
+      expect(src).toMatch(/pendingKind\?:\s*PeriodicKind\s*\|\s*null/);
+      expect(src).toMatch(/\bLoader2\b/);
+    });
+
+    it('shows the spinner only on the kind that is resolving, in both nav modes', () => {
+      expect(src).toMatch(/isPending\s*=\s*pendingKind\s*===\s*p\.kind/);
+      // One {#if isPending} per nav mode (horizontal mobile + vertical desktop rail).
+      const gates = src.match(/\{#if isPending\}/g) ?? [];
+      expect(gates.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('+page.svelte handlePeriodic pending lifecycle', () => {
+    const src = readSource('../../../routes/+page.svelte');
+
+    function handlePeriodicBody(): string {
+      const start = src.indexOf('async function handlePeriodic(');
+      expect(start).toBeGreaterThan(-1);
+      const after = src.slice(start + 1);
+      const next = after.indexOf('\n  async function ');
+      return src.slice(start, next > -1 ? start + 1 + next : src.length);
+    }
+
+    it('wires the pending kind into both IconNav instances', () => {
+      const mounts = src.match(/pendingKind=\{periodicPendingKind\}/g) ?? [];
+      expect(mounts.length).toBe(2);
+    });
+
+    it('clears the pending kind in finally so a failed/late resolve never sticks the spinner', () => {
+      const body = handlePeriodicBody();
+      // Re-click guard: a second click on a kind already resolving is a no-op
+      // (getOrCreateNote awaits the single-flight pull; a second await is redundant).
+      expect(body).toMatch(/if\s*\(\s*periodicPendingKind\s*===\s*kind\s*\)\s*return/);
+      // The reset MUST be in finally - on the error path too (toast + stuck spinner
+      // would otherwise be worse than the silence we're fixing).
+      const finallyIdx = body.indexOf('finally');
+      expect(finallyIdx).toBeGreaterThan(-1);
+      expect(body.slice(finallyIdx)).toMatch(/periodicPendingKind\s*=\s*null/);
+    });
+  });
+
+  describe('periodic duplicate prompt - modal, not toast (smoke #2)', () => {
+    const svc = readSource('../../services/periodic-dedup.service.ts');
+    const layout = readSource('../../../routes/+layout.svelte');
+
+    function exportBody(name: string): string {
+      const start = svc.indexOf('export ' + name);
+      expect(start).toBeGreaterThan(-1);
+      const next = svc.indexOf('\nexport ', start + 1);
+      return svc.slice(start, next > -1 ? next : svc.length);
+    }
+
+    it('exposes a store-driven prompt + confirm/dismiss API', () => {
+      expect(svc).toMatch(/export const periodicDuplicatePrompt = writable</);
+      expect(svc).toMatch(/export async function confirmMergePeriodicDuplicates/);
+      expect(svc).toMatch(/export function dismissPeriodicDuplicatePrompt/);
+    });
+
+    it('detection posts to the prompt store, not an auto-dismissing toast', () => {
+      const body = exportBody('async function detectAndNotifyPeriodicDuplicates');
+      expect(body).toMatch(/periodicDuplicatePrompt\.set\(/);
+      // The old warning toast (which vanished before the user could act) is gone.
+      expect(body).not.toMatch(/toastStore\.warning/);
+    });
+
+    it('confirm runs the merge and clears the prompt in finally so the modal always closes', () => {
+      const body = exportBody('async function confirmMergePeriodicDuplicates');
+      expect(body).toMatch(/mergeAllPeriodicDuplicates\(\)/);
+      const finallyIdx = body.indexOf('finally');
+      expect(finallyIdx).toBeGreaterThan(-1);
+      expect(body.slice(finallyIdx)).toMatch(/periodicDuplicatePrompt\.set\(\s*null\s*\)/);
+    });
+
+    it('mounts the merge confirmation modal globally in the layout', () => {
+      expect(layout).toMatch(/import\s+PeriodicDuplicatesDialog\s+from/);
+      expect(layout).toMatch(/<PeriodicDuplicatesDialog\b/);
+    });
+  });
+});

--- a/apps/reborn-notes/src/lib/services/periodic-dedup.service.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-dedup.service.ts
@@ -11,7 +11,11 @@
  * DETECT + MANUAL MERGE. We never mutate note content automatically after a
  * background pull - that would be a trust violation (the user didn't initiate
  * it) and the highest-risk option for the lowest-severity problem. Instead we
- * surface a toast; the merge runs only when the user clicks it.
+ * surface a confirmation modal (PeriodicDuplicatesDialog, driven by the
+ * `periodicDuplicatePrompt` store); the merge runs only when the user confirms.
+ * A modal, not a toast: the merge is semi-destructive (combines content, moves
+ * the extra copies to Trash), and an auto-dismissing toast vanished before the
+ * user could act on it (smoke #2 of PR #356).
  *
  * Detection is cheap: a title-prefix pre-filter (locale-independent ISO date -
  * the prefix both locales share, which is exactly the 2026-05-12 case) buckets
@@ -19,7 +23,7 @@
  * collisions, and only stamped periodic notes count as duplicates, so a regular
  * note that merely starts with a date inside a periodic folder is never touched.
  */
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { PeriodicKind } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
 import { createLogger } from '@reborn/utils';
@@ -211,22 +215,18 @@ export async function mergeAllPeriodicDuplicates(): Promise<{ groups: number; ar
  */
 const notifiedKeys = new Set<string>();
 
-async function runMerge(): Promise<void> {
-  try {
-    const { archived } = await mergeAllPeriodicDuplicates();
-    notifiedKeys.clear();
-    if (archived > 0) {
-      toastStore.success(tr('notes.periodic.dedup.merge_success', { count: archived }));
-    }
-  } catch (e) {
-    logger.error('Periodic duplicate merge failed', e);
-    toastStore.error(tr('notes.periodic.dedup.merge_error'));
-  }
-}
+/**
+ * Pending duplicate-merge prompt. `PeriodicDuplicatesDialog` opens the merge
+ * confirmation modal while this is non-null and reads `extra` for the count;
+ * null = no prompt. A store (not a toast) because the merge is semi-destructive
+ * and a deliberate decision - the old auto-dismissing toast vanished before the
+ * user could act (smoke #2 of PR #356).
+ */
+export const periodicDuplicatePrompt = writable<{ extra: number } | null>(null);
 
 /**
- * Detect duplicate periodic notes and, if any new ones are found, show a toast
- * offering a one-click merge. Fire-and-forget from `refreshStoresAfterPull()`.
+ * Detect duplicate periodic notes and, if a new batch is found, post a prompt
+ * for the merge modal. Fire-and-forget from `refreshStoresAfterPull()`.
  */
 export async function detectAndNotifyPeriodicDuplicates(): Promise<void> {
   const groups = await detectPeriodicDuplicates();
@@ -239,12 +239,34 @@ export async function detectAndNotifyPeriodicDuplicates(): Promise<void> {
   // Count of extra copies (everything beyond the canonical in each group).
   const extra = groups.reduce((sum, g) => sum + g.members.length - 1, 0);
 
-  toastStore.warning(tr('notes.periodic.dedup.toast_title'), {
-    description: tr('notes.periodic.dedup.toast_description', { count: extra }),
-    duration: 15000,
-    action: {
-      label: tr('notes.periodic.dedup.merge_action'),
-      onClick: () => void runMerge()
+  periodicDuplicatePrompt.set({ extra });
+}
+
+/**
+ * Dismiss the prompt without merging. `notifiedKeys` already holds this batch,
+ * so it won't re-pop this session; it returns next session if the duplicates
+ * are still there. Also used for an Escape / overlay close.
+ */
+export function dismissPeriodicDuplicatePrompt(): void {
+  periodicDuplicatePrompt.set(null);
+}
+
+/**
+ * Confirm the merge from the modal: run the merge, then clear the prompt (after
+ * the await, so the modal keeps its processing state while the merge runs).
+ * Never throws - errors surface as a toast so the modal closes cleanly.
+ */
+export async function confirmMergePeriodicDuplicates(): Promise<void> {
+  try {
+    const { archived } = await mergeAllPeriodicDuplicates();
+    notifiedKeys.clear();
+    if (archived > 0) {
+      toastStore.success(tr('notes.periodic.dedup.merge_success', { count: archived }));
     }
-  });
+  } catch (e) {
+    logger.error('Periodic duplicate merge failed', e);
+    toastStore.error(tr('notes.periodic.dedup.merge_error'));
+  } finally {
+    periodicDuplicatePrompt.set(null);
+  }
 }

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -33,6 +33,8 @@
   import { reAuthenticate, verifyTotpForReauth } from '$lib/services/notes-auth.service';
   import { SessionExpiredBanner, RequireSessionModal } from '@reborn/ui';
   import LoadingScreen from '$lib/components/LoadingScreen.svelte';
+  import InitialSyncBanner from '$lib/components/sync/InitialSyncBanner.svelte';
+  import PeriodicDuplicatesDialog from '$lib/components/notes/PeriodicDuplicatesDialog.svelte';
   import LocalModeWelcome from '$lib/components/LocalModeWelcome.svelte';
   import UpdateRequiredGate from '$lib/components/layout/UpdateRequiredGate.svelte';
   import { checkNativeUpdateGate } from '$lib/utils/native-app-update';
@@ -56,13 +58,15 @@
 
   let appReady = $state(false);
   let initTimeout = $state(false);
-  // Measured height of the session-expired banner. Exposed as --rn-banner-h so
-  // the viewport-height containers (main page panels, settings roots) can
-  // subtract it: the banner sits in normal flow ABOVE 100dvh layouts, so
-  // without the correction it pushes the bottom edge (IconNav avatar) off
-  // screen - on iOS the safe-area inset makes the banner taller and the clip
-  // obvious, but the overflow exists on web too. 0 when the banner is hidden.
-  let sessionBannerHeight = $state(0);
+  // Measured height of the top banner stack (session-expired + initial-sync).
+  // Exposed as --rn-banner-h so the viewport-height containers (main page
+  // panels, settings roots) can subtract it: the banners sit in normal flow
+  // ABOVE 100dvh layouts, so without the correction they push the bottom edge
+  // (IconNav avatar) off screen - on iOS the safe-area inset makes a banner
+  // taller and the clip obvious, but the overflow exists on web too. The two
+  // banners are mutually exclusive in practice (session-expired vs first sync),
+  // but measuring the wrapper sums them correctly if both ever show. 0 when none.
+  let bannerStackHeight = $state(0);
   let hasTriggeredInitialSync = $state(false);
 
   // Auth guard - blocked until onMount finishes initialization (appReady).
@@ -540,15 +544,16 @@
        keeps the wrapper transparent to the layout flow. -->
   <div
     class="svelte-app-ready"
-    style="display: contents; --rn-banner-h: {sessionBannerHeight}px"
+    style="display: contents; --rn-banner-h: {bannerStackHeight}px"
   >
-    <div bind:clientHeight={sessionBannerHeight}>
+    <div bind:clientHeight={bannerStackHeight}>
       <SessionExpiredBanner
         visible={$sessionExpired && navigator.onLine && !$localOnly}
         username={$authStore.username ?? ''}
         onReAuth={reAuthenticate}
         onVerifyTotp={verifyTotpForReauth}
       />
+      <InitialSyncBanner />
     </div>
     <RequireSessionModal
       username={$authStore.username ?? ''}
@@ -564,6 +569,7 @@
       fullChangelogHref={changelogHref}
     />
     <LocalModeWelcome />
+    <PeriodicDuplicatesDialog />
     {#if __REBORN_NATIVE__}
       <UpdateRequiredGate />
     {/if}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -175,6 +175,10 @@
 
   // First-use onboarding modal — open with the kind that triggered it.
   let periodicOnboardingKind = $state<PeriodicKind | null>(null);
+  // Periodic kind whose button is mid-resolve (waiting on the initial-sync
+  // pull). Drives the spinner on the IconNav button so a click doesn't look
+  // dead while getOrCreateNote awaits the pull. Null in steady state.
+  let periodicPendingKind = $state<PeriodicKind | null>(null);
 
   async function handleDetailPin() {
     detailActionSheetOpen = false;
@@ -714,6 +718,17 @@
   }
 
   async function handlePeriodic(kind: PeriodicKind) {
+    // A re-click on the kind already resolving is a no-op: getOrCreateNote is
+    // awaiting the (single-flight) initial-sync pull, so a second call would
+    // just duplicate the await.
+    if (periodicPendingKind === kind) return;
+    // Anti-flicker: only surface the button spinner if the resolve actually
+    // takes a beat (during the initial-sync pull, getOrCreateNote awaits it). A
+    // steady-state index hit returns in a few ms and must not flash a spinner.
+    let resolved = false;
+    const spinnerTimer = setTimeout(() => {
+      if (!resolved) periodicPendingKind = kind;
+    }, 150);
     try {
       // Service guarantees the folder exists and settings.folderId is populated
       // after the await, so we can safely read it for the sidebar filter.
@@ -738,6 +753,10 @@
       const message = $t(`notes.periodic.errors.failed`);
       toastStore.error(message);
       console.error('[periodic-notes] failed to open', kind, err);
+    } finally {
+      resolved = true;
+      clearTimeout(spinnerTimer);
+      periodicPendingKind = null;
     }
   }
 
@@ -1717,6 +1736,7 @@
           onNewNote={handleNewNote}
           onsectionclick={handleSectionClick}
           onPeriodic={handlePeriodic}
+          pendingKind={periodicPendingKind}
           alwaysVisible
         />
 
@@ -2119,6 +2139,7 @@
         onNewNote={handleNewNote}
         onsectionclick={handleSectionClick}
         onPeriodic={handlePeriodic}
+        pendingKind={periodicPendingKind}
       />
 
       <!-- ── Content panel ───────────────────────────────────────── -->

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -287,8 +287,9 @@
       },
       "errors": { "failed": "Notiz konnte nicht geöffnet werden" },
       "dedup": {
-        "toast_title": "Doppelte periodische Notizen",
-        "toast_description": "{count, plural, one {# doppelte Notiz wurde auf einem anderen Gerät erstellt.} other {# doppelte Notizen wurden auf einem anderen Gerät erstellt.}} Mit dem Original zusammenführen?",
+        "modal_title": "Doppelte Notizen zusammenführen?",
+        "modal_description": "{count, plural, one {# doppelte periodische Notiz gefunden.} other {# doppelte periodische Notizen gefunden.}} Beim Zusammenführen wird ihr Inhalt in das Original übernommen und die zusätzlichen Kopien werden in den Papierkorb verschoben, von wo Sie sie wiederherstellen können.",
+        "dismiss_action": "Jetzt nicht",
         "merge_action": "Zusammenführen",
         "merge_separator": "Aus einem Duplikat zusammengeführt, erstellt am {datetime}",
         "merge_success": "{count, plural, one {# doppelte Notiz zusammengeführt.} other {# doppelte Notizen zusammengeführt.}}",
@@ -727,7 +728,10 @@
     "re_login": "Erneut anmelden",
     "initial": {
       "title": "Notizen werden synchronisiert",
-      "message": "Das Herunterladen Ihrer verschlüsselten Daten vom Server kann einen Moment dauern."
+      "message": "Das Herunterladen Ihrer verschlüsselten Daten vom Server kann einen Moment dauern.",
+      "building": "Lokale Datenbank wird aufgebaut",
+      "count": "{done} / {total}",
+      "building_hint": "Einmalig nach der Anmeldung - danach öffnen sich Ihre Notizen sofort, auch offline."
     },
     "errors": {
       "count": "{count} nicht synchronisiert",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -287,8 +287,9 @@
       },
       "errors": { "failed": "Failed to open the note" },
       "dedup": {
-        "toast_title": "Duplicate periodic notes",
-        "toast_description": "{count, plural, one {# duplicate note was created on another device.} other {# duplicate notes were created on another device.}} Merge into the original?",
+        "modal_title": "Merge duplicate notes?",
+        "modal_description": "{count, plural, one {Found # duplicate periodic note.} other {Found # duplicate periodic notes.}} Merging combines their content into the original and moves the extra copies to Trash, where you can restore them.",
+        "dismiss_action": "Not now",
         "merge_action": "Merge",
         "merge_separator": "Merged from a duplicate created {datetime}",
         "merge_success": "{count, plural, one {Merged # duplicate note.} other {Merged # duplicate notes.}}",
@@ -727,7 +728,10 @@
     "re_login": "Log in again",
     "initial": {
       "title": "Syncing your notes",
-      "message": "Downloading your encrypted data from the server may take a moment."
+      "message": "Downloading your encrypted data from the server may take a moment.",
+      "building": "Building your local database",
+      "count": "{done} / {total}",
+      "building_hint": "One-time setup after sign-in - then your notes open instantly, even offline."
     },
     "errors": {
       "count": "{count} not synced",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -287,8 +287,9 @@
       },
       "errors": { "failed": "No se pudo abrir la nota" },
       "dedup": {
-        "toast_title": "Notas periódicas duplicadas",
-        "toast_description": "{count, plural, one {Se creó # nota duplicada en otro dispositivo.} other {Se crearon # notas duplicadas en otro dispositivo.}} ¿Combinar con la original?",
+        "modal_title": "¿Combinar notas duplicadas?",
+        "modal_description": "{count, plural, one {Se encontró # nota periódica duplicada.} other {Se encontraron # notas periódicas duplicadas.}} Al combinar, su contenido se añade al original y las copias adicionales se mueven a la papelera, desde donde puedes restaurarlas.",
+        "dismiss_action": "Ahora no",
         "merge_action": "Combinar",
         "merge_separator": "Combinado desde un duplicado creado el {datetime}",
         "merge_success": "{count, plural, one {Se combinó # nota duplicada.} other {Se combinaron # notas duplicadas.}}",
@@ -727,7 +728,10 @@
     "re_login": "Iniciar sesión de nuevo",
     "initial": {
       "title": "Sincronizando tus notas",
-      "message": "La descarga de tus datos cifrados desde el servidor puede tardar un momento."
+      "message": "La descarga de tus datos cifrados desde el servidor puede tardar un momento.",
+      "building": "Creando tu base de datos local",
+      "count": "{done} / {total}",
+      "building_hint": "Solo una vez tras iniciar sesión - después tus notas se abren al instante, incluso sin conexión."
     },
     "errors": {
       "count": "{count} sin sincronizar",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -287,8 +287,9 @@
       },
       "errors": { "failed": "Impossible d'ouvrir la note" },
       "dedup": {
-        "toast_title": "Notes périodiques en double",
-        "toast_description": "{count, plural, one {# note en double a été créée sur un autre appareil.} other {# notes en double ont été créées sur un autre appareil.}} Fusionner dans la note originale ?",
+        "modal_title": "Fusionner les notes en double ?",
+        "modal_description": "{count, plural, one {# note périodique en double trouvée.} other {# notes périodiques en double trouvées.}} La fusion ajoute leur contenu à la note originale et déplace les copies supplémentaires vers la corbeille, où vous pouvez les restaurer.",
+        "dismiss_action": "Plus tard",
         "merge_action": "Fusionner",
         "merge_separator": "Fusionné depuis un doublon créé le {datetime}",
         "merge_success": "{count, plural, one {# note en double fusionnée.} other {# notes en double fusionnées.}}",
@@ -727,7 +728,10 @@
     "re_login": "Se reconnecter",
     "initial": {
       "title": "Synchronisation de vos notes",
-      "message": "Le téléchargement de vos données chiffrées depuis le serveur peut prendre un instant."
+      "message": "Le téléchargement de vos données chiffrées depuis le serveur peut prendre un instant.",
+      "building": "Création de votre base de données locale",
+      "count": "{done} / {total}",
+      "building_hint": "Une seule fois après la connexion - ensuite vos notes s'ouvrent instantanément, même hors ligne."
     },
     "errors": {
       "count": "{count} non synchronisé(s)",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -287,8 +287,9 @@
       },
       "errors": { "failed": "Nie udało się otworzyć notatki" },
       "dedup": {
-        "toast_title": "Zduplikowane notatki okresowe",
-        "toast_description": "{count, plural, one {# zduplikowana notatka powstała na innym urządzeniu.} few {# zduplikowane notatki powstały na innym urządzeniu.} many {# zduplikowanych notatek powstało na innym urządzeniu.} other {# zduplikowanych notatek powstało na innym urządzeniu.}} Scalić z oryginałem?",
+        "modal_title": "Scalić zduplikowane notatki?",
+        "modal_description": "{count, plural, one {Znaleziono # zduplikowaną notatkę okresową.} few {Znaleziono # zduplikowane notatki okresowe.} many {Znaleziono # zduplikowanych notatek okresowych.} other {Znaleziono # zduplikowanych notatek okresowych.}} Scalanie połączy ich treść z oryginałem i przeniesie nadmiarowe kopie do Kosza, skąd możesz je przywrócić.",
+        "dismiss_action": "Nie teraz",
         "merge_action": "Scal",
         "merge_separator": "Scalono z duplikatu utworzonego {datetime}",
         "merge_success": "{count, plural, one {Scalono # duplikat.} few {Scalono # duplikaty.} many {Scalono # duplikatów.} other {Scalono # duplikatów.}}",
@@ -727,7 +728,10 @@
     "re_login": "Zaloguj ponownie",
     "initial": {
       "title": "Trwa synchronizacja Twoich notatek",
-      "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać."
+      "message": "Pobieranie zaszyfrowanych danych z serwera może chwilę potrwać.",
+      "building": "Budowanie lokalnej bazy danych",
+      "count": "{done} / {total}",
+      "building_hint": "Jednorazowo po zalogowaniu - potem notatki otwierają się natychmiast, też offline."
     },
     "errors": {
       "count": "{count} niezsynchronizowanych",


### PR DESCRIPTION
## Summary

Follow-up to smoke #2 of PR #356 (paginated delta sync). During a cold-login sync the notes stream into the list incrementally, but a few index-dependent actions silently waited with no feedback, and the duplicate-merge prompt was a toast that auto-dismissed before the user could act.

**Variant B** (chosen scope - non-blocking, deliberately not a blocking modal, which would undo #356's incremental reveal):

### Initial-sync visibility
- **`InitialSyncBanner`** - a non-blocking top banner with determinate progress ("Building your local database 320/2000"), mounted in the measured banner stack so it feeds `--rn-banner-h` (same slot pattern as `SessionExpiredBanner`). Indeterminate until the notes phase reports a total, then a real `role="progressbar"`. Gated on `isInitialSync` with a 300ms anti-flicker. Notes still stream in underneath - any loaded note is readable during the sync.
- **Periodic buttons** (daily/weekly/monthly) show a spinner while `getOrCreateNote` awaits the initial-sync pull, instead of looking dead. 150ms anti-flicker so a steady-state index hit never flashes; a re-click while pending is a no-op; the pending state is cleared in `finally` so an error never leaves a stuck spinner.

### Duplicate-merge prompt: toast to modal
- The semi-destructive merge prompt is now a confirmation modal (**`PeriodicDuplicatesDialog`**, driven by the `periodicDuplicatePrompt` store, reusing `shared/ConfirmDialog`) that waits for a decision and explains what merge does (content combined into the original, extra copies moved to Trash, restorable). Replaces the 15s auto-dismissing toast. `notifiedKeys` still gates it to once per session; Escape / overlay closes as a dismiss.

### i18n
`sync_status.initial.{building,count,building_hint}` added; dedup `toast_title`/`toast_description` replaced by `modal_{title,description}` / `dismiss_action` - all 5 locales, parity green, ICU plurals preserved (pl one/few/many/other).

## Test plan

Automated (green): svelte-check 0/0, eslint 0 errors, reborn-notes 1022/1022 vitest, `@reborn/i18n` 27/27, i18n parity, single-file svelte compile (client + server). New source-level spec `initial-sync-ux.regression.spec.ts` (11 tests) pins the contracts (banner gated on `isInitialSync`, spinner gated on `pendingKind`, pending cleared in `finally`, prompt store-driven not a toast, modal mounted in layout).

Smoke (manual):
- Cold login on a large account: the top banner shows "Building your local database N/total" with a progress bar and self-dismisses when done; notes are readable as they stream in.
- Click a periodic button (daily) mid-sync: it shows a spinner and opens the note once the pull settles, instead of doing nothing.
- An account with existing periodic duplicates: after sync, the "Merge duplicate notes?" modal appears and waits for a decision (Merge / Not now) - it no longer vanishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)