### PR TITLE
fix(notes): restore action menu for notes opened outside list filter

### DIFF
--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -244,6 +244,31 @@ class NoteIndex {
     return this._map.get(id);
   }
 
+  /**
+   * Resolve a single entry to a NoteListItem by id. Reactive. Null when absent.
+   *
+   * Unlike the filtered list in notes.store (which only holds rows matching the
+   * active search/folder/tag filter), this spans the WHOLE index - so a note
+   * opened via a [[link]] or the Back/Forward trail, which can land outside the
+   * current sidebar filter, still resolves its list metadata.
+   */
+  getItem(id: string): NoteListItem | null {
+    void this._version;
+    const e = this._map.get(id);
+    if (!e) return null;
+    return {
+      id,
+      title: e.title,
+      folder_id: e.folderId,
+      is_pinned: e.isPinned,
+      is_starred: e.isStarred,
+      is_archived: e.isArchived,
+      created_at: e.createdAt,
+      updated_at: e.updatedAt,
+      tags: e.tagIds
+    };
+  }
+
   /** Instant substring search across titles (sync). Reactive. */
   search(query: string): { id: string; title: string }[] {
     void this._version;

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -152,9 +152,16 @@
   let detailMovingNoteId = $state<string | null>(null);
   let detailDeleteDialogOpen = $state(false);
 
-  const detailMenuNote = $derived(
-    $activeNoteId ? ($notesStore.find((n) => n.id === $activeNoteId) ?? null) : null
-  );
+  // Prefer the filtered sidebar row (same live data, already in scope), but fall
+  // back to the full index: a note opened via a [[link]] or the Back/Forward
+  // trail lands outside the active search/folder filter and is absent from
+  // $notesStore. Without this fallback its kebab action menu and created/updated
+  // metadata silently vanish (detailMenuNote → null).
+  const detailMenuNote = $derived.by((): NoteListItem | null => {
+    const id = $activeNoteId;
+    if (!id) return null;
+    return $notesStore.find((n) => n.id === id) ?? noteIndex.getItem(id);
+  });
 
   // Tag the open note with its periodic kind (if any) so the editor can swap
   // its placeholder for kind-aware copy ("Zacznij pisać dzisiejszą notatkę…").


### PR DESCRIPTION
## Summary

Some notes lost their hamburger / kebab "..." action menu in the detail view (both desktop and mobile), and the note's created/updated dates disappeared too. The trigger was the **navigation path**: the same note showed its menu when opened from search, but not when opened via a related/`[[link]]` or the Back/Forward trail.

**Root cause.** `detailMenuNote` (the open note resolved for the header menu + metadata) was looked up only in `$notesStore` - the *filtered* sidebar list (active search query + folder/tag/starred/trash). `handleNoteLink` / `navigateNavHistory` set `activeNoteId` and load the body, but never add the note to that filtered list. When the opened note fell outside the active filter (e.g. a leftover search term in the box), `$notesStore.find()` returned `undefined` → `detailMenuNote` became `null`, and everything bound to it vanished:

- the kebab `...` action menu (`NoteDetailActions` renders `{#if note}`),
- the created/updated metadata dates,
- and (latent) the periodic-kind editor placeholder + the export/copy-link fallback targets.

**Fix.** Resolve `detailMenuNote` from the full in-memory `noteIndex` as a fallback when the note is absent from the filtered list. The index spans every note regardless of filter and is already reactive (its `_version` `$state` bumps on every pin/star/move/rename/delete), so the menu's labels stay live even for a link-opened note. The filtered list remains the fast path, so behaviour is byte-identical for notes already in view. Added a small `noteIndex.getItem(id)` helper that maps an index entry to a `NoteListItem` (the entry→item mapping already appeared 3× inline in that file).

Touches client UI data resolution only - no schema, crypto, server-visibility, dependency, or API-contract change.

## Test plan

- [ ] Open note A, insert a `[[link]]` to note B that lives in a different folder. Type a search term in the sidebar that excludes B, then click the link from A's preview. **B's `...` kebab menu and its Utworzono/Edytowano dates should now be present** (previously gone).
- [ ] Repeat on a narrow/mobile viewport - the mobile `...` button should appear and open the action sheet.
- [ ] Use the desktop Back/Forward (`‹ ›`) trail chevrons to walk between notes that don't match the current filter - the kebab stays visible the whole way.
- [ ] Open a note that IS in the current filtered list (via the sidebar) - menu + dates unchanged (regression guard).
- [ ] From a link-opened, out-of-filter note: Pin/Unpin and Star/Unstar from the kebab - the menu labels flip live, and Move-to-folder works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)