### PR TITLE
feat(notes): prevent and consolidate duplicate periodic folders

### DIFF
--- a/apps/reborn-notes/src/lib/components/notes/PeriodicFolderDuplicatesDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/PeriodicFolderDuplicatesDialog.svelte
@@ -1,0 +1,49 @@
+<!--
+  @component
+  Confirmation modal offering to consolidate duplicate periodic FOLDERS (the
+  2026-06-28 sync-race left some accounts with a dozen "Daily Notes" folders).
+  Opens when `detectAndNotifyPeriodicFolderDuplicates` (fire-and-forget after a
+  pull) posts to the `periodicFolderDuplicatePrompt` store. On confirm it moves
+  every note into one folder per kind, merges same-period copies, and removes the
+  empty duplicate folders. Mounted once, globally, in +layout.svelte.
+-->
+<script lang="ts">
+  import ConfirmDialog from '../shared/ConfirmDialog.svelte';
+  import {
+    periodicFolderDuplicatePrompt,
+    confirmMergePeriodicFolderDuplicates,
+    dismissPeriodicFolderDuplicatePrompt
+  } from '$lib/services/periodic-folder-dedup.service';
+  import { t } from '$lib/stores/i18n.store';
+
+  let open = $state(false);
+  // Latched so the close animation keeps its text after the store clears.
+  let folders = $state(0);
+
+  // `open` is a pure function of the store: opens on a posted prompt, closes when
+  // cleared (by confirm/dismiss).
+  $effect(() => {
+    const p = $periodicFolderDuplicatePrompt;
+    if (p) folders = p.folders;
+    open = p !== null;
+  });
+
+  // Closed via Escape / overlay click bypasses the action callbacks; treat that
+  // as a dismiss so `open` and the store stay consistent. notifiedFolderKeys
+  // already guards against re-popping the same batch this session.
+  $effect(() => {
+    if (!open && $periodicFolderDuplicatePrompt !== null) {
+      dismissPeriodicFolderDuplicatePrompt();
+    }
+  });
+</script>
+
+<ConfirmDialog
+  bind:open
+  title={$t('notes.periodic.folder_dedup.modal_title')}
+  description={$t('notes.periodic.folder_dedup.modal_description', { values: { count: folders } })}
+  confirmText={$t('notes.periodic.folder_dedup.merge_action')}
+  cancelText={$t('notes.periodic.folder_dedup.dismiss_action')}
+  onConfirm={confirmMergePeriodicFolderDuplicates}
+  onCancel={dismissPeriodicFolderDuplicatePrompt}
+/>

--- a/apps/reborn-notes/src/lib/services/periodic-dedup.service.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-dedup.service.ts
@@ -229,6 +229,18 @@ export const periodicDuplicatePrompt = writable<{ extra: number } | null>(null);
  * for the merge modal. Fire-and-forget from `refreshStoresAfterPull()`.
  */
 export async function detectAndNotifyPeriodicDuplicates(): Promise<void> {
+  // Folder-level duplicates take priority. Consolidating folders moves the notes
+  // into one folder per kind (and merges the same-period copies inline), so
+  // surfacing the note prompt at the same time would be redundant and confusing.
+  try {
+    const { detectAndNotifyPeriodicFolderDuplicates } = await import(
+      '$lib/services/periodic-folder-dedup.service'
+    );
+    if (await detectAndNotifyPeriodicFolderDuplicates()) return;
+  } catch (e) {
+    logger.warn('Periodic folder duplicate scan failed', e);
+  }
+
   const groups = await detectPeriodicDuplicates();
   if (groups.length === 0) return;
 

--- a/apps/reborn-notes/src/lib/services/periodic-folder-dedup.core.spec.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-folder-dedup.core.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import {
+  orderCanonicalFirst,
+  buildFolderDedupGroup,
+  detectFolderDuplicateGroups,
+  type FolderInfo,
+  type FolderDedupCandidate,
+  type PeriodicFolderContext
+} from './periodic-folder-dedup.core';
+
+function cand(p: Partial<FolderDedupCandidate> & { id: string }): FolderDedupCandidate {
+  return { createdAt: '', noteCount: 0, hasStampedNotes: false, ...p };
+}
+
+function folder(p: Partial<FolderInfo> & { id: string }): FolderInfo {
+  return {
+    name: p.id,
+    parentId: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    noteCount: 0,
+    stampedKinds: [],
+    ...p
+  };
+}
+
+const DEFAULT_NAMES: PeriodicFolderContext['defaultNamesByKind'] = {
+  daily: new Set(['Daily Notes', 'Dziennik']),
+  weekly: new Set(['Weekly Notes', 'Tygodnik']),
+  monthly: new Set(['Monthly Notes', 'Miesięcznik'])
+};
+
+function ctx(settings: Partial<Record<'daily' | 'weekly' | 'monthly', string>> = {}): PeriodicFolderContext {
+  return { defaultNamesByKind: DEFAULT_NAMES, settingsFolderIdByKind: settings };
+}
+
+describe('orderCanonicalFirst', () => {
+  it('prefers a stamped folder over an older empty shell', () => {
+    const ordered = orderCanonicalFirst([
+      cand({ id: 'shell', hasStampedNotes: false, noteCount: 0, createdAt: '2025-01-01' }),
+      cand({ id: 'real', hasStampedNotes: true, noteCount: 3, createdAt: '2026-06-01' })
+    ]);
+    expect(ordered[0].id).toBe('real');
+  });
+
+  it('among stamped folders, most notes then oldest then id', () => {
+    const ordered = orderCanonicalFirst([
+      cand({ id: 'b', hasStampedNotes: true, noteCount: 2, createdAt: '2026-02-01' }),
+      cand({ id: 'a', hasStampedNotes: true, noteCount: 5, createdAt: '2026-03-01' }),
+      cand({ id: 'c', hasStampedNotes: true, noteCount: 5, createdAt: '2026-01-01' })
+    ]);
+    // a and c both have 5 notes; c is older -> c wins, then a, then b.
+    expect(ordered.map((o) => o.id)).toEqual(['c', 'a', 'b']);
+  });
+});
+
+describe('buildFolderDedupGroup', () => {
+  it('returns null for fewer than two candidates', () => {
+    expect(buildFolderDedupGroup('daily', [])).toBeNull();
+    expect(buildFolderDedupGroup('daily', [cand({ id: 'a' })])).toBeNull();
+  });
+
+  it('keeps the canonical and lists the rest, summing notes to move', () => {
+    const group = buildFolderDedupGroup('daily', [
+      cand({ id: 'real', hasStampedNotes: true, noteCount: 4, createdAt: '2026-01-01' }),
+      cand({ id: 'dup1', noteCount: 1 }),
+      cand({ id: 'dup2', noteCount: 0 })
+    ]);
+    expect(group).not.toBeNull();
+    expect(group!.canonicalId).toBe('real');
+    expect(group!.duplicateIds.sort()).toEqual(['dup1', 'dup2']);
+    expect(group!.folderCount).toBe(3);
+    expect(group!.notesToMove).toBe(1); // dup1(1) + dup2(0); the canonical's notes stay put
+  });
+});
+
+describe('detectFolderDuplicateGroups', () => {
+  it('groups two stamped daily folders, keeping the one with more notes', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'big', name: 'Daily Notes', noteCount: 9, stampedKinds: ['daily'] }),
+        folder({ id: 'small', name: 'Daily Notes', noteCount: 1, stampedKinds: ['daily'] })
+      ],
+      ctx()
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].kind).toBe('daily');
+    expect(groups[0].canonicalId).toBe('big');
+    expect(groups[0].duplicateIds).toEqual(['small']);
+    expect(groups[0].notesToMove).toBe(1);
+  });
+
+  it('absorbs empty name-matched shells into the real stamped folder', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'real', name: 'Daily Notes', noteCount: 5, stampedKinds: ['daily'] }),
+        folder({ id: 'shell1', name: 'Daily Notes', noteCount: 0 }),
+        folder({ id: 'shell2', name: 'Daily Notes', noteCount: 0 })
+      ],
+      ctx()
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].canonicalId).toBe('real');
+    expect(groups[0].duplicateIds.sort()).toEqual(['shell1', 'shell2']);
+    expect(groups[0].notesToMove).toBe(0);
+  });
+
+  it('matches across locale default names (Dziennik + Daily Notes)', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'pl', name: 'Dziennik', noteCount: 3, stampedKinds: ['daily'] }),
+        folder({ id: 'en', name: 'Daily Notes', noteCount: 0 })
+      ],
+      ctx()
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].canonicalId).toBe('pl');
+    expect(groups[0].duplicateIds).toEqual(['en']);
+  });
+
+  it('does not group a single folder', () => {
+    const groups = detectFolderDuplicateGroups(
+      [folder({ id: 'only', name: 'Daily Notes', noteCount: 2, stampedKinds: ['daily'] })],
+      ctx()
+    );
+    expect(groups).toHaveLength(0);
+  });
+
+  it('leaves purely coincidental same-named empty folders alone (no periodic linkage)', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'a', name: 'Daily Notes', noteCount: 0 }),
+        folder({ id: 'b', name: 'Daily Notes', noteCount: 0 })
+      ],
+      ctx() // no settings pointer, no stamps -> not confirmed periodic
+    );
+    expect(groups).toHaveLength(0);
+  });
+
+  it('forms a group of empty shells once the settings pointer confirms one of them', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'a', name: 'Daily Notes', noteCount: 0 }),
+        folder({ id: 'b', name: 'Daily Notes', noteCount: 0 })
+      ],
+      ctx({ daily: 'a' })
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].folderCount).toBe(2);
+  });
+
+  it('never claims a folder that holds another kind via a name match', () => {
+    // "Daily Notes" name but it actually holds WEEKLY notes -> not a daily candidate.
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'realDaily', name: 'Daily Notes', noteCount: 2, stampedKinds: ['daily'] }),
+        folder({ id: 'mislabeled', name: 'Daily Notes', noteCount: 2, stampedKinds: ['weekly'] })
+      ],
+      ctx()
+    );
+    // Only realDaily is a daily candidate -> single -> no daily group. mislabeled is
+    // a lone weekly folder -> no weekly group either.
+    expect(groups).toHaveLength(0);
+  });
+
+  it('skips folders carrying more than one periodic kind (ambiguous)', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'mixed', name: 'Daily Notes', noteCount: 4, stampedKinds: ['daily', 'weekly'] }),
+        folder({ id: 'real', name: 'Daily Notes', noteCount: 2, stampedKinds: ['daily'] })
+      ],
+      ctx()
+    );
+    // mixed is skipped, leaving a single daily candidate -> no group.
+    expect(groups).toHaveLength(0);
+  });
+
+  it('ignores non-root folders', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'root', name: 'Daily Notes', noteCount: 3, stampedKinds: ['daily'] }),
+        folder({ id: 'child', name: 'Daily Notes', parentId: 'root', noteCount: 2, stampedKinds: ['daily'] })
+      ],
+      ctx()
+    );
+    expect(groups).toHaveLength(0);
+  });
+
+  it('detects independent groups for different kinds at once', () => {
+    const groups = detectFolderDuplicateGroups(
+      [
+        folder({ id: 'd1', name: 'Daily Notes', noteCount: 2, stampedKinds: ['daily'] }),
+        folder({ id: 'd2', name: 'Daily Notes', noteCount: 0 }),
+        folder({ id: 'm1', name: 'Monthly Notes', noteCount: 1, stampedKinds: ['monthly'] }),
+        folder({ id: 'm2', name: 'Monthly Notes', noteCount: 0 })
+      ],
+      ctx()
+    );
+    expect(groups.map((g) => g.kind).sort()).toEqual(['daily', 'monthly']);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/periodic-folder-dedup.core.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-folder-dedup.core.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure helpers for Periodic Notes *folder* de-duplication.
+ *
+ * Companion to `periodic-dedup.core.ts` (which dedups duplicate NOTES inside one
+ * folder). This file dedups duplicate periodic FOLDERS: the 2026-06-28 sync-race
+ * bug let `ensureFolder` mint a fresh "Daily Notes" folder every time a periodic
+ * button was clicked during the cold-login pull (the real folder wasn't in the
+ * in-memory store yet), so an account could accumulate a dozen identically-named
+ * periodic folders, each holding a stray note.
+ *
+ * Kept free of `$lib` / svelte / `@reborn/ui` imports (type-only dependency on
+ * `@reborn/storage`) so it is unit-testable in the plain Node vitest env. The
+ * orchestration (decryption, stores, folder/note moves) lives in
+ * `periodic-folder-dedup.service.ts`.
+ */
+import type { PeriodicKind } from '@reborn/storage';
+
+const KINDS: PeriodicKind[] = ['daily', 'weekly', 'monthly'];
+
+/** A root folder, as seen by the folder-dedup classifier. */
+export interface FolderInfo {
+  id: string;
+  name: string;
+  /** `null`/`undefined` for a root-level folder. */
+  parentId: string | null | undefined;
+  createdAt: string;
+  /** Active (non-trashed) notes currently in this folder. */
+  noteCount: number;
+  /** Kinds for which this folder holds >=1 note carrying a periodic stamp. */
+  stampedKinds: PeriodicKind[];
+}
+
+/** Inputs that disambiguate which folders count as periodic for a kind. */
+export interface PeriodicFolderContext {
+  /** Default folder names per kind, across every supported locale (exact match). */
+  defaultNamesByKind: Record<PeriodicKind, Set<string>>;
+  /** The folder currently configured as periodic per kind (local settings). */
+  settingsFolderIdByKind: Partial<Record<PeriodicKind, string>>;
+}
+
+/** One candidate folder within a kind's duplicate group. */
+export interface FolderDedupCandidate {
+  id: string;
+  createdAt: string;
+  noteCount: number;
+  /** True when the folder holds >=1 note stamped with this group's kind. */
+  hasStampedNotes: boolean;
+}
+
+export interface FolderDedupGroup {
+  kind: PeriodicKind;
+  /** The folder to keep: most notes, oldest on a tie. */
+  canonicalId: string;
+  /** Folders whose notes move into the canonical and which are then removed. */
+  duplicateIds: string[];
+  /** Total folders in the group (canonical + duplicates). */
+  folderCount: number;
+  /** Notes that will be moved out of the duplicate folders into the canonical. */
+  notesToMove: number;
+}
+
+/**
+ * Order candidates so the BEST keep-folder is first:
+ *   1. one that actually holds this kind's stamped notes (not an empty shell),
+ *   2. then the one with the most notes (minimises moving),
+ *   3. then the oldest (stable "original"),
+ *   4. then id, for determinism.
+ */
+export function orderCanonicalFirst(candidates: FolderDedupCandidate[]): FolderDedupCandidate[] {
+  return [...candidates].sort((a, b) => {
+    if (a.hasStampedNotes !== b.hasStampedNotes) return a.hasStampedNotes ? -1 : 1;
+    if (a.noteCount !== b.noteCount) return b.noteCount - a.noteCount;
+    const t = (a.createdAt || '').localeCompare(b.createdAt || '');
+    if (t !== 0) return t;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/** Build a group from a kind's candidates, or null if there's nothing to merge. */
+export function buildFolderDedupGroup(
+  kind: PeriodicKind,
+  candidates: FolderDedupCandidate[]
+): FolderDedupGroup | null {
+  if (candidates.length < 2) return null;
+  const [canonical, ...duplicates] = orderCanonicalFirst(candidates);
+  return {
+    kind,
+    canonicalId: canonical.id,
+    duplicateIds: duplicates.map((d) => d.id),
+    folderCount: candidates.length,
+    notesToMove: duplicates.reduce((sum, d) => sum + d.noteCount, 0)
+  };
+}
+
+/**
+ * Classify root folders into duplicate periodic-folder groups.
+ *
+ * A folder counts as a periodic folder for kind K when it is ROOT-LEVEL and any of:
+ *   - it holds >=1 note stamped with kind K (definitive, locale-independent), OR
+ *   - it is the folder currently configured as K in local settings, OR
+ *   - it is EMPTY of periodic notes AND its name equals a default K name in some
+ *     locale (the only way to catch the bug's empty duplicate shells without
+ *     grabbing a user's populated unrelated folder).
+ *
+ * Guards that keep this safe:
+ *   - Folders carrying MORE THAN ONE periodic kind are skipped entirely (ambiguous).
+ *   - A name match never claims a folder that holds another kind's notes.
+ *   - A group forms only if >=1 member is *confirmed* periodic (stamped or the
+ *     settings folder) - so folders that merely share a default name, with no
+ *     periodic linkage at all, are left untouched.
+ */
+export function detectFolderDuplicateGroups(
+  folders: FolderInfo[],
+  ctx: PeriodicFolderContext
+): FolderDedupGroup[] {
+  const groups: FolderDedupGroup[] = [];
+
+  for (const kind of KINDS) {
+    const names = ctx.defaultNamesByKind[kind] ?? new Set<string>();
+    const settingsId = ctx.settingsFolderIdByKind[kind];
+    const candidates: FolderDedupCandidate[] = [];
+
+    for (const f of folders) {
+      if (f.parentId) continue; // the bug only mints root folders
+      if (f.stampedKinds.length > 1) continue; // mixed kinds: ambiguous, leave alone
+
+      const stampedThisKind = f.stampedKinds.includes(kind);
+      const stampedOtherKind = f.stampedKinds.length > 0 && !stampedThisKind;
+      if (stampedOtherKind) continue; // belongs to a different kind
+
+      const isCandidate =
+        stampedThisKind ||
+        f.id === settingsId ||
+        (names.has(f.name) && f.stampedKinds.length === 0);
+      if (!isCandidate) continue;
+
+      candidates.push({
+        id: f.id,
+        createdAt: f.createdAt,
+        noteCount: f.noteCount,
+        hasStampedNotes: stampedThisKind
+      });
+    }
+
+    const group = buildFolderDedupGroup(kind, candidates);
+    if (!group) continue;
+    // Only act when at least one member is unambiguously a periodic folder.
+    const confirmed = candidates.some((c) => c.hasStampedNotes || c.id === settingsId);
+    if (!confirmed) continue;
+    groups.push(group);
+  }
+
+  return groups;
+}

--- a/apps/reborn-notes/src/lib/services/periodic-folder-dedup.service.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-folder-dedup.service.ts
@@ -1,0 +1,294 @@
+/**
+ * Post-sync de-duplication for Periodic Notes *folders* (Daily / Weekly / Monthly).
+ *
+ * Why this exists: the 2026-06-28 sync-race bug let `getOrCreateNote` run
+ * `ensureFolder` against an EMPTY in-memory `foldersStore` during the cold-login
+ * pull, so every periodic-button click mid-sync minted a fresh "Daily Notes"
+ * folder (the real one wasn't in memory yet) and stamped it as the active
+ * periodic folder. Accounts that hit it accumulated a dozen identically-named
+ * periodic folders, each holding a stray note - which also hid the copies from
+ * the note-level dedup (it groups by folderId). The resolver fix in
+ * `periodic-notes.service` stops new duplicates; this consolidates the ones that
+ * already exist.
+ *
+ * Strategy (mirrors note dedup): DETECT + CONFIRM + MERGE. We never restructure
+ * folders silently after a background pull - the merge moves notes between
+ * folders, deletes the empty shells, and merges the now-colocated same-period
+ * notes, so it runs only when the user confirms a modal
+ * (`PeriodicFolderDuplicatesDialog`, driven by `periodicFolderDuplicatePrompt`).
+ *
+ * Reversibility: notes are MOVED, never deleted, so nothing of the user's content
+ * is lost; the same-period note merge snapshots each canonical to version history
+ * and sends the extra copies to Trash (the existing note-dedup guarantees). Only
+ * the now-empty duplicate folder shells are removed for good - they hold no notes.
+ *
+ * Detection is cheap: note counts come from the plaintext in-memory index, and
+ * only ISO-prefix-titled notes are decrypted (to read their periodic stamp), the
+ * same pre-filter the note dedup uses.
+ */
+import { get, writable } from 'svelte/store';
+import { PERIODIC_NOTES_DEFAULTS, type PeriodicKind } from '@reborn/storage';
+import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
+import { toastStore } from '@reborn/ui';
+import { noteIndex } from '$lib/services/note-index.svelte';
+import { readNoteMetadata, moveNoteToFolder } from './note.service';
+import { foldersStore } from '$lib/stores/folders.store';
+import { notesStore } from '$lib/stores/notes.store';
+import { getSetting } from '$lib/utils/app-settings';
+import { appSettings } from '$lib/stores/app-settings.store';
+import { t as i18nT } from '$lib/stores/i18n.store';
+import {
+  detectFolderDuplicateGroups,
+  type FolderInfo,
+  type FolderDedupGroup
+} from './periodic-folder-dedup.core';
+
+const logger = createLogger('PeriodicFolderDedup');
+
+const KINDS: PeriodicKind[] = ['daily', 'weekly', 'monthly'];
+
+/** Matches the leading ISO date of a default-format periodic title. */
+const ISO_PREFIX_RE = /^(\d{4}-\d{2}(?:-\d{2})?)/;
+
+function tr(key: string, values?: Record<string, unknown>): string {
+  return get(i18nT)(key, values ? { values } : undefined);
+}
+
+function emptyKindSets(): Record<PeriodicKind, Set<string>> {
+  return { daily: new Set(), weekly: new Set(), monthly: new Set() };
+}
+
+// ── Detection ─────────────────────────────────────────────────────
+
+/**
+ * Build a `FolderInfo` per ROOT folder plus the set of folder names that
+ * actually hold each kind's stamped notes. The name set makes empty-shell
+ * matching locale-independent: an empty "Daily Notes" shell is recognised by the
+ * name a *real* daily folder uses, whatever the current UI locale.
+ */
+async function buildFolderInfos(): Promise<{
+  infos: FolderInfo[];
+  stampedNamesByKind: Record<PeriodicKind, Set<string>>;
+}> {
+  const rootFolders = get(foldersStore); // tree top level = root folders
+  const rootNameById = new Map(rootFolders.map((f) => [f.id, f.name]));
+
+  // Active note counts per folder (plaintext index, zero crypto).
+  const noteCountByFolder = new Map<string, number>();
+  for (const e of noteIndex.entries()) {
+    if (!e.folderId) continue;
+    noteCountByFolder.set(e.folderId, (noteCountByFolder.get(e.folderId) ?? 0) + 1);
+  }
+
+  // Stamped kinds per folder: decrypt only ISO-prefix-titled notes.
+  const stampedKindsByFolder = new Map<string, Set<PeriodicKind>>();
+  const stampedNamesByKind = emptyKindSets();
+  for (const e of noteIndex.entries()) {
+    if (!e.folderId) continue;
+    if (!ISO_PREFIX_RE.test(e.title)) continue;
+    const meta = await readNoteMetadata(e.id);
+    const stamp = meta?.periodic;
+    if (!stamp) continue;
+    let set = stampedKindsByFolder.get(e.folderId);
+    if (!set) {
+      set = new Set();
+      stampedKindsByFolder.set(e.folderId, set);
+    }
+    set.add(stamp.kind);
+    const name = rootNameById.get(e.folderId);
+    if (name) stampedNamesByKind[stamp.kind].add(name);
+  }
+
+  const infos: FolderInfo[] = rootFolders.map((f) => ({
+    id: f.id,
+    name: f.name,
+    parentId: f.parent_id ?? null,
+    createdAt: f.created_at,
+    noteCount: noteCountByFolder.get(f.id) ?? 0,
+    stampedKinds: Array.from(stampedKindsByFolder.get(f.id) ?? [])
+  }));
+
+  return { infos, stampedNamesByKind };
+}
+
+/**
+ * Scan root folders for duplicate periodic folders (same kind). Returns one
+ * group per affected kind, or [] when there's nothing to consolidate.
+ */
+export async function detectPeriodicFolderDuplicates(): Promise<FolderDedupGroup[]> {
+  if (!cryptoManager.isInitialized()) return [];
+
+  // Cheap gate (zero crypto): the bug's signature is >=2 ROOT folders sharing a
+  // name. If no root name repeats there are no duplicate periodic folders to find,
+  // so skip the decrypting stamp scan entirely - this keeps the per-pull cost at
+  // O(folders) string ops for the overwhelming majority of accounts. (Differently-
+  // named same-kind folders across locales are intentionally left alone: they may
+  // be deliberate, and merging them would be a surprise.)
+  const rootNameCounts = new Map<string, number>();
+  for (const f of get(foldersStore)) {
+    rootNameCounts.set(f.name, (rootNameCounts.get(f.name) ?? 0) + 1);
+  }
+  if (![...rootNameCounts.values()].some((n) => n >= 2)) return [];
+
+  const { infos, stampedNamesByKind } = await buildFolderInfos();
+
+  const settings = await getSetting('periodicNotes');
+  const settingsFolderIdByKind: Partial<Record<PeriodicKind, string>> = {};
+  if (settings) {
+    for (const k of KINDS) {
+      const fid = settings[k]?.folderId;
+      if (fid) settingsFolderIdByKind[k] = fid;
+    }
+  }
+
+  // Names that identify an empty shell as belonging to a kind: the current-locale
+  // default plus every name a real (stamped) folder of that kind uses.
+  const defaultNamesByKind = emptyKindSets();
+  for (const k of KINDS) {
+    const set = new Set<string>(stampedNamesByKind[k]);
+    const def = tr(`notes.periodic.${k}.folder.default`);
+    if (def) set.add(def);
+    defaultNamesByKind[k] = set;
+  }
+
+  return detectFolderDuplicateGroups(infos, { defaultNamesByKind, settingsFolderIdByKind });
+}
+
+// ── Merge ─────────────────────────────────────────────────────────
+
+/** Re-point local settings for `kind` at the canonical folder (idempotent). */
+async function repointSettings(kind: PeriodicKind, folderId: string): Promise<void> {
+  const current = (await getSetting('periodicNotes')) ?? PERIODIC_NOTES_DEFAULTS;
+  if (current[kind]?.folderId === folderId) return;
+  const next = {
+    ...current,
+    [kind]: { ...current[kind], folderId }
+  };
+  await appSettings.update('periodicNotes', next);
+}
+
+/**
+ * Consolidate every detected duplicate folder group: move each duplicate's notes
+ * into the canonical folder, re-point local settings at the canonical, then
+ * delete the (now-empty) duplicate folders. Re-detects at call time so it never
+ * acts on a stale group list.
+ *
+ * Does NOT merge the colocated same-period notes - that is the note dedup's job,
+ * chained by the caller after this returns.
+ */
+export async function mergePeriodicFolderDuplicates(): Promise<{
+  groups: number;
+  foldersRemoved: number;
+  notesMoved: number;
+}> {
+  const groups = await detectPeriodicFolderDuplicates();
+  let mergedGroups = 0;
+  let foldersRemoved = 0;
+  let notesMoved = 0;
+
+  const { deleteFolder } = await import('./folder.service');
+
+  for (const group of groups) {
+    // Move every note out of the duplicate folders into the canonical.
+    for (const dupId of group.duplicateIds) {
+      const noteIds = noteIndex
+        .entries()
+        .filter((e) => e.folderId === dupId)
+        .map((e) => e.id);
+      for (const id of noteIds) {
+        await moveNoteToFolder(id, group.canonicalId);
+        notesMoved++;
+      }
+    }
+
+    // Point local settings at the survivor BEFORE deleting shells, so a failure
+    // mid-delete still leaves the canonical configured.
+    await repointSettings(group.kind, group.canonicalId);
+
+    // Remove the now-empty duplicate folders (no notes left to detach).
+    for (const dupId of group.duplicateIds) {
+      try {
+        await deleteFolder(dupId, 'detach');
+        foldersRemoved++;
+      } catch (e) {
+        logger.warn('Failed to remove duplicate periodic folder', { id: dupId, error: e });
+      }
+    }
+    mergedGroups++;
+  }
+
+  await foldersStore.refresh();
+  await noteIndex.rebuild();
+  notesStore.refresh();
+
+  return { groups: mergedGroups, foldersRemoved, notesMoved };
+}
+
+// ── Detect + notify (the post-pull hook) ──────────────────────────
+
+/**
+ * Group keys already surfaced this session, so a periodic background pull does
+ * not re-pop the same unresolved folder duplicates. Reset after a merge.
+ */
+const notifiedFolderKeys = new Set<string>();
+
+/**
+ * Pending folder-consolidation prompt. `PeriodicFolderDuplicatesDialog` opens
+ * while this is non-null; null = no prompt. `folders` = extra folders to remove,
+ * `notes` = notes that will be moved.
+ */
+export const periodicFolderDuplicatePrompt = writable<{
+  folders: number;
+  notes: number;
+} | null>(null);
+
+/**
+ * Detect duplicate periodic folders and, if a new batch is found, post the
+ * consolidation prompt. Returns true when a prompt was posted, so the note-level
+ * scan can defer (folder consolidation colocates the notes first).
+ */
+export async function detectAndNotifyPeriodicFolderDuplicates(): Promise<boolean> {
+  const groups = await detectPeriodicFolderDuplicates();
+  if (groups.length === 0) return false;
+
+  const keys = groups.map((g) => `${g.kind}|${g.canonicalId}|${[...g.duplicateIds].sort().join(',')}`);
+  if (keys.every((k) => notifiedFolderKeys.has(k))) return false; // already surfaced this session
+  for (const k of keys) notifiedFolderKeys.add(k);
+
+  const folders = groups.reduce((sum, g) => sum + g.duplicateIds.length, 0);
+  const notes = groups.reduce((sum, g) => sum + g.notesToMove, 0);
+  periodicFolderDuplicatePrompt.set({ folders, notes });
+  return true;
+}
+
+/** Dismiss without consolidating; the batch returns next session if still present. */
+export function dismissPeriodicFolderDuplicatePrompt(): void {
+  periodicFolderDuplicatePrompt.set(null);
+}
+
+/**
+ * Confirm consolidation from the modal: move notes + remove empty shells, then
+ * merge the now-colocated same-period notes via the existing note dedup. Never
+ * throws - errors surface as a toast so the modal closes cleanly.
+ */
+export async function confirmMergePeriodicFolderDuplicates(): Promise<void> {
+  try {
+    const { foldersRemoved } = await mergePeriodicFolderDuplicates();
+    notifiedFolderKeys.clear();
+
+    // Same-period notes are now in one folder per kind; merge them (snapshots +
+    // Trash, reversible). Runs inline so the whole tidy-up is one confirmation.
+    const { mergeAllPeriodicDuplicates } = await import('./periodic-dedup.service');
+    await mergeAllPeriodicDuplicates();
+
+    if (foldersRemoved > 0) {
+      toastStore.success(tr('notes.periodic.folder_dedup.merge_success', { count: foldersRemoved }));
+    }
+  } catch (e) {
+    logger.error('Periodic folder duplicate merge failed', e);
+    toastStore.error(tr('notes.periodic.folder_dedup.merge_error'));
+  } finally {
+    periodicFolderDuplicatePrompt.set(null);
+  }
+}

--- a/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-notes-sync-race.regression.spec.ts
@@ -15,25 +15,35 @@ import { resolve } from 'path';
  *
  * The fix gates `getOrCreateNote` over TWO windows:
  *   1. A pull is in flight (`isSyncing`): wait for it to settle (the flag clears
- *      in the pull's `finally`, after the last page is upserted), then re-resolve.
+ *      in the pull's `finally`, after the last page is upserted), then resolve.
  *   2. Cold login, pre-pull window (`lastSyncedAt === null`, not local-only, no
  *      pull in flight yet but one imminent): the layout's runSync does a settings
  *      round-trip + push BEFORE pulling, so `isSyncing` is still false. Ensure a
  *      pull completes first via the single-flight `pullFromServer` (joins the
- *      imminent/in-flight pull, no extra round-trip), then re-resolve.
- * Only after both windows still miss do we create.
+ *      imminent/in-flight pull, no extra round-trip), then resolve.
  *
- * THIRD window (the one the first two fixes missed; smoke 2026-06-28): the
- * duplicate reproduced "directly after Synced", with isSyncing false AND
- * lastSyncedAt non-null - so neither gate window was open. Root cause was not in
- * the resolver at all but in `noteIndex.rebuild()`: it did `this._map.clear()`
- * before an async `build()` that yields between decrypt batches, leaving the
- * index observably EMPTY for the whole rebuild. `refreshStoresAfterPull` runs
- * that rebuild immediately after the pull flips lastSyncedAt -> "Synced", so a
- * periodic-note open in the gap saw zero notes and duplicated today's note. The
- * structural fix is in note-index.svelte.ts: rebuild() must delegate to build()
- * (which swaps a fresh Map in atomically) and never pre-clear. The two test
- * blocks below pin BOTH layers - the resolver gate and the atomic rebuild.
+ * THIRD window (smoke 2026-06-28): the duplicate reproduced "directly after
+ * Synced", with isSyncing false AND lastSyncedAt non-null - so neither gate
+ * window was open. Root cause was not in the resolver but in
+ * `noteIndex.rebuild()`: it did `this._map.clear()` before an async `build()`
+ * that yields between decrypt batches, leaving the index observably EMPTY for the
+ * whole rebuild. `refreshStoresAfterPull` runs that rebuild right after the pull
+ * flips lastSyncedAt -> "Synced", so a periodic-note open in the gap saw zero
+ * notes and duplicated today's note. The structural fix is in note-index.svelte.ts:
+ * rebuild() must delegate to build() (atomic Map swap) and never pre-clear.
+ *
+ * FOURTH window (smoke 2026-06-28, the real one): what was duplicating was not the
+ * NOTE but the FOLDER. `getOrCreateNote` ran `ensureFolder` BEFORE the gate, and
+ * `ensureFolder` resolves the periodic folder against the in-memory `foldersStore`
+ * - which a cold login leaves EMPTY (logout clears IndexedDB *and* settings; the
+ * pull writes folders to IndexedDB but does NOT refresh the in-memory foldersStore
+ * until refreshStoresAfterPull, AFTER the pull). So a click mid-pull saw no folder,
+ * minted a DUPLICATE one, persisted it as settings.folderId, and the note landed
+ * there - which also defeats post-sync note-dedup (it groups by folderId). The fix
+ * moves the gate to the TOP of getOrCreateNote (before ensureFolder) and refreshes
+ * foldersStore from the now-complete IndexedDB once the pull settles, so the folder
+ * is resolved against real data. The first test block below pins this ordering;
+ * the second pins the atomic rebuild.
  *
  * Source-level, like notes-sync.regression.spec.ts: periodic-notes.service pulls
  * in browser-only modules (cryptoManager, reactive stores) that are impractical
@@ -87,24 +97,46 @@ describe('periodic notes - resolver/sync race (PR #356 regression)', () => {
     expect(body).toMatch(/await\s+pullFromServer\(\)/);
   });
 
-  it('both windows re-resolve against the index AFTER settling and create only if still absent', () => {
+  it('gates BEFORE resolving the folder: ensureFolder runs after both settle windows', () => {
     const body = getOrCreateNoteBody();
-
-    const firstResolve = body.indexOf('findExistingPeriodicNote');
-    // The gate settles via either window before the second resolve.
     const inFlightWait = body.search(/await\s+whenFalsy\(\s*isSyncing\s*\)/);
     const coldWait = body.search(/await\s+pullFromServer\(\)/);
-    const createIdx = body.indexOf('createNote(');
-    // The re-resolve sits after BOTH window awaits (it's guarded by a `settled`
-    // flag set in either branch), and before create.
-    const lastWait = Math.max(inFlightWait, coldWait);
-    const secondResolve = body.indexOf('findExistingPeriodicNote', lastWait);
+    const ensureIdx = body.indexOf('ensureFolder(');
+    expect(inFlightWait).toBeGreaterThan(-1);
+    expect(coldWait).toBeGreaterThan(-1);
+    expect(ensureIdx).toBeGreaterThan(-1);
+    // ensureFolder() CREATES a folder when it can't find one, so it must not run
+    // until the pull has settled - otherwise it resolves against the empty
+    // pre-pull foldersStore and mints a duplicate periodic folder (the 2026-06-28
+    // bug). Both settle windows therefore precede it in source order.
+    expect(ensureIdx).toBeGreaterThan(inFlightWait);
+    expect(ensureIdx).toBeGreaterThan(coldWait);
+  });
 
-    expect(firstResolve).toBeGreaterThan(-1);
-    expect(inFlightWait).toBeGreaterThan(firstResolve);
-    expect(coldWait).toBeGreaterThan(firstResolve);
-    expect(secondResolve).toBeGreaterThan(lastWait);
-    expect(createIdx).toBeGreaterThan(secondResolve);
+  it('refreshes foldersStore after settling and before ensureFolder', () => {
+    const body = getOrCreateNoteBody();
+    const refreshIdx = body.search(/await\s+foldersStore\.refresh\(\)/);
+    const lastWait = Math.max(
+      body.search(/await\s+whenFalsy\(\s*isSyncing\s*\)/),
+      body.search(/await\s+pullFromServer\(\)/)
+    );
+    const ensureIdx = body.indexOf('ensureFolder(');
+    // The pull writes folders to IndexedDB but does NOT refresh the in-memory
+    // foldersStore; without this explicit refresh ensureFolder would still read
+    // the empty pre-pull snapshot. Refresh sits after the waits, before resolve.
+    expect(refreshIdx).toBeGreaterThan(lastWait);
+    expect(ensureIdx).toBeGreaterThan(refreshIdx);
+  });
+
+  it('resolves the note and creates only after the folder is resolved', () => {
+    const body = getOrCreateNoteBody();
+    // Match the CALLS (trailing paren) so the doc-comment mentions of these names
+    // don't register as earlier occurrences.
+    const ensureIdx = body.indexOf('ensureFolder(');
+    const resolveIdx = body.indexOf('findExistingPeriodicNote(');
+    const createIdx = body.indexOf('createNote(');
+    expect(resolveIdx).toBeGreaterThan(ensureIdx);
+    expect(createIdx).toBeGreaterThan(resolveIdx);
   });
 });
 

--- a/apps/reborn-notes/src/lib/services/periodic-notes.service.ts
+++ b/apps/reborn-notes/src/lib/services/periodic-notes.service.ts
@@ -310,6 +310,47 @@ export async function getOrCreateNote(
   const kindCfg = settings[kind];
   const format = kindCfg.format || PERIODIC_NOTES_DEFAULT_FORMATS[kind];
 
+  // Settle the initial-sync window BEFORE resolving the folder, then refresh the
+  // folder store. Both `ensureFolder` and `findExistingPeriodicNote` resolve
+  // against the in-memory `foldersStore` / `noteIndex`, and on a cold login those
+  // start EMPTY: logout clears IndexedDB *and* settings, the stores are rebuilt
+  // from the empty DB, and the paginated pull writes the server's folders/notes
+  // to IndexedDB WITHOUT refreshing the in-memory `foldersStore` until
+  // `refreshStoresAfterPull` runs AFTER the whole pull. Resolving mid-pull meant
+  // `ensureFolder` could not see the real periodic folder and CREATED A DUPLICATE
+  // one (persisted as settings.folderId) - then every periodic note for the
+  // session landed there, which ALSO hides the copies from post-sync note-dedup
+  // (it groups by folderId). The note-resolution gate added in PR #356/#358 sat
+  // AFTER `ensureFolder`, so it never protected the folder. Gate first.
+  //
+  // Two windows (the same ones the old note-level gate covered):
+  //   1. A pull is in flight (isSyncing): wait it out. The flag clears in the
+  //      pull's `finally`, after the last page is upserted into IndexedDB.
+  //   2. Cold login, pre-pull window (lastSyncedAt null, not local-only): the
+  //      layout's runSync does a synced-settings round-trip + pushPendingItems
+  //      BEFORE pullFromServer, so isSyncing is still false here. Join the
+  //      imminent single-flight pull so folders/notes are in IndexedDB first.
+  let settled = false;
+  if (get(isSyncing)) {
+    await whenFalsy(isSyncing);
+    settled = true;
+  } else if (!get(localOnly) && get(lastSyncedAt) === null) {
+    try {
+      const { pullFromServer } = await import('$lib/services/notes-sync.service');
+      await pullFromServer();
+    } catch {
+      // Offline / transient: fall through and resolve against what we have. The
+      // post-sync dedup scan reconciles a rare duplicate once connectivity returns.
+    }
+    settled = true;
+  }
+  // The pull has written to IndexedDB, but the in-memory foldersStore may still be
+  // the empty pre-pull snapshot (refreshStoresAfterPull races the isSyncing flip).
+  // Refresh it from IndexedDB so `ensureFolder` adopts the real folder instead of
+  // minting a duplicate. `noteIndex` is populated incrementally during the pull,
+  // so a refresh there is unnecessary for `findExistingPeriodicNote` below.
+  if (settled) await foldersStore.refresh();
+
   const folderId = await ensureFolder(kind);
 
   // One-time backfill of legacy notes in this folder. Runs at most once per
@@ -329,47 +370,6 @@ export async function getOrCreateNote(
 
   const existing = await findExistingPeriodicNote(folderId, kind, anchorIso);
   if (existing) return { noteId: existing, created: false };
-
-  // A miss in the in-memory index is not authoritative until the server's notes
-  // for this session are actually paged in. The index is built incrementally
-  // during the paginated pull, and the keyset order (updated_at ASC) puts today's
-  // freshly-touched periodic note on the LAST page - so a premature miss would
-  // duplicate a note that's about to arrive. Two windows to cover:
-  //
-  //   1. A pull is in flight (isSyncing): today's note may still be on an
-  //      un-paged page. isSyncing clears in the pull's `finally`, AFTER the last
-  //      page is upserted into the index, so waiting it out is sufficient.
-  //   2. Cold login, pre-pull window: the index was just (re)built from an empty
-  //      IndexedDB and no pull is in flight YET, but one is imminent - the
-  //      layout's runSync does a synced-settings round-trip + pushPendingItems
-  //      BEFORE it calls pullFromServer, and lastSyncedAt is still null. isSyncing
-  //      is false here, so window 1 misses it; we'd create a duplicate of the
-  //      note the pull is about to deliver. Ensure a pull completes first.
-  //      pullFromServer is single-flight, so this JOINS the imminent/in-flight
-  //      pull rather than adding a round-trip, and the index is populated
-  //      incrementally, so the re-resolve below sees today's note. lastSyncedAt
-  //      flips non-null after the first success, so steady-state opens skip this.
-  //
-  // Re-resolve after settling; create only if still absent. Post-sync dedup
-  // (detectAndNotifyPeriodicDuplicates) stays the backstop for any residue.
-  let settled = false;
-  if (get(isSyncing)) {
-    await whenFalsy(isSyncing);
-    settled = true;
-  } else if (!get(localOnly) && get(lastSyncedAt) === null) {
-    try {
-      const { pullFromServer } = await import('$lib/services/notes-sync.service');
-      await pullFromServer();
-    } catch {
-      // Offline / transient: fall through and create now; the post-sync dedup
-      // scan reconciles a rare duplicate once connectivity returns.
-    }
-    settled = true;
-  }
-  if (settled) {
-    const after = await findExistingPeriodicNote(folderId, kind, anchorIso);
-    if (after) return { noteId: after, created: false };
-  }
 
   const noteId = await createNote(title, '', folderId, {
     periodic: { kind, anchor: anchorIso }

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
   import LoadingScreen from '$lib/components/LoadingScreen.svelte';
   import InitialSyncBanner from '$lib/components/sync/InitialSyncBanner.svelte';
   import PeriodicDuplicatesDialog from '$lib/components/notes/PeriodicDuplicatesDialog.svelte';
+  import PeriodicFolderDuplicatesDialog from '$lib/components/notes/PeriodicFolderDuplicatesDialog.svelte';
   import LocalModeWelcome from '$lib/components/LocalModeWelcome.svelte';
   import UpdateRequiredGate from '$lib/components/layout/UpdateRequiredGate.svelte';
   import { checkNativeUpdateGate } from '$lib/utils/native-app-update';
@@ -570,6 +571,7 @@
     />
     <LocalModeWelcome />
     <PeriodicDuplicatesDialog />
+    <PeriodicFolderDuplicatesDialog />
     {#if __REBORN_NATIVE__}
       <UpdateRequiredGate />
     {/if}

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -286,6 +286,14 @@
         "got_it": "Verstanden"
       },
       "errors": { "failed": "Notiz konnte nicht geöffnet werden" },
+      "folder_dedup": {
+        "modal_title": "Doppelte Ordner aufräumen?",
+        "modal_description": "{count, plural, one {# doppelter periodischer Ordner gefunden.} other {# doppelte periodische Ordner gefunden.}} Beim Aufräumen werden alle Notizen in einen einzigen Ordner pro Typ verschoben, Notizen desselben Zeitraums zusammengeführt und die leeren Duplikate entfernt. Deine Notizen bleiben erhalten - es wird nichts gelöscht.",
+        "merge_action": "Aufräumen",
+        "dismiss_action": "Jetzt nicht",
+        "merge_success": "{count, plural, one {# doppelten Ordner entfernt.} other {# doppelte Ordner entfernt.}}",
+        "merge_error": "Die Ordner konnten nicht aufgeräumt werden. Bitte erneut versuchen."
+      },
       "dedup": {
         "modal_title": "Doppelte Notizen zusammenführen?",
         "modal_description": "{count, plural, one {# doppelte periodische Notiz gefunden.} other {# doppelte periodische Notizen gefunden.}} Beim Zusammenführen wird ihr Inhalt in das Original übernommen und die zusätzlichen Kopien werden in den Papierkorb verschoben, von wo Sie sie wiederherstellen können.",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -286,6 +286,14 @@
         "got_it": "Got it"
       },
       "errors": { "failed": "Failed to open the note" },
+      "folder_dedup": {
+        "modal_title": "Tidy up duplicate folders?",
+        "modal_description": "{count, plural, one {Found # duplicate periodic folder.} other {Found # duplicate periodic folders.}} Tidying up moves every note into a single folder per type, merges notes from the same period, and removes the empty duplicates. Your notes are kept - nothing is deleted.",
+        "merge_action": "Tidy up",
+        "dismiss_action": "Not now",
+        "merge_success": "{count, plural, one {Removed # duplicate folder.} other {Removed # duplicate folders.}}",
+        "merge_error": "Could not tidy up the folders. Please try again."
+      },
       "dedup": {
         "modal_title": "Merge duplicate notes?",
         "modal_description": "{count, plural, one {Found # duplicate periodic note.} other {Found # duplicate periodic notes.}} Merging combines their content into the original and moves the extra copies to Trash, where you can restore them.",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -286,6 +286,14 @@
         "got_it": "Entendido"
       },
       "errors": { "failed": "No se pudo abrir la nota" },
+      "folder_dedup": {
+        "modal_title": "¿Ordenar las carpetas duplicadas?",
+        "modal_description": "{count, plural, one {Se encontró # carpeta periódica duplicada.} other {Se encontraron # carpetas periódicas duplicadas.}} Ordenar mueve todas las notas a una sola carpeta por tipo, combina las notas del mismo periodo y elimina los duplicados vacíos. Tus notas se conservan: no se elimina nada.",
+        "merge_action": "Ordenar",
+        "dismiss_action": "Ahora no",
+        "merge_success": "{count, plural, one {Se eliminó # carpeta duplicada.} other {Se eliminaron # carpetas duplicadas.}}",
+        "merge_error": "No se pudieron ordenar las carpetas. Inténtalo de nuevo."
+      },
       "dedup": {
         "modal_title": "¿Combinar notas duplicadas?",
         "modal_description": "{count, plural, one {Se encontró # nota periódica duplicada.} other {Se encontraron # notas periódicas duplicadas.}} Al combinar, su contenido se añade al original y las copias adicionales se mueven a la papelera, desde donde puedes restaurarlas.",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -286,6 +286,14 @@
         "got_it": "Compris"
       },
       "errors": { "failed": "Impossible d'ouvrir la note" },
+      "folder_dedup": {
+        "modal_title": "Ranger les dossiers en double ?",
+        "modal_description": "{count, plural, one {# dossier périodique en double trouvé.} other {# dossiers périodiques en double trouvés.}} Le rangement déplace toutes les notes dans un seul dossier par type, fusionne les notes de la même période et supprime les doublons vides. Vos notes sont conservées - rien n'est supprimé.",
+        "merge_action": "Ranger",
+        "dismiss_action": "Plus tard",
+        "merge_success": "{count, plural, one {# dossier en double supprimé.} other {# dossiers en double supprimés.}}",
+        "merge_error": "Impossible de ranger les dossiers. Veuillez réessayer."
+      },
       "dedup": {
         "modal_title": "Fusionner les notes en double ?",
         "modal_description": "{count, plural, one {# note périodique en double trouvée.} other {# notes périodiques en double trouvées.}} La fusion ajoute leur contenu à la note originale et déplace les copies supplémentaires vers la corbeille, où vous pouvez les restaurer.",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -286,6 +286,14 @@
         "got_it": "Rozumiem"
       },
       "errors": { "failed": "Nie udało się otworzyć notatki" },
+      "folder_dedup": {
+        "modal_title": "Uporządkować zduplikowane foldery?",
+        "modal_description": "{count, plural, one {Znaleziono # zduplikowany folder okresowy.} few {Znaleziono # zduplikowane foldery okresowe.} many {Znaleziono # zduplikowanych folderów okresowych.} other {Znaleziono # zduplikowanych folderów okresowych.}} Porządkowanie przeniesie wszystkie notatki do jednego folderu danego typu, scali notatki z tego samego okresu i usunie puste duplikaty. Twoje notatki zostają - nic nie jest usuwane.",
+        "merge_action": "Uporządkuj",
+        "dismiss_action": "Nie teraz",
+        "merge_success": "{count, plural, one {Usunięto # zduplikowany folder.} few {Usunięto # zduplikowane foldery.} many {Usunięto # zduplikowanych folderów.} other {Usunięto # zduplikowanych folderów.}}",
+        "merge_error": "Nie udało się uporządkować folderów. Spróbuj ponownie."
+      },
       "dedup": {
         "modal_title": "Scalić zduplikowane notatki?",
         "modal_description": "{count, plural, one {Znaleziono # zduplikowaną notatkę okresową.} few {Znaleziono # zduplikowane notatki okresowe.} many {Znaleziono # zduplikowanych notatek okresowych.} other {Znaleziono # zduplikowanych notatek okresowych.}} Scalanie połączy ich treść z oryginałem i przeniesie nadmiarowe kopie do Kosza, skąd możesz je przywrócić.",


### PR DESCRIPTION
## Summary

Follow-up to today's periodic-note sync-race fixes (#356/#358 windows + atomic rebuild). The duplicate *kept reproducing* in the browser: a cold login + opening the daily note mid-sync produced an empty note, lost the edit, showed no merge modal - and the account had accumulated ~13 "Daily Notes" folders.

**Root cause: the FOLDER duplicated, not the note.** `getOrCreateNote` ran `ensureFolder` *before* the sync gate, and `ensureFolder` resolves the periodic folder against the in-memory `foldersStore`, which a cold login leaves empty (logout clears IndexedDB *and* settings; the pull writes folders to IndexedDB but only refreshes the in-memory store in `refreshStoresAfterPull`, after the pull). A click mid-pull couldn't see the real folder, minted a fresh one, persisted it as `settings.<kind>.folderId`, and the note landed there. One cause, all three symptoms: the duplicate, the missing merge modal (note-dedup groups by `folderId`), and the "lost" note (buried in a duplicate folder, or lost to a push/orphan-delete race at logout).

**Fix (commit 1):** move the two settle windows (in-flight `isSyncing` / cold pre-pull `pullFromServer`) to the top of `getOrCreateNote`, before `ensureFolder`, and `foldersStore.refresh()` once settled so the folder resolves against real data. The note resolves once afterwards; steady-state opens still don't block.

**Consolidation (commit 2):** a productized folder-dedup that detects duplicate periodic folders and, on a confirmation modal, moves every note into one folder per kind, re-points settings, removes the empty duplicates, and merges the now-colocated same-period notes inline.

### Decisions (for review)
- **In-app folder dedup** (not a one-off script) - chosen so early users who hit the bug are helped too; reversible.
- **Cheap "repeated root name" gate** before any decryption - keeps the per-pull cost at zero crypto for normal accounts. Differently-named same-kind folders across locales are intentionally NOT auto-merged (may be deliberate).
- **Empty-shell match by name** (not only by stamp) so shells whose note was lost still get cleaned; safe because a group needs >=1 *confirmed* member (stamp/settings) and shells are empty. Empty folder shells are hard-deleted (folders have no Trash) - no data inside.
- **One confirmation** does folder-merge + same-day note-merge inline (the modal discloses the whole operation).

No schema/server changes; folder moves + deletes and the note merge use existing endpoints. Zero Knowledge model untouched.

## Test plan
Local gate green: vitest 1048, svelte-check 0 errors in changed files (pre-existing `PUBLIC_SITE_URL` env-quirk only), eslint clean, i18n parity OK, single-file svelte compile OK.

Smoke:
1. Cold login, open the daily note *while* "Syncing" shows -> opens the existing today note with its content (no new empty note, no new "Daily Notes" folder).
2. Account with duplicate "Daily Notes" folders: after sync, the "Tidy up duplicate folders?" modal appears -> Tidy up -> one folder remains, all notes moved in, same-day copies merged, empty duplicates gone; nothing lost.
3. Steady state (synced): clicking daily/weekly/monthly is instant.
4. i18n: modal copy in PL/EN (+ DE/FR/ES if possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)