### PR TITLE
feat(notes): collapsible note list and pinnable outline dock

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -10,6 +10,7 @@
     RefreshCw,
     Trash2,
     Search,
+    Info,
     X,
     Pin,
     PinOff,
@@ -968,6 +969,18 @@
     {searchOnly}
     onsavesearch={isTrash ? undefined : () => (saveSearchDialogOpen = true)}
   />
+
+  <!-- Trash retention notice: trashed notes are auto-purged after 30 days
+       (cleanTrash(30) in hooks.client.ts). Pinned above the list so the policy
+       is visible whether trash is full or empty. -->
+  {#if isTrash}
+    <div
+      class="flex items-start gap-1.5 border-b px-4 py-2 text-[11px] leading-snug text-muted-foreground"
+    >
+      <Info class="mt-px h-3.5 w-3.5 shrink-0" />
+      <span>{$t('trash.auto_delete_notice', { values: { days: 30 } })}</span>
+    </div>
+  {/if}
 
   <!-- Notes list -->
   <div class="flex-1 overflow-y-auto px-3">

--- a/apps/reborn-notes/src/lib/components/OutlineSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/OutlineSheet.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
-  import { ListTree } from '@lucide/svelte';
+  import { ListTree, Pin } from '@lucide/svelte';
   import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@reborn/ui';
   import { t } from '$lib/stores/i18n.store';
-  import { extractHeadings, type DocHeading } from '$lib/utils/heading-outline';
-
-  interface OutlineNode extends DocHeading {
-    children: OutlineNode[];
-  }
+  import type { DocHeading } from '$lib/utils/heading-outline';
+  import OutlineTree from './OutlineTree.svelte';
 
   let {
     content,
     open,
     activeSlug = null,
     onnavigate,
-    onclose
+    onclose,
+    showPin = false,
+    onpin
   }: {
     /** Raw Markdown of the open note - the outline is derived from its headings. */
     content: string;
@@ -26,85 +25,16 @@
     /** Jump to a heading (the page scrolls the preview or the editor). */
     onnavigate: (heading: DocHeading) => void;
     onclose: () => void;
+    /** Show the "pin" affordance (desktop only) that docks the outline beside the editor. */
+    showPin?: boolean;
+    /** Dock the outline (sets the global pinned preference). */
+    onpin?: () => void;
   } = $props();
-
-  // Build a nesting tree from the flat heading list so each level can draw its
-  // own indent guide (a `border-left` on the nested <ul>). Headings may skip a
-  // level (H2 -> H4); a deeper heading just nests under the nearest shallower
-  // ancestor still on the stack.
-  const tree = $derived.by<OutlineNode[]>(() => {
-    if (!open || !content) return [];
-    const roots: OutlineNode[] = [];
-    const stack: OutlineNode[] = [];
-    for (const h of extractHeadings(content)) {
-      const node: OutlineNode = { ...h, children: [] };
-      while (stack.length && stack[stack.length - 1].depth >= h.depth) stack.pop();
-      (stack.length ? stack[stack.length - 1].children : roots).push(node);
-      stack.push(node);
-    }
-    return roots;
-  });
-
-  const isEmpty = $derived(open && tree.length === 0);
-
-  let listEl = $state<HTMLElement | null>(null);
-
-  // Keep the active (scroll-spied) entry visible, without yanking the panel when
-  // it is already on screen (`block: 'nearest'` is a no-op if in view).
-  $effect(() => {
-    const slug = activeSlug;
-    if (!slug || !listEl) return;
-    listEl.querySelector(`[data-slug="${slug}"]`)?.scrollIntoView({ block: 'nearest' });
-  });
-
-  // Split a heading into plain / inline-code segments so `code` in a heading
-  // renders monospace instead of showing literal backticks.
-  function segments(text: string): { code: boolean; text: string }[] {
-    return text
-      .split('`')
-      .map((part, i) => ({ code: i % 2 === 1, text: part }))
-      .filter((s) => s.text !== '');
-  }
-
-  // Font / size / colour gradation by nesting level (not raw depth, so a doc
-  // that starts at ## is treated as level 0).
-  function levelClass(level: number): string {
-    if (level === 0) return 'font-semibold text-foreground';
-    if (level === 1) return 'text-foreground';
-    return 'text-[0.92em] text-muted-foreground';
-  }
 
   function handleOpenChange(isOpen: boolean) {
     if (!isOpen) onclose();
   }
 </script>
-
-{#snippet rows(nodes: OutlineNode[], level: number)}
-  <ul class="m-0 list-none p-0 {level > 0 ? 'ml-[0.6rem] border-l border-border/40 pl-1' : ''}">
-    {#each nodes as node (node.slug)}
-      {@const active = node.slug === activeSlug}
-      <li>
-        <button
-          type="button"
-          data-slug={node.slug}
-          onclick={() => onnavigate(node)}
-          title={node.text}
-          aria-current={active ? 'location' : undefined}
-          class="flex w-full cursor-pointer rounded-md px-2 py-1 text-left leading-[1.35] transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:bg-accent
-            {levelClass(level)}
-            {active ? 'font-medium text-primary shadow-[inset_2px_0_0_0_var(--primary)]' : ''}"
-        >
-          <span class="line-clamp-2 min-w-0 flex-1 text-sm"
-            >{#each segments(node.text) as seg, i (i)}{#if seg.code}<code
-                  class="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">{seg.text}</code
-                >{:else}{seg.text}{/if}{/each}</span
-          >
-        </button>
-        {#if node.children.length}{@render rows(node.children, level + 1)}{/if}
-      </li>
-    {/each}
-  </ul>
-{/snippet}
 
 <Sheet {open} onOpenChange={handleOpenChange}>
   <SheetContent
@@ -113,22 +43,26 @@
     class="flex w-80 flex-col gap-0 p-0 sm:max-w-sm"
   >
     <SheetHeader class="shrink-0 border-b px-4 py-3">
-      <SheetTitle class="flex items-center gap-2 text-sm">
-        <ListTree class="h-4 w-4 text-muted-foreground" />
-        {$t('outline.title')}
-      </SheetTitle>
+      <div class="flex items-center gap-2">
+        <SheetTitle class="flex items-center gap-2 text-sm">
+          <ListTree class="h-4 w-4 text-muted-foreground" />
+          {$t('outline.title')}
+        </SheetTitle>
+        {#if showPin}
+          <button
+            type="button"
+            onclick={onpin}
+            title={$t('outline.pin')}
+            aria-label={$t('outline.pin')}
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground
+                   transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <Pin class="h-4 w-4" />
+          </button>
+        {/if}
+      </div>
     </SheetHeader>
 
-    <div bind:this={listEl} class="flex-1 overflow-y-auto px-2 py-1.5">
-      {#if isEmpty}
-        <div
-          class="flex items-center justify-center px-4 py-12 text-center text-sm text-muted-foreground"
-        >
-          {$t('outline.empty')}
-        </div>
-      {:else}
-        {@render rows(tree, 0)}
-      {/if}
-    </div>
+    <OutlineTree {content} {activeSlug} {onnavigate} enabled={open} />
   </SheetContent>
 </Sheet>

--- a/apps/reborn-notes/src/lib/components/OutlineTree.svelte
+++ b/apps/reborn-notes/src/lib/components/OutlineTree.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { t } from '$lib/stores/i18n.store';
+  import { extractHeadings, type DocHeading } from '$lib/utils/heading-outline';
+
+  interface OutlineNode extends DocHeading {
+    children: OutlineNode[];
+  }
+
+  let {
+    content,
+    activeSlug = null,
+    onnavigate,
+    enabled = true
+  }: {
+    /** Raw Markdown of the open note - the outline is derived from its headings. */
+    content: string;
+    /**
+     * Slug of the heading currently scrolled into view in the preview
+     * (scroll-spy, computed by the page). Highlighted and kept on screen.
+     */
+    activeSlug?: string | null;
+    /** Jump to a heading (the page scrolls the preview or the editor). */
+    onnavigate: (heading: DocHeading) => void;
+    /**
+     * When false, the tree is not built (skips heading parsing for a hidden
+     * host, e.g. a closed Sheet still mounted in the DOM).
+     */
+    enabled?: boolean;
+  } = $props();
+
+  // Build a nesting tree from the flat heading list so each level can draw its
+  // own indent guide (a `border-left` on the nested <ul>). Headings may skip a
+  // level (H2 -> H4); a deeper heading just nests under the nearest shallower
+  // ancestor still on the stack.
+  const tree = $derived.by<OutlineNode[]>(() => {
+    if (!enabled || !content) return [];
+    const roots: OutlineNode[] = [];
+    const stack: OutlineNode[] = [];
+    for (const h of extractHeadings(content)) {
+      const node: OutlineNode = { ...h, children: [] };
+      while (stack.length && stack[stack.length - 1].depth >= h.depth) stack.pop();
+      (stack.length ? stack[stack.length - 1].children : roots).push(node);
+      stack.push(node);
+    }
+    return roots;
+  });
+
+  const isEmpty = $derived(enabled && tree.length === 0);
+
+  let listEl = $state<HTMLElement | null>(null);
+
+  // Keep the active (scroll-spied) entry visible, without yanking the panel when
+  // it is already on screen (`block: 'nearest'` is a no-op if in view).
+  $effect(() => {
+    const slug = activeSlug;
+    if (!slug || !listEl) return;
+    listEl.querySelector(`[data-slug="${slug}"]`)?.scrollIntoView({ block: 'nearest' });
+  });
+
+  // Split a heading into plain / inline-code segments so `code` in a heading
+  // renders monospace instead of showing literal backticks.
+  function segments(text: string): { code: boolean; text: string }[] {
+    return text
+      .split('`')
+      .map((part, i) => ({ code: i % 2 === 1, text: part }))
+      .filter((s) => s.text !== '');
+  }
+
+  // Font / size / colour gradation by nesting level (not raw depth, so a doc
+  // that starts at ## is treated as level 0).
+  function levelClass(level: number): string {
+    if (level === 0) return 'font-semibold text-foreground';
+    if (level === 1) return 'text-foreground';
+    return 'text-[0.92em] text-muted-foreground';
+  }
+</script>
+
+{#snippet rows(nodes: OutlineNode[], level: number)}
+  <ul class="m-0 list-none p-0 {level > 0 ? 'ml-[0.6rem] border-l border-border/40 pl-1' : ''}">
+    {#each nodes as node (node.slug)}
+      {@const active = node.slug === activeSlug}
+      <li>
+        <button
+          type="button"
+          data-slug={node.slug}
+          onclick={() => onnavigate(node)}
+          title={node.text}
+          aria-current={active ? 'location' : undefined}
+          class="flex w-full cursor-pointer rounded-md px-2 py-1 text-left leading-[1.35] transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:bg-accent
+            {levelClass(level)}
+            {active ? 'font-medium text-primary shadow-[inset_2px_0_0_0_var(--primary)]' : ''}"
+        >
+          <span class="line-clamp-2 min-w-0 flex-1 text-sm"
+            >{#each segments(node.text) as seg, i (i)}{#if seg.code}<code
+                  class="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">{seg.text}</code
+                >{:else}{seg.text}{/if}{/each}</span
+          >
+        </button>
+        {#if node.children.length}{@render rows(node.children, level + 1)}{/if}
+      </li>
+    {/each}
+  </ul>
+{/snippet}
+
+<div bind:this={listEl} class="flex-1 overflow-y-auto px-2 py-1.5">
+  {#if isEmpty}
+    <div
+      class="flex items-center justify-center px-4 py-12 text-center text-sm text-muted-foreground"
+    >
+      {$t('outline.empty')}
+    </div>
+  {:else}
+    {@render rows(tree, 0)}
+  {/if}
+</div>

--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -7,6 +7,8 @@
     Waypoints,
     ListTree,
     ArrowLeft,
+    PanelLeftClose,
+    PanelLeftOpen,
     ChevronLeft,
     ChevronRight,
     Lock,
@@ -44,6 +46,8 @@
     onnotehistoryback,
     onnotehistoryforward,
     onback,
+    noteListCollapsed = false,
+    onToggleNoteList,
     onshowxray,
     onrestore,
     onpermanentdelete,
@@ -80,6 +84,10 @@
     /** Go Forward one note in the visit trail (desktop chevron). */
     onnotehistoryforward?: () => void;
     onback: () => void;
+    /** Desktop only: whether the note-list panel is collapsed (drives the toggle icon). */
+    noteListCollapsed?: boolean;
+    /** Desktop only: collapse/expand the note-list panel. Omitted on mobile (no side panel). */
+    onToggleNoteList?: () => void;
     onshowxray: () => void;
     onrestore: () => void;
     onpermanentdelete: () => void;
@@ -122,12 +130,33 @@
     pt-[env(safe-area-inset-top,0px)]
     {isMobile ? 'gap-2 px-3' : 'gap-1 px-3 @lg:gap-2 @lg:px-6'}"
 >
+  <!-- Note-list panel toggle (desktop only). It lives here, not in the icon
+       rail, because it only applies while a note is open; mounting it on the
+       always-present rail would pop the icon in/out and shift the rail. -->
+  {#if !isMobile && onToggleNoteList}
+    <button
+      type="button"
+      onclick={onToggleNoteList}
+      class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-foreground
+         hover:bg-accent transition-colors -ml-1"
+      title={noteListCollapsed ? $t('nav.show_note_list') : $t('nav.hide_note_list')}
+      aria-label={noteListCollapsed ? $t('nav.show_note_list') : $t('nav.hide_note_list')}
+      aria-pressed={!noteListCollapsed}
+    >
+      {#if noteListCollapsed}
+        <PanelLeftOpen class="h-4 w-4" />
+      {:else}
+        <PanelLeftClose class="h-4 w-4" />
+      {/if}
+    </button>
+  {/if}
+
   <button
     type="button"
     onclick={onback}
     class="flex shrink-0 items-center justify-center rounded-md text-foreground
-       hover:bg-accent transition-colors -ml-1
-       {isMobile ? 'h-11 w-11' : 'h-8 w-8'}"
+       hover:bg-accent transition-colors
+       {isMobile ? '-ml-1 h-11 w-11' : 'h-8 w-8'}"
     aria-label={$t('nav.back')}
   >
     <ArrowLeft class={isMobile ? 'h-5 w-5' : 'h-4 w-4'} />

--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -36,9 +36,7 @@
     UserPlus,
     LogIn,
     Lock,
-    Loader2,
-    PanelLeftClose,
-    PanelLeftOpen
+    Loader2
   } from '@lucide/svelte';
   import * as Tooltip from '@reborn/ui/components/tooltip';
   import * as DropdownMenu from '@reborn/ui/components/dropdown-menu';
@@ -64,9 +62,7 @@
     onPeriodic,
     pendingKind = null,
     horizontal = false,
-    alwaysVisible = false,
-    ontogglepanel,
-    panelCollapsed = false
+    alwaysVisible = false
   }: {
     activeSection?: Section;
     onNewNote?: () => void;
@@ -81,11 +77,6 @@
     horizontal?: boolean;
     /** Show icon rail regardless of breakpoint (for mobile master-detail layout) */
     alwaysVisible?: boolean;
-    /** Desktop only: toggle the note-list panel collapsed/expanded. When omitted
-     *  (mobile master-detail), the toggle button is not rendered. */
-    ontogglepanel?: () => void;
-    /** Whether the note-list panel is currently collapsed (drives the toggle's icon/label). */
-    panelCollapsed?: boolean;
   } = $props();
 
   const isMobileQuery = useIsMobile();
@@ -327,34 +318,6 @@
     style="background-color: var(--icon-rail); padding-top: calc(0.5rem + env(safe-area-inset-top, 0px)); padding-bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));"
     aria-label={$t('nav.main_navigation')}
   >
-    <!-- Note-list panel toggle (desktop only; omitted in mobile master-detail) -->
-    {#if ontogglepanel}
-      <Tooltip.Root>
-        <Tooltip.Trigger>
-          {#snippet child({ props })}
-            <button
-              {...props}
-              type="button"
-              onclick={ontogglepanel}
-              class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg text-muted-foreground
-                     hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
-              aria-label={panelCollapsed ? $t('nav.show_note_list') : $t('nav.hide_note_list')}
-              aria-pressed={!panelCollapsed}
-            >
-              {#if panelCollapsed}
-                <PanelLeftOpen class="h-6 w-6 md:h-5 md:w-5" />
-              {:else}
-                <PanelLeftClose class="h-6 w-6 md:h-5 md:w-5" />
-              {/if}
-            </button>
-          {/snippet}
-        </Tooltip.Trigger>
-        <Tooltip.Content side="right" sideOffset={6}>
-          {panelCollapsed ? $t('nav.show_note_list') : $t('nav.hide_note_list')}
-        </Tooltip.Content>
-      </Tooltip.Root>
-    {/if}
-
     <!-- New note -->
     <Tooltip.Root>
       <Tooltip.Trigger>

--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -36,7 +36,9 @@
     UserPlus,
     LogIn,
     Lock,
-    Loader2
+    Loader2,
+    PanelLeftClose,
+    PanelLeftOpen
   } from '@lucide/svelte';
   import * as Tooltip from '@reborn/ui/components/tooltip';
   import * as DropdownMenu from '@reborn/ui/components/dropdown-menu';
@@ -62,7 +64,9 @@
     onPeriodic,
     pendingKind = null,
     horizontal = false,
-    alwaysVisible = false
+    alwaysVisible = false,
+    ontogglepanel,
+    panelCollapsed = false
   }: {
     activeSection?: Section;
     onNewNote?: () => void;
@@ -77,6 +81,11 @@
     horizontal?: boolean;
     /** Show icon rail regardless of breakpoint (for mobile master-detail layout) */
     alwaysVisible?: boolean;
+    /** Desktop only: toggle the note-list panel collapsed/expanded. When omitted
+     *  (mobile master-detail), the toggle button is not rendered. */
+    ontogglepanel?: () => void;
+    /** Whether the note-list panel is currently collapsed (drives the toggle's icon/label). */
+    panelCollapsed?: boolean;
   } = $props();
 
   const isMobileQuery = useIsMobile();
@@ -318,6 +327,34 @@
     style="background-color: var(--icon-rail); padding-top: calc(0.5rem + env(safe-area-inset-top, 0px)); padding-bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));"
     aria-label={$t('nav.main_navigation')}
   >
+    <!-- Note-list panel toggle (desktop only; omitted in mobile master-detail) -->
+    {#if ontogglepanel}
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              onclick={ontogglepanel}
+              class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg text-muted-foreground
+                     hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
+              aria-label={panelCollapsed ? $t('nav.show_note_list') : $t('nav.hide_note_list')}
+              aria-pressed={!panelCollapsed}
+            >
+              {#if panelCollapsed}
+                <PanelLeftOpen class="h-6 w-6 md:h-5 md:w-5" />
+              {:else}
+                <PanelLeftClose class="h-6 w-6 md:h-5 md:w-5" />
+              {/if}
+            </button>
+          {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content side="right" sideOffset={6}>
+          {panelCollapsed ? $t('nav.show_note_list') : $t('nav.hide_note_list')}
+        </Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+
     <!-- New note -->
     <Tooltip.Root>
       <Tooltip.Trigger>

--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -363,7 +363,7 @@
             {...props}
             type="button"
             onclick={onNewNote}
-            class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg text-sidebar-foreground
+            class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg text-muted-foreground
                    hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
             aria-label={$t('nav.new_note')}
           >

--- a/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
@@ -33,7 +33,7 @@
   import type { RowAction } from '$lib/utils/row-action';
   import { t } from '$lib/stores/i18n.store';
   import { tagsStore } from '$lib/stores/tags.store';
-  import { dateFormat } from '$lib/stores/app-settings.store';
+  import { dateFormat, timeFormat } from '$lib/stores/app-settings.store';
   import { activeNoteId, notesStore, type NoteListItem } from '$lib/stores/notes.store';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
   import { formatNoteDate } from '$lib/utils/date-format';
@@ -308,7 +308,7 @@
               </div>
             {/if}
             <p class="mt-0.5 text-[13px] md:text-xs text-muted-foreground line-clamp-2">
-              {formatNoteDate(displayDate, $dateFormat, $t)}
+              {formatNoteDate(displayDate, $dateFormat, $timeFormat)}
             </p>
             <!-- Visible per-note rejection reason - not just the badge/hover tooltip,
                  so the user knows WHY a note won't sync (and it works on touch). -->

--- a/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/SyncStatusFooter.svelte
@@ -22,6 +22,8 @@
     requestFullReconcileNextPull
   } from '$lib/services/notes-sync.service';
   import { t } from '$lib/stores/i18n.store';
+  import { dateFormat, timeFormat } from '$lib/stores/app-settings.store';
+  import { formatSyncTimestamp } from '$lib/utils/date-format';
 
   let manualSyncing = $state(false);
 
@@ -124,16 +126,6 @@
     }
   }
 
-  function formatTime(iso: string | null): string | null {
-    if (!iso) return null;
-    try {
-      const d = new Date(iso);
-      return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    } catch {
-      return null;
-    }
-  }
-
   let Icon = $derived(getIcon($syncStatus.status));
   // Reactive to $syncProgress: getLabel reads it in the 'syncing' case, so the
   // counter ("Syncing notes… 320/2000") updates as pages land.
@@ -147,7 +139,13 @@
       !manualSyncing
   );
   let isSessionExpired = $derived($syncStatus.status === 'session_expired');
-  let timeStr = $derived(formatTime($syncStatus.lastSyncedAt));
+  // Honors the user's 12h/24h and date-format settings; same-day syncs show
+  // just the time, earlier ones add the date (issue #376).
+  let timeStr = $derived(
+    $syncStatus.lastSyncedAt
+      ? formatSyncTimestamp($syncStatus.lastSyncedAt, $dateFormat, $timeFormat)
+      : null
+  );
 </script>
 
 <div

--- a/apps/reborn-notes/src/lib/stores/device-prefs.store.ts
+++ b/apps/reborn-notes/src/lib/stores/device-prefs.store.ts
@@ -28,13 +28,21 @@ export interface DevicePrefs {
    * which uses a separate master-detail layout.
    */
   noteListCollapsed: boolean;
+  /**
+   * Desktop only: the outline (table of contents) is docked beside the editor
+   * instead of opening as a transient overlay drawer. Global across notes on
+   * this device; the dock auto-hides for notes that have no headings. Ignored
+   * on mobile, which always uses the drawer.
+   */
+  tocPinned: boolean;
 }
 
 const STORAGE_KEY = 'reborn-notes-device-prefs';
 
 const DEFAULTS: DevicePrefs = {
   noteOpenMode: 'preview',
-  noteListCollapsed: false
+  noteListCollapsed: false,
+  tocPinned: false
 };
 
 const NOTE_OPEN_MODES: readonly NoteOpenMode[] = ['preview', 'edit', 'split'];
@@ -52,7 +60,9 @@ function load(): DevicePrefs {
       noteListCollapsed:
         typeof parsed.noteListCollapsed === 'boolean'
           ? parsed.noteListCollapsed
-          : DEFAULTS.noteListCollapsed
+          : DEFAULTS.noteListCollapsed,
+      tocPinned:
+        typeof parsed.tocPinned === 'boolean' ? parsed.tocPinned : DEFAULTS.tocPinned
     };
   } catch (err) {
     logger.warn('Failed to read device prefs, using defaults', err);
@@ -97,11 +107,20 @@ function createDevicePrefsStore() {
     });
   }
 
+  function setTocPinned(pinned: boolean): void {
+    store.update((prev) => {
+      const next = { ...prev, tocPinned: pinned };
+      persist(next);
+      return next;
+    });
+  }
+
   return {
     subscribe: store.subscribe,
     setNoteOpenMode,
     setNoteListCollapsed,
-    toggleNoteList
+    toggleNoteList,
+    setTocPinned
   };
 }
 
@@ -112,3 +131,6 @@ export const noteOpenMode = derived(devicePrefs, ($p) => $p.noteOpenMode);
 
 /** Desktop: whether the note-list panel is collapsed (icon rail stays visible). */
 export const noteListCollapsed = derived(devicePrefs, ($p) => $p.noteListCollapsed);
+
+/** Desktop: whether the outline is docked beside the editor (global, this device). */
+export const tocPinned = derived(devicePrefs, ($p) => $p.tocPinned);

--- a/apps/reborn-notes/src/lib/stores/device-prefs.store.ts
+++ b/apps/reborn-notes/src/lib/stores/device-prefs.store.ts
@@ -21,12 +21,20 @@ export interface DevicePrefs {
    * always open in 'edit' regardless (you just made it to write in it).
    */
   noteOpenMode: NoteOpenMode;
+  /**
+   * Desktop only: the note-list panel (the column between the icon rail and the
+   * editor) is collapsed, leaving just the always-visible icon rail. Lets you
+   * hand the freed width to the editor / docked outline. Ignored on mobile,
+   * which uses a separate master-detail layout.
+   */
+  noteListCollapsed: boolean;
 }
 
 const STORAGE_KEY = 'reborn-notes-device-prefs';
 
 const DEFAULTS: DevicePrefs = {
-  noteOpenMode: 'preview'
+  noteOpenMode: 'preview',
+  noteListCollapsed: false
 };
 
 const NOTE_OPEN_MODES: readonly NoteOpenMode[] = ['preview', 'edit', 'split'];
@@ -40,7 +48,11 @@ function load(): DevicePrefs {
     return {
       noteOpenMode: NOTE_OPEN_MODES.includes(parsed.noteOpenMode as NoteOpenMode)
         ? (parsed.noteOpenMode as NoteOpenMode)
-        : DEFAULTS.noteOpenMode
+        : DEFAULTS.noteOpenMode,
+      noteListCollapsed:
+        typeof parsed.noteListCollapsed === 'boolean'
+          ? parsed.noteListCollapsed
+          : DEFAULTS.noteListCollapsed
     };
   } catch (err) {
     logger.warn('Failed to read device prefs, using defaults', err);
@@ -69,9 +81,27 @@ function createDevicePrefsStore() {
     });
   }
 
+  function setNoteListCollapsed(collapsed: boolean): void {
+    store.update((prev) => {
+      const next = { ...prev, noteListCollapsed: collapsed };
+      persist(next);
+      return next;
+    });
+  }
+
+  function toggleNoteList(): void {
+    store.update((prev) => {
+      const next = { ...prev, noteListCollapsed: !prev.noteListCollapsed };
+      persist(next);
+      return next;
+    });
+  }
+
   return {
     subscribe: store.subscribe,
-    setNoteOpenMode
+    setNoteOpenMode,
+    setNoteListCollapsed,
+    toggleNoteList
   };
 }
 
@@ -79,3 +109,6 @@ export const devicePrefs = createDevicePrefsStore();
 
 /** The view mode an existing note opens in on this device. */
 export const noteOpenMode = derived(devicePrefs, ($p) => $p.noteOpenMode);
+
+/** Desktop: whether the note-list panel is collapsed (icon rail stays visible). */
+export const noteListCollapsed = derived(devicePrefs, ($p) => $p.noteListCollapsed);

--- a/apps/reborn-notes/src/lib/utils/date-format.ts
+++ b/apps/reborn-notes/src/lib/utils/date-format.ts
@@ -5,8 +5,22 @@
 import { formatDateWithSetting } from '@reborn/utils';
 
 /**
- * Format an ISO date string as date + time using the user's preferred date format.
- * Example: "2026-04-05, 14:32".
+ * Format the time-of-day of a Date, honoring the user's 12h/24h preference.
+ * Mirrors the manual formatting in VersionHistorySheet so a 24h user never
+ * sees a locale-driven "01:05 PM" (issue #376). Examples: "13:05" / "1:05 PM".
+ */
+export function formatTimeWithSetting(d: Date, timeFormatSetting: string): string {
+  if (timeFormatSetting === '12h') {
+    const hours12 = d.getHours() % 12 || 12;
+    const ampm = d.getHours() >= 12 ? 'PM' : 'AM';
+    return `${hours12}:${String(d.getMinutes()).padStart(2, '0')} ${ampm}`;
+  }
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+/**
+ * Format an ISO date string as date + time using the user's preferred formats.
+ * Example: "2026-04-05, 14:32" (24h) or "2026-04-05, 2:32 PM" (12h).
  *
  * Time is always shown so that notes created/modified on the same day are
  * visibly distinguishable in the list (sort uses full-timestamp precision).
@@ -14,11 +28,29 @@ import { formatDateWithSetting } from '@reborn/utils';
 export function formatNoteDate(
   iso: string,
   dateFormatSetting: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- reserved for future i18n use, caller passes $t
-  _tFn?: (key: string) => string
+  timeFormatSetting = '24h'
 ): string {
   const d = new Date(iso);
   const dateStr = formatDateWithSetting(d, dateFormatSetting);
-  const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  return `${dateStr}, ${time}`;
+  return `${dateStr}, ${formatTimeWithSetting(d, timeFormatSetting)}`;
+}
+
+/**
+ * Format a "last synced" timestamp for the compact sidebar footer.
+ * Same calendar day -> time only; an earlier day -> date + time. Honors both
+ * the time-format and date-format settings (issue #376).
+ */
+export function formatSyncTimestamp(
+  iso: string,
+  dateFormatSetting: string,
+  timeFormatSetting: string
+): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  const time = formatTimeWithSetting(d, timeFormatSetting);
+  return sameDay ? time : `${formatDateWithSetting(d, dateFormatSetting)} ${time}`;
 }

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -5,7 +5,7 @@
   import { base } from '$app/paths';
   import { copyText } from '$lib/utils/clipboard';
   import { SvelteSet, SvelteMap } from 'svelte/reactivity';
-  import { FolderPlus, Plus, ArrowLeft, Lock } from '@lucide/svelte';
+  import { FolderPlus, Plus, ArrowLeft, Lock, ListTree, PinOff } from '@lucide/svelte';
 
   // Layout
   import IconNav, { type Section, isPeriodicSection } from '$lib/components/layout/IconNav.svelte';
@@ -24,6 +24,7 @@
   import VersionHistorySheet from '$lib/components/VersionHistorySheet.svelte';
   import LinkedNotesSheet from '$lib/components/LinkedNotesSheet.svelte';
   import OutlineSheet from '$lib/components/OutlineSheet.svelte';
+  import OutlineTree from '$lib/components/OutlineTree.svelte';
   import FolderTree from '$lib/components/sidebar/FolderTree.svelte';
   import { pendingNewFolderDraft } from '$lib/stores/new-folder-draft.store';
   import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
@@ -67,7 +68,12 @@
     periodicNotesSettings,
     confirmBeforeDelete
   } from '$lib/stores/app-settings.store';
-  import { devicePrefs, noteOpenMode, noteListCollapsed } from '$lib/stores/device-prefs.store';
+  import {
+    devicePrefs,
+    noteOpenMode,
+    noteListCollapsed,
+    tocPinned
+  } from '$lib/stores/device-prefs.store';
   import EditorModeIntroDialog from '$lib/components/editor/EditorModeIntroDialog.svelte';
   import PeriodicNoteOnboardingDialog from '$lib/components/editor/PeriodicNoteOnboardingDialog.svelte';
   import type { EditorMode } from '@reborn/storage';
@@ -87,7 +93,7 @@
   import { goto } from '$lib/utils/navigation';
   import { createScrollSync } from '$lib/utils/scroll-sync';
   import { scrollToHeading } from '$lib/utils/heading-scroll';
-  import type { DocHeading } from '$lib/utils/heading-outline';
+  import { extractHeadings, type DocHeading } from '$lib/utils/heading-outline';
   import { applyToc, removeToc, hasToc, isTocStale, tocHiddenSpans } from '$lib/utils/toc';
   import { createEditorAdapter, createPreviewAdapter } from '$lib/utils/line-adapter';
   import { requireActiveSession } from '$lib/utils/require-active-session';
@@ -324,11 +330,30 @@
   }
 
   function toggleOutline() {
+    // When the outline is docked (desktop, pinned, has headings) the header
+    // toggle unpins it - a docked panel has no transient per-note "hide".
+    if (tocDocked) {
+      devicePrefs.setTocPinned(false);
+      return;
+    }
     outlineOpen = !outlineOpen;
     if (outlineOpen) {
       linkedNotesOpen = false;
       if (historyMode !== 'closed') closeHistory();
     }
+  }
+
+  // Dock the outline beside the editor (from the floating drawer's Pin button).
+  // Global, per-device; hands the drawer off to the dock.
+  function pinOutline() {
+    devicePrefs.setTocPinned(true);
+    outlineOpen = false;
+  }
+
+  // Undock (from the docked panel). The outline is fully hidden; the header
+  // button reopens it as a floating drawer.
+  function unpinOutline() {
+    devicePrefs.setTocPinned(false);
   }
 
   function handleDetailOutline() {
@@ -435,6 +460,27 @@
   let isMobile = $state(false);
   let closeSidebarSignal = $state(0);
   const effectiveViewMode = $derived(isMobile && viewMode === 'split' ? 'edit' : viewMode);
+
+  // ── Outline (TOC) presentation ──────────────────────────────────
+  // Desktop + pinned (global, per-device) docks the outline beside the editor,
+  // but only for notes that actually have headings (else the dock auto-hides).
+  // Otherwise the outline is the transient floating drawer toggled by the header
+  // button. `outlineOpen` drives ONLY the floating drawer; the dock is derived.
+  const tocDocked = $derived.by(() => {
+    if (
+      isMobile ||
+      !$tocPinned ||
+      $activeNoteId == null ||
+      historyMode !== 'closed' ||
+      linkedNotesOpen
+    )
+      return false;
+    return extractHeadings(noteDetailService.content).length > 0;
+  });
+  const tocFloating = $derived(outlineOpen && !tocDocked);
+  // Outline visible in any form - drives the header toggle's pressed state and
+  // gates the scroll-spy.
+  const outlineVisible = $derived(tocDocked || tocFloating);
 
   // Mobile drill-down navigation state
   type MobileView = 'list' | 'folder-tree' | 'tag-list';
@@ -1332,7 +1378,7 @@
   // Re-attaches when the preview re-renders (new heading elements) or the note
   // changes; no-op when the panel is closed or no preview is mounted (edit-only).
   $effect(() => {
-    if (!outlineOpen) {
+    if (!outlineVisible) {
       activeOutlineSlug = null;
       return;
     }
@@ -2059,7 +2105,7 @@
               bind:historyMode
               linkedNotesActive={linkedNotesOpen}
               ontogglelinkednotes={toggleLinkedNotes}
-              outlineActive={outlineOpen}
+              outlineActive={outlineVisible}
               ontoggleoutline={toggleOutline}
               canGoBackNote={noteNavHistory.canGoBack}
               canGoForwardNote={noteNavHistory.canGoForward}
@@ -2367,7 +2413,7 @@
             bind:historyMode
             linkedNotesActive={linkedNotesOpen}
             ontogglelinkednotes={toggleLinkedNotes}
-            outlineActive={outlineOpen}
+            outlineActive={outlineVisible}
             ontoggleoutline={toggleOutline}
             canGoBackNote={noteNavHistory.canGoBack}
             canGoForwardNote={noteNavHistory.canGoForward}
@@ -2541,6 +2587,37 @@
         {/if}
       {/if}
     </main>
+
+    <!-- ── Docked outline (desktop, pinned, note has headings). Reserves layout
+         space beside the editor and never closes on outside-click - the whole
+         point of #375 vs. the overlay drawer. ──────────────────────────────── -->
+    {#if tocDocked}
+      <aside
+        class="my-2 mr-2 flex w-80 shrink-0 flex-col overflow-hidden rounded-xl border bg-background shadow-sm"
+        aria-label={$t('outline.title')}
+      >
+        <div class="flex shrink-0 items-center gap-2 border-b px-4 py-3">
+          <ListTree class="h-4 w-4 text-muted-foreground" />
+          <span class="flex-1 truncate text-sm font-semibold">{$t('outline.title')}</span>
+          <button
+            type="button"
+            onclick={unpinOutline}
+            title={$t('outline.unpin')}
+            aria-label={$t('outline.unpin')}
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground
+                   transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <PinOff class="h-4 w-4" />
+          </button>
+        </div>
+        <OutlineTree
+          content={noteDetailService.content}
+          activeSlug={activeOutlineSlug}
+          onnavigate={handleOutlineNavigate}
+          enabled={tocDocked}
+        />
+      </aside>
+    {/if}
   </SidebarProvider>
 {/if}
 
@@ -2633,9 +2710,11 @@
 {#if $activeNoteId}
   <OutlineSheet
     content={noteDetailService.content}
-    open={outlineOpen}
+    open={tocFloating}
     activeSlug={activeOutlineSlug}
     onnavigate={handleOutlineNavigate}
+    showPin={!isMobile}
+    onpin={pinOutline}
     onclose={() => {
       outlineOpen = false;
     }}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -14,14 +14,7 @@
   import InitialSyncState from '$lib/components/sync/InitialSyncState.svelte';
   import { isInitialSync } from '$lib/stores/sync-status.store';
   import { platform } from '$lib/platform';
-  import {
-    SidebarProvider,
-    Sidebar,
-    SidebarHeader,
-    SidebarContent,
-    SidebarInset,
-    SidebarTrigger
-  } from '@reborn/ui/sidebar';
+  import { SidebarProvider, SidebarHeader, SidebarContent } from '@reborn/ui/sidebar';
   import * as Tooltip from '@reborn/ui/components/tooltip';
 
   // Content components
@@ -74,7 +67,7 @@
     periodicNotesSettings,
     confirmBeforeDelete
   } from '$lib/stores/app-settings.store';
-  import { noteOpenMode } from '$lib/stores/device-prefs.store';
+  import { devicePrefs, noteOpenMode, noteListCollapsed } from '$lib/stores/device-prefs.store';
   import EditorModeIntroDialog from '$lib/components/editor/EditorModeIntroDialog.svelte';
   import PeriodicNoteOnboardingDialog from '$lib/components/editor/PeriodicNoteOnboardingDialog.svelte';
   import type { EditorMode } from '@reborn/storage';
@@ -2214,26 +2207,32 @@
        keyboard's height, 0 when closed, so the scroll container shrinks to the
        visible area exactly as the old vv.height pin did. -->
   <SidebarProvider
-    style="height: calc(100dvh - var(--rn-banner-h, 0px) - var(--rn-keyboard-inset, 0px)); min-height: 0; overflow: hidden; --sidebar-width: 24rem;"
+    class="bg-sidebar overflow-hidden"
+    open={!$noteListCollapsed}
+    onOpenChange={(o) => devicePrefs.setNoteListCollapsed(!o)}
+    style="height: calc(100dvh - var(--rn-banner-h, 0px) - var(--rn-keyboard-inset, 0px)); min-height: 0; --sidebar-width: 24rem;"
   >
-    <Sidebar
-      variant="inset"
-      collapsible="offcanvas"
-      class="overflow-hidden [&>[data-sidebar=sidebar]]:flex-row"
+    <SidebarAutoClose {closeSidebarSignal} />
+
+    <!-- ── Icon rail (always visible; its first button toggles the note-list
+         panel, mirrored by Cmd/Ctrl+B via the provider). ──────────── -->
+    <IconNav
+      bind:activeSection
+      onNewNote={handleNewNote}
+      onsectionclick={handleSectionClick}
+      onPeriodic={handlePeriodic}
+      pendingKind={periodicPendingKind}
+      panelCollapsed={$noteListCollapsed}
+      ontogglepanel={() => devicePrefs.toggleNoteList()}
+    />
+
+    <!-- ── Note-list panel (collapsible). Outer div animates width; the inner
+         keeps a fixed 24rem width so its content never reflows mid-slide. ── -->
+    <div
+      class="shrink-0 overflow-hidden transition-[width] duration-200 ease-linear"
+      style="width: {$noteListCollapsed ? '0px' : '24rem'}"
     >
-      <SidebarAutoClose {closeSidebarSignal} />
-
-      <!-- ── Icon rail (desktop only) ────────────────────────────── -->
-      <IconNav
-        bind:activeSection
-        onNewNote={handleNewNote}
-        onsectionclick={handleSectionClick}
-        onPeriodic={handlePeriodic}
-        pendingKind={periodicPendingKind}
-      />
-
-      <!-- ── Content panel ───────────────────────────────────────── -->
-      <div class="flex flex-1 flex-col min-w-0 overflow-hidden">
+      <div class="flex h-full w-96 flex-col min-w-0 overflow-hidden bg-sidebar">
         <SidebarHeader class="border-b p-0 gap-0">
           <!-- pt + min-h grow together by the iOS notch inset so the content
                keeps its full 3rem box (env() is 0 elsewhere) -->
@@ -2313,10 +2312,15 @@
         </SidebarContent>
         <SyncStatusFooter />
       </div>
-    </Sidebar>
+    </div>
 
-    <!-- ── Column 3: Main content area ─────────────────────────────── -->
-    <SidebarInset class="overflow-hidden flex flex-col min-w-0 bg-background">
+    <!-- ── Editor column (was SidebarInset; the variant=inset card classes are
+         inlined here and the left margin follows the panel's collapsed state). ── -->
+    <main
+      class="bg-background relative flex flex-1 flex-col min-w-0 overflow-hidden my-2 mr-2 rounded-xl shadow-sm"
+      class:ml-0={!$noteListCollapsed}
+      class:ml-2={$noteListCollapsed}
+    >
       {#if $activeNoteId}
         {#if historyMode === 'diff' && selectedVersion}
           <HistoryHeader
@@ -2511,7 +2515,6 @@
         <header
           class="flex min-h-[calc(3rem+env(safe-area-inset-top,0px))] shrink-0 items-center gap-2 border-b border-border/60 px-6 pt-[env(safe-area-inset-top,0px)]"
         >
-          <SidebarTrigger class="md:hidden -ml-1 shrink-0" />
           <span class="min-w-0 flex-1 truncate text-sm text-muted-foreground">
             {activeFolderName}
           </span>
@@ -2537,7 +2540,7 @@
           </div>
         {/if}
       {/if}
-    </SidebarInset>
+    </main>
   </SidebarProvider>
 {/if}
 

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -123,6 +123,13 @@
   let lastVisitedFolderId = $state<string | null>(null);
   const activeStarred = $derived(activeSection === 'starred');
   const activeTrash = $derived(activeSection === 'trash');
+
+  // The note-list collapse is a focus affordance for an OPEN note. With no note
+  // in the main pane (e.g. right after clicking a rail section, which clears
+  // activeNoteId), a collapsed list would leave an empty pane - so the panel
+  // always returns when no note is open. The collapse toggle lives in the note
+  // header (present only with a note open), not the always-visible rail.
+  const panelCollapsedEffective = $derived($noteListCollapsed && $activeNoteId != null);
   const activeFolderSubfolders = $derived(
     activeSection === 'folders' && activeFolderId
       ? findChildrenOfParent($foldersStore, activeFolderId)
@@ -2254,7 +2261,7 @@
        visible area exactly as the old vv.height pin did. -->
   <SidebarProvider
     class="bg-sidebar overflow-hidden"
-    open={!$noteListCollapsed}
+    open={!panelCollapsedEffective}
     onOpenChange={(o) => devicePrefs.setNoteListCollapsed(!o)}
     style="height: calc(100dvh - var(--rn-banner-h, 0px) - var(--rn-keyboard-inset, 0px)); min-height: 0; --sidebar-width: 24rem;"
   >
@@ -2268,15 +2275,13 @@
       onsectionclick={handleSectionClick}
       onPeriodic={handlePeriodic}
       pendingKind={periodicPendingKind}
-      panelCollapsed={$noteListCollapsed}
-      ontogglepanel={() => devicePrefs.toggleNoteList()}
     />
 
     <!-- ── Note-list panel (collapsible). Outer div animates width; the inner
          keeps a fixed 24rem width so its content never reflows mid-slide. ── -->
     <div
       class="shrink-0 overflow-hidden transition-[width] duration-200 ease-linear"
-      style="width: {$noteListCollapsed ? '0px' : '24rem'}"
+      style="width: {panelCollapsedEffective ? '0px' : '24rem'}"
     >
       <div class="flex h-full w-96 flex-col min-w-0 overflow-hidden bg-sidebar">
         <SidebarHeader class="border-b p-0 gap-0">
@@ -2364,8 +2369,8 @@
          inlined here and the left margin follows the panel's collapsed state). ── -->
     <main
       class="bg-background relative flex flex-1 flex-col min-w-0 overflow-hidden my-2 mr-2 rounded-xl shadow-sm"
-      class:ml-0={!$noteListCollapsed}
-      class:ml-2={$noteListCollapsed}
+      class:ml-0={!panelCollapsedEffective}
+      class:ml-2={panelCollapsedEffective}
     >
       {#if $activeNoteId}
         {#if historyMode === 'diff' && selectedVersion}
@@ -2421,6 +2426,8 @@
             {forwardNoteTitle}
             onnotehistoryback={goBackNote}
             onnotehistoryforward={goForwardNote}
+            noteListCollapsed={$noteListCollapsed}
+            onToggleNoteList={() => devicePrefs.toggleNoteList()}
             onback={() => activeNoteId.set(null)}
             onshowxray={() => {
               showEncryptionXRay = true;

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -644,6 +644,7 @@
     "restore": "Wiederherstellen",
     "delete_permanently": "Endgültig löschen",
     "days_until_deletion": "{days} Tage bis zur endgültigen Löschung",
+    "auto_delete_notice": "Notizen im Papierkorb werden nach {days} Tagen automatisch gelöscht",
     "empty_message": "Der Papierkorb ist leer",
     "empty_short": "Papierkorb ist leer.",
     "confirm_empty": "Möchten Sie wirklich alle Elemente im Papierkorb endgültig löschen?",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -126,6 +126,8 @@
     "user_menu": "Benutzermenü",
     "main_navigation": "Hauptnavigation",
     "notes_navigation": "Notizennavigation",
+    "show_note_list": "Notizliste anzeigen",
+    "hide_note_list": "Notizliste ausblenden",
     "e2ee_account": "E2EE-Konto",
     "reborn_account": "Reborn-Konto",
     "log_out": "Abmelden",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -683,7 +683,9 @@
   },
   "outline": {
     "title": "Gliederung",
-    "empty": "Diese Notiz hat noch keine Überschriften."
+    "empty": "Diese Notiz hat noch keine Überschriften.",
+    "pin": "Gliederung anheften",
+    "unpin": "Gliederung lösen"
   },
   "toc": {
     "title": "Inhaltsverzeichnis",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -644,6 +644,7 @@
     "restore": "Restore",
     "delete_permanently": "Delete Permanently",
     "days_until_deletion": "{days} days until permanent deletion",
+    "auto_delete_notice": "Trashed notes are automatically deleted after {days} days",
     "empty_message": "Trash is empty",
     "empty_short": "Trash is empty.",
     "confirm_empty": "Are you sure you want to permanently delete all items in trash?",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -126,6 +126,8 @@
     "user_menu": "User menu",
     "main_navigation": "Main navigation",
     "notes_navigation": "Notes navigation",
+    "show_note_list": "Show note list",
+    "hide_note_list": "Hide note list",
     "e2ee_account": "E2EE account",
     "reborn_account": "Reborn account",
     "log_out": "Log out",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -683,7 +683,9 @@
   },
   "outline": {
     "title": "Outline",
-    "empty": "No headings in this note yet."
+    "empty": "No headings in this note yet.",
+    "pin": "Pin outline",
+    "unpin": "Unpin outline"
   },
   "toc": {
     "title": "Table of contents",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -644,6 +644,7 @@
     "restore": "Restaurar",
     "delete_permanently": "Eliminar permanentemente",
     "days_until_deletion": "{days} días para la eliminación permanente",
+    "auto_delete_notice": "Las notas de la papelera se eliminan automáticamente después de {days} días",
     "empty_message": "La papelera está vacía",
     "empty_short": "La papelera está vacía.",
     "confirm_empty": "¿Está seguro de que desea eliminar permanentemente todos los elementos de la papelera?",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -126,6 +126,8 @@
     "user_menu": "Menú de usuario",
     "main_navigation": "Navegación principal",
     "notes_navigation": "Navegación de notas",
+    "show_note_list": "Mostrar lista de notas",
+    "hide_note_list": "Ocultar lista de notas",
     "e2ee_account": "Cuenta E2EE",
     "reborn_account": "Cuenta Reborn",
     "log_out": "Cerrar sesión",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -683,7 +683,9 @@
   },
   "outline": {
     "title": "Esquema",
-    "empty": "Esta nota aún no tiene encabezados."
+    "empty": "Esta nota aún no tiene encabezados.",
+    "pin": "Anclar esquema",
+    "unpin": "Desanclar esquema"
   },
   "toc": {
     "title": "Tabla de contenido",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -644,6 +644,7 @@
     "restore": "Restaurer",
     "delete_permanently": "Supprimer définitivement",
     "days_until_deletion": "{days} jours avant la suppression définitive",
+    "auto_delete_notice": "Les notes de la corbeille sont automatiquement supprimées après {days} jours",
     "empty_message": "La corbeille est vide",
     "empty_short": "La corbeille est vide.",
     "confirm_empty": "Êtes-vous sûr de vouloir supprimer définitivement tous les éléments de la corbeille ?",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -126,6 +126,8 @@
     "user_menu": "Menu utilisateur",
     "main_navigation": "Navigation principale",
     "notes_navigation": "Navigation des notes",
+    "show_note_list": "Afficher la liste des notes",
+    "hide_note_list": "Masquer la liste des notes",
     "e2ee_account": "Compte E2EE",
     "reborn_account": "Compte Reborn",
     "log_out": "Se déconnecter",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -683,7 +683,9 @@
   },
   "outline": {
     "title": "Plan",
-    "empty": "Cette note n'a pas encore de titres."
+    "empty": "Cette note n'a pas encore de titres.",
+    "pin": "Épingler le plan",
+    "unpin": "Détacher le plan"
   },
   "toc": {
     "title": "Table des matières",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -126,6 +126,8 @@
     "user_menu": "Menu użytkownika",
     "main_navigation": "Nawigacja główna",
     "notes_navigation": "Nawigacja notatek",
+    "show_note_list": "Pokaż listę notatek",
+    "hide_note_list": "Ukryj listę notatek",
     "e2ee_account": "Konto E2EE",
     "reborn_account": "Konto Reborn",
     "log_out": "Wyloguj się",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -683,7 +683,9 @@
   },
   "outline": {
     "title": "Konspekt",
-    "empty": "Ta notatka nie ma jeszcze nagłówków."
+    "empty": "Ta notatka nie ma jeszcze nagłówków.",
+    "pin": "Przypnij konspekt",
+    "unpin": "Odepnij konspekt"
   },
   "toc": {
     "title": "Spis treści",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -644,6 +644,7 @@
     "restore": "Przywróć",
     "delete_permanently": "Usuń trwale",
     "days_until_deletion": "{days} dni do trwałego usunięcia",
+    "auto_delete_notice": "Notatki w koszu są automatycznie usuwane po {days} dniach",
     "empty_message": "Kosz jest pusty",
     "empty_short": "Kosz jest pusty.",
     "confirm_empty": "Czy na pewno chcesz trwale usunąć wszystkie elementy z kosza?",


### PR DESCRIPTION
## Summary

Desktop-only UI work for Reborn Notes. The first two items are the side-panel features this branch started as; the last two are smaller UI fixes folded in on request. The mobile master-detail layout (a separate branch) is untouched. Resolves #375 and #376 (both reported by @computrav).

**1. Collapsible note-list panel, persistent icon rail.** The left sidebar was a single shadcn `Sidebar collapsible="offcanvas"`, so collapsing it slid the icon rail off-screen too, and there was no desktop toggle at all. The desktop layout is restructured so the icon rail stays visible and only the note-list panel hides/shows. Collapsing is a focus affordance for an open note: the effective collapse is `noteListCollapsed && activeNoteId != null`, so the list always returns whenever no note is open (e.g. clicking a rail section clears the active note - otherwise you'd be left staring at an empty main pane). The toggle sits at the note header's left edge (it only applies while a note is open) plus the existing Cmd/Ctrl+B; collapsed state persists per-device.

**2. Pinnable docked outline (#375).** The outline (TOC) was an overlay drawer that closed on any outside-click, so you could not read/edit a note and see the outline at once. A new "pin" docks it beside the editor instead - reserving layout space and staying put. Pin is global per-device: once pinned, the outline docks for every note with headings and auto-hides for notes without. Unpinned it stays the floating drawer; mobile always uses the drawer.

**3. Last-synced time respects the time-format setting (#376).** The sidebar "Synced" footer formatted the time with `toLocaleTimeString` and no `hour12`, so the browser locale - not the user's 12h/24h Settings choice - decided the format, and a 24h user saw "01:05 PM". The identical bug affected the note-list timestamps. Fixed at the root with a shared `formatTimeWithSetting` helper; the footer now also shows the date only when the sync was not today (time-only for same-day, date + time for earlier), honoring both the time- and date-format settings.

**4. Trash retention notice.** Trashed notes are auto-purged after 30 days (`cleanTrash(30)`), but nothing surfaced that. A subtle info line is now pinned above the trash list, shown whether trash is full or empty.

### Decisions (for review)
- **TOC pin scope: global per-device, not per-note** (the issue suggested per-note). Chosen with Michał: lower friction, symmetric with the note-list toggle, matches VS Code / Obsidian; auto-hide-when-no-headings covers the "don't clutter short notes" intent. Stored in `device-prefs` (localStorage), outside the Zero-Knowledge sync surface - it is a view preference of this screen.
- **Layout: kept `SidebarProvider` as a thin shell** and replaced `Sidebar`/`SidebarInset` with explicit flex columns. The provider still supplies `Tooltip.Provider`, the Cmd/Ctrl+B shortcut and the `useSidebar` context; the `variant=inset` card classes are inlined on the editor `<main>`. Reusing shadcn `collapsible="icon"` was rejected (its inset padding math fought the custom rail).
- **Kept `SidebarAutoClose`** (inert on desktop, gated on `sidebar.isMobile`) instead of removing it, so the shared `closeSidebarSignal` stays wired - a smaller, lower-risk diff than the plan's "remove it".
- **#376 footer display: smart date** (chosen via a question with Michał): time-only for same-day syncs, date + time for earlier ones - the reporter's preferred sub-option, compact in the narrow footer. The fix lives in `date-format.ts`, so the note-list times are corrected by the same change.
- **Trash notice: persistent info line** (chosen via a question): shown whether trash is full or empty, rather than empty-state-only or a per-note countdown (the unused `trash.days_until_deletion` string is left in place for a possible future countdown).
- **Collapse = focus-for-open-note; toggle in the note header** (refined after smoke). Collapsing only takes effect while a note is open, so navigating to a section always re-shows its list (no empty pane); periodic sections open a real note, so they're unaffected. The toggle was moved off the always-present icon rail - where it popped in/out and shifted the rail - to the note header's left edge, which exists exactly when a note is open (the VS Code / Notion / Linear placement).
- Shared `OutlineTree.svelte` extracted from `OutlineSheet`; `heading-outline.ts` is untouched (its tests are unaffected).

State model: `outlineOpen` drives only the floating drawer; `tocDocked` is derived (desktop && pinned && note-has-headings && no history/linked-notes overlay). The header outline button toggles the drawer when not docked and unpins when docked; the scroll-spy tracks whichever form is visible.

Six commits: the layout panel, the outline dock, the rail icon-shade fix, the #376 time-format fix, the trash notice, and the collapse-focus refinement.

## Test plan

Local gate (green): `svelte-check` 0 errors · `eslint` clean · `check-i18n-parity.mjs` PASS (5 locales) · full notes `vitest` 1144 pass · single-file `svelte.compile()` of every changed component OK. The full `vite build` runs in CI (the sandbox cannot reinstall deps).

Desktop smoke (>=768px):
- Icon rail always visible and stable. With a note open, the collapse toggle (note header left edge + Cmd/Ctrl+B) hides/shows the list with a smooth slide and the editor fills the freed space; reload preserves the state. Collapse then click a rail section (Starred/Folders/Tags/Trash) and that list shows - never an empty pane; the toggle is absent when no note is open.
- Outline button opens the TOC: floating when unpinned, docked when pinned; the docked panel does NOT close on outside-click and reserves ~20rem beside the editor.
- Pin (drawer header) docks it; Unpin (dock header) undocks; a note without headings while pinned auto-hides the dock and the button opens the empty-state drawer instead.
- Scroll-spy highlight + scroll-into-view work in both floating and docked; clicking a heading scrolls the preview (preview mode) and the editor line (edit mode); the bottom-of-note case still promotes the last heading.
- Switching notes / opening version history / linked notes hides the outline cleanly (never two right-side panels at once).
- **#376:** Settings > time format = 24h: the sidebar "Synced" footer shows 24h (e.g. 13:05, not 01:05 PM); switch to 12h and it reads "1:05 PM". A sync from an earlier day shows date + time, today shows time only. Note-list timestamps follow the same setting.
- **Trash:** the "deleted after 30 days" notice shows above the list whether trash has items or is empty, in all 5 locales.
- Mobile unchanged: the outline is the drawer (no Pin button, closes on navigate); the master-detail layout is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
