### PR TITLE
fix(notes): reset note back/forward trail on fresh open

### DIFF
--- a/apps/reborn-notes/src/lib/services/note-nav-history-utils.spec.ts
+++ b/apps/reborn-notes/src/lib/services/note-nav-history-utils.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   emptyTrail,
+  freshTrail,
   recordVisit,
   stepBack,
   stepForward,
@@ -36,6 +37,32 @@ describe('note-nav-history-utils', () => {
     const t = recordVisit(trailOf('a'), 'a');
     expect(t.entries).toEqual(['a']);
     expect(backTargetId(t)).toBeNull();
+  });
+
+  it('freshTrail roots a single-entry trail with no Back/Forward', () => {
+    const t = freshTrail('a');
+    expect(t.entries).toEqual(['a']);
+    expect(currentId(t)).toBe('a');
+    expect(backTargetId(t)).toBeNull();
+    expect(forwardTargetId(t)).toBeNull();
+  });
+
+  it('freshTrail discards an existing chain, so Back closes instead of chaining', () => {
+    // a→b were visited (e.g. an earlier section); a fresh top-level open of c
+    // must not leave b reachable by Back.
+    const existing = trailOf('a', 'b');
+    expect(backTargetId(existing)).toBe('a');
+    const fresh = freshTrail('c');
+    expect(fresh.entries).toEqual(['c']);
+    expect(backTargetId(fresh)).toBeNull();
+  });
+
+  it('a link visit after a fresh open extends the trail', () => {
+    let t = freshTrail('a');
+    t = recordVisit(t, 'b'); // internal-link follow
+    expect(t.entries).toEqual(['a', 'b']);
+    expect(currentId(t)).toBe('b');
+    expect(backTargetId(t)).toBe('a');
   });
 
   it('walks Back and Forward along the trail', () => {

--- a/apps/reborn-notes/src/lib/services/note-nav-history-utils.ts
+++ b/apps/reborn-notes/src/lib/services/note-nav-history-utils.ts
@@ -23,6 +23,18 @@ export function emptyTrail(): NavTrail {
   return { entries: [], cursor: -1 };
 }
 
+/**
+ * Start a fresh trail rooted at a single note - a top-level open (list pick,
+ * new note, periodic note, deep link) that is NOT a continuation of the visit
+ * chain. Back from such a note has nothing behind it, so the caller closes the
+ * note back to its list/section rather than chaining to an unrelated note
+ * opened earlier (possibly in a different section). Only following an internal
+ * `note:` link extends the trail, via `recordVisit`.
+ */
+export function freshTrail(id: string): NavTrail {
+  return { entries: [id], cursor: 0 };
+}
+
 export function currentId(t: NavTrail): string | null {
   return t.entries[t.cursor] ?? null;
 }

--- a/apps/reborn-notes/src/lib/services/note-nav-history.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-nav-history.svelte.ts
@@ -27,6 +27,7 @@
  */
 import {
   emptyTrail,
+  freshTrail,
   recordVisit,
   stepBack,
   stepForward,
@@ -79,6 +80,17 @@ class NoteNavHistory {
   /** Record a visit to `id` (truncates forward entries, like a browser). */
   visit(id: string): void {
     this._trail = recordVisit(this._trail, id);
+    this._version++;
+  }
+
+  /**
+   * Start a fresh trail at `id` - a top-level open (list pick, new note,
+   * periodic) that must not chain Back to a previously-visited note. After this
+   * `canGoBack` is false, so Back closes the note to its list/section instead.
+   * Only following an internal `note:` link extends the trail, via `visit`.
+   */
+  reset(id: string): void {
+    this._trail = freshTrail(id);
     this._version++;
   }
 

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -987,6 +987,11 @@
   // for a scroll restore. `suppressHistoryRecord` marks an activeNoteId change
   // that came from Back/Forward itself, so it isn't recorded as a new visit.
   let suppressHistoryRecord = false;
+  // Armed for exactly one activeNoteId change by handleNoteLink, so following an
+  // internal `note:` link EXTENDS the trail (Back returns to the source note).
+  // Every other open (list pick, new note, periodic) leaves it false and starts
+  // a fresh trail, so Back closes the note back to its list/section.
+  let extendNavTrailOnce = false;
   let prevHistoryNoteId: string | null = null;
   let pendingScrollRestore = $state<{ noteId: string; top: number } | null>(null);
 
@@ -1077,6 +1082,10 @@
       }
     }
     pendingAnchor = slug ? { noteId, slug } : null;
+    // Chain onto the trail so Back returns to this source note. Guard the
+    // self-link no-op: if the target is already open, activeNoteId.set won't
+    // fire the recorder, so don't leave the flag armed for the next open.
+    extendNavTrailOnce = noteId !== $activeNoteId;
     activeNoteId.set(noteId);
   }
 
@@ -1175,8 +1184,15 @@
         const el = activeNoteScrollEl();
         if (el) noteNavHistory.saveScroll(prevHistoryNoteId, el.scrollTop);
       }
-      if (id != null && !suppressHistoryRecord) noteNavHistory.visit(id);
+      if (id != null && !suppressHistoryRecord) {
+        // A fresh top-level open starts a new trail so Back closes the note back
+        // to its list/section; only an internal `note:` link (incl. the
+        // Linked-notes panel, which routes through handleNoteLink) extends it.
+        if (extendNavTrailOnce) noteNavHistory.visit(id);
+        else noteNavHistory.reset(id);
+      }
       suppressHistoryRecord = false;
+      extendNavTrailOnce = false;
       prevHistoryNoteId = id;
     });
   });


### PR DESCRIPTION
## Summary

Pressing the in-app Back (editor header arrow, edge-swipe, or Alt+Left) after opening a note always jumped to the **first** note opened in the session (e.g. `TODO.md`) instead of returning to the folder/section the current note was opened from.

**Root cause.** Those affordances consult `noteNavHistory.canGoBack` - a browser-like trail that records every note that becomes active and is only wiped on lock/logout. It was never reset on a fresh top-level open, so `canGoBack` stayed `true` across section boundaries and Back walked into a note from an earlier, unrelated context. (The OS/browser back button goes `popstate -> navigateUp -> close` and was already correct - only the in-app affordances showed the bug, matching the report.)

**Fix.** Model the trail as one linked-navigation chain, matching the browser back/forward model (where `list -> note` is a navigation whose Back target is the list, i.e. closing the note):

- A **top-level open** (list pick, new note, periodic, deep link, anything unenumerated) starts a **fresh trail** -> Back closes the note back to its list/section.
- Following an **internal `note:` link** - incl. the Linked-notes panel, which routes through `handleNoteLink` - **extends** the trail -> Back returns to the source note; only at the chain root does Back close.

`handleNoteLink` arms a one-shot `extendNavTrailOnce` flag (guarded against the self-link no-op); the recorder `$effect` branches `visit()` vs new `reset()`. Default-reset is self-correcting - an open path not marked "extend" fails safe (closes, never chains). RAM-only navigation state: no persistence, server, schema, or encryption surface touched (Zero-Knowledge unaffected).

Works for both web and native, across all in-app Back affordances.

### Decisions (auto mode - for review)
- **Reset-on-fresh-open** (this) over **clear-the-trail-on-section-switch**: reset also fixes the within-a-section case (open A from list -> Back to list -> open B -> Back returns to the list, not A) and covers any future entry point a section-switch hook would miss. More correct per the browser model, smaller and self-correcting surface.
- **Extend only `handleNoteLink`**, default everything else to reset, rather than annotating every list/new/periodic call site. Fewer touch points; unknown paths fail safe.

See commit `b3dffba` for the full rationale.

## Test plan

Automated (all green locally): `lint` (0 errors), `check`/svelte-check (0 errors), `test` (1032 passed incl. 3 new `freshTrail` cases), `build`.

Manual smoke (mobile + desktop, web + native):
1. Log in, open a note (e.g. `TODO.md`) from **All notes**. Switch to **Folders**, drill into a folder, open a note there.
   - Press Back (header arrow / edge-swipe / OS back): should return to the **folder list**, not `TODO.md`. ✅
2. From a folder note, follow internal `note:` links A -> B -> C.
   - Back should step C -> B -> A (with scroll restored), then one more Back **closes** the note to the folder list - never to `TODO.md`. ✅
3. Same via the **Linked notes** panel jumps (should chain like internal links). ✅
4. Within a single section: open note A from the list, Back to list, open note B, Back -> should return to the **list**, not A. ✅
5. Forward (Alt+Right / header forward chevron) still works inside a link chain. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)