### PR TITLE
refactor(notes): move editor mode from Appearance to Behavior

### DIFF
--- a/apps/reborn-notes/src/routes/settings/appearance/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/appearance/+page.svelte
@@ -15,17 +15,16 @@
     SelectTrigger,
     Button
   } from '@reborn/ui';
-  import { Globe, ImageIcon, Pencil } from '@lucide/svelte';
+  import { Globe, ImageIcon } from '@lucide/svelte';
   import {
     appSettings,
     currentTheme,
     currentLanguage,
     dateFormat,
     timeFormat,
-    imageLoadMode as imageLoadModeStore,
-    editorMode as editorModeStore
+    imageLoadMode as imageLoadModeStore
   } from '$lib/stores/app-settings.store';
-  import type { ImageLoadMode, EditorMode } from '@reborn/storage';
+  import type { ImageLoadMode } from '@reborn/storage';
   import { t } from '$lib/stores/i18n.store';
   import { SUPPORTED_LOCALES } from '@reborn/i18n';
   import type { AppSettings } from '@reborn/storage';
@@ -42,7 +41,6 @@
   let dateFormatValue = $state('DD/MM/YYYY');
   let timeFormatValue = $state('24h');
   let imageLoadModeValue = $state<ImageLoadMode>('ask');
-  let editorModeValue = $state<EditorMode>('markdown');
 
   const languageOptions = [
     { value: 'en', label: 'English' },
@@ -124,21 +122,6 @@
     }
   }
 
-  async function updateEditorMode(value: string | undefined) {
-    if (value !== 'markdown' && value !== 'live') return;
-    try {
-      isLoading = true;
-      error = null;
-      await appSettings.update('editorMode', value);
-      editorModeValue = value;
-      toast.success($t('settings_page.appearance.editor_mode_updated'));
-    } catch (err: unknown) {
-      logger.error('Failed to update editor mode', err);
-    } finally {
-      isLoading = false;
-    }
-  }
-
   async function updateTimeFormat(value: string) {
     try {
       isLoading = true;
@@ -163,7 +146,6 @@
       dateFormatValue = 'DD/MM/YYYY';
       timeFormatValue = '24h';
       imageLoadModeValue = 'ask';
-      editorModeValue = 'markdown';
       toast.success($t('settings_page.appearance.reset_done'));
     } catch (err: unknown) {
       logger.error('Failed to reset settings', err);
@@ -178,8 +160,7 @@
       currentLanguage.subscribe((value) => (language = value)),
       dateFormat.subscribe((value) => (dateFormatValue = value)),
       timeFormat.subscribe((value) => (timeFormatValue = value)),
-      imageLoadModeStore.subscribe((value) => (imageLoadModeValue = value)),
-      editorModeStore.subscribe((value) => (editorModeValue = value))
+      imageLoadModeStore.subscribe((value) => (imageLoadModeValue = value))
     ];
     return () => unsubscribes.forEach((fn) => fn());
   });
@@ -301,37 +282,6 @@
             {$t('settings_page.appearance.image_loading_warning')}
           </p>
         {/if}
-      </CardContent>
-    </Card>
-
-    <!-- Editor mode -->
-    <Card>
-      <CardHeader>
-        <CardTitle class="text-base flex items-center gap-2">
-          <Pencil class="h-4 w-4 text-muted-foreground" />
-          {$t('settings_page.appearance.editor_mode')}
-        </CardTitle>
-        <CardDescription>{$t('settings_page.appearance.editor_mode_desc')}</CardDescription>
-      </CardHeader>
-      <CardContent class="space-y-3">
-        <Select
-          type="single"
-          value={editorModeValue}
-          onValueChange={(value) => updateEditorMode(value)}
-          disabled={isLoading}
-        >
-          <SelectTrigger class="w-full">
-            {editorModeValue === 'live'
-              ? $t('settings_page.appearance.editor_mode_live')
-              : $t('settings_page.appearance.editor_mode_markdown')}
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="markdown"
-              >{$t('settings_page.appearance.editor_mode_markdown')}</SelectItem
-            >
-            <SelectItem value="live">{$t('settings_page.appearance.editor_mode_live')}</SelectItem>
-          </SelectContent>
-        </Select>
       </CardContent>
     </Card>
 

--- a/apps/reborn-notes/src/routes/settings/behavior/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/behavior/+page.svelte
@@ -14,11 +14,13 @@
     Switch,
     toast
   } from '@reborn/ui';
-  import { Eye, Trash2 } from '@lucide/svelte';
+  import { Eye, Pencil, Trash2 } from '@lucide/svelte';
   import {
     appSettings,
-    confirmBeforeDelete as confirmBeforeDeleteStore
+    confirmBeforeDelete as confirmBeforeDeleteStore,
+    editorMode as editorModeStore
   } from '$lib/stores/app-settings.store';
+  import type { EditorMode } from '@reborn/storage';
   import {
     devicePrefs,
     noteOpenMode as noteOpenModeStore,
@@ -32,6 +34,7 @@
   const isMobile = useIsMobile();
 
   let openModeValue = $state<NoteOpenMode>('preview');
+  let editorModeValue = $state<EditorMode>('markdown');
   let confirmDeleteValue = $state(true);
 
   // Split is a desktop layout (editor + preview side by side). On phones the app
@@ -55,6 +58,17 @@
     toast.success($t('settings_page.behavior.open_mode_updated'));
   }
 
+  async function updateEditorMode(value: string | undefined) {
+    if (value !== 'markdown' && value !== 'live') return;
+    try {
+      await appSettings.update('editorMode', value);
+      editorModeValue = value;
+      toast.success($t('settings_page.behavior.editor_mode_updated'));
+    } catch (err: unknown) {
+      logger.error('Failed to update editor mode', err);
+    }
+  }
+
   async function updateConfirmDelete(value: boolean) {
     try {
       await appSettings.update('confirmBeforeDelete', value);
@@ -68,6 +82,7 @@
   onMount(() => {
     const unsubscribes = [
       noteOpenModeStore.subscribe((v) => (openModeValue = v)),
+      editorModeStore.subscribe((v) => (editorModeValue = v)),
       confirmBeforeDeleteStore.subscribe((v) => (confirmDeleteValue = v))
     ];
     return () => unsubscribes.forEach((fn) => fn());
@@ -103,6 +118,36 @@
         <p class="text-xs text-muted-foreground">
           {$t('settings_page.behavior.open_mode_device_hint')}
         </p>
+      </CardContent>
+    </Card>
+
+    <!-- Editor mode (synced across devices) -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-base flex items-center gap-2">
+          <Pencil class="h-4 w-4 text-muted-foreground" />
+          {$t('settings_page.behavior.editor_mode')}
+        </CardTitle>
+        <CardDescription>{$t('settings_page.behavior.editor_mode_desc')}</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-3">
+        <Select
+          type="single"
+          value={editorModeValue}
+          onValueChange={(value) => updateEditorMode(value)}
+        >
+          <SelectTrigger class="w-full">
+            {editorModeValue === 'live'
+              ? $t('settings_page.behavior.editor_mode_live')
+              : $t('settings_page.behavior.editor_mode_markdown')}
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="markdown"
+              >{$t('settings_page.behavior.editor_mode_markdown')}</SelectItem
+            >
+            <SelectItem value="live">{$t('settings_page.behavior.editor_mode_live')}</SelectItem>
+          </SelectContent>
+        </Select>
       </CardContent>
     </Card>
 

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -773,7 +773,7 @@
     "option_markdown_description": "Rohe Marker wie ** # [Text](Link) bleiben sichtbar. Für Nutzer, die volle Kontrolle über die Syntax wollen.",
     "recommended": "Empfohlen",
     "hint_switch_before_icon": "Du kannst den Modus jederzeit über die",
-    "hint_switch_after_icon": "Schaltfläche in der Notiz-Kopfzeile oder in Einstellungen → Darstellung wechseln.",
+    "hint_switch_after_icon": "Schaltfläche in der Notiz-Kopfzeile oder in Einstellungen → Verhalten wechseln.",
     "continue_button": "Loslegen"
   },
   "save_status": {
@@ -807,7 +807,7 @@
     },
     "behavior": {
       "title": "Verhalten",
-      "hub_desc": "Wie Notizen geöffnet werden, Löschbestätigung",
+      "hub_desc": "Wie Notizen geöffnet werden, Bearbeitungsmodus, Löschbestätigung",
       "open_mode": "Notizen öffnen in",
       "open_mode_desc": "Ansicht, in der eine vorhandene Notiz beim Auswählen geöffnet wird. Neue Notizen öffnen sich immer bearbeitungsbereit.",
       "open_mode_preview": "Vorschau (schreibgeschützt)",
@@ -815,6 +815,11 @@
       "open_mode_split": "Geteilt (Bearbeiten und Vorschau)",
       "open_mode_device_hint": "Gilt nur für dieses Gerät",
       "open_mode_updated": "Standard-Öffnungsmodus aktualisiert",
+      "editor_mode": "Bearbeitungsmodus",
+      "editor_mode_desc": "Wie Markdown beim Bearbeiten einer Notiz angezeigt wird",
+      "editor_mode_markdown": "Markdown (gesamte Syntax anzeigen)",
+      "editor_mode_live": "Live-Vorschau (Syntax außerhalb des Cursors ausblenden)",
+      "editor_mode_updated": "Bearbeitungsmodus aktualisiert",
       "confirm_delete": "Vor dem Löschen bestätigen",
       "confirm_delete_desc": "Vor dem Verschieben einer Notiz in den Papierkorb nachfragen. Notizen im Papierkorb können wiederhergestellt werden, werden aber nach 30 Tagen endgültig gelöscht.",
       "confirm_delete_on": "Bestätigung ein",
@@ -843,12 +848,7 @@
       "image_loading_always": "Immer automatisch laden",
       "image_loading_never": "Externe Bilder niemals laden",
       "image_loading_updated": "Einstellung zum Laden von Bildern aktualisiert",
-      "image_loading_warning": "Das automatische Laden von Bildern kann Ihre IP-Adresse gegenüber externen Servern offenlegen",
-      "editor_mode": "Bearbeitungsmodus",
-      "editor_mode_desc": "Wie Markdown beim Bearbeiten einer Notiz angezeigt wird",
-      "editor_mode_markdown": "Markdown (gesamte Syntax anzeigen)",
-      "editor_mode_live": "Live-Vorschau (Syntax außerhalb des Cursors ausblenden)",
-      "editor_mode_updated": "Bearbeitungsmodus aktualisiert"
+      "image_loading_warning": "Das automatische Laden von Bildern kann Ihre IP-Adresse gegenüber externen Servern offenlegen"
     },
     "security": {
       "title": "Sicherheit",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -773,7 +773,7 @@
     "option_markdown_description": "Raw markers like ** # [text](link) stay visible. For users who prefer full control over the syntax.",
     "recommended": "Recommended",
     "hint_switch_before_icon": "You can switch modes any time using the",
-    "hint_switch_after_icon": "button in the note header or in Settings → Appearance.",
+    "hint_switch_after_icon": "button in the note header or in Settings → Behavior.",
     "continue_button": "Get started"
   },
   "save_status": {
@@ -807,7 +807,7 @@
     },
     "behavior": {
       "title": "Behavior",
-      "hub_desc": "How notes open, delete confirmation",
+      "hub_desc": "How notes open, editor mode, delete confirmation",
       "open_mode": "Open notes in",
       "open_mode_desc": "Which view an existing note opens in when you select it. New notes always open ready to edit.",
       "open_mode_preview": "Preview (read-only)",
@@ -815,6 +815,11 @@
       "open_mode_split": "Split (edit and preview)",
       "open_mode_device_hint": "Applies to this device only",
       "open_mode_updated": "Default open mode updated",
+      "editor_mode": "Editor mode",
+      "editor_mode_desc": "How Markdown is shown while you edit a note",
+      "editor_mode_markdown": "Markdown (show all syntax)",
+      "editor_mode_live": "Live preview (hide syntax outside cursor)",
+      "editor_mode_updated": "Editor mode updated",
       "confirm_delete": "Confirm before deleting",
       "confirm_delete_desc": "Ask before moving a note to Trash. Notes in Trash can be restored, but are permanently deleted after 30 days.",
       "confirm_delete_on": "Confirmation on",
@@ -843,12 +848,7 @@
       "image_loading_always": "Always load automatically",
       "image_loading_never": "Never load external images",
       "image_loading_updated": "Image loading setting updated",
-      "image_loading_warning": "Loading images automatically may reveal your IP address to external servers",
-      "editor_mode": "Editor mode",
-      "editor_mode_desc": "How Markdown is shown while you edit a note",
-      "editor_mode_markdown": "Markdown (show all syntax)",
-      "editor_mode_live": "Live preview (hide syntax outside cursor)",
-      "editor_mode_updated": "Editor mode updated"
+      "image_loading_warning": "Loading images automatically may reveal your IP address to external servers"
     },
     "security": {
       "title": "Security",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -773,7 +773,7 @@
     "option_markdown_description": "Los marcadores en bruto como ** # [texto](enlace) permanecen visibles. Para usuarios que prefieren control total sobre la sintaxis.",
     "recommended": "Recomendado",
     "hint_switch_before_icon": "Puedes cambiar el modo en cualquier momento con el botón",
-    "hint_switch_after_icon": "en el encabezado de la nota o en Ajustes → Apariencia.",
+    "hint_switch_after_icon": "en el encabezado de la nota o en Ajustes → Comportamiento.",
     "continue_button": "Empezar"
   },
   "save_status": {
@@ -807,7 +807,7 @@
     },
     "behavior": {
       "title": "Comportamiento",
-      "hub_desc": "Cómo se abren las notas, confirmación de eliminación",
+      "hub_desc": "Cómo se abren las notas, modo de edición, confirmación de eliminación",
       "open_mode": "Abrir las notas en",
       "open_mode_desc": "Vista en la que se abre una nota existente al seleccionarla. Las notas nuevas siempre se abren listas para editar.",
       "open_mode_preview": "Vista previa (solo lectura)",
@@ -815,6 +815,11 @@
       "open_mode_split": "Dividido (edición y vista previa)",
       "open_mode_device_hint": "Se aplica solo a este dispositivo",
       "open_mode_updated": "Modo de apertura predeterminado actualizado",
+      "editor_mode": "Modo de edición",
+      "editor_mode_desc": "Cómo se muestra Markdown mientras editas una nota",
+      "editor_mode_markdown": "Markdown (mostrar toda la sintaxis)",
+      "editor_mode_live": "Vista previa en vivo (ocultar sintaxis fuera del cursor)",
+      "editor_mode_updated": "Modo de edición actualizado",
       "confirm_delete": "Confirmar antes de eliminar",
       "confirm_delete_desc": "Preguntar antes de mover una nota a la Papelera. Las notas en la Papelera se pueden restaurar, pero se eliminan definitivamente después de 30 días.",
       "confirm_delete_on": "Confirmación activada",
@@ -843,12 +848,7 @@
       "image_loading_always": "Cargar siempre automáticamente",
       "image_loading_never": "Nunca cargar imágenes externas",
       "image_loading_updated": "Configuración de carga de imágenes actualizada",
-      "image_loading_warning": "Cargar imágenes automáticamente puede revelar su dirección IP a servidores externos",
-      "editor_mode": "Modo de edición",
-      "editor_mode_desc": "Cómo se muestra Markdown mientras editas una nota",
-      "editor_mode_markdown": "Markdown (mostrar toda la sintaxis)",
-      "editor_mode_live": "Vista previa en vivo (ocultar sintaxis fuera del cursor)",
-      "editor_mode_updated": "Modo de edición actualizado"
+      "image_loading_warning": "Cargar imágenes automáticamente puede revelar su dirección IP a servidores externos"
     },
     "security": {
       "title": "Seguridad",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -773,7 +773,7 @@
     "option_markdown_description": "Les marqueurs bruts comme ** # [texte](lien) restent visibles. Pour les utilisateurs qui préfèrent un contrôle total sur la syntaxe.",
     "recommended": "Recommandé",
     "hint_switch_before_icon": "Vous pouvez changer de mode à tout moment via le bouton",
-    "hint_switch_after_icon": "dans l'en-tête de la note ou dans Paramètres → Apparence.",
+    "hint_switch_after_icon": "dans l'en-tête de la note ou dans Paramètres → Comportement.",
     "continue_button": "Commencer"
   },
   "save_status": {
@@ -807,7 +807,7 @@
     },
     "behavior": {
       "title": "Comportement",
-      "hub_desc": "Mode d'ouverture des notes, confirmation de suppression",
+      "hub_desc": "Mode d'ouverture des notes, mode d'édition, confirmation de suppression",
       "open_mode": "Ouvrir les notes en",
       "open_mode_desc": "Vue dans laquelle une note existante s'ouvre lorsque vous la sélectionnez. Les nouvelles notes s'ouvrent toujours prêtes à être modifiées.",
       "open_mode_preview": "Aperçu (lecture seule)",
@@ -815,6 +815,11 @@
       "open_mode_split": "Partagé (édition et aperçu)",
       "open_mode_device_hint": "S'applique uniquement à cet appareil",
       "open_mode_updated": "Mode d'ouverture par défaut mis à jour",
+      "editor_mode": "Mode d'édition",
+      "editor_mode_desc": "Comment le Markdown est affiché pendant l'édition d'une note",
+      "editor_mode_markdown": "Markdown (afficher toute la syntaxe)",
+      "editor_mode_live": "Aperçu en direct (masquer la syntaxe hors du curseur)",
+      "editor_mode_updated": "Mode d'édition mis à jour",
       "confirm_delete": "Confirmer avant de supprimer",
       "confirm_delete_desc": "Demander avant de déplacer une note vers la Corbeille. Les notes dans la Corbeille peuvent être restaurées, mais sont définitivement supprimées après 30 jours.",
       "confirm_delete_on": "Confirmation activée",
@@ -843,12 +848,7 @@
       "image_loading_always": "Toujours charger automatiquement",
       "image_loading_never": "Ne jamais charger les images externes",
       "image_loading_updated": "Paramètre de chargement des images mis à jour",
-      "image_loading_warning": "Le chargement automatique des images peut révéler votre adresse IP à des serveurs externes",
-      "editor_mode": "Mode d'édition",
-      "editor_mode_desc": "Comment le Markdown est affiché pendant l'édition d'une note",
-      "editor_mode_markdown": "Markdown (afficher toute la syntaxe)",
-      "editor_mode_live": "Aperçu en direct (masquer la syntaxe hors du curseur)",
-      "editor_mode_updated": "Mode d'édition mis à jour"
+      "image_loading_warning": "Le chargement automatique des images peut révéler votre adresse IP à des serveurs externes"
     },
     "security": {
       "title": "Sécurité",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -773,7 +773,7 @@
     "option_markdown_description": "Surowe znaczniki ** # [tekst](link) pozostają widoczne. Dla osób, które wolą pełną kontrolę nad składnią.",
     "recommended": "Polecane",
     "hint_switch_before_icon": "Tryb przełączysz w każdej chwili przyciskiem",
-    "hint_switch_after_icon": "w nagłówku notatki lub w Ustawieniach → Wygląd.",
+    "hint_switch_after_icon": "w nagłówku notatki lub w Ustawieniach → Zachowanie.",
     "continue_button": "Zaczynaj"
   },
   "save_status": {
@@ -807,7 +807,7 @@
     },
     "behavior": {
       "title": "Zachowanie",
-      "hub_desc": "Sposób otwierania notatek, potwierdzanie usuwania",
+      "hub_desc": "Sposób otwierania notatek, tryb edycji, potwierdzanie usuwania",
       "open_mode": "Otwieraj notatki w trybie",
       "open_mode_desc": "Widok, w którym otwiera się istniejąca notatka po jej wybraniu. Nowe notatki zawsze otwierają się gotowe do edycji.",
       "open_mode_preview": "Podgląd (tylko do odczytu)",
@@ -815,6 +815,11 @@
       "open_mode_split": "Podział (edycja i podgląd)",
       "open_mode_device_hint": "Dotyczy tylko tego urządzenia",
       "open_mode_updated": "Zaktualizowano domyślny tryb otwierania",
+      "editor_mode": "Tryb edycji",
+      "editor_mode_desc": "Jak Markdown jest wyświetlany podczas edycji notatki",
+      "editor_mode_markdown": "Markdown (pokaż całą składnię)",
+      "editor_mode_live": "Podgląd na żywo (ukryj składnię poza kursorem)",
+      "editor_mode_updated": "Tryb edycji zaktualizowany",
       "confirm_delete": "Potwierdzaj przed usunięciem",
       "confirm_delete_desc": "Pytaj przed przeniesieniem notatki do Kosza. Notatki w Koszu można przywrócić, ale po 30 dniach są trwale usuwane.",
       "confirm_delete_on": "Potwierdzanie włączone",
@@ -843,12 +848,7 @@
       "image_loading_always": "Zawsze ładuj automatycznie",
       "image_loading_never": "Nigdy nie ładuj zewnętrznych obrazów",
       "image_loading_updated": "Ustawienie ładowania obrazów zaktualizowane",
-      "image_loading_warning": "Automatyczne ładowanie obrazów może ujawnić Twój adres IP zewnętrznym serwerom",
-      "editor_mode": "Tryb edycji",
-      "editor_mode_desc": "Jak Markdown jest wyświetlany podczas edycji notatki",
-      "editor_mode_markdown": "Markdown (pokaż całą składnię)",
-      "editor_mode_live": "Podgląd na żywo (ukryj składnię poza kursorem)",
-      "editor_mode_updated": "Tryb edycji zaktualizowany"
+      "image_loading_warning": "Automatyczne ładowanie obrazów może ujawnić Twój adres IP zewnętrznym serwerom"
     },
     "security": {
       "title": "Bezpieczeństwo",


### PR DESCRIPTION
## Summary

Editor mode (Markdown source vs Live preview) is "how you edit", not "how the app looks". After the Behavior settings page landed (#366: default open mode + delete confirmation), editor mode was the only editing control still under Appearance, split from its twin (default open mode) that users look for together (#351). This moves it next to open mode.

- **UI**: editor mode card (select + handler + store subscription) moved from `settings/appearance` to `settings/behavior`, placed between open mode and delete confirmation. Appearance stays purely visual/regional (theme, language, date/time, image loading).
- **i18n (5 locales)**: intro-dialog hint `editor_mode_intro.hint_switch_after_icon` now points to "Settings -> Behavior" (localized page name per locale); keys `settings_page.appearance.editor_mode*` moved to `settings_page.behavior.editor_mode*` so the key path matches the UI; `behavior.hub_desc` extended with "editor mode".

**No schema/sync/crypto change** - `editorMode` stays the same per-app synced `AppSettings` field; only its UI location and the modal pointer move. Type `refactor` (relocation, no new capability, so no version bump).

Not touched: `imageLoadMode` stays in Appearance (tied to the IP-leak privacy warning, distinct character; one borderline setting there is fine, splitting two editing settings is not).

## Test plan

- [ ] Settings > Behavior shows the **Editor mode** card between "Open notes in" and "Confirm before deleting"; switching markdown / live preview shows a toast and persists.
- [ ] Settings > Appearance no longer shows Editor mode (theme, language, date/time, image loading only).
- [ ] First-run editor mode intro dialog hint reads "...in Settings -> Behavior" (spot-check a couple of locales: EN, PL, DE).
- [ ] Editor mode still takes effect in the note editor (open a note, confirm the chosen mode applies) and syncs across devices.
- [ ] "Reset to defaults" on Appearance still resets editor mode to markdown (bundle-level reset).

Gates green locally: i18n parity (1208 keys, 5 locales, missing=0 extra=0), svelte-check 0/0, eslint 0 errors, i18n vitest 27 passed, vite build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)