### PR TITLE
feat(notes): add Behavior settings page (open mode, delete confirm)

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -29,6 +29,7 @@
   import { tagsStore } from '$lib/stores/tags.store';
   import { SidebarTrigger } from '@reborn/ui/sidebar';
   import { t } from '$lib/stores/i18n.store';
+  import { confirmBeforeDelete } from '$lib/stores/app-settings.store';
   import { sessionExpired, isInitialSync, syncProgress } from '$lib/stores/sync-status.store';
   import { requireActiveSession } from '$lib/utils/require-active-session';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
@@ -297,6 +298,11 @@
     menuOpenId = null;
     noteActionSheetOpen = false;
     noteToDelete = id;
+    // When confirmation is disabled (#350), delete straight to Trash (recoverable).
+    if (!$confirmBeforeDelete) {
+      confirmDelete();
+      return;
+    }
     deleteDialogOpen = true;
   }
 

--- a/apps/reborn-notes/src/lib/stores/app-settings.store.ts
+++ b/apps/reborn-notes/src/lib/stores/app-settings.store.ts
@@ -228,6 +228,16 @@ export const editorModeIntroSeen = derived(
 );
 
 /**
+ * When true (default), deleting a single note shows a confirmation dialog.
+ * When false, single-note deletes go straight to Trash. Synced across devices.
+ * Falls back to `true` for settings rows written before this field existed.
+ */
+export const confirmBeforeDelete = derived(
+  appSettings,
+  ($settings) => $settings?.confirmBeforeDelete ?? true
+);
+
+/**
  * Per-kind Periodic Notes settings (Daily / Weekly / Monthly).
  * Falls back to defaults when settings haven't loaded yet so consumers can
  * render eagerly without null checks; missing kinds (e.g. legacy settings

--- a/apps/reborn-notes/src/lib/stores/device-prefs.store.ts
+++ b/apps/reborn-notes/src/lib/stores/device-prefs.store.ts
@@ -1,0 +1,81 @@
+import { writable, derived } from 'svelte/store';
+import { browser } from '$app/environment';
+import { createLogger } from '@reborn/utils';
+
+const logger = createLogger('device-prefs');
+
+/**
+ * Per-device UI preferences.
+ *
+ * Unlike `appSettings` (E2E-synced across all of a user's devices), these live
+ * ONLY in this device's localStorage and never sync. They capture how *this*
+ * device should behave - e.g. a desktop where you mostly edit vs a phone where
+ * you mostly read. There is no user content here (just a view-mode enum), so
+ * plain localStorage is fine and outside the Zero-Knowledge sync surface.
+ */
+export type NoteOpenMode = 'preview' | 'edit' | 'split';
+
+export interface DevicePrefs {
+  /**
+   * View mode an EXISTING note opens in when selected. Newly created notes
+   * always open in 'edit' regardless (you just made it to write in it).
+   */
+  noteOpenMode: NoteOpenMode;
+}
+
+const STORAGE_KEY = 'reborn-notes-device-prefs';
+
+const DEFAULTS: DevicePrefs = {
+  noteOpenMode: 'preview'
+};
+
+const NOTE_OPEN_MODES: readonly NoteOpenMode[] = ['preview', 'edit', 'split'];
+
+function load(): DevicePrefs {
+  if (!browser) return { ...DEFAULTS };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULTS };
+    const parsed = JSON.parse(raw) as Partial<DevicePrefs>;
+    return {
+      noteOpenMode: NOTE_OPEN_MODES.includes(parsed.noteOpenMode as NoteOpenMode)
+        ? (parsed.noteOpenMode as NoteOpenMode)
+        : DEFAULTS.noteOpenMode
+    };
+  } catch (err) {
+    logger.warn('Failed to read device prefs, using defaults', err);
+    return { ...DEFAULTS };
+  }
+}
+
+function persist(prefs: DevicePrefs): void {
+  if (!browser) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch (err) {
+    // Quota / private mode - keep the in-memory value, just skip persistence.
+    logger.warn('Failed to persist device prefs', err);
+  }
+}
+
+function createDevicePrefsStore() {
+  const store = writable<DevicePrefs>(load());
+
+  function setNoteOpenMode(mode: NoteOpenMode): void {
+    store.update((prev) => {
+      const next = { ...prev, noteOpenMode: mode };
+      persist(next);
+      return next;
+    });
+  }
+
+  return {
+    subscribe: store.subscribe,
+    setNoteOpenMode
+  };
+}
+
+export const devicePrefs = createDevicePrefsStore();
+
+/** The view mode an existing note opens in on this device. */
+export const noteOpenMode = derived(devicePrefs, ($p) => $p.noteOpenMode);

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy, tick, untrack } from 'svelte';
+  import { get } from 'svelte/store';
   import { beforeNavigate } from '$app/navigation';
   import { base } from '$app/paths';
   import { copyText } from '$lib/utils/clipboard';
@@ -69,8 +70,10 @@
     imageLoadMode,
     editorMode,
     editorModeIntroSeen,
-    periodicNotesSettings
+    periodicNotesSettings,
+    confirmBeforeDelete
   } from '$lib/stores/app-settings.store';
+  import { noteOpenMode } from '$lib/stores/device-prefs.store';
   import EditorModeIntroDialog from '$lib/components/editor/EditorModeIntroDialog.svelte';
   import PeriodicNoteOnboardingDialog from '$lib/components/editor/PeriodicNoteOnboardingDialog.svelte';
   import type { EditorMode } from '@reborn/storage';
@@ -295,6 +298,11 @@
 
   function handleDetailDelete() {
     detailActionSheetOpen = false;
+    // When confirmation is disabled (#350), delete straight to Trash (recoverable).
+    if (!$confirmBeforeDelete) {
+      confirmDetailDelete();
+      return;
+    }
     detailDeleteDialogOpen = true;
   }
 
@@ -687,7 +695,11 @@
     if (untrack(() => noteDetailService.isNewNote)) {
       viewMode = 'edit';
     } else {
-      viewMode = 'preview';
+      // Existing note: open in the per-device default view mode (#351). Read
+      // untracked via get() so changing the preference later doesn't re-run
+      // this effect for the already-open note. effectiveViewMode clamps 'split'
+      // to 'edit' on mobile, so 'split' is safe to set here.
+      viewMode = get(noteOpenMode);
     }
     untrack(() => noteDetailService.loadNote(id));
   });

--- a/apps/reborn-notes/src/routes/settings/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/+page.svelte
@@ -27,7 +27,8 @@
     HardDrive,
     ShieldAlert,
     CalendarDays,
-    Sparkles
+    Sparkles,
+    SlidersHorizontal
   } from '@lucide/svelte';
   import { goto } from '$lib/utils/navigation';
   import {
@@ -276,6 +277,16 @@
               <div class="font-medium">{$t('settings_page.appearance.title')}</div>
               <div class="text-sm text-muted-foreground">
                 {$t('settings_page.appearance.hub_desc')}
+              </div>
+            </div>
+            <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />
+          </a>
+          <a href={resolve('/settings/behavior')} class={itemClasses}>
+            <SlidersHorizontal class="h-5 w-5 text-muted-foreground shrink-0" />
+            <div class="flex-1 min-w-0">
+              <div class="font-medium">{$t('settings_page.behavior.title')}</div>
+              <div class="text-sm text-muted-foreground">
+                {$t('settings_page.behavior.hub_desc')}
               </div>
             </div>
             <ChevronRight class="h-5 w-5 text-muted-foreground shrink-0" />

--- a/apps/reborn-notes/src/routes/settings/behavior/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/behavior/+page.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    SettingsLayout,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    CardDescription,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    Switch,
+    toast
+  } from '@reborn/ui';
+  import { Eye, Trash2 } from '@lucide/svelte';
+  import {
+    appSettings,
+    confirmBeforeDelete as confirmBeforeDeleteStore
+  } from '$lib/stores/app-settings.store';
+  import {
+    devicePrefs,
+    noteOpenMode as noteOpenModeStore,
+    type NoteOpenMode
+  } from '$lib/stores/device-prefs.store';
+  import { t } from '$lib/stores/i18n.store';
+  import { createLogger } from '@reborn/utils';
+  import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
+
+  const logger = createLogger('behavior-settings');
+  const isMobile = useIsMobile();
+
+  let openModeValue = $state<NoteOpenMode>('preview');
+  let confirmDeleteValue = $state(true);
+
+  // Split is a desktop layout (editor + preview side by side). On phones the app
+  // collapses it to plain edit, so don't offer it as a choice on this device.
+  const openModeOptions = $derived<readonly NoteOpenMode[]>(
+    isMobile.value ? ['preview', 'edit'] : ['preview', 'edit', 'split']
+  );
+
+  function openModeLabel(mode: NoteOpenMode): string {
+    return mode === 'edit'
+      ? $t('settings_page.behavior.open_mode_edit')
+      : mode === 'split'
+        ? $t('settings_page.behavior.open_mode_split')
+        : $t('settings_page.behavior.open_mode_preview');
+  }
+
+  function updateOpenMode(value: string | undefined) {
+    if (value !== 'preview' && value !== 'edit' && value !== 'split') return;
+    devicePrefs.setNoteOpenMode(value);
+    openModeValue = value;
+    toast.success($t('settings_page.behavior.open_mode_updated'));
+  }
+
+  async function updateConfirmDelete(value: boolean) {
+    try {
+      await appSettings.update('confirmBeforeDelete', value);
+      confirmDeleteValue = value;
+      toast.success($t('settings_page.behavior.confirm_delete_updated'));
+    } catch (err: unknown) {
+      logger.error('Failed to update delete confirmation', err);
+    }
+  }
+
+  onMount(() => {
+    const unsubscribes = [
+      noteOpenModeStore.subscribe((v) => (openModeValue = v)),
+      confirmBeforeDeleteStore.subscribe((v) => (confirmDeleteValue = v))
+    ];
+    return () => unsubscribes.forEach((fn) => fn());
+  });
+</script>
+
+<svelte:head>
+  <title>{$t('settings_page.behavior.title')} — re/notes</title>
+</svelte:head>
+
+<SettingsLayout title={$t('settings_page.behavior.title')} backHref="/settings">
+  <div class="space-y-6 px-4 sm:px-0">
+    <!-- Default open mode (per-device, localStorage - not synced) -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-base flex items-center gap-2">
+          <Eye class="h-4 w-4 text-muted-foreground" />
+          {$t('settings_page.behavior.open_mode')}
+        </CardTitle>
+        <CardDescription>{$t('settings_page.behavior.open_mode_desc')}</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-3">
+        <Select type="single" value={openModeValue} onValueChange={(value) => updateOpenMode(value)}>
+          <SelectTrigger class="w-full">
+            {openModeLabel(openModeValue)}
+          </SelectTrigger>
+          <SelectContent>
+            {#each openModeOptions as mode (mode)}
+              <SelectItem value={mode}>{openModeLabel(mode)}</SelectItem>
+            {/each}
+          </SelectContent>
+        </Select>
+        <p class="text-xs text-muted-foreground">
+          {$t('settings_page.behavior.open_mode_device_hint')}
+        </p>
+      </CardContent>
+    </Card>
+
+    <!-- Confirm before deleting (synced across devices) -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-base flex items-center gap-2">
+          <Trash2 class="h-4 w-4 text-muted-foreground" />
+          {$t('settings_page.behavior.confirm_delete')}
+        </CardTitle>
+        <CardDescription>{$t('settings_page.behavior.confirm_delete_desc')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div class="flex items-center justify-between gap-4">
+          <span class="text-sm text-muted-foreground">
+            {confirmDeleteValue
+              ? $t('settings_page.behavior.confirm_delete_on')
+              : $t('settings_page.behavior.confirm_delete_off')}
+          </span>
+          <Switch
+            checked={confirmDeleteValue}
+            onCheckedChange={(v: boolean) => updateConfirmDelete(v)}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+</SettingsLayout>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -805,6 +805,22 @@
       "create": "Konto erstellen",
       "create_desc": "Behalte deine Notizen und synchronisiere geräteübergreifend. Deine vorhandenen Notizen bleiben erhalten."
     },
+    "behavior": {
+      "title": "Verhalten",
+      "hub_desc": "Wie Notizen geöffnet werden, Löschbestätigung",
+      "open_mode": "Notizen öffnen in",
+      "open_mode_desc": "Ansicht, in der eine vorhandene Notiz beim Auswählen geöffnet wird. Neue Notizen öffnen sich immer bearbeitungsbereit.",
+      "open_mode_preview": "Vorschau (schreibgeschützt)",
+      "open_mode_edit": "Bearbeiten",
+      "open_mode_split": "Geteilt (Bearbeiten und Vorschau)",
+      "open_mode_device_hint": "Gilt nur für dieses Gerät",
+      "open_mode_updated": "Standard-Öffnungsmodus aktualisiert",
+      "confirm_delete": "Vor dem Löschen bestätigen",
+      "confirm_delete_desc": "Vor dem Verschieben einer Notiz in den Papierkorb nachfragen. Notizen im Papierkorb können wiederhergestellt werden, werden aber nach 30 Tagen endgültig gelöscht.",
+      "confirm_delete_on": "Bestätigung ein",
+      "confirm_delete_off": "Bestätigung aus",
+      "confirm_delete_updated": "Löschbestätigung aktualisiert"
+    },
     "appearance": {
       "title": "Erscheinungsbild",
       "hub_desc": "App-Thema, Sprache der Benutzeroberfläche, Datums- und Zeitformat",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -805,6 +805,22 @@
       "create": "Create an account",
       "create_desc": "Keep your notes and sync across devices. Your existing notes are kept."
     },
+    "behavior": {
+      "title": "Behavior",
+      "hub_desc": "How notes open, delete confirmation",
+      "open_mode": "Open notes in",
+      "open_mode_desc": "Which view an existing note opens in when you select it. New notes always open ready to edit.",
+      "open_mode_preview": "Preview (read-only)",
+      "open_mode_edit": "Edit",
+      "open_mode_split": "Split (edit and preview)",
+      "open_mode_device_hint": "Applies to this device only",
+      "open_mode_updated": "Default open mode updated",
+      "confirm_delete": "Confirm before deleting",
+      "confirm_delete_desc": "Ask before moving a note to Trash. Notes in Trash can be restored, but are permanently deleted after 30 days.",
+      "confirm_delete_on": "Confirmation on",
+      "confirm_delete_off": "Confirmation off",
+      "confirm_delete_updated": "Delete confirmation updated"
+    },
     "appearance": {
       "title": "Appearance",
       "hub_desc": "App theme, interface language, date and time format",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -805,6 +805,22 @@
       "create": "Crear una cuenta",
       "create_desc": "Conserva tus notas y sincroniza entre dispositivos. Tus notas actuales se conservan."
     },
+    "behavior": {
+      "title": "Comportamiento",
+      "hub_desc": "Cómo se abren las notas, confirmación de eliminación",
+      "open_mode": "Abrir las notas en",
+      "open_mode_desc": "Vista en la que se abre una nota existente al seleccionarla. Las notas nuevas siempre se abren listas para editar.",
+      "open_mode_preview": "Vista previa (solo lectura)",
+      "open_mode_edit": "Edición",
+      "open_mode_split": "Dividido (edición y vista previa)",
+      "open_mode_device_hint": "Se aplica solo a este dispositivo",
+      "open_mode_updated": "Modo de apertura predeterminado actualizado",
+      "confirm_delete": "Confirmar antes de eliminar",
+      "confirm_delete_desc": "Preguntar antes de mover una nota a la Papelera. Las notas en la Papelera se pueden restaurar, pero se eliminan definitivamente después de 30 días.",
+      "confirm_delete_on": "Confirmación activada",
+      "confirm_delete_off": "Confirmación desactivada",
+      "confirm_delete_updated": "Confirmación de eliminación actualizada"
+    },
     "appearance": {
       "title": "Apariencia",
       "hub_desc": "Tema de la aplicación, idioma de la interfaz, formato de fecha y hora",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -805,6 +805,22 @@
       "create": "Créer un compte",
       "create_desc": "Conservez vos notes et synchronisez entre appareils. Vos notes actuelles sont conservées."
     },
+    "behavior": {
+      "title": "Comportement",
+      "hub_desc": "Mode d'ouverture des notes, confirmation de suppression",
+      "open_mode": "Ouvrir les notes en",
+      "open_mode_desc": "Vue dans laquelle une note existante s'ouvre lorsque vous la sélectionnez. Les nouvelles notes s'ouvrent toujours prêtes à être modifiées.",
+      "open_mode_preview": "Aperçu (lecture seule)",
+      "open_mode_edit": "Édition",
+      "open_mode_split": "Partagé (édition et aperçu)",
+      "open_mode_device_hint": "S'applique uniquement à cet appareil",
+      "open_mode_updated": "Mode d'ouverture par défaut mis à jour",
+      "confirm_delete": "Confirmer avant de supprimer",
+      "confirm_delete_desc": "Demander avant de déplacer une note vers la Corbeille. Les notes dans la Corbeille peuvent être restaurées, mais sont définitivement supprimées après 30 jours.",
+      "confirm_delete_on": "Confirmation activée",
+      "confirm_delete_off": "Confirmation désactivée",
+      "confirm_delete_updated": "Confirmation de suppression mise à jour"
+    },
     "appearance": {
       "title": "Apparence",
       "hub_desc": "Thème de l'application, langue de l'interface, format de date et d'heure",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -805,6 +805,22 @@
       "create": "Załóż konto",
       "create_desc": "Zachowaj notatki i synchronizuj między urządzeniami. Twoje obecne notatki zostaną zachowane."
     },
+    "behavior": {
+      "title": "Zachowanie",
+      "hub_desc": "Sposób otwierania notatek, potwierdzanie usuwania",
+      "open_mode": "Otwieraj notatki w trybie",
+      "open_mode_desc": "Widok, w którym otwiera się istniejąca notatka po jej wybraniu. Nowe notatki zawsze otwierają się gotowe do edycji.",
+      "open_mode_preview": "Podgląd (tylko do odczytu)",
+      "open_mode_edit": "Edycja",
+      "open_mode_split": "Podział (edycja i podgląd)",
+      "open_mode_device_hint": "Dotyczy tylko tego urządzenia",
+      "open_mode_updated": "Zaktualizowano domyślny tryb otwierania",
+      "confirm_delete": "Potwierdzaj przed usunięciem",
+      "confirm_delete_desc": "Pytaj przed przeniesieniem notatki do Kosza. Notatki w Koszu można przywrócić, ale po 30 dniach są trwale usuwane.",
+      "confirm_delete_on": "Potwierdzanie włączone",
+      "confirm_delete_off": "Potwierdzanie wyłączone",
+      "confirm_delete_updated": "Zaktualizowano potwierdzanie usuwania"
+    },
     "appearance": {
       "title": "Wygląd",
       "hub_desc": "Motyw aplikacji, język interfejsu, format daty i czasu",

--- a/packages/storage/src/__tests__/settings-bundle.spec.ts
+++ b/packages/storage/src/__tests__/settings-bundle.spec.ts
@@ -33,6 +33,7 @@ const NOTES_FIXTURE: AppSettings = {
   imageLoadMode: 'always',
   editorMode: 'live',
   editorModeIntroSeen: true,
+  confirmBeforeDelete: false,
   periodicNotes: PERIODIC_FIXTURE,
   created_at: '2026-05-01T00:00:00.000Z',
   updated_at: '2026-05-09T10:00:00.000Z'
@@ -71,6 +72,7 @@ describe('settings-bundle: extract', () => {
     expect(app.notifications_enabled).toBe(true);
     expect(app.editorMode).toBe('live');
     expect(app.editorModeIntroSeen).toBe(true);
+    expect(app.confirmBeforeDelete).toBe(false);
     expect(app.periodicNotes).toEqual(PERIODIC_FIXTURE);
   });
 
@@ -109,6 +111,7 @@ describe('settings-bundle: applyBundlesToSettings', () => {
       theme: 'light',
       editorMode: 'markdown',
       editorModeIntroSeen: false,
+      confirmBeforeDelete: true,
       periodicNotes: {
         daily: { ...PERIODIC_FIXTURE.daily, enabled: false },
         weekly: PERIODIC_FIXTURE.weekly,
@@ -118,6 +121,7 @@ describe('settings-bundle: applyBundlesToSettings', () => {
     expect(merged.theme).toBe('light');
     expect(merged.editorMode).toBe('markdown');
     expect(merged.editorModeIntroSeen).toBe(false);
+    expect(merged.confirmBeforeDelete).toBe(true);
     expect(merged.periodicNotes?.daily.enabled).toBe(false);
     expect(merged.language).toBe('pl');
   });
@@ -178,10 +182,12 @@ describe('settings-bundle: migrate (decrypt → unknown JSON → typed bundle)',
       schema_version: 1,
       theme: 'dark',
       editorModeIntroSeen: true,
+      confirmBeforeDelete: true,
       periodicNotes: PERIODIC_FIXTURE
     });
     expect(out.theme).toBe('dark');
     expect(out.editorModeIntroSeen).toBe(true);
+    expect(out.confirmBeforeDelete).toBe(true);
     expect(out.periodicNotes).toEqual(PERIODIC_FIXTURE);
   });
 

--- a/packages/storage/src/services/synced-settings.service.ts
+++ b/packages/storage/src/services/synced-settings.service.ts
@@ -187,6 +187,7 @@ export class SyncedSettingsService {
         imageLoadMode: 'ask',
         editorMode: 'live',
         editorModeIntroSeen: false,
+        confirmBeforeDelete: true,
         created_at: new Date(serverUpdated).toISOString(),
         updated_at: new Date(serverUpdated).toISOString()
       };

--- a/packages/storage/src/stores/settings.store.ts
+++ b/packages/storage/src/stores/settings.store.ts
@@ -72,6 +72,14 @@ export interface AppSettings {
   editorMode: EditorMode;
   editorModeIntroSeen: boolean;
   /**
+   * When true, deleting a single note shows a confirmation dialog before moving
+   * it to Trash. When false, single-note deletes go straight to Trash (which is
+   * recoverable - notes are soft-deleted, never auto-purged). Default true.
+   * Synced across devices: it's a caution preference, not a device trait. Bulk
+   * deletes always confirm regardless of this flag.
+   */
+  confirmBeforeDelete: boolean;
+  /**
    * Notes-only: per-kind settings for Daily / Weekly / Monthly Notes (Obsidian-style).
    * Local & device-specific - not synced. Optional in the type so reborn-task settings
    * don't carry the field. Defaults are written by `initializeDefaults` for the notes app.
@@ -188,6 +196,7 @@ export const settingsOperations = {
           imageLoadMode: 'ask',
           editorMode: 'live',
           editorModeIntroSeen: false,
+          confirmBeforeDelete: true,
           ...(appName === 'reborn-notes'
             ? { periodicNotes: structuredClone(PERIODIC_NOTES_DEFAULTS) }
             : {}),

--- a/packages/storage/src/utils/settings-bundle.ts
+++ b/packages/storage/src/utils/settings-bundle.ts
@@ -57,6 +57,7 @@ export interface AppSettingsBundle {
   imageLoadMode?: AppSettings['imageLoadMode'];
   editorMode?: AppSettings['editorMode'];
   editorModeIntroSeen?: AppSettings['editorModeIntroSeen'];
+  confirmBeforeDelete?: AppSettings['confirmBeforeDelete'];
   periodicNotes?: AppSettings['periodicNotes'];
 }
 
@@ -84,7 +85,8 @@ export function extractAppBundle(s: AppSettings): AppSettingsBundle {
     sync_interval_minutes: s.sync_interval_minutes,
     imageLoadMode: s.imageLoadMode,
     editorMode: s.editorMode,
-    editorModeIntroSeen: s.editorModeIntroSeen
+    editorModeIntroSeen: s.editorModeIntroSeen,
+    confirmBeforeDelete: s.confirmBeforeDelete
   };
   if (s.periodicNotes !== undefined) {
     bundle.periodicNotes = s.periodicNotes;
@@ -120,6 +122,7 @@ export function applyBundlesToSettings(
     if (app.imageLoadMode !== undefined) merged.imageLoadMode = app.imageLoadMode;
     if (app.editorMode !== undefined) merged.editorMode = app.editorMode;
     if (app.editorModeIntroSeen !== undefined) merged.editorModeIntroSeen = app.editorModeIntroSeen;
+    if (app.confirmBeforeDelete !== undefined) merged.confirmBeforeDelete = app.confirmBeforeDelete;
     if (app.periodicNotes !== undefined) merged.periodicNotes = app.periodicNotes;
   }
   return merged;
@@ -163,6 +166,7 @@ export function migrateAppBundle(raw: unknown): AppSettingsBundle {
   if (typeof obj.imageLoadMode === 'string') out.imageLoadMode = obj.imageLoadMode as AppSettings['imageLoadMode'];
   if (typeof obj.editorMode === 'string') out.editorMode = obj.editorMode as AppSettings['editorMode'];
   if (typeof obj.editorModeIntroSeen === 'boolean') out.editorModeIntroSeen = obj.editorModeIntroSeen;
+  if (typeof obj.confirmBeforeDelete === 'boolean') out.confirmBeforeDelete = obj.confirmBeforeDelete;
   if (typeof obj.periodicNotes === 'object' && obj.periodicNotes !== null) {
     out.periodicNotes = obj.periodicNotes as AppSettings['periodicNotes'];
   }


### PR DESCRIPTION
## Summary

Adds a **Behavior** page under Settings > Preferences, implementing two settings reported by @computrav:

- **Default open mode (#351)** - which view an existing note opens in: Preview / Edit / Split. Stored **per-device** in `localStorage` (a new `device-prefs` store), deliberately **not synced**, so a desktop can default to Edit while a phone stays on Preview. New notes still open in Edit. Split is hidden on phones (the layout's `effectiveViewMode` already clamps Split to Edit on mobile). Default is **Preview**, so existing users see no change unless they opt in.
- **Confirm before deleting (#350)** - toggle, **default ON**, **synced** across devices via the encrypted `AppSettings` bundle (a caution preference, not a device trait). When OFF, single-note deletes go straight to Trash; **bulk deletes always confirm**. The copy tells users Trash auto-purges after **30 days** (`cleanTrash(30)` in `hooks.client.ts`).

### Notes for review (decisions)
- **Per-device vs synced split**: open mode is per-device (the desktop-edits / phone-reads case); confirm-delete is synced (a habit, same everywhere). A "this device only" hint marks the open-mode setting.
- **#360 (toggle button) intentionally NOT done** - per discussion, making the edit icon toggle Markdown/Live risks an accidental mode-flip for non-technical users; the explicit menu stays. A keyboard shortcut is the safer way to serve that need if we want it later.
- `confirmBeforeDelete` flows through extract/apply/migrate of the synced bundle with round-trip test coverage; falls back to `true` for rows written before the field existed (no migration needed).

## Test plan
- [ ] Settings > Preferences shows **Behavior** and opens the page.
- [ ] **Open mode**: Edit -> existing notes open in the editor; Preview -> read-only; Split (desktop) -> split view. New note always opens in Edit. On a phone, Split is not offered.
- [ ] Open mode is **per-device**: changing it on desktop does not change the phone.
- [ ] **Confirm before deleting** ON (default) still asks; OFF -> single delete goes straight to Trash; bulk delete still asks.
- [ ] Toggling confirm-delete syncs to another device; open mode does NOT sync.
- [ ] Deleted note is restorable from Trash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)