### PR TITLE
fix(notes): discard untouched new note instead of syncing it (#349)

### DIFF
--- a/apps/reborn-notes/src/hooks.client.ts
+++ b/apps/reborn-notes/src/hooks.client.ts
@@ -107,10 +107,14 @@ if (!isPublicShareRoute) {
   // This is fire-and-forget: if it fails, +layout.svelte will retry in onMount.
   initializeStorage('notes')
     .then(async () => {
-      // Auto-purge old trash items (notes trashed more than 30 days ago)
+      // Auto-purge old trash items (notes trashed more than 30 days ago) and
+      // any leftover pristine ephemeral notes - New Note rows the user created
+      // but never touched, then reloaded/closed before the in-session discard
+      // could run (#349). Both are local-only, no decryption needed.
       try {
-        const { cleanTrash } = await import('$lib/services/note.service');
+        const { cleanTrash, cleanEphemeralNotes } = await import('$lib/services/note.service');
         await cleanTrash(30);
+        await cleanEphemeralNotes();
       } catch {
         // Non-critical — trash cleanup is also attempted in layout onMount
       }

--- a/apps/reborn-notes/src/lib/services/folder.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder.service.ts
@@ -215,7 +215,10 @@ export async function deleteFolder(
         const current = await noteStore.get(note.id);
         if (current) await noteStore.save({ ...current, sync_status: 'pending' });
         noteIndex.patch(note.id, { folderId: undefined });
-        pushNoteUpdate(note.id, { folder_id: null });
+        // A pristine ephemeral note has no server row (deleting its folder is not
+        // a deliberate action on the note, so it is not promoted) - skip the push
+        // to avoid a 404; it stays ephemeral and is cleaned up. #349
+        if (!current?.is_ephemeral) pushNoteUpdate(note.id, { folder_id: null });
       }
     }
   }

--- a/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@reborn/utils';
 import { notesStore } from '$lib/stores/notes.store';
-import { saveVersionSnapshot, saveBaselineSnapshot } from '$lib/services/note.service';
+import { saveVersionSnapshot, saveBaselineSnapshot, discardIfEphemeral } from '$lib/services/note.service';
 import { t } from '$lib/stores/i18n.store';
 import { get } from 'svelte/store';
 import { MAX_NOTE_CONTENT_BYTES } from '@reborn/types';
@@ -64,11 +64,17 @@ class NoteDetailService {
     const prevId = this.noteId;
     const shouldSnapshot = this.editedSinceLastSnapshot; // capture before await
     if (prevId && prevId !== id) {
-      await this.flushPendingSave(prevId);
-      if (shouldSnapshot) {
-        await saveVersionSnapshot(prevId).catch((e) =>
-          logger.error('Failed to snapshot previous note:', e)
-        );
+      // A pristine ephemeral previous note the user never touched is discarded
+      // instead of flushed+snapshotted, so an accidental New Note leaves no
+      // trace (client or server). #349
+      const discarded = this.isUntouchedThisLoad() && (await discardIfEphemeral(prevId));
+      if (!discarded) {
+        await this.flushPendingSave(prevId);
+        if (shouldSnapshot) {
+          await saveVersionSnapshot(prevId).catch((e) =>
+            logger.error('Failed to snapshot previous note:', e)
+          );
+        }
       }
       this.editedSinceLastSnapshot = false;
     }
@@ -244,6 +250,25 @@ class NoteDetailService {
   }
 
   /**
+   * Leave the currently open note (note switch to null, route navigation).
+   *
+   * If it is a pristine ephemeral blank the user never touched, discard it with
+   * zero server contact (#349) - an accidental New Note click that the user backs
+   * out of leaves no trace. Otherwise flush pending edits + snapshot. Returns
+   * true when handled cleanly (discarded or flushed OK), false only when a flush
+   * failed (e.g. over the size limit) so the caller can keep the user on the note.
+   */
+  async leaveNote(noteId?: string): Promise<boolean> {
+    const id = noteId ?? this.noteId;
+    if (!id) return true;
+    if (this.isUntouchedThisLoad() && (await discardIfEphemeral(id))) {
+      this.editedSinceLastSnapshot = false;
+      return true;
+    }
+    return this.flushAndSnapshot(id);
+  }
+
+  /**
    * Mark this as a new note (sets viewMode hint).
    */
   setNewNote(): void {
@@ -276,6 +301,21 @@ class NoteDetailService {
   }
 
   // ── Private ────────────────────────────────────────────────────
+
+  /**
+   * True when the currently-loaded note has had zero edits this load: no pending
+   * debounced save, nothing edited since the last snapshot, and an empty body.
+   * Gate for silently discarding a pristine ephemeral note on leave (#349).
+   * Reflects this.noteId's in-memory editor state, so call it while that note is
+   * still the open one (e.g. before reassigning this.noteId in loadNote).
+   */
+  private isUntouchedThisLoad(): boolean {
+    return (
+      !this.hasPendingChanges() &&
+      !this.editedSinceLastSnapshot &&
+      this.content.trim() === ''
+    );
+  }
 
   /**
    * Snapshot the open note's pristine (pre-edit) state the first time it's

--- a/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
@@ -75,6 +75,11 @@ class NoteDetailService {
             logger.error('Failed to snapshot previous note:', e)
           );
         }
+      } else {
+        // discardEphemeralNote removed the row from IndexedDB + noteIndex, but the
+        // visible sidebar list (_raw) only re-renders on refresh - without this the
+        // discarded note lingers until the next sync. #349
+        notesStore.refresh();
       }
       this.editedSinceLastSnapshot = false;
     }
@@ -263,6 +268,8 @@ class NoteDetailService {
     if (!id) return true;
     if (this.isUntouchedThisLoad() && (await discardIfEphemeral(id))) {
       this.editedSinceLastSnapshot = false;
+      // Drop the discarded note from the sidebar list immediately (see loadNote). #349
+      notesStore.refresh();
       return true;
     }
     return this.flushAndSnapshot(id);

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -25,6 +25,7 @@ import { noteNavHistory } from '$lib/services/note-nav-history.svelte';
 import {
   pushNote,
   pushNoteUpdate,
+  pushNoteMutation,
   pushNoteDelete,
   pushNoteRestore,
   pushNoteVersion,
@@ -238,12 +239,21 @@ export async function createNote(
      * regardless of locale-dependent title formatting.
      */
     periodic?: PeriodicNoteMetadata;
+    /**
+     * Create a pristine "ephemeral" new note (#349): saved locally with a real
+     * id (so the editor can open it) but its push is deferred until the user's
+     * first deliberate action. Implies `skipSync` - the row is flagged
+     * `is_ephemeral` so the sync sweep skips it and the server never sees it
+     * until promoted. Used only by the New Note button.
+     */
+    ephemeral?: boolean;
   }
 ): Promise<string> {
   const now = new Date().toISOString();
   const createdAt = options?.createdAt ?? now;
   const updatedAt = options?.updatedAt ?? now;
   const id = options?.id ?? crypto.randomUUID();
+  const ephemeral = options?.ephemeral === true;
   const metadata: NoteSensitiveMetadata = {
     is_pinned: false,
     is_starred: false,
@@ -265,10 +275,14 @@ export async function createNote(
     sync_version: 0,
     sync_status: 'pending',
     created_at: createdAt,
-    updated_at: updatedAt
+    updated_at: updatedAt,
+    // Local-only: defer the push for a pristine new note until first action (#349).
+    ...(ephemeral ? { is_ephemeral: true } : {})
   };
   await noteStore.save(note);
-  if (!options?.skipSync) {
+  // An ephemeral note is never pushed at create time - the deferred push fires
+  // on the first deliberate action (see pushNoteMutation), not here.
+  if (!options?.skipSync && !ephemeral) {
     pushNote(note);
   }
   noteIndex.update(id, {
@@ -301,17 +315,21 @@ export async function updateNote(
 ): Promise<void> {
   const existing = await noteStore.get(id);
   if (!existing) throw new Error('Note not found');
+  // First edit promotes a pristine ephemeral note: clear the flag so the push
+  // goes out as a POST (create), not a PATCH that would 404 (#349).
+  const wasEphemeral = existing.is_ephemeral === true;
   const updatedAt = options?.updatedAt ?? new Date().toISOString();
   const updated: NoteStoredLocal = {
     ...existing,
     title_encrypted: await encodeText(title),
     content_encrypted: await encodeText(content),
     updated_at: updatedAt,
-    sync_status: 'pending'
+    sync_status: 'pending',
+    ...(wasEphemeral ? { is_ephemeral: false } : {})
   };
   await noteStore.save(updated);
   if (!options?.skipSync) {
-    pushNoteUpdate(id, {
+    pushNoteMutation(updated, wasEphemeral, {
       title_encrypted: updated.title_encrypted,
       content_encrypted: updated.content_encrypted
     });
@@ -327,15 +345,18 @@ export async function updateNote(
 export async function renameNote(id: string, title: string): Promise<void> {
   const existing = await noteStore.get(id);
   if (!existing) throw new Error('Note not found');
+  const wasEphemeral = existing.is_ephemeral === true;
   const now = new Date().toISOString();
   const title_encrypted = await encodeText(title.trim() || 'Untitled');
-  await noteStore.save({
+  const updated: NoteStoredLocal = {
     ...existing,
     title_encrypted,
     updated_at: now,
-    sync_status: 'pending'
-  });
-  pushNoteUpdate(id, { title_encrypted });
+    sync_status: 'pending',
+    ...(wasEphemeral ? { is_ephemeral: false } : {})
+  };
+  await noteStore.save(updated);
+  pushNoteMutation(updated, wasEphemeral, { title_encrypted });
   noteIndex.patch(id, {
     title: title.trim() || 'Untitled',
     updatedAt: now
@@ -345,6 +366,13 @@ export async function renameNote(id: string, title: string): Promise<void> {
 /** Soft-delete (archive) a note. */
 export async function deleteNote(id: string): Promise<void> {
   const existing = await noteStore.get(id);
+  // A pristine ephemeral note never reached the server and holds nothing the
+  // user touched - hard-delete it with zero server contact instead of moving it
+  // to Trash, so it leaves no trace anywhere. #349
+  if (existing?.is_ephemeral) {
+    await discardEphemeralNote(id);
+    return;
+  }
   await noteOperations.archive(id);
 
   // Update cache: mark as archived
@@ -370,10 +398,27 @@ export async function deleteNote(id: string): Promise<void> {
 export async function moveNoteToFolder(id: string, folderId: string | null): Promise<void> {
   await noteOperations.moveToFolder(id, folderId);
   const current = await noteStore.get(id);
-  if (current) await noteStore.save({ ...current, sync_status: 'pending' });
-  // Send null (not undefined) so the server's `'folder_id' in data` check fires
-  // and Prisma actually clears the column when moving to root.
-  pushNoteUpdate(id, { folder_id: folderId });
+  const wasEphemeral = current?.is_ephemeral === true;
+  if (current) {
+    await noteStore.save({
+      ...current,
+      sync_status: 'pending',
+      ...(wasEphemeral ? { is_ephemeral: false } : {})
+    });
+  }
+  if (current && wasEphemeral) {
+    // Moving a pristine new note is a deliberate "keep it" action: promote it
+    // via POST (a PATCH would 404 - the server has no row yet). #349
+    pushNoteMutation(
+      { ...current, sync_status: 'pending', is_ephemeral: false },
+      true,
+      { folder_id: folderId }
+    );
+  } else {
+    // Send null (not undefined) so the server's `'folder_id' in data` check fires
+    // and Prisma actually clears the column when moving to root.
+    pushNoteUpdate(id, { folder_id: folderId });
+  }
   noteIndex.patch(id, { folderId: folderId ?? undefined });
 }
 
@@ -420,19 +465,23 @@ export async function setNotePeriodicMetadata(
     return;
   }
   meta.periodic = periodic;
+  const wasEphemeral = existing.is_ephemeral === true;
   const metadataEncrypted = await cryptoManager.encryptObject(meta);
-  await noteStore.save({
+  const updated: NoteStoredLocal = {
     ...existing,
     metadata_encrypted: metadataEncrypted,
-    sync_status: 'pending'
-  });
-  pushNoteUpdate(id, { metadata_encrypted: metadataEncrypted });
+    sync_status: 'pending',
+    ...(wasEphemeral ? { is_ephemeral: false } : {})
+  };
+  await noteStore.save(updated);
+  pushNoteMutation(updated, wasEphemeral, { metadata_encrypted: metadataEncrypted });
 }
 
 /** Toggle pin status. */
 export async function togglePin(id: string): Promise<void> {
   const existing = await noteStore.get(id);
   if (!existing) return;
+  const wasEphemeral = existing.is_ephemeral === true;
   const newPinned = !existing.is_pinned;
 
   // Update metadata_encrypted with new pin status
@@ -445,14 +494,17 @@ export async function togglePin(id: string): Promise<void> {
   } catch { /* use default */ }
   const metadataEncrypted = await cryptoManager.encryptObject(meta);
 
-  await noteStore.save({
+  const updated: NoteStoredLocal = {
     ...existing,
     is_pinned: newPinned,
     metadata_encrypted: metadataEncrypted,
     updated_at: new Date().toISOString(),
-    sync_status: 'pending'
-  });
-  pushNoteUpdate(id, { metadata_encrypted: metadataEncrypted });
+    sync_status: 'pending',
+    ...(wasEphemeral ? { is_ephemeral: false } : {})
+  };
+  await noteStore.save(updated);
+  // Pinning is a deliberate "keep it" action - promotes a pristine note (#349).
+  pushNoteMutation(updated, wasEphemeral, { metadata_encrypted: metadataEncrypted });
   noteIndex.patch(id, { isPinned: newPinned });
 }
 
@@ -460,6 +512,7 @@ export async function togglePin(id: string): Promise<void> {
 export async function toggleStar(id: string): Promise<void> {
   const existing = await noteStore.get(id);
   if (!existing) return;
+  const wasEphemeral = existing.is_ephemeral === true;
   const newStarred = !existing.is_starred;
 
   // Update metadata_encrypted with new star status
@@ -472,14 +525,17 @@ export async function toggleStar(id: string): Promise<void> {
   } catch { /* use default */ }
   const metadataEncrypted = await cryptoManager.encryptObject(meta);
 
-  await noteStore.save({
+  const updated: NoteStoredLocal = {
     ...existing,
     is_starred: newStarred,
     metadata_encrypted: metadataEncrypted,
     updated_at: new Date().toISOString(),
-    sync_status: 'pending'
-  });
-  pushNoteUpdate(id, { metadata_encrypted: metadataEncrypted });
+    sync_status: 'pending',
+    ...(wasEphemeral ? { is_ephemeral: false } : {})
+  };
+  await noteStore.save(updated);
+  // Starring is a deliberate "keep it" action - promotes a pristine note (#349).
+  pushNoteMutation(updated, wasEphemeral, { metadata_encrypted: metadataEncrypted });
   noteIndex.patch(id, { isStarred: newStarred });
 }
 
@@ -512,6 +568,57 @@ export async function permanentlyDeleteNote(id: string): Promise<void> {
   noteLinkGraph.onNoteRemoved(id);
   noteNavHistory.remove(id);
   pushNoteDelete(id, true);
+}
+
+/**
+ * Hard-delete a pristine ephemeral note's local row with zero server contact (#349).
+ *
+ * Unlike permanentlyDeleteNote, this never calls pushNoteDelete: an ephemeral
+ * note was deferred and never POSTed, so the server has no row to delete -
+ * issuing a DELETE would be a pointless (and 404-prone) round-trip that defeats
+ * the whole point (the server must never learn the note existed). Cleans the
+ * in-memory index, link graph, nav history, and any local version-history rows.
+ */
+export async function discardEphemeralNote(id: string): Promise<void> {
+  await noteHistoryOperations.deleteAllForNote(id);
+  await noteStore.delete(id);
+  noteIndex.remove(id);
+  noteLinkGraph.onNoteRemoved(id);
+  noteNavHistory.remove(id);
+}
+
+/**
+ * Discard the note iff it is still a pristine ephemeral row (#349). Returns true
+ * when it was discarded, false when the note is absent or already promoted (any
+ * deliberate action clears the flag). The caller is responsible for first
+ * confirming the editor has no unsaved changes for this note.
+ */
+export async function discardIfEphemeral(id: string): Promise<boolean> {
+  const existing = await noteStore.get(id);
+  if (!existing?.is_ephemeral) return false;
+  await discardEphemeralNote(id);
+  return true;
+}
+
+/**
+ * Startup sweep: hard-delete any leftover pristine ephemeral notes (#349).
+ *
+ * These are New Note rows the user created but never touched in a prior session,
+ * then closed the tab / reloaded before the in-session discard could run. The
+ * `is_ephemeral` flag is cleared atomically with the first edit's save, so a row
+ * still carrying it provably never received an edit - safe to drop without
+ * decrypting. Never reached the server, so no DELETE is sent. Returns the count
+ * removed.
+ */
+export async function cleanEphemeralNotes(): Promise<number> {
+  const all = (await noteStore.getAll()) as NoteStoredLocal[];
+  const ephemeral = all.filter((n) => n.is_ephemeral === true);
+  if (ephemeral.length === 0) return 0;
+  for (const n of ephemeral) {
+    await discardEphemeralNote(n.id);
+  }
+  logger.info(`Cleaned ${ephemeral.length} leftover ephemeral note(s)`);
+  return ephemeral.length;
 }
 
 /** Permanently delete all notes in trash (and their history). */

--- a/apps/reborn-notes/src/lib/services/notes-discard-ephemeral.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-discard-ephemeral.regression.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression: discard a pristine "new note" the user backs out of (#349).
+ *
+ * A New Note created via the button is saved locally with a real id (so the
+ * editor can open it) but flagged `is_ephemeral` and NOT pushed. The sync sweep
+ * skips it, so the server never sees it. The first deliberate action (edit,
+ * rename, move, pin, star, tag) promotes it: the flag is cleared and the row is
+ * POSTed as a normal create (a PATCH would 404 - the server has no row yet).
+ * Leaving it untouched discards the local row with zero server contact.
+ *
+ * Source-level, like notes-sync.regression.spec.ts and
+ * note-version-baseline.regression.spec.ts: these services import browser-only
+ * modules (IndexedDB stores, i18n, crypto) that are impractical to wire up in a
+ * Node test env, so the invariants are pinned against the source text.
+ */
+
+function readSource(relative: string): string {
+  return readFileSync(resolve(__dirname, relative), 'utf-8');
+}
+
+function noteServiceSrc(): string {
+  return readSource('./note.service.ts');
+}
+
+/** Slice a top-level `export ... function NAME` body up to the next top-level close. */
+function sliceFn(src: string, header: string): string {
+  const start = src.indexOf(header);
+  expect(start, `function not found: ${header}`).toBeGreaterThan(-1);
+  const end = src.indexOf('\n}', start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+/** Slice a one-level-indented class method body up to the next `\n  }`. */
+function sliceMethod(src: string, header: string): string {
+  const start = src.indexOf(header);
+  expect(start, `method not found: ${header}`).toBeGreaterThan(-1);
+  const end = src.indexOf('\n  }', start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+describe('#349 ephemeral new note - the local-only marker', () => {
+  it('NoteStoredLocal carries an optional local-only is_ephemeral flag', () => {
+    const iface = readSource('../../../../../packages/types/src/entities/note.ts');
+    expect(iface).toMatch(/is_ephemeral\?:\s*boolean/);
+    // It must live on the LOCAL type only, never on the wire (NoteEncrypted).
+    const encrypted = iface.slice(
+      iface.indexOf('interface NoteEncrypted'),
+      iface.indexOf('interface NoteStoredLocal')
+    );
+    expect(encrypted).not.toMatch(/is_ephemeral/);
+  });
+
+  it('the zod schema allows is_ephemeral on NoteStoredLocal only', () => {
+    const schema = readSource('../../../../../packages/types/src/schemas/entities/note.ts');
+    const local = schema.slice(schema.indexOf('NoteStoredLocalSchema'));
+    expect(local).toMatch(/is_ephemeral:\s*z\.boolean\(\)\.optional\(\)/);
+    const wire = schema.slice(
+      schema.indexOf('NoteEncryptedSchema = '),
+      schema.indexOf('NoteStoredLocalSchema')
+    );
+    expect(wire).not.toMatch(/is_ephemeral/);
+  });
+});
+
+describe('#349 create defers the push', () => {
+  it('createNote flags is_ephemeral and skips the push for an ephemeral note', () => {
+    const fn = sliceFn(noteServiceSrc(), 'export async function createNote');
+    // Option plumbed through.
+    expect(fn).toMatch(/ephemeral\?:\s*boolean/);
+    expect(fn).toMatch(/const\s+ephemeral\s*=\s*options\?\.ephemeral\s*===\s*true/);
+    // Row carries the flag only when ephemeral.
+    expect(fn).toMatch(/ephemeral\s*\?\s*\{\s*is_ephemeral:\s*true\s*\}\s*:\s*\{\s*\}/);
+    // Push is gated on BOTH skipSync and ephemeral - an ephemeral note is never
+    // POSTed at create time.
+    expect(fn).toMatch(/if\s*\(\s*!options\?\.skipSync\s*&&\s*!ephemeral\s*\)/);
+  });
+
+  it('handleNewNote creates the New Note as ephemeral', () => {
+    const page = readSource('../../routes/+page.svelte');
+    const fn = page.slice(page.indexOf('async function handleNewNote'));
+    expect(fn).toMatch(/notesStore\.create\([^)]*\{\s*ephemeral:\s*true\s*\}\s*\)/s);
+  });
+});
+
+describe('#349 the sync sweep never pushes an ephemeral note (zero-knowledge)', () => {
+  it('pushPendingItems excludes is_ephemeral from both note buckets', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function pushPendingItems'),
+      src.indexOf('/** Retry a function with exponential backoff')
+    );
+    // Non-archived pending creates/updates.
+    expect(fn).toMatch(/const\s+pendingNotes\s*=\s*allNotes\.filter/);
+    // Archived pending soft-deletes.
+    expect(fn).toMatch(/const\s+pendingArchivedNotes\s*=\s*allNotes\.filter/);
+    // BOTH filters must drop ephemeral rows - the server must never learn the
+    // note existed until the user's first deliberate action promotes it.
+    const ephemeralGuards = fn.match(/!n\.is_ephemeral/g) ?? [];
+    expect(ephemeralGuards.length).toBe(2);
+  });
+});
+
+describe('#349 the first deliberate action promotes via POST', () => {
+  it('pushNoteMutation POSTs a never-synced ephemeral row, PATCHes otherwise', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const fn = src.slice(
+      src.indexOf('export function pushNoteMutation'),
+      src.indexOf('export function pushNoteDelete')
+    );
+    expect(fn).toMatch(/wasEphemeral:\s*boolean/);
+    // First server contact for an ephemeral note is a POST (full row), not a PATCH.
+    expect(fn).toMatch(/if\s*\(\s*wasEphemeral\s*\)\s*\{\s*pushNote\s*\(\s*row\s*\)/s);
+    expect(fn).toMatch(/pushNoteUpdate\s*\(\s*row\.id/);
+  });
+
+  it.each([
+    ['updateNote', 'export async function updateNote'],
+    ['renameNote', 'export async function renameNote'],
+    ['togglePin', 'export async function togglePin'],
+    ['toggleStar', 'export async function toggleStar'],
+    ['setNotePeriodicMetadata', 'export async function setNotePeriodicMetadata']
+  ])('%s captures wasEphemeral, clears the flag, and routes through pushNoteMutation', (_name, header) => {
+    const fn = sliceFn(noteServiceSrc(), header);
+    expect(fn).toMatch(/wasEphemeral\s*=\s*existing\.is_ephemeral\s*===\s*true/);
+    // Clear the flag only when promoting (keeps normal rows clean).
+    expect(fn).toMatch(/wasEphemeral\s*\?\s*\{\s*is_ephemeral:\s*false\s*\}\s*:\s*\{\s*\}/);
+    expect(fn).toMatch(/pushNoteMutation\s*\(/);
+  });
+
+  it('setTagsForNote promotes an ephemeral note when tags are assigned', () => {
+    const fn = sliceFn(readSource('./tag.service.ts'), 'export async function setTagsForNote');
+    expect(fn).toMatch(/wasEphemeral\s*=\s*existing\.is_ephemeral\s*===\s*true/);
+    expect(fn).toMatch(/pushNoteMutation\s*\(/);
+  });
+
+  it('moveNoteToFolder POSTs when ephemeral, PATCHes otherwise', () => {
+    const fn = sliceFn(noteServiceSrc(), 'export async function moveNoteToFolder');
+    expect(fn).toMatch(/wasEphemeral\s*=\s*current\?\.is_ephemeral\s*===\s*true/);
+    expect(fn).toMatch(/pushNoteMutation\s*\(/);
+    // Normal (non-ephemeral) move keeps the explicit folder_id PATCH.
+    expect(fn).toMatch(/pushNoteUpdate\s*\(\s*id,\s*\{\s*folder_id:\s*folderId\s*\}\s*\)/);
+  });
+
+  it('folder detach skips the push for an ephemeral note (no promotion, no 404)', () => {
+    const fn = readSource('./folder.service.ts');
+    const detach = fn.slice(fn.indexOf('// Detach'), fn.indexOf('// Detach') + 600);
+    expect(detach).toMatch(/if\s*\(\s*!current\?\.is_ephemeral\s*\)\s*pushNoteUpdate/);
+  });
+});
+
+describe('#349 discard leaves no trace', () => {
+  it('discardEphemeralNote hard-deletes the row WITHOUT any server delete', () => {
+    const fn = sliceFn(noteServiceSrc(), 'export async function discardEphemeralNote');
+    expect(fn).toMatch(/noteStore\.delete\s*\(\s*id\s*\)/);
+    expect(fn).toMatch(/noteIndex\.remove\s*\(\s*id\s*\)/);
+    // The whole point: the server never saw it, so we must NOT issue a DELETE.
+    expect(fn).not.toMatch(/pushNoteDelete/);
+  });
+
+  it('discardIfEphemeral is gated on the flag', () => {
+    const fn = sliceFn(noteServiceSrc(), 'export async function discardIfEphemeral');
+    expect(fn).toMatch(/if\s*\(\s*!existing\?\.is_ephemeral\s*\)\s*return\s+false/);
+    expect(fn).toMatch(/discardEphemeralNote\s*\(\s*id\s*\)/);
+    expect(fn).toMatch(/return\s+true/);
+  });
+
+  it('deleteNote hard-deletes an ephemeral note instead of moving it to Trash', () => {
+    const fn = sliceFn(noteServiceSrc(), 'export async function deleteNote');
+    // The ephemeral branch must come BEFORE the archive call and return early.
+    const branchIdx = fn.search(/if\s*\(\s*existing\?\.is_ephemeral\s*\)/);
+    const archiveIdx = fn.search(/noteOperations\.archive/);
+    expect(branchIdx).toBeGreaterThan(-1);
+    expect(archiveIdx).toBeGreaterThan(branchIdx);
+    expect(fn).toMatch(/discardEphemeralNote\s*\(\s*id\s*\)/);
+  });
+
+  it('cleanEphemeralNotes sweeps leftover ephemeral rows on startup', () => {
+    const fn = sliceFn(noteServiceSrc(), 'export async function cleanEphemeralNotes');
+    expect(fn).toMatch(/filter\s*\(\s*\(n\)\s*=>\s*n\.is_ephemeral\s*===\s*true\s*\)/);
+    expect(fn).toMatch(/discardEphemeralNote/);
+  });
+
+  it('the client startup hook runs cleanEphemeralNotes', () => {
+    const hook = readSource('../../hooks.client.ts');
+    expect(hook).toMatch(/cleanEphemeralNotes/);
+  });
+});
+
+describe('#349 leave-on-untouched (note-detail service)', () => {
+  function noteDetailSrc(): string {
+    return readSource('./note-detail.service.svelte.ts');
+  }
+
+  it('isUntouchedThisLoad requires no pending edits, no edits since snapshot, empty body', () => {
+    const method = sliceMethod(noteDetailSrc(), 'private isUntouchedThisLoad');
+    expect(method).toMatch(/!this\.hasPendingChanges\(\)/);
+    expect(method).toMatch(/!this\.editedSinceLastSnapshot/);
+    expect(method).toMatch(/this\.content\.trim\(\)\s*===\s*''/);
+  });
+
+  it('leaveNote discards a pristine ephemeral note, else flushes+snapshots', () => {
+    const method = sliceMethod(noteDetailSrc(), 'async leaveNote');
+    expect(method).toMatch(/this\.isUntouchedThisLoad\(\)\s*&&\s*\(await\s+discardIfEphemeral/);
+    expect(method).toMatch(/return\s+this\.flushAndSnapshot\s*\(\s*id\s*\)/);
+  });
+
+  it('loadNote discards a pristine ephemeral previous note instead of saving it', () => {
+    const method = sliceMethod(noteDetailSrc(), 'async loadNote');
+    expect(method).toMatch(/this\.isUntouchedThisLoad\(\)\s*&&\s*\(await\s+discardIfEphemeral\s*\(\s*prevId\s*\)\s*\)/);
+    // Falls back to the original flush+snapshot when not discarded.
+    expect(method).toMatch(/if\s*\(\s*!discarded\s*\)/);
+  });
+
+  it('+page.svelte routes both leave paths (note close, navigation) through leaveNote', () => {
+    const page = readSource('../../routes/+page.svelte');
+    // Closing the open note (activeNoteId -> null).
+    expect(page).toMatch(/noteDetailService\.leaveNote\(prev\)/);
+    // beforeNavigate, clean path (the call, not the import of the same name).
+    const navIdx = page.indexOf('beforeNavigate((');
+    expect(navIdx).toBeGreaterThan(-1);
+    const beforeNav = page.slice(navIdx, navIdx + 600);
+    expect(beforeNav).toMatch(/noteDetailService\.leaveNote\(\)/);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/notes-discard-ephemeral.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-discard-ephemeral.regression.spec.ts
@@ -204,17 +204,21 @@ describe('#349 leave-on-untouched (note-detail service)', () => {
     expect(method).toMatch(/this\.content\.trim\(\)\s*===\s*''/);
   });
 
-  it('leaveNote discards a pristine ephemeral note, else flushes+snapshots', () => {
+  it('leaveNote discards a pristine ephemeral note (refreshing the list), else flushes+snapshots', () => {
     const method = sliceMethod(noteDetailSrc(), 'async leaveNote');
     expect(method).toMatch(/this\.isUntouchedThisLoad\(\)\s*&&\s*\(await\s+discardIfEphemeral/);
+    // The discarded note must leave the sidebar immediately, not at the next sync.
+    expect(method).toMatch(/notesStore\.refresh\(\)/);
     expect(method).toMatch(/return\s+this\.flushAndSnapshot\s*\(\s*id\s*\)/);
   });
 
-  it('loadNote discards a pristine ephemeral previous note instead of saving it', () => {
+  it('loadNote discards a pristine ephemeral previous note (refreshing the list) instead of saving it', () => {
     const method = sliceMethod(noteDetailSrc(), 'async loadNote');
     expect(method).toMatch(/this\.isUntouchedThisLoad\(\)\s*&&\s*\(await\s+discardIfEphemeral\s*\(\s*prevId\s*\)\s*\)/);
     // Falls back to the original flush+snapshot when not discarded.
     expect(method).toMatch(/if\s*\(\s*!discarded\s*\)/);
+    // Drops the discarded note from the visible list right away.
+    expect(method).toMatch(/notesStore\.refresh\(\)/);
   });
 
   it('+page.svelte routes both leave paths (note close, navigation) through leaveNote', () => {

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -939,11 +939,16 @@ export async function pushPendingItems(): Promise<void> {
   // failed soft-deletes and must be retried via pushNoteDelete. Before this
   // split, a retried archived note would have been POSTed like a new note,
   // resurrecting it on the server.
+  //
+  // is_ephemeral rows are excluded entirely: these are pristine untouched "new
+  // notes" whose push is deferred until the user's first action (#349). The
+  // server must never see them, so the retry sweep must skip them too - the
+  // first deliberate action clears the flag and POSTs the row.
   const pendingNotes = allNotes.filter(
-    (n) => n.sync_status === 'pending' && !n.is_archived
+    (n) => n.sync_status === 'pending' && !n.is_archived && !n.is_ephemeral
   );
   const pendingArchivedNotes = allNotes.filter(
-    (n) => n.sync_status === 'pending' && n.is_archived
+    (n) => n.sync_status === 'pending' && n.is_archived && !n.is_ephemeral
   );
 
   if (
@@ -1322,6 +1327,34 @@ export function pushNoteUpdate(
       }
     )
   );
+}
+
+/**
+ * Push a note mutation, choosing POST-create vs. PATCH-update based on whether
+ * the note has ever reached the server.
+ *
+ * A note created as a deferred-push ephemeral blank (#349) has no server row, so
+ * its first server contact MUST be a POST - a PATCH would 404. Any deliberate
+ * action (edit, rename, move, pin, star, tag) promotes it: the caller clears
+ * `is_ephemeral` on the saved row and passes `wasEphemeral=true` here so the
+ * full row is POSTed (carrying the just-applied change). An already-synced note
+ * takes the normal partial PATCH path.
+ */
+export function pushNoteMutation(
+  row: NoteStoredLocal,
+  wasEphemeral: boolean,
+  patchFields: {
+    title_encrypted?: string;
+    content_encrypted?: string;
+    folder_id?: string | null;
+    metadata_encrypted?: string;
+  }
+): void {
+  if (wasEphemeral) {
+    pushNote(row);
+  } else {
+    pushNoteUpdate(row.id, patchFields);
+  }
 }
 
 export function pushNoteDelete(id: string, permanent = false): void {

--- a/apps/reborn-notes/src/lib/services/tag.service.ts
+++ b/apps/reborn-notes/src/lib/services/tag.service.ts
@@ -15,9 +15,9 @@ import type { TagDecrypted } from '@reborn/types';
 import { cryptoManager } from '@reborn/crypto';
 import { get } from 'svelte/store';
 import { authStore } from '$lib/stores/auth.store';
-import { pushTag, pushTagUpdate, pushTagDelete, pushNoteUpdate } from './notes-sync.service';
+import { pushTag, pushTagUpdate, pushTagDelete, pushNoteUpdate, pushNoteMutation } from './notes-sync.service';
 import { noteStore } from '@reborn/storage';
-import type { NoteSensitiveMetadata } from '@reborn/types';
+import type { NoteSensitiveMetadata, NoteStoredLocal } from '@reborn/types';
 import { noteIndex } from '$lib/services/note-index.svelte';
 
 // ── User identity ─────────────────────────────────────────────────
@@ -264,15 +264,20 @@ export async function setTagsForNote(noteId: string, tagIds: string[], options?:
     } catch {
       /* use default */
     }
+    const wasEphemeral = existing.is_ephemeral === true;
     const metadataEncrypted = await cryptoManager.encryptObject(meta);
-    await noteStore.save({
+    const updated: NoteStoredLocal = {
       ...existing,
       metadata_encrypted: metadataEncrypted,
       updated_at: new Date().toISOString(),
-      sync_status: 'pending'
-    });
+      sync_status: 'pending',
+      ...(wasEphemeral ? { is_ephemeral: false } : {})
+    };
+    await noteStore.save(updated);
     if (!options?.skipSync) {
-      pushNoteUpdate(noteId, { metadata_encrypted: metadataEncrypted });
+      // Tagging is a deliberate "keep it" action - promotes a pristine ephemeral
+      // note via POST (a PATCH would 404 - the server has no row yet). #349
+      pushNoteMutation(updated, wasEphemeral, { metadata_encrypted: metadataEncrypted });
     }
   }
   // Update tagIds in the NoteIndex cache

--- a/apps/reborn-notes/src/lib/stores/notes.store.ts
+++ b/apps/reborn-notes/src/lib/stores/notes.store.ts
@@ -303,14 +303,19 @@ function createNotesStore() {
     sortBy.set(sort);
   }
 
-  async function create(title: string, content = '', folderId?: string): Promise<string> {
+  async function create(
+    title: string,
+    content = '',
+    folderId?: string,
+    options?: { ephemeral?: boolean }
+  ): Promise<string> {
     const resolvedFolder =
       folderId !== undefined
         ? folderId
         : currentFolderId === undefined
           ? undefined
           : (currentFolderId ?? undefined);
-    const id = await NoteService.createNote(title, content, resolvedFolder);
+    const id = await NoteService.createNote(title, content, resolvedFolder, options);
     refresh();
     return id;
   }

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -694,7 +694,10 @@
 
     if (!id) {
       if (prev) {
-        untrack(() => noteDetailService.flushAndSnapshot(prev));
+        // leaveNote discards a pristine ephemeral note (#349) or flushes+snapshots
+        // a touched one. isUntouchedThisLoad() reads prev's state synchronously
+        // here, before reset() clears it below.
+        untrack(() => noteDetailService.leaveNote(prev));
       }
       untrack(() => noteDetailService.reset());
       return;
@@ -739,7 +742,11 @@
     const date = new Date().toISOString().slice(0, 10);
     const settings = await getSettings();
     const prefix = settings?.language === 'pl' ? 'Notatka' : 'Note';
-    const id = await notesStore.create(`${prefix} ${date}`, '');
+    // Create as ephemeral (#349): saved locally with a real id so the editor can
+    // open it, but its push is deferred until the first deliberate action. If the
+    // user backs out without touching it, leaveNote discards it and the server
+    // never sees it.
+    const id = await notesStore.create(`${prefix} ${date}`, '', undefined, { ephemeral: true });
     noteDetailService.setNewNote();
     activeNoteId.set(id);
   }
@@ -1595,6 +1602,11 @@
           saveErrorDialogOpen = true;
         }
       });
+    } else {
+      // No unsaved edits: silently discard a pristine ephemeral note so
+      // navigating away (e.g. to settings) leaves no ghost. Local-only and fast,
+      // so no need to cancel the navigation. No-op for non-ephemeral notes. #349
+      void noteDetailService.leaveNote();
     }
   });
 

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -76,6 +76,17 @@ export interface NoteStoredLocal extends NoteEncrypted {
    * a successful push, or whenever a local edit re-marks the note 'pending'.
    */
   sync_error_code?: SyncErrorCode;
+  /**
+   * Local-only marker for a pristine "new note" the user has not touched yet
+   * (created via the New Note button, default title, empty body, no edit / star /
+   * pin / tag / move). Such a note's push is deferred: the sync sweep skips it
+   * and the server never sees it, so an accidental New Note click that the user
+   * backs out of leaves zero trace (client or server). The first deliberate
+   * action promotes it - the flag is cleared and the note is POSTed as a normal
+   * create. Never sent to the server (push payloads use an explicit allowlist).
+   * See issue #349.
+   */
+  is_ephemeral?: boolean;
 }
 
 /** Maximum number of version snapshots kept per note (client and server). */

--- a/packages/types/src/schemas/entities/note.ts
+++ b/packages/types/src/schemas/entities/note.ts
@@ -60,7 +60,10 @@ export const NoteStoredLocalSchema = NoteEncryptedSchema.extend({
   is_starred: z.boolean().optional(),
   // Local-only: reason the last push was permanently rejected (paired with
   // sync_status: 'sync_error'). Never sent to the server. See SyncErrorCode.
-  sync_error_code: z.enum(['too_large', 'quota_exceeded', 'invalid', 'rejected']).optional()
+  sync_error_code: z.enum(['too_large', 'quota_exceeded', 'invalid', 'rejected']).optional(),
+  // Local-only: pristine untouched "new note" whose push is deferred until the
+  // first deliberate action. Never sent to the server. See issue #349.
+  is_ephemeral: z.boolean().optional()
 });
 
 // Export inferred types


### PR DESCRIPTION
## Summary

The New Note button created, saved **and pushed** a `Note YYYY-MM-DD` with an empty body immediately, so an accidental click left a ghost note - synced to the server and sitting in the list (Michał: had to delete these by hand). Reported by Travis (#349). Apple Notes' pattern: a note is **ephemeral until touched**.

A New Note is now created locally with a real id (the editor can open it) but its push is **deferred until the first deliberate action**. Carried by a local-only `is_ephemeral` shadow flag on `NoteStoredLocal` - it lives on the local type only (never on `NoteEncrypted`/wire), and push payloads use an explicit field allowlist, so the flag **never reaches the server**. No Prisma schema / crypto / wire-contract change.

**Lifecycle** (`is_ephemeral` = pristine, zero actions):
- **create** (`createNote({ ephemeral: true })`, New Note only): flagged, **not pushed**.
- **sync sweep** (`pushPendingItems`): excludes `is_ephemeral` from both note buckets - the primary ZK guarantee that the server never sees a ghost, even if a sync cycle fires while an untouched note is open.
- **promotion** (first edit / rename / move / pin / star / tag): clears the flag and POSTs the full row via the new `pushNoteMutation` - a PATCH would 404 since the server has no row yet.
- **discard-on-leave** (`leaveNote` in the `activeNoteId` effect + `beforeNavigate`): hard-deletes the local row with **zero server contact** when still untouched.
- **startup sweep** (`cleanEphemeralNotes`, alongside `cleanTrash`): drops leftover ephemeral rows after a reload; safe without decryption since the flag clears atomically with the first edit's save.
- **delete from list** (`deleteNote`) on an ephemeral note hard-deletes (no Trash).

**Design decisions surfaced for review** (Approach B from triage, refined with Michał):
1. **Any deliberate action promotes** (not just title/content). Star/pin/tag/move go through the note menu = intent to keep. Uniform model: pristine vs. touched.
2. **Folder-delete reparent (`detach`) does NOT promote** - it's a side effect, not an action on the note; it skips the push and the pristine note is cleaned up.
3. **`is_ephemeral` is orthogonal to the transient `isNewNote` viewMode hint** (consumed once by the effect, cleared in `loadNote`).

**Zero-knowledge:** server visibility strictly **shrinks** (untouched notes are never sent; today they're POSTed immediately) - stronger ZK, not weaker.

Docs: `guidelines/36-sync-architecture.md` new section (reapps-docs).

## Test plan

Gate (all green): vitest **1071 passed** (70 files; +23 new in `notes-discard-ephemeral.regression.spec.ts`), svelte-check **0/0**, eslint **0 errors**, `@reborn/types` typecheck+test, vite build OK. i18n parity unchanged (no new user-facing strings).

Smoke (Michał):
1. New Note, then leave without editing (click another note / back arrow) -> it disappears silently; not in Trash; nothing on the server.
2. New Note -> type one character -> it stays and syncs.
3. New Note -> star / pin / tag without typing -> it stays (POSTed).
4. New Note -> reload before editing -> gone after startup.
5. Existing notes: edit / rename / move / star / pin / tag - no sync regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)