### PR TITLE
feat(notes): render inline markdown in live preview table cells

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteEditor.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteEditor.svelte
@@ -22,8 +22,10 @@
     createLivePreviewExtension,
     getMarkdownExtension,
     rebuildLivePreview,
-    registerCodeBlockView
+    registerCodeBlockView,
+    wrapCellSelection
   } from '$lib/editor/live-preview';
+  import { computeInlineWrap } from '$lib/editor/inline-wrap';
   import { effectiveEditorMode } from '$lib/stores/app-settings.store';
   import type { ImageLoadMode } from '@reborn/storage';
   import { isDataUri } from '$lib/utils/markdown-sanitizer';
@@ -172,56 +174,52 @@
 
   // ── Formatting helpers ──────────────────────────────────────────
 
+  /** The focused Live Preview table cell, if the caret is currently inside one.
+   *  Toolbar/shortcut formatting must target the cell's own contenteditable
+   *  selection, not the (stale) CM6 document selection. */
+  function focusedTableCell(): HTMLElement | null {
+    const el = document.activeElement;
+    if (
+      el instanceof HTMLElement &&
+      (el.tagName === 'TD' || el.tagName === 'TH') &&
+      el.closest('.cm-lp-table-wrap')
+    ) {
+      return el;
+    }
+    return null;
+  }
+
+  /** Keep the editor/cell focused (and its selection alive) when a toolbar
+   *  button is pressed: without this, mousedown moves focus to the button,
+   *  blurring a table cell and losing its selection before the command runs.
+   *  Harmless for normal editing (CM6 keeps its focus + selection). */
+  function keepEditorFocus(node: HTMLElement) {
+    const handler = (e: MouseEvent) => e.preventDefault();
+    node.addEventListener('mousedown', handler);
+    return {
+      destroy() {
+        node.removeEventListener('mousedown', handler);
+      }
+    };
+  }
+
   function wrapSelection(marker: string): boolean {
     if (!view) return false;
+
+    // Inside a Live Preview table cell the editable text lives in the cell's
+    // contenteditable, not the CM6 doc — delegate so the wrap lands on the
+    // cell's selection and round-trips through the table's edit pipeline.
+    const cell = focusedTableCell();
+    if (cell) return wrapCellSelection(cell, marker);
+
     const { state } = view;
     const sel = state.selection.main;
     const selected = state.sliceDoc(sel.from, sel.to);
-
-    let insert: string;
-    let anchor: number;
-    let head: number;
-
-    if (selected) {
-      // Markdown emphasis delimiters must hug non-whitespace: per CommonMark's
-      // flanking rule `** x **` renders literally, only `**x**` is bold. So any
-      // leading/trailing whitespace caught in the selection has to stay OUTSIDE
-      // the markers. Split it off and wrap only the trimmed core; this also
-      // makes toggle-off work when the selection includes surrounding spaces.
-      const leadingWs = (selected.match(/^\s*/) ?? [''])[0];
-      const rest = selected.slice(leadingWs.length);
-      const trailingWs = (rest.match(/\s*$/) ?? [''])[0];
-      const core = rest.slice(0, rest.length - trailingWs.length);
-
-      if (!core) {
-        // Whitespace-only selection: nothing to emphasize. Keep the spaces,
-        // drop empty markers in place, leave the cursor between them to type.
-        insert = `${leadingWs}${marker}${marker}${trailingWs}`;
-        anchor = sel.from + leadingWs.length + marker.length;
-        head = anchor;
-      } else if (
-        core.startsWith(marker) &&
-        core.endsWith(marker) &&
-        core.length > marker.length * 2
-      ) {
-        const unwrapped = core.slice(marker.length, -marker.length);
-        insert = `${leadingWs}${unwrapped}${trailingWs}`;
-        anchor = sel.from + leadingWs.length;
-        head = anchor + unwrapped.length;
-      } else {
-        insert = `${leadingWs}${marker}${core}${marker}${trailingWs}`;
-        anchor = sel.from + leadingWs.length;
-        head = anchor + marker.length * 2 + core.length;
-      }
-    } else {
-      insert = `${marker}${marker}`;
-      anchor = sel.from + marker.length;
-      head = anchor;
-    }
+    const { insert, anchor, head } = computeInlineWrap(selected, marker);
 
     view.dispatch({
       changes: { from: sel.from, to: sel.to, insert },
-      selection: { anchor, head }
+      selection: { anchor: sel.from + anchor, head: sel.from + head }
     });
     view.focus();
     return true;
@@ -823,6 +821,7 @@
       <!-- Inline formatting -->
       <button
         type="button"
+        use:keepEditorFocus
         onclick={() => wrapSelection('**')}
         title={$t('editor.formatting.bold') + ' (Ctrl+B)'}
         class="toolbar-btn"
@@ -832,6 +831,7 @@
       </button>
       <button
         type="button"
+        use:keepEditorFocus
         onclick={() => wrapSelection('_')}
         title={$t('editor.formatting.italic') + ' (Ctrl+I)'}
         class="toolbar-btn"
@@ -841,6 +841,7 @@
       </button>
       <button
         type="button"
+        use:keepEditorFocus
         onclick={() => wrapSelection('~~')}
         title={$t('editor.formatting.strikethrough')}
         class="toolbar-btn"
@@ -850,6 +851,7 @@
       </button>
       <button
         type="button"
+        use:keepEditorFocus
         onclick={() => wrapSelection('`')}
         title={$t('editor.formatting.code')}
         class="toolbar-btn"

--- a/apps/reborn-notes/src/lib/editor/inline-wrap.test.ts
+++ b/apps/reborn-notes/src/lib/editor/inline-wrap.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { computeInlineWrap } from './inline-wrap';
+
+describe('computeInlineWrap', () => {
+  it('inserts empty markers with the caret between them for no selection', () => {
+    expect(computeInlineWrap('', '**')).toEqual({ insert: '****', anchor: 2, head: 2 });
+  });
+
+  it('wraps a word and selects the whole result', () => {
+    expect(computeInlineWrap('word', '**')).toEqual({ insert: '**word**', anchor: 0, head: 8 });
+  });
+
+  it('toggles an already-wrapped word off', () => {
+    expect(computeInlineWrap('**word**', '**')).toEqual({ insert: 'word', anchor: 0, head: 4 });
+  });
+
+  it('keeps surrounding whitespace outside the markers', () => {
+    expect(computeInlineWrap(' word ', '**')).toEqual({ insert: ' **word** ', anchor: 1, head: 9 });
+  });
+
+  it('drops empty markers for a whitespace-only selection', () => {
+    expect(computeInlineWrap('   ', '**')).toEqual({ insert: '   ****', anchor: 5, head: 5 });
+  });
+
+  it('works with single-character markers (italic)', () => {
+    expect(computeInlineWrap('x', '_')).toEqual({ insert: '_x_', anchor: 0, head: 3 });
+  });
+
+  it('works with strikethrough', () => {
+    expect(computeInlineWrap('x', '~~')).toEqual({ insert: '~~x~~', anchor: 0, head: 5 });
+  });
+
+  it('works with inline code', () => {
+    expect(computeInlineWrap('x', '`')).toEqual({ insert: '`x`', anchor: 0, head: 3 });
+  });
+
+  it('toggles italic off', () => {
+    expect(computeInlineWrap('_x_', '_')).toEqual({ insert: 'x', anchor: 0, head: 1 });
+  });
+
+  it('does not toggle off when only one side is marked', () => {
+    expect(computeInlineWrap('_x', '_')).toEqual({ insert: '__x_', anchor: 0, head: 4 });
+  });
+});

--- a/apps/reborn-notes/src/lib/editor/inline-wrap.ts
+++ b/apps/reborn-notes/src/lib/editor/inline-wrap.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure logic for toggling an inline markdown wrap (`**`, `_`, `~~`, `` ` ``)
+ * around a selected string. Shared by the CM6 editor toolbar (`wrapSelection`
+ * in `NoteEditor.svelte`) and the Live Preview table cell editor
+ * (`wrapCellSelection` in `live-preview/table-widget.ts`) so both apply
+ * identical semantics — keeping them from drifting.
+ *
+ * Returns the replacement text plus the selection to leave behind, expressed as
+ * offsets *relative to the start of the replaced range*. The caller adds its own
+ * base offset (a doc position for CM6, a node offset for a contenteditable cell).
+ */
+export interface InlineWrapResult {
+  /** Text to replace the selection with. */
+  insert: string;
+  /** Selection anchor within `insert`. */
+  anchor: number;
+  /** Selection head within `insert`. */
+  head: number;
+}
+
+export function computeInlineWrap(selected: string, marker: string): InlineWrapResult {
+  if (!selected) {
+    // No selection: drop empty markers, caret between them to type into.
+    return { insert: `${marker}${marker}`, anchor: marker.length, head: marker.length };
+  }
+
+  // Markdown emphasis delimiters must hug non-whitespace: per CommonMark's
+  // flanking rule `** x **` renders literally, only `**x**` is bold. So any
+  // leading/trailing whitespace caught in the selection stays OUTSIDE the
+  // markers. Split it off and wrap only the trimmed core; this also makes
+  // toggle-off work when the selection includes surrounding spaces.
+  const leadingWs = (selected.match(/^\s*/) ?? [''])[0];
+  const rest = selected.slice(leadingWs.length);
+  const trailingWs = (rest.match(/\s*$/) ?? [''])[0];
+  const core = rest.slice(0, rest.length - trailingWs.length);
+
+  if (!core) {
+    // Whitespace-only selection: nothing to emphasize. Keep the spaces, drop
+    // empty markers in place, caret between them.
+    const insert = `${leadingWs}${marker}${marker}${trailingWs}`;
+    const anchor = leadingWs.length + marker.length;
+    return { insert, anchor, head: anchor };
+  }
+
+  if (core.startsWith(marker) && core.endsWith(marker) && core.length > marker.length * 2) {
+    // Already wrapped → toggle off.
+    const unwrapped = core.slice(marker.length, -marker.length);
+    const insert = `${leadingWs}${unwrapped}${trailingWs}`;
+    const anchor = leadingWs.length;
+    return { insert, anchor, head: anchor + unwrapped.length };
+  }
+
+  const insert = `${leadingWs}${marker}${core}${marker}${trailingWs}`;
+  const anchor = leadingWs.length;
+  return { insert, anchor, head: anchor + marker.length * 2 + core.length };
+}

--- a/apps/reborn-notes/src/lib/editor/live-preview/index.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/index.ts
@@ -135,7 +135,7 @@ export {
   getLoadedImages,
   type ImageWidgetLabels
 } from './image-widget';
-export { TableWidget, tableCellEditAnnotation } from './table-widget';
+export { TableWidget, tableCellEditAnnotation, wrapCellSelection } from './table-widget';
 export {
   highlightCodeToHtml,
   triggerLanguageLoad,

--- a/apps/reborn-notes/src/lib/editor/live-preview/table-cell-render.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/table-cell-render.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { parseInlineCell, cellHasFormatting, type InlineNode } from './table-cell-render';
+
+/** Collapse an AST to a compact string so assertions read clearly. */
+function sketch(nodes: InlineNode[]): string {
+  return nodes
+    .map((n) => {
+      switch (n.type) {
+        case 'text':
+          return n.value;
+        case 'br':
+          return '<br>';
+        case 'code':
+          return `code(${n.value})`;
+        case 'strong':
+          return `strong(${sketch(n.children)})`;
+        case 'em':
+          return `em(${sketch(n.children)})`;
+        case 'strike':
+          return `strike(${sketch(n.children)})`;
+        case 'link':
+          return `link(${n.text}|${n.url})`;
+      }
+    })
+    .join('');
+}
+
+describe('parseInlineCell — basic constructs', () => {
+  it('parses **bold**', () => {
+    expect(sketch(parseInlineCell('**bold**'))).toBe('strong(bold)');
+  });
+
+  it('parses __bold__', () => {
+    expect(sketch(parseInlineCell('__bold__'))).toBe('strong(bold)');
+  });
+
+  it('parses *italic*', () => {
+    expect(sketch(parseInlineCell('*italic*'))).toBe('em(italic)');
+  });
+
+  it('parses _italic_', () => {
+    expect(sketch(parseInlineCell('_italic_'))).toBe('em(italic)');
+  });
+
+  it('parses ~~strike~~', () => {
+    expect(sketch(parseInlineCell('~~gone~~'))).toBe('strike(gone)');
+  });
+
+  it('parses `code`', () => {
+    expect(sketch(parseInlineCell('`code`'))).toBe('code(code)');
+  });
+
+  it('does not parse markdown inside code spans', () => {
+    expect(sketch(parseInlineCell('`a *b* c`'))).toBe('code(a *b* c)');
+  });
+
+  it('strips one padding space inside a code span', () => {
+    expect(sketch(parseInlineCell('` x `'))).toBe('code(x)');
+  });
+});
+
+describe('parseInlineCell — links', () => {
+  it('parses [text](url)', () => {
+    expect(sketch(parseInlineCell('[home](https://x.dev)'))).toBe('link(home|https://x.dev)');
+  });
+
+  it('drops a link title', () => {
+    expect(sketch(parseInlineCell('[t](https://x.dev "title")'))).toBe('link(t|https://x.dev)');
+  });
+
+  it('keeps note links intact', () => {
+    const url = 'note:11111111-2222-3333-4444-555555555555';
+    expect(sketch(parseInlineCell(`[ref](${url})`))).toBe(`link(ref|${url})`);
+  });
+
+  it('leaves bracket text without a destination literal', () => {
+    expect(sketch(parseInlineCell('[not a link]'))).toBe('[not a link]');
+  });
+});
+
+describe('parseInlineCell — mixed & nested', () => {
+  it('mixes formatting with surrounding text', () => {
+    expect(sketch(parseInlineCell('a **b** c `d`'))).toBe('a strong(b) c code(d)');
+  });
+
+  it('nests emphasis inside strong', () => {
+    expect(sketch(parseInlineCell('**a _b_ c**'))).toBe('strong(a em(b) c)');
+  });
+
+  it('allows intraword asterisk emphasis', () => {
+    expect(sketch(parseInlineCell('a*b*c'))).toBe('aem(b)c');
+  });
+});
+
+describe('parseInlineCell — guards against false positives', () => {
+  it('keeps snake_case literal', () => {
+    expect(sketch(parseInlineCell('snake_case'))).toBe('snake_case');
+  });
+
+  it('keeps intraword underscores literal', () => {
+    expect(sketch(parseInlineCell('a_b_c'))).toBe('a_b_c');
+  });
+
+  it('keeps an unmatched delimiter literal', () => {
+    expect(sketch(parseInlineCell('**bold'))).toBe('**bold');
+  });
+
+  it('does not open emphasis on a space', () => {
+    expect(sketch(parseInlineCell('a * b * c'))).toBe('a * b * c');
+  });
+
+  it('treats an empty delimiter run as literal', () => {
+    expect(sketch(parseInlineCell('****'))).toBe('****');
+  });
+
+  it('does not treat a bare asterisk as emphasis', () => {
+    expect(sketch(parseInlineCell('2 * 3 = 6'))).toBe('2 * 3 = 6');
+  });
+});
+
+describe('parseInlineCell — line breaks', () => {
+  it('splits lines into br nodes', () => {
+    expect(sketch(parseInlineCell('a\nb'))).toBe('a<br>b');
+  });
+
+  it('keeps formatting per line', () => {
+    expect(sketch(parseInlineCell('**a**\n*b*'))).toBe('strong(a)<br>em(b)');
+  });
+
+  it('handles an empty cell', () => {
+    expect(parseInlineCell('')).toEqual([]);
+  });
+});
+
+describe('cellHasFormatting', () => {
+  it.each(['**bold**', '_em_', '`code`', '~~s~~', '[t](https://x.dev)', 'a **b**'])(
+    'is true for %s',
+    (input) => {
+      expect(cellHasFormatting(input)).toBe(true);
+    }
+  );
+
+  it.each(['plain text', 'snake_case', 'a_b_c', '2 * 3', 'line one\nline two', '', '[not a link]'])(
+    'is false for %s',
+    (input) => {
+      expect(cellHasFormatting(input)).toBe(false);
+    }
+  );
+});

--- a/apps/reborn-notes/src/lib/editor/live-preview/table-cell-render.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/table-cell-render.ts
@@ -1,0 +1,319 @@
+/**
+ * Minimal inline-markdown renderer for Live Preview table cells.
+ *
+ * GFM table cells can't host block content, so a cell only ever needs the
+ * handful of inline constructs: bold, italic, strikethrough, inline code and
+ * links (plus `\n` soft breaks from Shift+Enter). The full markdown pipeline
+ * (`@lezer/markdown` / `marked` + DOMPurify) is overkill and can't run on the
+ * tiny string slices a single cell holds, so we hand-roll a tiny scanner.
+ *
+ * Two layers:
+ *  - `parseInlineCell(text)` → a flat-ish AST (`InlineNode[]`). PURE and
+ *    DOM-free, so it is the unit-tested surface (vitest runs in `node`).
+ *  - `buildInlineFragment(text)` → a `DocumentFragment` built from that AST.
+ *    Browser-only (touches `document`); verified by manual smoke, mirroring how
+ *    the other Live Preview widgets keep their `toDOM` out of unit tests.
+ *
+ * Security: every leaf string reaches the DOM through `createTextNode` /
+ * `textContent` (never `innerHTML`), and links are delegated to the existing,
+ * allowlist-guarded `LinkWidget`. A cell containing `<script>` renders as the
+ * literal text `<script>`. No new sink, no DOMPurify needed.
+ */
+import { LinkWidget } from './widgets';
+
+export type InlineNode =
+  | { type: 'text'; value: string }
+  | { type: 'br' }
+  | { type: 'code'; value: string }
+  | { type: 'strong'; children: InlineNode[] }
+  | { type: 'em'; children: InlineNode[] }
+  | { type: 'strike'; children: InlineNode[] }
+  | { type: 'link'; text: string; url: string };
+
+/** Unicode letter or number — used for emphasis flanking rules. */
+const WORD = /[\p{L}\p{N}]/u;
+function isWordChar(ch: string | undefined): boolean {
+  return ch !== undefined && WORD.test(ch);
+}
+
+interface DelimMatch {
+  /** Raw text between the delimiters (parsed recursively by the caller). */
+  content: string;
+  /** Total characters consumed from `open`, including both delimiters. */
+  length: number;
+}
+
+/**
+ * Try to match an emphasis-style span (`**`, `__`, `*`, `_`, `~~`) starting at
+ * `open`. Returns the inner content and consumed length, or `null` if there is
+ * no well-formed span here.
+ *
+ * Implements a pragmatic subset of CommonMark's delimiter rules — enough to be
+ * intuitive without a full delimiter-stack parser:
+ *  - the opener must be immediately followed by non-space content;
+ *  - the closer must be immediately preceded by non-space;
+ *  - `_`/`__` need a word boundary on the outside, so `snake_case` and
+ *    `a_b_c` stay literal while `*a*` intraword still works (matching the GFM
+ *    intuition most users carry);
+ *  - a candidate closer that is part of a longer delimiter run is skipped, so
+ *    `*` does not close on the first `*` of a `**`.
+ */
+function matchDelimiter(text: string, open: number, delim: string): DelimMatch | null {
+  const dl = delim.length;
+  if (text.slice(open, open + dl) !== delim) return null;
+
+  const charBeforeOpen = text[open - 1];
+  const charAfterOpen = text[open + dl];
+
+  // Opener needs content right after it (no `** bold**`, no empty `****`).
+  if (charAfterOpen === undefined || /\s/.test(charAfterOpen)) return null;
+
+  const underscore = delim[0] === '_';
+  if (underscore && isWordChar(charBeforeOpen)) return null;
+
+  let search = open + dl;
+  while (search < text.length) {
+    const idx = text.indexOf(delim, search);
+    if (idx === -1) return null;
+
+    // Empty content (`****`) — keep looking for a later closer.
+    if (idx === open + dl) {
+      search = idx + dl;
+      continue;
+    }
+
+    const charBeforeClose = text[idx - 1];
+    const charAfterClose = text[idx + dl];
+
+    // Closer must not have a space right before it (`bold **` is not a closer).
+    if (charBeforeClose !== undefined && /\s/.test(charBeforeClose)) {
+      search = idx + dl;
+      continue;
+    }
+    // Single-char delimiters: skip a candidate that is really part of a longer
+    // run (so `*` in `**x**` is handled by the `**` matcher, not this one).
+    if ((delim === '*' || delim === '_') && (charBeforeClose === delim || charAfterClose === delim)) {
+      search = idx + 1;
+      continue;
+    }
+    // Underscore emphasis also needs a word boundary on the right.
+    if (underscore && isWordChar(charAfterClose)) {
+      search = idx + 1;
+      continue;
+    }
+
+    return { content: text.slice(open + dl, idx), length: idx + dl - open };
+  }
+  return null;
+}
+
+/** Match an inline code span (`` `code` ``, ``` ``code with ` inside`` ```). */
+function matchCode(text: string, pos: number): DelimMatch | null {
+  if (text[pos] !== '`') return null;
+  let run = 0;
+  while (text[pos + run] === '`') run += 1;
+  const fence = '`'.repeat(run);
+
+  let search = pos + run;
+  while (search <= text.length - run) {
+    const idx = text.indexOf(fence, search);
+    if (idx === -1) return null;
+    // Require an exact-length backtick run for the closer.
+    if (text[idx - 1] === '`' || text[idx + run] === '`') {
+      search = idx + 1;
+      continue;
+    }
+    let content = text.slice(pos + run, idx);
+    // CommonMark: strip one leading and trailing space if the span isn't blank.
+    if (content.length >= 2 && content.startsWith(' ') && content.endsWith(' ') && content.trim() !== '') {
+      content = content.slice(1, -1);
+    }
+    return { content, length: idx + run - pos };
+  }
+  return null;
+}
+
+interface LinkMatch {
+  text: string;
+  url: string;
+  length: number;
+}
+
+/** Match a `[text](url)` link. Titles (`[t](url "x")`) are dropped. */
+function matchLink(text: string, pos: number): LinkMatch | null {
+  if (text[pos] !== '[') return null;
+  const closeBracket = text.indexOf(']', pos + 1);
+  if (closeBracket === -1 || text[closeBracket + 1] !== '(') return null;
+  const closeParen = text.indexOf(')', closeBracket + 2);
+  if (closeParen === -1) return null;
+
+  const linkText = text.slice(pos + 1, closeBracket);
+  let dest = text.slice(closeBracket + 2, closeParen).trim();
+  const spaceIdx = dest.search(/\s/);
+  if (spaceIdx !== -1) dest = dest.slice(0, spaceIdx); // drop optional title
+  if (!dest) return null;
+
+  return { text: linkText, url: dest, length: closeParen + 1 - pos };
+}
+
+/** Parse a single line (no `\n`) into inline nodes. */
+function parseInline(text: string): InlineNode[] {
+  const nodes: InlineNode[] = [];
+  let buf = '';
+  let i = 0;
+
+  const flush = () => {
+    if (buf) {
+      nodes.push({ type: 'text', value: buf });
+      buf = '';
+    }
+  };
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    if (ch === '`') {
+      const code = matchCode(text, i);
+      if (code) {
+        flush();
+        nodes.push({ type: 'code', value: code.content });
+        i += code.length;
+        continue;
+      }
+    } else if (ch === '[') {
+      const link = matchLink(text, i);
+      if (link) {
+        flush();
+        nodes.push({ type: 'link', text: link.text, url: link.url });
+        i += link.length;
+        continue;
+      }
+    } else if (ch === '*') {
+      const strong = matchDelimiter(text, i, '**');
+      if (strong) {
+        flush();
+        nodes.push({ type: 'strong', children: parseInline(strong.content) });
+        i += strong.length;
+        continue;
+      }
+      const em = matchDelimiter(text, i, '*');
+      if (em) {
+        flush();
+        nodes.push({ type: 'em', children: parseInline(em.content) });
+        i += em.length;
+        continue;
+      }
+    } else if (ch === '_') {
+      const strong = matchDelimiter(text, i, '__');
+      if (strong) {
+        flush();
+        nodes.push({ type: 'strong', children: parseInline(strong.content) });
+        i += strong.length;
+        continue;
+      }
+      const em = matchDelimiter(text, i, '_');
+      if (em) {
+        flush();
+        nodes.push({ type: 'em', children: parseInline(em.content) });
+        i += em.length;
+        continue;
+      }
+    } else if (ch === '~') {
+      const strike = matchDelimiter(text, i, '~~');
+      if (strike) {
+        flush();
+        nodes.push({ type: 'strike', children: parseInline(strike.content) });
+        i += strike.length;
+        continue;
+      }
+    }
+
+    buf += ch;
+    i += 1;
+  }
+
+  flush();
+  return nodes;
+}
+
+/**
+ * Parse a full cell value (decoded form: literal `\n` for Shift+Enter breaks)
+ * into inline nodes, inserting a `br` node between lines.
+ */
+export function parseInlineCell(text: string): InlineNode[] {
+  const out: InlineNode[] = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0) out.push({ type: 'br' });
+    out.push(...parseInline(lines[i]));
+  }
+  return out;
+}
+
+/**
+ * True if the cell contains any inline formatting (i.e. its rendered form
+ * differs from its raw source). Plain text — even multi-line — returns false,
+ * which lets the widget skip the rendered↔raw swap and keep native caret
+ * placement when such a cell is focused.
+ */
+export function cellHasFormatting(text: string): boolean {
+  return parseInlineCell(text).some((n) => n.type !== 'text' && n.type !== 'br');
+}
+
+function appendChildren(el: HTMLElement, children: InlineNode[]): void {
+  for (const child of children) el.appendChild(nodeToDom(child));
+}
+
+function nodeToDom(node: InlineNode): Node {
+  switch (node.type) {
+    case 'text':
+      return document.createTextNode(node.value);
+    case 'br':
+      return document.createElement('br');
+    case 'code': {
+      const el = document.createElement('code');
+      el.className = 'cm-lp-code';
+      el.textContent = node.value;
+      return el;
+    }
+    case 'strong': {
+      const el = document.createElement('strong');
+      el.className = 'cm-lp-strong';
+      appendChildren(el, node.children);
+      return el;
+    }
+    case 'em': {
+      const el = document.createElement('em');
+      el.className = 'cm-lp-em';
+      appendChildren(el, node.children);
+      return el;
+    }
+    case 'strike': {
+      const el = document.createElement('del');
+      el.className = 'cm-lp-strike';
+      appendChildren(el, node.children);
+      return el;
+    }
+    case 'link': {
+      // Reuse the Live Preview link renderer: same URL allowlist, same
+      // note-link / blocked-link handling as links elsewhere in the editor.
+      const el = new LinkWidget(node.text, node.url).toDOM();
+      // Keep a left-click on the link from focusing the cell — focusing would
+      // swap the rendered view for raw source before the click resolves, so the
+      // link would never open. (Note links already do this inside LinkWidget;
+      // we extend it to every link type.) The cell stays editable: click its
+      // padding or any non-link text, or Tab in.
+      el.addEventListener('mousedown', (e) => {
+        if (e.button === 0) e.preventDefault();
+      });
+      return el;
+    }
+  }
+}
+
+/** Build a DocumentFragment rendering `text` with inline formatting applied. */
+export function buildInlineFragment(text: string): DocumentFragment {
+  const frag = document.createDocumentFragment();
+  for (const node of parseInlineCell(text)) frag.appendChild(nodeToDom(node));
+  return frag;
+}

--- a/apps/reborn-notes/src/lib/editor/live-preview/table-widget.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/table-widget.ts
@@ -43,6 +43,7 @@ import {
   serializeTable
 } from './table-parse';
 import { buildInlineFragment, cellHasFormatting } from './table-cell-render';
+import { computeInlineWrap } from '../inline-wrap';
 
 /** Annotation marking a transaction as a cell-level table edit. Reserved for
  *  potential future use (e.g. suppressing analytics or scroll-sync); not
@@ -186,6 +187,40 @@ function caretToEnd(cell: HTMLElement): void {
   range.collapse(false);
   sel?.removeAllRanges();
   sel?.addRange(range);
+}
+
+/**
+ * Apply an inline markdown wrap (`**`, `_`, `~~`, `` ` ``) to the selection
+ * inside a focused table cell, then push the edit through the cell's normal
+ * serialization pipeline (a synthetic `input`). Operates on the cell's own DOM
+ * selection — when focused the cell holds raw, editable text — mirroring the
+ * CM6 toolbar's `wrapSelection`. Used by the toolbar buttons and the in-cell
+ * Mod-b / Mod-i shortcuts. Returns false when there is no usable selection.
+ */
+export function wrapCellSelection(cell: HTMLElement, marker: string): boolean {
+  const sel = cell.ownerDocument.defaultView?.getSelection();
+  if (!sel || sel.rangeCount === 0) return false;
+  const range = sel.getRangeAt(0);
+  if (!cell.contains(range.commonAncestorContainer)) return false;
+
+  const { insert, anchor, head } = computeInlineWrap(range.toString(), marker);
+
+  range.deleteContents();
+  const textNode = cell.ownerDocument.createTextNode(insert);
+  range.insertNode(textNode);
+
+  // Re-select the wrapped core so a second press toggles it off and the user
+  // sees what changed. `insert` is one text node, so computeInlineWrap's
+  // relative offsets map straight onto it.
+  const newRange = cell.ownerDocument.createRange();
+  newRange.setStart(textNode, Math.min(anchor, insert.length));
+  newRange.setEnd(textNode, Math.min(head, insert.length));
+  sel.removeAllRanges();
+  sel.addRange(newRange);
+
+  // Serialize the table + write back to the CM6 doc via the existing handler.
+  cell.dispatchEvent(new Event('input', { bubbles: true }));
+  return true;
 }
 
 /**
@@ -427,6 +462,19 @@ export class TableWidget extends WidgetType {
   ): void {
     const root = this.getRoot(cell);
     if (!root) return;
+
+    // Bold / italic shortcuts. Handle them here because the widget sets
+    // `ignoreEvent() = true`, so CM6's `Mod-b`/`Mod-i` keymap never sees keys
+    // typed inside a cell. Also stops the browser's contenteditable default,
+    // which would inject `<b>`/`<i>` HTML instead of markdown.
+    if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
+      const key = e.key.toLowerCase();
+      if (key === 'b' || key === 'i') {
+        e.preventDefault();
+        wrapCellSelection(cell, key === 'b' ? '**' : '_');
+        return;
+      }
+    }
 
     if (e.key === 'Tab') {
       e.preventDefault();

--- a/apps/reborn-notes/src/lib/editor/live-preview/table-widget.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/table-widget.ts
@@ -17,6 +17,19 @@
  * Structural changes (new row added) intentionally fail `eq()`, forcing a full
  * `toDOM` rebuild. The handler that triggered the structural change manually
  * re-focuses the appropriate cell after the rebuild.
+ *
+ * Cell content has two presentations (Obsidian-style):
+ *  - **rendered** when the cell is not focused — inline markdown (`**bold**`,
+ *    `*em*`, `` `code` ``, `~~strike~~`, `[t](url)`) is shown formatted, built
+ *    by `table-cell-render`;
+ *  - **raw** when the cell is focused — the markdown source, so it can be
+ *    edited character by character (identical to the old plain-text cell).
+ * The swap happens on `focus`/`blur`. Because a rendered cell's visible text
+ * drops the markdown markers, the canonical source for each rendered cell is
+ * stashed on `dataset.lpSrc` and read back from there at serialization time —
+ * never re-derived from the rendered DOM. Plain (unformatted) cells render
+ * identically in both modes, so they skip the swap and keep native caret
+ * placement on click.
  */
 import type { EditorView } from '@codemirror/view';
 import { WidgetType } from '@codemirror/view';
@@ -29,6 +42,7 @@ import {
   sameTableStructure,
   serializeTable
 } from './table-parse';
+import { buildInlineFragment, cellHasFormatting } from './table-cell-render';
 
 /** Annotation marking a transaction as a cell-level table edit. Reserved for
  *  potential future use (e.g. suppressing analytics or scroll-sync); not
@@ -108,7 +122,7 @@ function readDomTable(
   const headerRow = root.querySelector('thead > tr');
   if (headerRow) {
     headerRow.querySelectorAll('th').forEach((th) => {
-      header.push({ text: readCellText(th) });
+      header.push({ text: readCellSource(th) });
     });
   }
   // Pad if DOM has fewer header cells than expected (defensive).
@@ -118,7 +132,7 @@ function readDomTable(
   root.querySelectorAll('tbody > tr').forEach((tr) => {
     const row: { text: string }[] = [];
     tr.querySelectorAll('td').forEach((td) => {
-      row.push({ text: readCellText(td) });
+      row.push({ text: readCellSource(td) });
     });
     while (row.length < cols) row.push({ text: '' });
     rows.push(row);
@@ -139,6 +153,39 @@ function setCellContent(cell: HTMLElement, text: string): void {
     if (part.length > 0) cell.appendChild(document.createTextNode(part));
     if (i < parts.length - 1) cell.appendChild(document.createElement('br'));
   });
+}
+
+/**
+ * Render a non-focused cell with inline markdown formatting applied, and stash
+ * the markdown source on `dataset.lpSrc`. The source — not the formatted DOM —
+ * is what `readCellSource` returns at serialization time, so the markers
+ * survive even though they aren't visible. For plain text this produces the
+ * exact same DOM as `setCellContent`.
+ */
+function renderCellContent(cell: HTMLElement, text: string): void {
+  cell.replaceChildren();
+  cell.appendChild(buildInlineFragment(text));
+  cell.dataset.lpSrc = text;
+}
+
+/**
+ * The markdown source of a cell. The focused cell is read live from the DOM
+ * (it holds raw, editable text); every other cell is rendered, so its visible
+ * text omits markers — we read the stashed `dataset.lpSrc` instead.
+ */
+function readCellSource(cell: HTMLElement): string {
+  if (cell === cell.ownerDocument.activeElement) return readCellText(cell);
+  return cell.dataset.lpSrc ?? readCellText(cell);
+}
+
+/** Collapse the selection to the end of a cell's content. */
+function caretToEnd(cell: HTMLElement): void {
+  const range = document.createRange();
+  const sel = window.getSelection();
+  range.selectNodeContents(cell);
+  range.collapse(false);
+  sel?.removeAllRanges();
+  sel?.addRange(range);
 }
 
 /**
@@ -179,29 +226,6 @@ function insertLineBreakAtSelection(cell: HTMLElement): void {
   sel.addRange(newRange);
 }
 
-/**
- * True if `cell`'s current DOM exactly represents `text` (text nodes + `<br>`
- * for `\n`). Used by `updateDOM` to skip touching cells that haven't changed
- * — `setCellContent` would otherwise rebuild children and wipe the caret on
- * every keystroke in the active cell.
- */
-function cellMatchesText(cell: HTMLElement, text: string): boolean {
-  let i = 0;
-  for (const node of Array.from(cell.childNodes)) {
-    if (node instanceof HTMLBRElement) {
-      if (text[i] !== '\n') return false;
-      i += 1;
-    } else if (node.nodeType === Node.TEXT_NODE) {
-      const part = node.textContent ?? '';
-      if (text.slice(i, i + part.length) !== part) return false;
-      i += part.length;
-    } else {
-      return false;
-    }
-  }
-  return i === text.length;
-}
-
 /** Locate a cell DOM node for `(row, col)` — `row === -1` is the header. */
 function cellAt(root: HTMLElement, row: number, col: number): HTMLElement | null {
   if (row === -1) {
@@ -214,18 +238,14 @@ function cellAt(root: HTMLElement, row: number, col: number): HTMLElement | null
   return tr.querySelectorAll<HTMLElement>('td')[col] ?? null;
 }
 
-/** Move browser focus to a cell, placing the caret at the end of its text. */
+/** Move browser focus to a cell, placing the caret at the end of its text.
+ *  The cell's own `focus` listener reveals raw source first (if formatted); the
+ *  caret is then collapsed to the end of that source. */
 function focusCell(root: HTMLElement, row: number, col: number): void {
   const el = cellAt(root, row, col);
   if (!el) return;
   el.focus();
-  // Place caret at end of cell content.
-  const range = document.createRange();
-  const sel = window.getSelection();
-  range.selectNodeContents(el);
-  range.collapse(false);
-  sel?.removeAllRanges();
-  sel?.addRange(range);
+  caretToEnd(el);
 }
 
 export class TableWidget extends WidgetType {
@@ -267,7 +287,7 @@ export class TableWidget extends WidgetType {
       th.dataset.col = String(col);
       const align = alignStyle(this.table.alignments[col]);
       if (align) th.style.textAlign = align;
-      setCellContent(th, cell.text);
+      renderCellContent(th, cell.text);
       this.attachCellListeners(th, { row: -1, col });
       headerTr.appendChild(th);
     });
@@ -286,7 +306,7 @@ export class TableWidget extends WidgetType {
         td.dataset.col = String(col);
         const align = alignStyle(this.table.alignments[col]);
         if (align) td.style.textAlign = align;
-        setCellContent(td, cell.text);
+        renderCellContent(td, cell.text);
         this.attachCellListeners(td, { row: rowIdx, col });
         tr.appendChild(td);
       });
@@ -318,11 +338,14 @@ export class TableWidget extends WidgetType {
 
     const active = document.activeElement;
 
+    // The focused cell holds raw, editable source — never touch it (that would
+    // wipe the caret). Every other cell is re-rendered from its target source
+    // only when that source actually changed, keyed off the stashed `lpSrc`.
     headerCells.forEach((th, col) => {
       const target = this.table.header[col]?.text ?? '';
-      const align = alignStyle(this.table.alignments[col]);
-      th.style.textAlign = align;
-      if (th !== active && !cellMatchesText(th, target)) setCellContent(th, target);
+      th.style.textAlign = alignStyle(this.table.alignments[col]);
+      if (th === active) return;
+      if (th.dataset.lpSrc !== target) renderCellContent(th, target);
     });
 
     bodyRows.forEach((tr, rowIdx) => {
@@ -330,9 +353,9 @@ export class TableWidget extends WidgetType {
       if (cells.length !== cols) return;
       cells.forEach((td, col) => {
         const target = this.table.rows[rowIdx]?.[col]?.text ?? '';
-        const align = alignStyle(this.table.alignments[col]);
-        td.style.textAlign = align;
-        if (td !== active && !cellMatchesText(td, target)) setCellContent(td, target);
+        td.style.textAlign = alignStyle(this.table.alignments[col]);
+        if (td === active) return;
+        if (td.dataset.lpSrc !== target) renderCellContent(td, target);
       });
     });
 
@@ -347,6 +370,21 @@ export class TableWidget extends WidgetType {
   // ─── Event wiring ───────────────────────────────────────────────
 
   private attachCellListeners(cell: HTMLElement, addr: CellAddress): void {
+    // Reveal raw markdown source when the cell is focused (so it can be edited),
+    // and re-render the formatted view when focus leaves. A plain cell renders
+    // identically raw and formatted, so it skips the swap — that keeps the
+    // browser's native click-to-position caret instead of jumping to the end.
+    cell.addEventListener('focus', () => {
+      const src = cell.dataset.lpSrc ?? readCellText(cell);
+      if (cellHasFormatting(src)) {
+        setCellContent(cell, src);
+        caretToEnd(cell);
+      }
+    });
+    cell.addEventListener('blur', () => {
+      renderCellContent(cell, readCellText(cell));
+    });
+
     cell.addEventListener('compositionstart', () => {
       this.composing = true;
     });


### PR DESCRIPTION
## Summary

Table cells in Live Preview rendered bold/italic/code/strikethrough/link markup as **raw text**, even though View (marked) and Markdown Source render it correctly. Travis reported the inconsistency as a bug (#359); promoted P3→P2 (greenlit 2026-06-28).

Cells now use the Obsidian-style **rendered/raw split**:
- **rendered** when not focused - inline markdown shown formatted (`**bold**`, `*em*`, `` `code` ``, `~~strike~~`, `[t](url)` + soft `\n`→`<br>`);
- **raw** when focused - the markdown source, editable character by character (identical to the previous plain-text cell). Swapped on `focus`/`blur`.

New `table-cell-render.ts`:
- `parseInlineCell(text)` - **pure, DOM-free** inline parser → unit-tested (37 cases, node env);
- `buildInlineFragment(text)` - DOM builder (browser-only); links reuse the existing allowlist-guarded `LinkWidget`;
- `cellHasFormatting(text)` - `true` only when rendered ≠ source, so plain cells skip the swap and keep native caret.

The canonical markdown of each non-focused cell is stashed on `dataset.lpSrc`; `readCellSource` reads it for unfocused cells (live DOM only for the focused one). This is the key guard: without it, serializing the table while typing in one cell would strip the `**`/`*` from every other formatted cell.

**Security / ZK:** every leaf reaches the DOM via `createTextNode`/`textContent` - never `innerHTML` (a cell with `<script>` renders the literal text). Links go through `sanitizeLinkUrl` (`javascript:`/`data:` blocked). No schema, crypto or wire changes; operates on already-decrypted in-memory plaintext. Zero-knowledge neutral.

### Decisions for review (auto mode - below the architectural-decision bar, UI polish)
- **Caret jumps to end on first focus of a formatted cell** (consistent with Tab/Enter navigation). A second click positions natively; plain cells keep native click positioning from the first click. Full click→source mapping was rejected as fragile cross-browser and overkill for a desktop beta.
- **Links in a cell don't steal focus** (`mousedown` preventDefault, like note links in `LinkWidget`) so a click opens them; edit such a cell via padding/other text or Tab.
- **Pragmatic emphasis subset** (not a full CommonMark delimiter stack): `_`/`__` need a word boundary (`snake_case` stays literal), `*` works intraword. Deep mixed nesting degrades to readable text, never breaks the parser.
- **Separate PR** (not bundled with the P1 structural-table-ops "tables sprint"), matching the "bug" framing.

## Test plan

Quality gate (green): vitest **1108 passed** (+37 new), eslint **0**, svelte-check **0/0**, `vite build` OK. i18n parity unchanged (no new strings).

Smoke (Live Preview, desktop):
1. Table with `**bold**` / `*em*` / `` `code` `` / `~~s~~` / `[t](url)` in cells → renders formatted while the cursor is outside the cell.
2. Click a formatted cell → reveals raw source for editing; blur → renders again.
3. Typing in one cell does not corrupt the formatting of neighbouring cells (source preserved).
4. Click a link inside a cell → it opens (does not enter edit mode).
5. `snake_case` / `2 * 3` in a cell → no false formatting.
6. Tab / Enter / Shift+Enter / add-row still work; plain cell → click positions caret natively.