### PR TITLE
feat(notes): add no:folder and no:tag search operators

### DIFF
--- a/docs/search-operators.md
+++ b/docs/search-operators.md
@@ -21,6 +21,8 @@ All search runs **client-side** over already-decrypted data - the server never s
 | `is:completed` | re/task | `is:completed` |
 | `is:overdue` | re/task | `is:overdue` |
 | `has:link` | both | `has:link` (matches notes/descriptions containing URLs or Markdown links) |
+| `no:folder` | re/notes | `no:folder` - notes that aren't in any folder |
+| `no:tag` | re/notes | `no:tag` - notes with no tags |
 
 **Modifiers**
 
@@ -157,6 +159,28 @@ modified:yesterday
 ```
 
 Dates are interpreted in your **local timezone**, not UTC - "today" matches your wall clock.
+
+---
+
+## Empty-field filters (`no:`)
+
+> **re/notes**
+
+`no:` matches notes where a container field is *empty* - the mirror image of `folder:` and `tag:`. Two fields are supported:
+
+- `no:folder` - notes that don't live in any folder (they sit at the top level of the notes list, not inside any folder).
+- `no:tag` - notes with no tags attached.
+
+This mirrors the convention GitHub uses for `no:label` / `no:assignee`. Like every operator, `no:` composes with the rest and can be negated:
+
+```
+no:folder                  # loose notes, not filed anywhere
+no:folder no:tag           # neither filed nor tagged - your "inbox" of unsorted notes
+-no:folder                 # the inverse: only notes that ARE in some folder
+folder:projects no:tag     # untagged notes inside Projects (and its subfolders)
+```
+
+Matching is metadata-only, so `no:` filters run on the instant title path and never decrypt note bodies.
 
 ---
 

--- a/packages/utils/src/search-query/ast.ts
+++ b/packages/utils/src/search-query/ast.ts
@@ -9,6 +9,7 @@
  *   due:<7d              (task only)
  *   has:link             (forces content-search path)
  *   is:starred | pinned | completed | overdue
+ *   no:folder | tag      (notes only) - entity has no folder / no tags
  *   -OPERATOR            negation prefix on operators (-tag:archived, -is:completed)
  *   "quoted value"       allows whitespace and colons in operator values
  *
@@ -57,13 +58,23 @@ export type IsFlag = 'starred' | 'pinned' | 'completed' | 'overdue';
 
 export type HasFlag = 'link';
 
+/**
+ * Fields the `no:` operator can assert are empty (GitHub-style `no:label`).
+ * `folder` → entity belongs to no folder; `tag` → entity has no tags. Both are
+ * re/notes concepts; the operator parses everywhere but only matches where the
+ * field exists (a task always has `folderId === null`, so `no:folder` there is
+ * a no-op filter - same harmless cross-app leakage as `folder:`/`list:`).
+ */
+export type NoFlag = 'folder' | 'tag';
+
 export type Filter =
   | { kind: 'tag'; value: string; negated: boolean }
   | { kind: 'folder'; value: string; negated: boolean }
   | { kind: 'list'; value: string; negated: boolean }
   | { kind: 'date'; field: DateField; expr: DateExpression; negated: boolean }
   | { kind: 'has'; value: HasFlag; negated: boolean }
-  | { kind: 'is'; value: IsFlag; negated: boolean };
+  | { kind: 'is'; value: IsFlag; negated: boolean }
+  | { kind: 'no'; value: NoFlag; negated: boolean };
 
 /**
  * Tree-shaped AST node. AND / OR are n-ary so a flat sequence like

--- a/packages/utils/src/search-query/evaluator.test.ts
+++ b/packages/utils/src/search-query/evaluator.test.ts
@@ -245,6 +245,55 @@ describe('evaluate — folder and list filters', () => {
   });
 });
 
+describe('evaluate — no: filters (empty folder / tags)', () => {
+  it('no:folder matches an entity with no folder', () => {
+    expect(evaluate(parseQuery('no:folder'), makeEntity({ folderId: null }), makeCtx())).toBe(true);
+  });
+
+  it('no:folder does not match an entity inside a folder', () => {
+    expect(
+      evaluate(parseQuery('no:folder'), makeEntity({ folderId: 'f-1' }), makeCtx())
+    ).toBe(false);
+  });
+
+  it('-no:folder is the inverse (only foldered entities)', () => {
+    expect(
+      evaluate(parseQuery('-no:folder'), makeEntity({ folderId: 'f-1' }), makeCtx())
+    ).toBe(true);
+    expect(
+      evaluate(parseQuery('-no:folder'), makeEntity({ folderId: null }), makeCtx())
+    ).toBe(false);
+  });
+
+  it('no:tag matches an untagged entity', () => {
+    expect(evaluate(parseQuery('no:tag'), makeEntity({ tagIds: [] }), makeCtx())).toBe(true);
+  });
+
+  it('no:tag does not match a tagged entity', () => {
+    expect(
+      evaluate(parseQuery('no:tag'), makeEntity({ tagIds: ['t-1'] }), makeCtx())
+    ).toBe(false);
+  });
+
+  it('composes with other operators (untagged notes outside any folder)', () => {
+    const ast = parseQuery('no:folder no:tag');
+    expect(
+      evaluate(ast, makeEntity({ folderId: null, tagIds: [] }), makeCtx())
+    ).toBe(true);
+    expect(
+      evaluate(ast, makeEntity({ folderId: null, tagIds: ['t-1'] }), makeCtx())
+    ).toBe(false);
+    expect(
+      evaluate(ast, makeEntity({ folderId: 'f-1', tagIds: [] }), makeCtx())
+    ).toBe(false);
+  });
+
+  it('no:folder / no:tag never force the content path (metadata-only)', () => {
+    expect(requiresContent(parseQuery('no:folder'))).toBe(false);
+    expect(requiresContent(parseQuery('no:tag'))).toBe(false);
+  });
+});
+
 describe('evaluate — date filters', () => {
   it('created:>YYYY-MM-DD matches newer entities', () => {
     const ast = parseQuery('created:>2026-04-01');

--- a/packages/utils/src/search-query/evaluator.ts
+++ b/packages/utils/src/search-query/evaluator.ts
@@ -164,6 +164,13 @@ function matchFilterPositive(
       return false;
     }
 
+    case 'no': {
+      // notes-only structural emptiness; metadata-only, so no body decryption.
+      return filter.value === 'folder'
+        ? entity.folderId === null
+        : entity.tagIds.length === 0;
+    }
+
     case 'is': {
       switch (filter.value) {
         case 'starred':

--- a/packages/utils/src/search-query/parser.test.ts
+++ b/packages/utils/src/search-query/parser.test.ts
@@ -25,6 +25,10 @@ const is = (
   value: 'starred' | 'pinned' | 'completed' | 'overdue',
   negated = false
 ): Node => ({ kind: 'leaf-filter', filter: { kind: 'is', value, negated } });
+const no = (value: 'folder' | 'tag', negated = false): Node => ({
+  kind: 'leaf-filter',
+  filter: { kind: 'no', value, negated }
+});
 const and = (...children: Node[]): Node => ({ kind: 'and', children });
 const or = (...children: Node[]): Node => ({ kind: 'or', children });
 const not = (child: Node): Node => ({ kind: 'not', child });
@@ -101,6 +105,24 @@ describe('parseQuery — operators', () => {
     expect(ast).toEqual({
       root: and(is('starred'), is('pinned'), is('completed'), is('overdue'))
     });
+  });
+
+  it('parses no: flags (folder, tag)', () => {
+    expect(parseQuery('no:folder')).toEqual({ root: no('folder') });
+    expect(parseQuery('no:tag')).toEqual({ root: no('tag') });
+  });
+
+  it('lowercases no: values', () => {
+    expect(parseQuery('no:Folder')).toEqual({ root: no('folder') });
+  });
+
+  it('parses negated no: flag', () => {
+    expect(parseQuery('-no:folder')).toEqual({ root: no('folder', true) });
+  });
+
+  it('unknown no: value falls back to plain text (graceful degradation)', () => {
+    expect(parseQuery('no:list')).toEqual({ root: text('no:list') });
+    expect(parseQuery('-no:list')).toEqual({ root: text('no:list', true) });
   });
 
   it('combines operators with freetext (implicit AND)', () => {

--- a/packages/utils/src/search-query/parser.ts
+++ b/packages/utils/src/search-query/parser.ts
@@ -1,4 +1,4 @@
-import type { DateField, Filter, IsFlag, Node, QueryAST } from './ast';
+import type { DateField, Filter, IsFlag, NoFlag, Node, QueryAST } from './ast';
 import { parseDateExpression } from './date-parser';
 
 const IS_FLAGS: ReadonlySet<IsFlag> = new Set([
@@ -8,6 +8,8 @@ const IS_FLAGS: ReadonlySet<IsFlag> = new Set([
   'overdue'
 ]);
 
+const NO_FLAGS: ReadonlySet<NoFlag> = new Set(['folder', 'tag']);
+
 const KNOWN_KEYS = new Set([
   'tag',
   'folder',
@@ -16,7 +18,8 @@ const KNOWN_KEYS = new Set([
   'modified',
   'due',
   'has',
-  'is'
+  'is',
+  'no'
 ]);
 
 /**
@@ -258,6 +261,13 @@ function parseOperator(key: string, value: string, negated: boolean): Filter | n
       const v = value.toLowerCase();
       return IS_FLAGS.has(v as IsFlag)
         ? { kind: 'is', value: v as IsFlag, negated }
+        : null;
+    }
+
+    case 'no': {
+      const v = value.toLowerCase();
+      return NO_FLAGS.has(v as NoFlag)
+        ? { kind: 'no', value: v as NoFlag, negated }
         : null;
     }
 


### PR DESCRIPTION
## Summary

Adds a GitHub-style `no:` operator family to the unified search box (re/notes) so users can find notes that aren't filed or tagged:

- `no:folder` - notes that aren't in any folder (top-level notes)
- `no:tag` - notes with no tags

Both compose and negate like every other operator: `no:folder no:tag` is your unsorted "inbox"; `-no:folder` is only foldered notes; `folder:projects no:tag` is untagged notes inside Projects.

**Why `no:`** (chosen over `is:unfiled` / `folder:none`): it mirrors GitHub's `no:label` / `no:assignee` - a convention the docs already cite - and forms a bounded, extensible family for "this container field is empty." `is:` is reserved for behavioral-state flags (starred/pinned/...), and `folder:none` would collide with a real folder literally named "none."

**Implementation:** entirely in `@reborn/utils` (`search-query` ast/parser/evaluator). Matching is metadata-only (`folderId === null` / empty `tagIds`), so it stays on the instant title path with no body decryption, and the lite-AST pre-filter keeps it. The notes adapter already maps `folderId ?? null` and `tagIds`, so **no app code changed**. Documented in `docs/search-operators.md`.

**Zero-Knowledge:** neutral - pure client-side UX over already-decrypted metadata, no new server surface.

## Test plan

Quality gate (green):
- `@reborn/utils`: ESLint 0, tsc 0, **157 vitest** (parser 65, evaluator 51; +13 new for `no:`), tsup build OK
- `reborn-notes`: svelte-check **0 errors / 0 warnings** (5553 files)
- `reborn-task`: svelte-check **0 errors / 0 warnings** (5351 files)
- No i18n changes (operators are typed English; there is no translated operator legend)

Smoke (re/notes search box):
1. `no:folder` -> only notes not inside any folder.
2. `no:tag` -> only notes with no tags.
3. `no:folder no:tag` -> notes that are neither filed nor tagged.
4. `-no:folder` -> only notes that ARE in a folder.
5. `folder:<name> no:tag` -> untagged notes within that folder (and its subfolders).
6. Save one of these as a smart folder, reopen with an empty box -> the saved view stays live.