### PR TITLE
fix(notes): unblock native cross-origin deletes and restores

### DIFF
--- a/apps/reborn-notes/src/lib/csrf-config.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/csrf-config.regression.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Both PWAs ship a native (Capacitor) build that talks to the remote API
+ * cross-origin (the WebView loads from a local scheme and calls the remote
+ * API). SvelteKit's default CSRF `checkOrigin` forbids any cross-origin
+ * POST/PUT/PATCH/DELETE carrying a "form" content-type, which 403s every
+ * bodiless native mutation - note / folder / tag / saved-search delete and note
+ * restore (they send no application/json content-type to exempt them) - while
+ * same-origin web never trips it. That silently broke ALL native deletes and
+ * restores (found in native smoke 2026-06-28).
+ *
+ * Disabling it is safe: API auth is bearer-token (Authorization header, never an
+ * ambient cookie auto-attached cross-site) and the only cookie - the web
+ * refresh_token - is httpOnly + SameSite=Lax (never sent on a cross-site
+ * request). The origin check is redundant with those defenses and only ever
+ * rejected the legitimate native client. `trustedOrigins: ['*']` is SvelteKit
+ * 2.63's non-deprecated spelling of "trust every origin" (SvelteKit compiles it
+ * to `csrf_check_origin: false`); it also covers a native request that carries
+ * no Origin header, which an explicit allowlist could not. This source-level
+ * guard pins the decision for both apps so it cannot be re-enabled by accident.
+ * See guideline 36.
+ */
+function readConfig(relative: string): string {
+  return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+const APPS: ReadonlyArray<readonly [string, string]> = [
+  ['reborn-notes', '../../svelte.config.js'],
+  ['reborn-task', '../../../reborn-task/svelte.config.js']
+];
+
+describe('CSRF origin check disabled for native cross-origin clients', () => {
+  for (const [app, rel] of APPS) {
+    it(`${app}: kit.csrf.trustedOrigins is ['*']`, () => {
+      const cfg = readConfig(rel);
+      expect(
+        cfg,
+        `${app} must set csrf.trustedOrigins:['*'] (native cross-origin mutations)`
+      ).toMatch(/csrf:\s*\{\s*trustedOrigins:\s*\[\s*'\*'\s*\]\s*\}/);
+    });
+  }
+});

--- a/apps/reborn-notes/src/lib/services/notes-sync.push-rejection.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.push-rejection.spec.ts
@@ -64,6 +64,30 @@ describe('notes-sync - permanent push rejection (sync_error)', () => {
     }
   });
 
+  it('note DELETE/restore paths assert via ensureOk and mark sync_error on permanent failure', () => {
+    const s = src();
+    // Bound each function body to the next export so the assertion cannot borrow
+    // a neighbour's ensureOk / markNoteSyncError.
+    const bodyOf = (sig: string): string => {
+      const start = s.search(new RegExp(sig));
+      expect(start, sig).toBeGreaterThan(-1);
+      const rest = s.slice(start + 1);
+      const next = rest.search(/\nexport (?:async )?function /);
+      return next > -1 ? rest.slice(0, next) : rest;
+    };
+    for (const sig of ['export function pushNoteDelete\\b', 'export function pushNoteRestore\\b']) {
+      const body = bodyOf(sig);
+      expect(body, `${sig} must assert via ensureOk`).toMatch(/ensureOk\(/);
+      expect(body, `${sig} must mark sync_error on permanent failure`).toMatch(/markNoteSyncError/);
+      // Guard the old bare-throw from regressing: `if (!res.ok) throw new Error`
+      // left the note 'pending' and re-pushed the doomed request on every
+      // periodic sync - the native CSRF-403 delete loop (smoke 2026-06-28).
+      expect(body, `${sig} must not bare-throw on !res.ok`).not.toMatch(
+        /if \(!res\.ok\) throw new Error/
+      );
+    }
+  });
+
   it('pushPendingItems batch tallies new sync_errors and raises one aggregated toast', () => {
     const s = src();
     const body = s.slice(

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -1326,91 +1326,114 @@ export function pushNoteUpdate(
 
 export function pushNoteDelete(id: string, permanent = false): void {
   void serializePerEntity('note', id, () =>
-    pushSilently(async (idempotencyKey) => {
-      const path = permanent ? `/notes/${id}?permanent=true` : `/notes/${id}`;
-      const res = await authFetch(`${API_BASE}${path}`, {
-        method: 'DELETE',
-        headers: { 'Idempotency-Key': idempotencyKey }
-      });
-      if (!res.ok) throw new Error(`DELETE /api/notes/${id}: ${res.status}`);
-      if (permanent) return;
-
-      // Server bumps sync_version on soft-delete (since rule 11.e) and returns
-      // the new value. We MUST mirror it locally, otherwise the next pull sees
-      // server=N+1 vs local=N and re-applies the archive state we already have
-      // - harmless but churn. More importantly, future pushes would operate on
-      // stale sync_version and look like conflicts.
-      let serverSyncVersion: number | undefined;
-      try {
-        const body = await res.json();
-        serverSyncVersion = body?.data?.sync_version;
-      } catch {
-        // Old server deploy - no body. Leave sync_version untouched.
-      }
-
-      // Intent-check: if the user restored the note while DELETE was in flight,
-      // `current.is_archived` will be false. Marking 'synced' would strand the
-      // local restore - chain a pushNoteRestore instead. See guideline 36 rule 11.b.
-      const current = await noteStore.get(id);
-      if (!current) return;
-      if (current.is_archived) {
-        await noteStore.save({
-          ...current,
-          sync_status: 'synced',
-          sync_version: serverSyncVersion ?? current.sync_version
+    pushSilently(
+      async (idempotencyKey) => {
+        const path = permanent ? `/notes/${id}?permanent=true` : `/notes/${id}`;
+        const res = await authFetch(`${API_BASE}${path}`, {
+          method: 'DELETE',
+          headers: { 'Idempotency-Key': idempotencyKey }
         });
-      } else {
-        logger.debug(`Note ${id} restored during delete push - chaining restore`);
-        await noteStore.save({
-          ...current,
-          sync_status: 'pending',
-          sync_version: serverSyncVersion ?? current.sync_version
-        });
-        pushNoteRestore(id);
+        // ensureOk (not a bare throw) so a permanent 4xx (400/403/413) becomes an
+        // HttpPushError that skips retry and marks the note sync_error below,
+        // instead of looping every periodic sync forever. A bodiless cross-origin
+        // DELETE used to 403 on native (CSRF origin check, now disabled); even so,
+        // a doomed delete must never re-push endlessly. See guideline 36 rule 14.
+        await ensureOk(res, `DELETE /api/notes/${id}`);
+        if (permanent) return;
+
+        // Server bumps sync_version on soft-delete (since rule 11.e) and returns
+        // the new value. We MUST mirror it locally, otherwise the next pull sees
+        // server=N+1 vs local=N and re-applies the archive state we already have
+        // - harmless but churn. More importantly, future pushes would operate on
+        // stale sync_version and look like conflicts.
+        let serverSyncVersion: number | undefined;
+        try {
+          const body = await res.json();
+          serverSyncVersion = body?.data?.sync_version;
+        } catch {
+          // Old server deploy - no body. Leave sync_version untouched.
+        }
+
+        // Intent-check: if the user restored the note while DELETE was in flight,
+        // `current.is_archived` will be false. Marking 'synced' would strand the
+        // local restore - chain a pushNoteRestore instead. See guideline 36 rule 11.b.
+        const current = await noteStore.get(id);
+        if (!current) return;
+        if (current.is_archived) {
+          await noteStore.save({
+            ...current,
+            sync_status: 'synced',
+            sync_version: serverSyncVersion ?? current.sync_version
+          });
+        } else {
+          logger.debug(`Note ${id} restored during delete push - chaining restore`);
+          await noteStore.save({
+            ...current,
+            sync_status: 'pending',
+            sync_version: serverSyncVersion ?? current.sync_version
+          });
+          pushNoteRestore(id);
+        }
+      },
+      async (err) => {
+        // Permanent rejection of a delete: stop re-pushing the doomed request
+        // (a bare throw would leave it 'pending' and retry on every periodic
+        // sync) and mark the note so its row shows the reason. No per-call toast
+        // - a batch can reject many; the inline badge is the durable surface.
+        await markNoteSyncError(id, err.code);
       }
-    })
+    )
   );
 }
 
 export function pushNoteRestore(id: string): void {
   void serializePerEntity('note', id, () =>
-    pushSilently(async (idempotencyKey) => {
-      const res = await authFetch(`${API_BASE}/notes/${id}/restore`, {
-        method: 'POST',
-        headers: { 'Idempotency-Key': idempotencyKey }
-      });
-      if (!res.ok) throw new Error(`POST /api/notes/${id}/restore: ${res.status}`);
-
-      // Server bumps sync_version on restore (since rule 11.e) and returns it.
-      // Mirror locally; fall back to preserving the current value on old deploys.
-      let serverSyncVersion: number | undefined;
-      try {
-        const body = await res.json();
-        serverSyncVersion = body?.data?.sync_version;
-      } catch {
-        // Old server deploy - no body.
-      }
-
-      // Intent-check: if the user re-archived the note while /restore was in
-      // flight, chain a pushNoteDelete to catch up. See guideline 36 rule 11.b.
-      const current = await noteStore.get(id);
-      if (!current) return;
-      if (!current.is_archived) {
-        await noteStore.save({
-          ...current,
-          sync_status: 'synced',
-          sync_version: serverSyncVersion ?? current.sync_version
+    pushSilently(
+      async (idempotencyKey) => {
+        const res = await authFetch(`${API_BASE}/notes/${id}/restore`, {
+          method: 'POST',
+          headers: { 'Idempotency-Key': idempotencyKey }
         });
-      } else {
-        logger.debug(`Note ${id} re-archived during restore push - chaining delete`);
-        await noteStore.save({
-          ...current,
-          sync_status: 'pending',
-          sync_version: serverSyncVersion ?? current.sync_version
-        });
-        pushNoteDelete(id);
+        // ensureOk so a permanent 4xx stops instead of retrying forever - same
+        // reasoning as pushNoteDelete. See guideline 36 rule 14.
+        await ensureOk(res, `POST /api/notes/${id}/restore`);
+
+        // Server bumps sync_version on restore (since rule 11.e) and returns it.
+        // Mirror locally; fall back to preserving the current value on old deploys.
+        let serverSyncVersion: number | undefined;
+        try {
+          const body = await res.json();
+          serverSyncVersion = body?.data?.sync_version;
+        } catch {
+          // Old server deploy - no body.
+        }
+
+        // Intent-check: if the user re-archived the note while /restore was in
+        // flight, chain a pushNoteDelete to catch up. See guideline 36 rule 11.b.
+        const current = await noteStore.get(id);
+        if (!current) return;
+        if (!current.is_archived) {
+          await noteStore.save({
+            ...current,
+            sync_status: 'synced',
+            sync_version: serverSyncVersion ?? current.sync_version
+          });
+        } else {
+          logger.debug(`Note ${id} re-archived during restore push - chaining delete`);
+          await noteStore.save({
+            ...current,
+            sync_status: 'pending',
+            sync_version: serverSyncVersion ?? current.sync_version
+          });
+          pushNoteDelete(id);
+        }
+      },
+      async (err) => {
+        // Permanent rejection of a restore: stop re-pushing and mark the note so
+        // its row shows the reason (mirrors pushNoteDelete).
+        await markNoteSyncError(id, err.code);
       }
-    })
+    )
   );
 }
 

--- a/apps/reborn-notes/svelte.config.js
+++ b/apps/reborn-notes/svelte.config.js
@@ -51,6 +51,24 @@ const config = {
 
   kit: {
     adapter: selectAdapter(),
+    // CSRF origin check OFF. The native (Capacitor) client is cross-origin by
+    // design - the WebView loads from a local scheme (https://localhost on
+    // Android, capacitor://localhost on iOS) and talks to the remote API.
+    // SvelteKit's default `checkOrigin` forbids any cross-origin
+    // POST/PUT/PATCH/DELETE that carries a "form" content-type, which 403s every
+    // bodiless native mutation (note / folder / tag / saved-search delete, note
+    // restore - they send no Content-Type, unlike POST/PATCH which declare
+    // application/json and slip through) while same-origin web never trips it.
+    // So the check only ever rejected the legitimate native client. Safe to
+    // disable: API auth is bearer-token (Authorization header, never an ambient
+    // cookie, so it is not auto-attached cross-site) and the lone cookie - the
+    // web refresh_token - is httpOnly + SameSite=Lax (never sent cross-site).
+    // The origin check is redundant with those defenses. `trustedOrigins: ['*']`
+    // is SvelteKit 2.63's non-deprecated spelling of "trust every origin" (the
+    // old `checkOrigin: false` is deprecated); the wildcard also covers the
+    // native request that carries no Origin header at all, which an explicit
+    // allowlist could not. Found in native smoke 2026-06-28; see guideline 36.
+    csrf: { trustedOrigins: ['*'] },
     // Native prerenders the SPA fallback; SvelteKit cannot fill `%sveltekit.nonce%`
     // in a static page, so native uses a nonce-free template variant. Web keeps the
     // nonce template (SSR fills the nonce per request for the nonce-mode CSP).

--- a/apps/reborn-task/svelte.config.js
+++ b/apps/reborn-task/svelte.config.js
@@ -16,6 +16,23 @@ const config = {
 
 	kit: {
 		adapter: isProduction ? adapterNode() : adapterAuto(),
+		// CSRF origin check OFF. The native (Capacitor) client is cross-origin by
+		// design - the WebView loads from a local scheme (https://localhost on
+		// Android, capacitor://localhost on iOS) and talks to the remote API.
+		// SvelteKit's default `checkOrigin` forbids any cross-origin
+		// POST/PUT/PATCH/DELETE that carries a "form" content-type, which 403s every
+		// bodiless native mutation (delete / restore that send no Content-Type,
+		// unlike POST/PATCH which declare application/json and slip through) while
+		// same-origin web never trips it. So the check only ever rejected the
+		// legitimate native client. Safe to disable: API auth is bearer-token
+		// (Authorization header, never an ambient cookie, so it is not auto-attached
+		// cross-site) and the lone cookie - the web refresh_token - is httpOnly +
+		// SameSite=Lax (never sent cross-site). The origin check is redundant with
+		// those defenses. `trustedOrigins: ['*']` is SvelteKit 2.63's non-deprecated
+		// spelling of "trust every origin" (old `checkOrigin: false` is deprecated)
+		// and also covers a native request that carries no Origin header. Found in
+		// native smoke 2026-06-28; see guideline 36.
+		csrf: { trustedOrigins: ['*'] },
 		// BASE_PATH controls same-origin deployment path (e.g. "/task").
 		// Empty in dev. Set PUBLIC_BASE_PATH=/task in production env.
 		//


### PR DESCRIPTION
## Summary

Follow-up to the native smoke of PR #356 / #358. In the native (Capacitor) build, clicking a periodic note during sync and then merging a duplicate looped forever, with the console flooded by `DELETE /api/notes/<id>: 403`. The root cause is broader than dedup: **the native client cannot delete or restore anything server-side.**

The native client is cross-origin by design (WebView local scheme -> remote API). SvelteKit's default CSRF `checkOrigin` 403s every cross-origin POST/PUT/PATCH/DELETE that carries a "form" content-type. `pushNote` (POST) and `pushNoteUpdate` (PATCH) declare `application/json` and pass; the **bodiless** mutations - `pushNoteDelete` (DELETE), `pushNoteRestore` (POST `/restore`), and folder/tag/saved-search deletes - send no `Content-Type`, so they were rejected. Web is same-origin and never trips it, so it surfaced only in native. The periodic auto-merge loop was a downstream symptom: the un-deletable copy resurrected on the next pull and re-fired the merge modal.

Ruled in by elimination: the `DELETE /api/notes/[id]` handler returns idempotent `200` for a missing note (never 403), nginx has no method rules, hooks emit only 429/413, and `authFetch` acts only on 401 - SvelteKit emits a framework-level 403 only for the CSRF origin check.

### Fix 1 - CSRF origin check (the unblocker)

`kit.csrf = { trustedOrigins: ['*'] }` in **both** apps. SvelteKit 2.63 compiles `['*']` to `csrf_check_origin: false` (the boolean `checkOrigin: false` is deprecated); the wildcard also covers a native request that carries **no** Origin header, which an explicit allowlist could not.

**Why it is safe (no CSRF regression):** API auth is bearer-token (`Authorization`, never an ambient cookie auto-attached cross-site), and the only cookie - the web `refresh_token` - is `httpOnly` + `SameSite=Lax` (never sent on a cross-site request). The origin check was redundant with those defenses and only ever rejected the legitimate native client.

### Fix 2 - delete/restore retry classification (defense-in-depth)

`pushNoteDelete` / `pushNoteRestore` moved from a bare `if (!res.ok) throw` to `ensureOk` + `markNoteSyncError` on permanent failure. Previously a permanent 4xx (this 403) was treated as transient: 3x backoff, left `pending`, and `pushPendingItems` re-issued the DELETE on **every** periodic sync - the console flood. Now a permanent rejection drops the note from the retry set, matching `pushNote` / `pushNoteUpdate`.

## Test plan

Automated (green locally): reborn-notes lint + check + test (1018) + build; reborn-task lint + check + test (87); no SvelteKit deprecation warning after moving to `trustedOrigins`. New `csrf-config.regression.spec.ts` pins `trustedOrigins:['*']` in both configs; `notes-sync.push-rejection.spec.ts` extended to assert DELETE/restore use `ensureOk` + `markNoteSyncError` (no bare throw).

Smoke (native build, where it reproduced):
- Trash a note in the native app, then check another device / re-login: the deletion now propagates (no `DELETE ... 403` in the console).
- An account with periodic duplicates: after "Merge", the extra copy goes to Trash and stays there - no resurrection, the modal does not re-fire.
- Restore a note from Trash in native: it un-archives server-side too.

Note: this is a separate branch from #358 (the initial-sync banner / spinner / modal UX); they are complementary - #358 made the loop visible, this fixes its root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)