### PR TITLE
chore(deps): drop esbuild audit ignore now that override is 0.28.1

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,11 +20,6 @@ overrides:
   ws: '8.21.0' # GHSA-58qx-3vcg-4xpx ws uninitialized memory disclosure
   qs: '6.15.2' # GHSA-q8mj-m7cp-5q26 qs.stringify DoS
   undici@<7.28.0: '7.28.0' # GHSA-vmh5-mc38-953g (high) + GHSA-pr7r-676h-xcf6 (moderate) undici, via vitest>jsdom (test-only)
-auditConfig:
-  ignoreGhsas:
-    # esbuild Deno-loader RCE; unreachable here (Node-only toolchain). Remove
-    # once the esbuild override above reaches >=0.28.1 (24h maturity gate).
-    - GHSA-gv7w-rqvm-qjhr
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true


### PR DESCRIPTION
## Summary

The esbuild override reached `0.28.1` in `pnpm-workspace.yaml`, so the Deno-loader RCE advisory `GHSA-gv7w-rqvm-qjhr` (esbuild `>=0.17.0 <0.28.1`, unreachable in our Node-only toolchain) no longer applies to the resolved version. This removes the temporary `auditConfig.ignoreGhsas` entry added in #272.

## Test plan

- `pnpm audit --audit-level high` exits 0 (clean) without the ignore.
- The advisory is absent from the full report; esbuild resolves to `0.28.1` across all vite contexts in the lockfile.
- The remaining audit findings (uuid moderate via Storybook, @babel/core low) are pre-existing dev-only transitives below the `high` gate, untouched by this change.
- Lockfile unaffected - audit config is not part of dependency resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)