### PR TITLE
feat(notes): shares sidebar master-detail view

### DIFF
--- a/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
+++ b/apps/reborn-notes/src/lib/components/layout/IconNav.svelte
@@ -5,6 +5,7 @@
     | 'folders'
     | 'tags'
     | 'trash'
+    | 'shares'
     | 'search'
     | 'periodic-daily'
     | 'periodic-weekly'
@@ -52,7 +53,6 @@
   import type { PeriodicKind } from '@reborn/storage';
   import { activeSharesCount } from '$lib/stores/shares.store';
   import { requireActiveSession } from '$lib/utils/require-active-session';
-  import ManageSharesDialog from '../notes/ManageSharesDialog.svelte';
   import AccountRequiredDialog from '../shared/AccountRequiredDialog.svelte';
 
   let {
@@ -82,7 +82,6 @@
   const isMobileQuery = useIsMobile();
   let loggingOut = $state(false);
   let userSheetOpen = $state(false);
-  let sharesDialogOpen = $state(false);
   // Local-only mode: sharing needs a server account - nudge to register instead.
   let accountRequiredOpen = $state(false);
 
@@ -103,7 +102,8 @@
       description: $t('share.session_required.view')
     });
     if (!ok) return;
-    sharesDialogOpen = true;
+    activeSection = 'shares';
+    onsectionclick?.('shares');
   }
 
   // Refresh `now` every minute so tooltips stay accurate across midnight /
@@ -267,8 +267,11 @@
       type="button"
       onclick={handleOpenShares}
       class="flex flex-1 flex-col items-center gap-0.5 rounded-md py-2 px-1.5 text-xs transition-colors
-        text-muted-foreground hover:bg-sidebar-accent/60"
+        {activeSection === 'shares'
+        ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+        : 'text-muted-foreground hover:bg-sidebar-accent/60'}"
       aria-label={$t('nav.shares')}
+      aria-current={activeSection === 'shares' ? 'page' : undefined}
     >
       <span class="relative">
         <Share2 class="h-5 w-5" />
@@ -456,9 +459,12 @@
             {...props}
             type="button"
             onclick={handleOpenShares}
-            class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg
-                   text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
+            class="flex h-11 w-11 md:h-9 md:w-9 items-center justify-center rounded-lg transition-colors
+              {activeSection === 'shares'
+              ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+              : 'text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
             aria-label={$t('nav.shares')}
+            aria-current={activeSection === 'shares' ? 'page' : undefined}
           >
             <span class="relative">
               <Share2 class="h-6 w-6 md:h-5 md:w-5" />
@@ -642,8 +648,6 @@
   </nav>
 {/if}
 
-<!-- Shares manage dialog (mounted once, used by both nav modes) -->
-<ManageSharesDialog bind:open={sharesDialogOpen} sourceId={null} />
 <AccountRequiredDialog bind:open={accountRequiredOpen} />
 
 <!-- Mobile: User menu Sheet -->

--- a/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
@@ -8,15 +8,29 @@
     AlertTriangle,
     ChevronDown,
     ChevronUp,
-    Eye
+    Eye,
+    Ellipsis,
+    Download,
+    ClipboardCopy,
+    FileClock
   } from '@lucide/svelte';
-  import { t } from '$lib/stores/i18n.store';
+  import { t, locale } from '$lib/stores/i18n.store';
   import { shareLink } from '$lib/utils/native-share';
   import { copyText } from '$lib/utils/clipboard';
-  import { toastStore } from '@reborn/ui';
+  import {
+    toastStore,
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator
+  } from '@reborn/ui';
   import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
   import NoteSnapshotView from '$lib/components/notes/NoteSnapshotView.svelte';
+  import { exportMarkdownString } from '$lib/services/export-import.service';
   import { sharesStore, activeShareId } from '$lib/stores/shares.store';
+  import { notesStore } from '$lib/stores/notes.store';
+  import { formatExpiryRelative } from '$lib/utils/expiry-format';
   import type { OwnShareListItem } from '@reborn/types';
 
   let { shareId, onback }: { shareId: string; onback?: () => void } = $props();
@@ -44,6 +58,35 @@
   // Native build only: OS share sheet. Web is copy-only (DCE'd via the define).
   const isNative = __REBORN_NATIVE__;
 
+  // Stale hint: load the source note (by the id baked into the encrypted payload)
+  // only to read its updated_at, and compare it to when the snapshot was taken.
+  // loadNote returns null when the note isn't on this device (or was deleted) ->
+  // no badge. Archived (trashed) notes are treated as "gone", so we suppress the
+  // badge rather than flag a trash-induced bump. NOTE: updated_at also moves on
+  // non-content edits (pin / move), so this is an informational hint, not a proof
+  // the shared text changed.
+  const sourceId = $derived(entry?.payload.source_id ?? null);
+  let sourceUpdatedAt = $state<string | null>(null);
+  $effect(() => {
+    const sid = sourceId;
+    sourceUpdatedAt = null;
+    if (!sid) return;
+    let cancelled = false;
+    void notesStore.loadNote(sid).then((n) => {
+      if (!cancelled) sourceUpdatedAt = n && !n.is_archived ? n.updated_at : null;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+  const snapshotStale = $derived(
+    !!(
+      sourceUpdatedAt
+      && entry?.payload.shared_at
+      && new Date(sourceUpdatedAt).getTime() > new Date(entry.payload.shared_at).getTime()
+    )
+  );
+
   const headline = $derived(
     entry
       ? entry.payload.display_name?.trim() || entry.payload.title || $t('share.list.untitled')
@@ -62,7 +105,7 @@
   function formatOpens(s: OwnShareListItem): string {
     return s.max_access_count !== null
       ? `${s.access_count} / ${s.max_access_count}`
-      : String(s.access_count);
+      : `${s.access_count} (${$t('share.list.opens_unlimited')})`;
   }
 
   async function copyUrl() {
@@ -79,6 +122,25 @@
       dialogTitle: $t('share.create.share_sheet_title')
     });
     if (!ok) await copyUrl();
+  }
+
+  // Copy / export the FROZEN snapshot markdown (entry.payload.content) - the exact
+  // text that was shared, not the live note. No frontmatter (export), no server hit.
+  async function copyMarkdown() {
+    if (!entry) return;
+    if (await copyText(entry.payload.content)) toastStore.success($t('share.list.copied_markdown'));
+    else toastStore.error($t('share.create.copy_failed'));
+  }
+
+  async function exportMarkdown() {
+    if (!entry) return;
+    const name =
+      entry.payload.display_name?.trim() || entry.payload.title || $t('share.list.untitled');
+    try {
+      await exportMarkdownString(name, entry.payload.content);
+    } catch {
+      toastStore.error($t('notes.export_failed'));
+    }
   }
 
   async function doRevoke() {
@@ -127,8 +189,10 @@
         {/if}
       </p>
     </div>
-    <!-- Labelled on desktop (the header has room and icon-only actions read as
-         ambiguous), icon-only on the cramped mobile header. -->
+    <!-- Copy link stays inline + labelled: it is the primary, most-used action.
+         The rarer / destructive actions live in the kebab, where every item is
+         labelled (so nothing reads as an icon-only guess) and the header stays
+         uncluttered on the narrow mobile layout. -->
     {#if entry}
       <button
         type="button"
@@ -140,34 +204,51 @@
         <Copy class="h-4 w-4" />
         <span class="hidden md:inline">{$t('share.create.copy_link')}</span>
       </button>
-      {#if isNative}
-        <button
-          type="button"
-          onclick={shareUrl}
-          class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm
-                 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          aria-label={$t('share.create.share_cta')}
-        >
-          <Share2 class="h-4 w-4" />
-          <span class="hidden md:inline">{$t('share.create.share_cta')}</span>
-        </button>
-      {/if}
     {/if}
-    {#if share && !share.revoked_at}
-      <!-- Revoke kills the public link permanently - not a recoverable trash like a
-           note. A Link2Off glyph + explicit label disambiguate it from note delete. -->
-      <button
-        type="button"
-        disabled={revoking}
-        onclick={() => (confirmRevokeOpen = true)}
-        class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm
-               text-destructive transition-colors hover:bg-destructive/10
-               disabled:pointer-events-none disabled:opacity-50"
-        aria-label={$t('share.list.revoke_action')}
-      >
-        <Link2Off class="h-4 w-4" />
-        <span class="hidden md:inline">{$t('share.list.revoke_action')}</span>
-      </button>
+    {#if entry || (share && !share.revoked_at)}
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              title={$t('share.list.column.actions')}
+              aria-label={$t('share.list.column.actions')}
+              class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground
+                     transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <Ellipsis class="h-5 w-5" />
+            </button>
+          {/snippet}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" class="min-w-48">
+          {#if entry}
+            {#if isNative}
+              <DropdownMenuItem onclick={shareUrl}>
+                <Share2 class="mr-2 h-4 w-4" />{$t('share.create.share_cta')}
+              </DropdownMenuItem>
+            {/if}
+            <DropdownMenuItem onclick={exportMarkdown}>
+              <Download class="mr-2 h-4 w-4" />{$t('share.list.export_markdown')}
+            </DropdownMenuItem>
+            <DropdownMenuItem onclick={copyMarkdown}>
+              <ClipboardCopy class="mr-2 h-4 w-4" />{$t('share.list.copy_markdown')}
+            </DropdownMenuItem>
+          {/if}
+          {#if share && !share.revoked_at}
+            <!-- Revoke kills the public link permanently - not a recoverable trash
+                 like a note. Separated + destructive-coloured at the bottom. -->
+            {#if entry}<DropdownMenuSeparator />{/if}
+            <DropdownMenuItem
+              class="text-destructive focus:text-destructive"
+              disabled={revoking}
+              onclick={() => (confirmRevokeOpen = true)}
+            >
+              <Link2Off class="mr-2 h-4 w-4" />{$t('share.list.revoke_action')}
+            </DropdownMenuItem>
+          {/if}
+        </DropdownMenuContent>
+      </DropdownMenu>
     {/if}
   </header>
 
@@ -209,7 +290,24 @@
                 <Copy class="h-3.5 w-3.5" />
               </button>
               <p class="break-all pr-9 font-mono text-xs text-muted-foreground">{entry.url}</p>
+              <!-- Privacy nudge: the link carries the decryption key in its
+                   fragment, so anyone with it can read the snapshot. -->
+              <p class="mt-1 flex items-start gap-1 text-[11px] leading-snug text-muted-foreground">
+                <Lock class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+                <span>{$t('share.list.link_key_warning')}</span>
+              </p>
             {/if}
+          </div>
+        {/if}
+
+        <!-- Source note changed since the snapshot was frozen (informational). -->
+        {#if snapshotStale}
+          <div
+            class="flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10
+                   px-3 py-2 text-xs text-amber-700 dark:text-amber-400"
+          >
+            <FileClock class="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span>{$t('share.list.snapshot_stale')}</span>
           </div>
         {/if}
 
@@ -222,7 +320,17 @@
           <div>
             <dt class="text-muted-foreground">{$t('share.list.column.expires')}</dt>
             <dd class="mt-0.5 font-medium">
-              {share.expires_at ? formatDate(share.expires_at) : $t('share.create.expires.never')}
+              {#if share.expires_at}
+                {@const rel = formatExpiryRelative(share.expires_at, $locale ?? 'en')}
+                {formatDate(share.expires_at)}
+                {#if rel?.expired}
+                  <span class="font-normal text-destructive">({$t('share.list.expired')})</span>
+                {:else if rel}
+                  <span class="font-normal text-muted-foreground">({rel.text})</span>
+                {/if}
+              {:else}
+                {$t('share.create.expires.never')}
+              {/if}
             </dd>
           </div>
           <div>

--- a/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
@@ -181,7 +181,7 @@
     <div class="min-w-0 flex-1">
       <p class="truncate text-sm font-medium">{headline}</p>
       <p class="flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
-        <span>{$t('share.list.type.note')}</span>
+        <span>{$t('share.list.snapshot_eyebrow')}</span>
         {#if share?.has_password}
           <span class="inline-flex items-center gap-0.5">
             <Lock class="h-3 w-3" />{$t('share.list.password_protected')}

--- a/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
@@ -3,7 +3,7 @@
     ArrowLeft,
     Copy,
     Share2,
-    Trash2,
+    Link2Off,
     Lock,
     AlertTriangle,
     ChevronDown,
@@ -13,7 +13,7 @@
   import { t } from '$lib/stores/i18n.store';
   import { shareLink } from '$lib/utils/native-share';
   import { copyText } from '$lib/utils/clipboard';
-  import { Button, toastStore } from '@reborn/ui';
+  import { toastStore } from '@reborn/ui';
   import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
   import NoteSnapshotView from '$lib/components/notes/NoteSnapshotView.svelte';
   import { sharesStore, activeShareId } from '$lib/stores/shares.store';
@@ -127,26 +127,47 @@
         {/if}
       </p>
     </div>
+    <!-- Labelled on desktop (the header has room and icon-only actions read as
+         ambiguous), icon-only on the cramped mobile header. -->
     {#if entry}
-      <Button variant="ghost" size="icon" aria-label={$t('share.create.copy_link')} onclick={copyUrl}>
+      <button
+        type="button"
+        onclick={copyUrl}
+        class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm
+               text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        aria-label={$t('share.create.copy_link')}
+      >
         <Copy class="h-4 w-4" />
-      </Button>
+        <span class="hidden md:inline">{$t('share.create.copy_link')}</span>
+      </button>
       {#if isNative}
-        <Button variant="ghost" size="icon" aria-label={$t('share.create.share_cta')} onclick={shareUrl}>
+        <button
+          type="button"
+          onclick={shareUrl}
+          class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm
+                 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          aria-label={$t('share.create.share_cta')}
+        >
           <Share2 class="h-4 w-4" />
-        </Button>
+          <span class="hidden md:inline">{$t('share.create.share_cta')}</span>
+        </button>
       {/if}
     {/if}
     {#if share && !share.revoked_at}
-      <Button
-        variant="ghost"
-        size="icon"
-        aria-label={$t('share.list.revoke_action')}
+      <!-- Revoke kills the public link permanently - not a recoverable trash like a
+           note. A Link2Off glyph + explicit label disambiguate it from note delete. -->
+      <button
+        type="button"
         disabled={revoking}
         onclick={() => (confirmRevokeOpen = true)}
+        class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm
+               text-destructive transition-colors hover:bg-destructive/10
+               disabled:pointer-events-none disabled:opacity-50"
+        aria-label={$t('share.list.revoke_action')}
       >
-        <Trash2 class="h-4 w-4 text-destructive" />
-      </Button>
+        <Link2Off class="h-4 w-4" />
+        <span class="hidden md:inline">{$t('share.list.revoke_action')}</span>
+      </button>
     {/if}
   </header>
 
@@ -163,7 +184,7 @@
       <div class="mx-auto flex max-w-3xl flex-col gap-4 px-4 md:px-6 py-4">
         <!-- Public link URL (hidden by default) -->
         {#if entry}
-          <div class="flex flex-col gap-1.5 rounded-lg border bg-muted/30 p-3">
+          <div class="relative flex flex-col gap-1.5 rounded-lg border bg-muted/30 p-3">
             <button
               type="button"
               class="inline-flex w-fit items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
@@ -176,7 +197,18 @@
               {/if}
             </button>
             {#if urlShown}
-              <p class="break-all font-mono text-xs text-muted-foreground">{entry.url}</p>
+              <!-- Copy affordance pinned top-right, mirroring note code blocks. -->
+              <button
+                type="button"
+                onclick={copyUrl}
+                class="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-md border
+                       bg-background text-muted-foreground opacity-70 transition hover:text-foreground hover:opacity-100"
+                aria-label={$t('share.create.copy_link')}
+                title={$t('share.create.copy_link')}
+              >
+                <Copy class="h-3.5 w-3.5" />
+              </button>
+              <p class="break-all pr-9 font-mono text-xs text-muted-foreground">{entry.url}</p>
             {/if}
           </div>
         {/if}

--- a/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import {
+    ArrowLeft,
+    Copy,
+    Share2,
+    Trash2,
+    Lock,
+    AlertTriangle,
+    ChevronDown,
+    ChevronUp,
+    Eye
+  } from '@lucide/svelte';
+  import { t } from '$lib/stores/i18n.store';
+  import { shareLink } from '$lib/utils/native-share';
+  import { copyText } from '$lib/utils/clipboard';
+  import { Button, toastStore } from '@reborn/ui';
+  import ConfirmDialog from '$lib/components/shared/ConfirmDialog.svelte';
+  import NoteSnapshotView from '$lib/components/notes/NoteSnapshotView.svelte';
+  import { sharesStore, activeShareId } from '$lib/stores/shares.store';
+  import type { OwnShareListItem } from '@reborn/types';
+
+  let { shareId, onback }: { shareId: string; onback?: () => void } = $props();
+
+  const storeState = $derived($sharesStore);
+  const share = $derived<OwnShareListItem | null>(
+    storeState.shares.find((s) => s.id === shareId) ?? null
+  );
+  // Already decrypted locally by the store (owner_key_wrapped + master key). The
+  // preview reads this plaintext - it never calls the public /s endpoint, so it
+  // consumes no access slot (ZK-safe, free).
+  const entry = $derived(storeState.decoded[shareId] ?? null);
+  const hasDecryptError = $derived(storeState.decryptErrors.has(shareId));
+
+  let urlShown = $state(false);
+  let revoking = $state(false);
+  let confirmRevokeOpen = $state(false);
+
+  // Reset the per-share UI toggles when a different share is selected.
+  $effect(() => {
+    void shareId;
+    urlShown = false;
+  });
+
+  // Native build only: OS share sheet. Web is copy-only (DCE'd via the define).
+  const isNative = __REBORN_NATIVE__;
+
+  const headline = $derived(
+    entry
+      ? entry.payload.display_name?.trim() || entry.payload.title || $t('share.list.untitled')
+      : $t('share.list.title')
+  );
+
+  function formatDate(iso: string | null): string {
+    if (!iso) return '-';
+    try {
+      return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+    } catch {
+      return iso;
+    }
+  }
+
+  function formatOpens(s: OwnShareListItem): string {
+    return s.max_access_count !== null
+      ? `${s.access_count} / ${s.max_access_count}`
+      : String(s.access_count);
+  }
+
+  async function copyUrl() {
+    if (!entry?.url) return;
+    if (await copyText(entry.url)) toastStore.success($t('share.create.copied'));
+    else toastStore.error($t('share.create.copy_failed'));
+  }
+
+  async function shareUrl() {
+    if (!entry?.url) return;
+    const ok = await shareLink({
+      url: entry.url,
+      title: entry.payload.title || $t('share.list.untitled'),
+      dialogTitle: $t('share.create.share_sheet_title')
+    });
+    if (!ok) await copyUrl();
+  }
+
+  async function doRevoke() {
+    if (!share) return;
+    revoking = true;
+    const ok = await sharesStore.revoke(share.slug);
+    revoking = false;
+    if (ok) {
+      toastStore.success($t('share.list.revoked_toast'));
+      activeShareId.set(null);
+      onback?.();
+    } else {
+      toastStore.error($t('share.list.revoke_error'));
+    }
+  }
+
+  function close() {
+    activeShareId.set(null);
+    onback?.();
+  }
+</script>
+
+<div class="flex h-full flex-col">
+  <!-- Header bar: back + title + actions -->
+  <header
+    class="flex min-h-[calc(3rem+env(safe-area-inset-top,0px))] shrink-0 items-center gap-1
+           border-b border-border/60 px-3 md:px-4 pt-[env(safe-area-inset-top,0px)]"
+  >
+    <button
+      type="button"
+      onclick={close}
+      class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground
+             transition-colors hover:bg-accent hover:text-foreground"
+      aria-label={$t('nav.back')}
+    >
+      <ArrowLeft class="h-5 w-5" />
+    </button>
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-medium">{headline}</p>
+      <p class="flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+        <span>{$t('share.list.type.note')}</span>
+        {#if share?.has_password}
+          <span class="inline-flex items-center gap-0.5">
+            <Lock class="h-3 w-3" />{$t('share.list.password_protected')}
+          </span>
+        {/if}
+      </p>
+    </div>
+    {#if entry}
+      <Button variant="ghost" size="icon" aria-label={$t('share.create.copy_link')} onclick={copyUrl}>
+        <Copy class="h-4 w-4" />
+      </Button>
+      {#if isNative}
+        <Button variant="ghost" size="icon" aria-label={$t('share.create.share_cta')} onclick={shareUrl}>
+          <Share2 class="h-4 w-4" />
+        </Button>
+      {/if}
+    {/if}
+    {#if share && !share.revoked_at}
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label={$t('share.list.revoke_action')}
+        disabled={revoking}
+        onclick={() => (confirmRevokeOpen = true)}
+      >
+        <Trash2 class="h-4 w-4 text-destructive" />
+      </Button>
+    {/if}
+  </header>
+
+  <!-- Body -->
+  <div class="flex-1 overflow-y-auto">
+    {#if !share}
+      <div
+        class="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground"
+      >
+        <AlertTriangle class="h-5 w-5 text-amber-500" aria-hidden="true" />
+        <p>{$t('share.list.empty')}</p>
+      </div>
+    {:else}
+      <div class="mx-auto flex max-w-3xl flex-col gap-4 px-4 md:px-6 py-4">
+        <!-- Public link URL (hidden by default) -->
+        {#if entry}
+          <div class="flex flex-col gap-1.5 rounded-lg border bg-muted/30 p-3">
+            <button
+              type="button"
+              class="inline-flex w-fit items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
+              onclick={() => (urlShown = !urlShown)}
+            >
+              {#if urlShown}
+                <ChevronUp class="h-3 w-3" />{$t('share.list.hide_link')}
+              {:else}
+                <ChevronDown class="h-3 w-3" />{$t('share.list.show_link')}
+              {/if}
+            </button>
+            {#if urlShown}
+              <p class="break-all font-mono text-xs text-muted-foreground">{entry.url}</p>
+            {/if}
+          </div>
+        {/if}
+
+        <!-- Metadata -->
+        <dl class="grid grid-cols-2 gap-x-4 gap-y-3 text-xs sm:grid-cols-4">
+          <div>
+            <dt class="text-muted-foreground">{$t('share.list.column.created')}</dt>
+            <dd class="mt-0.5 font-medium">{formatDate(share.created_at)}</dd>
+          </div>
+          <div>
+            <dt class="text-muted-foreground">{$t('share.list.column.expires')}</dt>
+            <dd class="mt-0.5 font-medium">
+              {share.expires_at ? formatDate(share.expires_at) : $t('share.create.expires.never')}
+            </dd>
+          </div>
+          <div>
+            <dt class="text-muted-foreground">{$t('share.list.column.access_count')}</dt>
+            <dd class="mt-0.5 font-medium">{formatOpens(share)}</dd>
+          </div>
+          <div>
+            <dt class="text-muted-foreground">{$t('share.list.column.last_accessed')}</dt>
+            <dd class="mt-0.5 font-medium">
+              {share.last_accessed_at ? formatDate(share.last_accessed_at) : '-'}
+            </dd>
+          </div>
+        </dl>
+
+        <!-- Snapshot preview (what the recipient sees) -->
+        <div class="rounded-lg border p-4">
+          <p class="mb-3 flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+            <Eye class="h-3.5 w-3.5" />{$t('share.list.preview_dialog_title')}
+          </p>
+          {#if entry}
+            <NoteSnapshotView payload={entry.payload} showHeader={false} />
+            <p class="mt-4 text-xs italic text-muted-foreground">{$t('share.list.preview_hint')}</p>
+          {:else if hasDecryptError}
+            <p class="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+              <AlertTriangle class="h-4 w-4" />{$t('share.list.decrypt_failed')}
+            </p>
+          {:else}
+            <p class="text-sm italic text-muted-foreground">{$t('share.list.decrypting')}</p>
+          {/if}
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<ConfirmDialog
+  bind:open={confirmRevokeOpen}
+  title={$t('share.list.confirm_revoke_title')}
+  description={$t('share.list.confirm_revoke_desc')}
+  confirmText={$t('share.list.revoke_action')}
+  destructive
+  onConfirm={doRevoke}
+/>

--- a/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
@@ -7,8 +7,9 @@
     DropdownMenuItem,
     DropdownMenuTrigger
   } from '@reborn/ui';
-  import { t } from '$lib/stores/i18n.store';
+  import { t, locale } from '$lib/stores/i18n.store';
   import { activeShares, activeShareId, sharesBySourceId, sharesStore } from '$lib/stores/shares.store';
+  import { formatExpiryRelative } from '$lib/utils/expiry-format';
   import type { OwnShareListItem } from '@reborn/types';
 
   // One row per active share LINK (flat list). A note shared more than once shows
@@ -214,6 +215,7 @@
           {@const title = titleOf(share)}
           {@const expiringSoon = isExpiringSoon(share)}
           {@const links = linkCountFor(share)}
+          {@const expRel = share.expires_at ? formatExpiryRelative(share.expires_at, $locale ?? 'en') : null}
           <li>
             <button
               type="button"
@@ -245,7 +247,7 @@
                   <span
                     >{$t('share.list.column.expires')}: {share.expires_at
                       ? formatDate(share.expires_at)
-                      : $t('share.create.expires.never')}</span
+                      : $t('share.create.expires.never')}{#if expRel && !expRel.expired} ({expRel.text}){/if}</span
                   >
                   <span aria-hidden="true">·</span>
                   <span>{$t('share.list.column.access_count')}: {formatOpens(share)}</span>

--- a/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RefreshCw, AlertTriangle, FileText, Lock, ArrowDownUp, Search, X, Clock } from '@lucide/svelte';
+  import { RefreshCw, AlertTriangle, Lock, ArrowDownUp, Search, X, Clock } from '@lucide/svelte';
   import {
     Button,
     DropdownMenu,
@@ -96,18 +96,25 @@
 </script>
 
 <div class="flex h-full flex-col overflow-hidden">
-  <!-- Header: title + count + sort + refresh. Grows by the iOS notch inset on
-       mobile (where this list owns the panel header); compact h-10 on desktop. -->
+  <!-- Header mirrors NoteList: row 1 = title, row 2 = count + actions, then
+       search. Row 1 grows by the iOS notch inset on mobile (where this list owns
+       the panel header) and is compact h-10 on desktop. -->
   <div
-    class="flex shrink-0 items-center gap-1 px-5 pt-[env(safe-area-inset-top,0px)]
-           min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] md:min-h-10 md:pt-0"
+    class="flex shrink-0 items-center gap-1 px-5
+           min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] pt-[env(safe-area-inset-top,0px)]
+           md:min-h-0 md:h-10 md:pt-0"
   >
-    <div class="min-w-0 flex-1">
-      <p class="truncate text-sm font-medium md:font-normal">{$t('share.list.title')}</p>
-      <p class="text-xs text-muted-foreground">
-        {$t('share.list.count', { values: { count: rows.length } })}
-      </p>
-    </div>
+    <span class="min-w-0 flex-1 truncate text-sm font-medium md:font-normal">
+      {$t('share.list.title')}
+    </span>
+  </div>
+
+  <!-- Row 2: count + sort + refresh. Prominent sizing on mobile (h-14 / h-11),
+       compact on desktop (h-10 / h-9) - same tap targets as NoteList's row 2. -->
+  <div class="flex h-14 md:h-10 shrink-0 items-center gap-1 pl-5 pr-5">
+    <span class="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+      {$t('share.list.count', { values: { count: rows.length } })}
+    </span>
 
     <DropdownMenu>
       <DropdownMenuTrigger>
@@ -117,10 +124,10 @@
             type="button"
             title={$t('share.list.sort_label')}
             aria-label={$t('share.list.sort_label')}
-            class="flex h-9 w-9 md:h-7 md:w-7 shrink-0 items-center justify-center rounded-md
+            class="flex h-11 w-11 md:h-9 md:w-9 shrink-0 items-center justify-center rounded-md
                    text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
           >
-            <ArrowDownUp class="h-4 w-4 md:h-3.5 md:w-3.5" />
+            <ArrowDownUp class="h-5 w-5 md:h-4 md:w-4" />
           </button>
         {/snippet}
       </DropdownMenuTrigger>
@@ -146,16 +153,16 @@
       disabled={isLoading}
       title={$t('share.list.retry_action')}
       aria-label={$t('share.list.retry_action')}
-      class="flex h-9 w-9 md:h-7 md:w-7 shrink-0 items-center justify-center rounded-md
+      class="flex h-11 w-11 md:h-9 md:w-9 shrink-0 items-center justify-center rounded-md
              text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground
              disabled:pointer-events-none disabled:opacity-50"
     >
-      <RefreshCw class="h-4 w-4 md:h-3.5 md:w-3.5 {isLoading ? 'animate-spin' : ''}" />
+      <RefreshCw class="h-5 w-5 md:h-4 md:w-4 {isLoading ? 'animate-spin' : ''}" />
     </button>
   </div>
 
-  <!-- Search -->
-  <div class="px-3 pb-2">
+  <!-- Search (matches NoteListSearchBar) -->
+  <div class="shrink-0 px-3 pb-2">
     <div class="relative">
       <Search
         class="absolute left-2.5 top-1/2 h-4 w-4 md:h-3.5 md:w-3.5 -translate-y-1/2 text-muted-foreground"
@@ -164,15 +171,16 @@
         type="text"
         placeholder={$t('share.list.search_placeholder')}
         bind:value={searchInput}
-        class="w-full rounded-md border bg-background py-2.5 md:py-2 pl-8 md:pl-7 pr-9 text-sm md:text-xs
-               placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        class="w-full rounded-md border bg-background py-2.5 md:py-2 pl-8 md:pl-7 pr-10 md:pr-8 text-sm md:text-xs
+               focus:outline-none focus:ring-1 focus:ring-primary"
         aria-label={$t('share.list.search_placeholder')}
       />
       {#if searchInput}
         <button
           type="button"
           onclick={() => (searchInput = '')}
-          class="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          class="absolute right-1 top-1/2 -translate-y-1/2 flex h-9 w-9 md:h-7 md:w-7 items-center justify-center
+                 text-muted-foreground hover:text-foreground"
           aria-label={$t('notes.clear_search')}
         >
           <X class="h-4 w-4 md:h-3.5 md:w-3.5" />
@@ -181,10 +189,8 @@
     </div>
   </div>
 
-  <div class="mx-3 border-t"></div>
-
   <!-- List -->
-  <div class="flex-1 overflow-y-auto px-2 py-2">
+  <div class="flex-1 overflow-y-auto px-3">
     {#if isLoading && rows.length === 0}
       <div class="flex justify-center py-8">
         <RefreshCw class="h-5 w-5 animate-spin text-muted-foreground" />
@@ -203,56 +209,59 @@
         {searchInput ? $t('share.list.search_no_match') : $t('share.list.empty')}
       </p>
     {:else}
-      {#each rows as share (share.id)}
-        {@const title = titleOf(share)}
-        {@const expiringSoon = isExpiringSoon(share)}
-        {@const links = linkCountFor(share)}
-        <button
-          type="button"
-          onclick={() => activeShareId.set(share.id)}
-          class="group mb-0.5 flex w-full items-start gap-2 rounded-md px-2 py-2 text-left transition-colors
-            {$activeShareId === share.id
-            ? 'list-row-active text-sidebar-accent-foreground'
-            : 'text-sidebar-foreground hover:bg-sidebar-accent/60'}"
-          aria-current={$activeShareId === share.id ? 'true' : undefined}
-        >
-          <FileText class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          <span class="min-w-0 flex-1">
-            <span class="flex items-center gap-1.5">
-              <span class="min-w-0 flex-1 truncate text-sm font-medium">
-                {title || $t('share.list.untitled')}
-              </span>
-              {#if share.has_password}
-                <Lock
-                  class="h-3 w-3 shrink-0 text-muted-foreground"
-                  aria-label={$t('share.list.password_protected')}
-                />
-              {/if}
-            </span>
-            <span
-              class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground"
+      <ul class="flex flex-col gap-2 py-1" role="list">
+        {#each rows as share (share.id)}
+          {@const title = titleOf(share)}
+          {@const expiringSoon = isExpiringSoon(share)}
+          {@const links = linkCountFor(share)}
+          <li>
+            <button
+              type="button"
+              onclick={() => activeShareId.set(share.id)}
+              class="note-item-bg group flex w-full cursor-pointer items-start gap-2 rounded-lg p-4 md:p-3 text-left transition-colors
+                {$activeShareId === share.id ? 'list-row-active text-accent-foreground' : ''}"
+              aria-current={$activeShareId === share.id ? 'true' : undefined}
             >
-              {#if expiringSoon}
-                <span class="inline-flex items-center gap-0.5 font-medium text-amber-600 dark:text-amber-400">
-                  <Clock class="h-3 w-3" />{$t('share.list.expiring_soon')}
-                </span>
-              {/if}
-              <span
-                >{$t('share.list.column.expires')}: {share.expires_at
-                  ? formatDate(share.expires_at)
-                  : $t('share.create.expires.never')}</span
-              >
-              <span aria-hidden="true">·</span>
-              <span>{$t('share.list.column.access_count')}: {formatOpens(share)}</span>
-              {#if links > 1}
-                <span class="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                  {$t('share.list.links_badge', { values: { count: links } })}
-                </span>
-              {/if}
-            </span>
-          </span>
-        </button>
-      {/each}
+              <div class="min-w-0 flex-1">
+                <div class="flex items-start gap-1">
+                  <p class="min-w-0 flex-1 line-clamp-2 text-base md:text-sm font-normal leading-snug text-foreground">
+                    {title || $t('share.list.untitled')}
+                  </p>
+                  {#if share.has_password}
+                    <Lock
+                      class="mt-1.5 h-3.5 w-3.5 md:mt-1 md:h-3 md:w-3 shrink-0 text-muted-foreground"
+                      aria-label={$t('share.list.password_protected')}
+                    />
+                  {/if}
+                </div>
+                <div
+                  class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[13px] md:text-xs text-muted-foreground"
+                >
+                  {#if expiringSoon}
+                    <span class="inline-flex items-center gap-0.5 font-medium text-amber-600 dark:text-amber-400">
+                      <Clock class="h-3 w-3" />{$t('share.list.expiring_soon')}
+                    </span>
+                  {/if}
+                  <span
+                    >{$t('share.list.column.expires')}: {share.expires_at
+                      ? formatDate(share.expires_at)
+                      : $t('share.create.expires.never')}</span
+                  >
+                  <span aria-hidden="true">·</span>
+                  <span>{$t('share.list.column.access_count')}: {formatOpens(share)}</span>
+                  {#if links > 1}
+                    <span
+                      class="rounded-full border bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                    >
+                      {$t('share.list.links_badge', { values: { count: links } })}
+                    </span>
+                  {/if}
+                </div>
+              </div>
+            </button>
+          </li>
+        {/each}
+      </ul>
     {/if}
   </div>
 </div>

--- a/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+  import { RefreshCw, AlertTriangle, FileText, Lock, ArrowDownUp, Search, X, Clock } from '@lucide/svelte';
+  import {
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger
+  } from '@reborn/ui';
+  import { t } from '$lib/stores/i18n.store';
+  import { activeShares, activeShareId, sharesBySourceId, sharesStore } from '$lib/stores/shares.store';
+  import type { OwnShareListItem } from '@reborn/types';
+
+  // One row per active share LINK (flat list). A note shared more than once shows
+  // one row per link, distinguished by expiry / opens and an "N links" pill -
+  // matches the rail badge (which counts links) and avoids the snapshot-divergence
+  // ambiguity of grouping by note (each link is its own point-in-time snapshot).
+  type ShareSort = 'created' | 'expires' | 'opens' | 'title';
+
+  let searchInput = $state('');
+  let sortBy = $state<ShareSort>('created');
+
+  const storeState = $derived($sharesStore);
+  const decoded = $derived(storeState.decoded);
+  const isLoading = $derived(storeState.loading);
+  const loadError = $derived(storeState.error !== null);
+  const everLoaded = $derived(storeState.lastFetchedAt !== null);
+
+  function titleOf(s: OwnShareListItem): string {
+    const p = decoded[s.id]?.payload;
+    return (p?.display_name?.trim() || p?.title || '').trim();
+  }
+
+  function expiresMs(s: OwnShareListItem): number {
+    return s.expires_at ? new Date(s.expires_at).getTime() : Number.POSITIVE_INFINITY;
+  }
+
+  // Expiring soon = within 24h: surfaces a badge so the user can renew a link
+  // before it silently dies.
+  function isExpiringSoon(s: OwnShareListItem): boolean {
+    if (!s.expires_at) return false;
+    const remaining = expiresMs(s) - Date.now();
+    return remaining > 0 && remaining < 24 * 60 * 60 * 1000;
+  }
+
+  // activeShares already excludes revoked / expired / exhausted links.
+  const rows = $derived.by(() => {
+    const q = searchInput.trim().toLowerCase();
+    const list = q
+      ? $activeShares.filter((s) => titleOf(s).toLowerCase().includes(q))
+      : [...$activeShares];
+    list.sort((a, b) => {
+      switch (sortBy) {
+        case 'title':
+          return titleOf(a).localeCompare(titleOf(b), undefined, { sensitivity: 'base' });
+        case 'expires':
+          return expiresMs(a) - expiresMs(b);
+        case 'opens':
+          return b.access_count - a.access_count;
+        case 'created':
+        default:
+          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+      }
+    });
+    return list;
+  });
+
+  function formatDate(iso: string | null): string {
+    if (!iso) return '-';
+    try {
+      return new Date(iso).toLocaleDateString(undefined, { dateStyle: 'medium' });
+    } catch {
+      return iso;
+    }
+  }
+
+  function formatOpens(s: OwnShareListItem): string {
+    return s.max_access_count !== null
+      ? `${s.access_count} / ${s.max_access_count}`
+      : String(s.access_count);
+  }
+
+  // Number of active links pointing at the same source note (>1 => show a pill).
+  function linkCountFor(s: OwnShareListItem): number {
+    const src = decoded[s.id]?.payload.source_id;
+    if (!src) return 1;
+    return $sharesBySourceId.get(src)?.length ?? 1;
+  }
+
+  const SORT_OPTIONS: { value: ShareSort; label: string }[] = $derived([
+    { value: 'created', label: $t('share.list.sort.created') },
+    { value: 'expires', label: $t('share.list.sort.expires') },
+    { value: 'opens', label: $t('share.list.sort.opens') },
+    { value: 'title', label: $t('share.list.sort.title') }
+  ]);
+</script>
+
+<div class="flex h-full flex-col overflow-hidden">
+  <!-- Header: title + count + sort + refresh. Grows by the iOS notch inset on
+       mobile (where this list owns the panel header); compact h-10 on desktop. -->
+  <div
+    class="flex shrink-0 items-center gap-1 px-5 pt-[env(safe-area-inset-top,0px)]
+           min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] md:min-h-10 md:pt-0"
+  >
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-medium md:font-normal">{$t('share.list.title')}</p>
+      <p class="text-xs text-muted-foreground">
+        {$t('share.list.count', { values: { count: rows.length } })}
+      </p>
+    </div>
+
+    <DropdownMenu>
+      <DropdownMenuTrigger>
+        {#snippet child({ props })}
+          <button
+            {...props}
+            type="button"
+            title={$t('share.list.sort_label')}
+            aria-label={$t('share.list.sort_label')}
+            class="flex h-9 w-9 md:h-7 md:w-7 shrink-0 items-center justify-center rounded-md
+                   text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <ArrowDownUp class="h-4 w-4 md:h-3.5 md:w-3.5" />
+          </button>
+        {/snippet}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" class="min-w-44">
+        <p class="px-3 pb-1 pt-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          {$t('share.list.sort_label')}
+        </p>
+        {#each SORT_OPTIONS as option (option.value)}
+          <DropdownMenuItem
+            class={sortBy === option.value ? 'font-medium text-foreground' : 'text-muted-foreground'}
+            onclick={() => (sortBy = option.value)}
+          >
+            {option.label}
+            {#if sortBy === option.value}<span class="ml-auto text-primary">✓</span>{/if}
+          </DropdownMenuItem>
+        {/each}
+      </DropdownMenuContent>
+    </DropdownMenu>
+
+    <button
+      type="button"
+      onclick={() => sharesStore.refresh()}
+      disabled={isLoading}
+      title={$t('share.list.retry_action')}
+      aria-label={$t('share.list.retry_action')}
+      class="flex h-9 w-9 md:h-7 md:w-7 shrink-0 items-center justify-center rounded-md
+             text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground
+             disabled:pointer-events-none disabled:opacity-50"
+    >
+      <RefreshCw class="h-4 w-4 md:h-3.5 md:w-3.5 {isLoading ? 'animate-spin' : ''}" />
+    </button>
+  </div>
+
+  <!-- Search -->
+  <div class="px-3 pb-2">
+    <div class="relative">
+      <Search
+        class="absolute left-2.5 top-1/2 h-4 w-4 md:h-3.5 md:w-3.5 -translate-y-1/2 text-muted-foreground"
+      />
+      <input
+        type="text"
+        placeholder={$t('share.list.search_placeholder')}
+        bind:value={searchInput}
+        class="w-full rounded-md border bg-background py-2.5 md:py-2 pl-8 md:pl-7 pr-9 text-sm md:text-xs
+               placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        aria-label={$t('share.list.search_placeholder')}
+      />
+      {#if searchInput}
+        <button
+          type="button"
+          onclick={() => (searchInput = '')}
+          class="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          aria-label={$t('notes.clear_search')}
+        >
+          <X class="h-4 w-4 md:h-3.5 md:w-3.5" />
+        </button>
+      {/if}
+    </div>
+  </div>
+
+  <div class="mx-3 border-t"></div>
+
+  <!-- List -->
+  <div class="flex-1 overflow-y-auto px-2 py-2">
+    {#if isLoading && rows.length === 0}
+      <div class="flex justify-center py-8">
+        <RefreshCw class="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    {:else if loadError && !everLoaded}
+      <div class="flex flex-col items-center gap-2 px-4 py-8 text-center text-xs text-muted-foreground">
+        <AlertTriangle class="h-5 w-5 text-amber-500" aria-hidden="true" />
+        <p>{$t('share.list.error_load')}</p>
+        <Button variant="outline" size="sm" disabled={isLoading} onclick={() => sharesStore.refresh()}>
+          <RefreshCw class="mr-1.5 h-3.5 w-3.5 {isLoading ? 'animate-spin' : ''}" />
+          {$t('share.list.retry_action')}
+        </Button>
+      </div>
+    {:else if rows.length === 0}
+      <p class="px-2 py-6 text-center text-xs text-muted-foreground">
+        {searchInput ? $t('share.list.search_no_match') : $t('share.list.empty')}
+      </p>
+    {:else}
+      {#each rows as share (share.id)}
+        {@const title = titleOf(share)}
+        {@const expiringSoon = isExpiringSoon(share)}
+        {@const links = linkCountFor(share)}
+        <button
+          type="button"
+          onclick={() => activeShareId.set(share.id)}
+          class="group mb-0.5 flex w-full items-start gap-2 rounded-md px-2 py-2 text-left transition-colors
+            {$activeShareId === share.id
+            ? 'list-row-active text-sidebar-accent-foreground'
+            : 'text-sidebar-foreground hover:bg-sidebar-accent/60'}"
+          aria-current={$activeShareId === share.id ? 'true' : undefined}
+        >
+          <FileText class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <span class="min-w-0 flex-1">
+            <span class="flex items-center gap-1.5">
+              <span class="min-w-0 flex-1 truncate text-sm font-medium">
+                {title || $t('share.list.untitled')}
+              </span>
+              {#if share.has_password}
+                <Lock
+                  class="h-3 w-3 shrink-0 text-muted-foreground"
+                  aria-label={$t('share.list.password_protected')}
+                />
+              {/if}
+            </span>
+            <span
+              class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground"
+            >
+              {#if expiringSoon}
+                <span class="inline-flex items-center gap-0.5 font-medium text-amber-600 dark:text-amber-400">
+                  <Clock class="h-3 w-3" />{$t('share.list.expiring_soon')}
+                </span>
+              {/if}
+              <span
+                >{$t('share.list.column.expires')}: {share.expires_at
+                  ? formatDate(share.expires_at)
+                  : $t('share.create.expires.never')}</span
+              >
+              <span aria-hidden="true">·</span>
+              <span>{$t('share.list.column.access_count')}: {formatOpens(share)}</span>
+              {#if links > 1}
+                <span class="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                  {$t('share.list.links_badge', { values: { count: links } })}
+                </span>
+              {/if}
+            </span>
+          </span>
+        </button>
+      {/each}
+    {/if}
+  </div>
+</div>

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -210,6 +210,17 @@ export async function exportNoteAsMarkdown(
 }
 
 /**
+ * Export a raw markdown string as a .md download. Unlike `exportNoteAsMarkdown`
+ * this adds NO frontmatter and takes the content verbatim - it exports a share
+ * snapshot's FROZEN markdown (the exact text that was shared at snapshot time),
+ * not a live note. Reuses the same download + filename-sanitising path.
+ */
+export async function exportMarkdownString(title: string, content: string): Promise<void> {
+  const blob = new Blob([content], { type: 'text/markdown; charset=utf-8' });
+  await downloadBlob(blob, `${sanitizeFilename(title)}.md`);
+}
+
+/**
  * Style block injected into the off-screen container that jsPDF rasterizes.
  * html2canvas reads computed styles from a real DOM element, so the rules
  * below define the visual output. No `@page` — page geometry is set on the

--- a/apps/reborn-notes/src/lib/stores/shares.store.ts
+++ b/apps/reborn-notes/src/lib/stores/shares.store.ts
@@ -22,6 +22,14 @@ import { createLogger } from '@reborn/utils';
 
 const logger = createLogger('Notes-SharesStore');
 
+/**
+ * Currently selected share in the Shares master-detail view (null = none).
+ * Mirrors `activeNoteId` in notes.store: the sidebar list writes it, the main
+ * detail pane reads it. Cleared on crypto lock/reset so a stale selection never
+ * outlives the decrypted payloads it points at.
+ */
+export const activeShareId = writable<string | null>(null);
+
 export type DecodedNoteShare = {
   payload: SharedSnapshotNotePayload;
   url: string;
@@ -166,6 +174,7 @@ function createSharesStore() {
 
   function reset() {
     state.set({ ...initialState, decryptErrors: new Set(), decoded: {}, shares: [] });
+    activeShareId.set(null);
   }
 
   function init() {

--- a/apps/reborn-notes/src/lib/utils/expiry-format.spec.ts
+++ b/apps/reborn-notes/src/lib/utils/expiry-format.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { formatExpiryRelative } from './expiry-format';
+
+const NOW = new Date('2026-06-30T12:00:00.000Z').getTime();
+
+describe('formatExpiryRelative', () => {
+  it('returns null for null/invalid input', () => {
+    expect(formatExpiryRelative(null, 'en', NOW)).toBeNull();
+    expect(formatExpiryRelative('not-a-date', 'en', NOW)).toBeNull();
+  });
+
+  it('flags a past instant as expired with no text', () => {
+    const past = new Date(NOW - 60_000).toISOString();
+    const r = formatExpiryRelative(past, 'en', NOW);
+    expect(r).toEqual({ text: '', expired: true });
+  });
+
+  it('treats the exact boundary as expired', () => {
+    const r = formatExpiryRelative(new Date(NOW).toISOString(), 'en', NOW);
+    expect(r?.expired).toBe(true);
+  });
+
+  it('formats a multi-day future as not expired (day unit)', () => {
+    const future = new Date(NOW + 6 * 24 * 60 * 60 * 1000).toISOString();
+    const r = formatExpiryRelative(future, 'en', NOW);
+    expect(r?.expired).toBe(false);
+    expect(r?.text).toContain('6');
+    expect(r?.text.toLowerCase()).toContain('day');
+  });
+
+  it('uses an hour unit for sub-day futures', () => {
+    const future = new Date(NOW + 5 * 60 * 60 * 1000).toISOString();
+    const r = formatExpiryRelative(future, 'en', NOW);
+    expect(r?.expired).toBe(false);
+    expect(r?.text.toLowerCase()).toContain('hour');
+  });
+
+  it('honours the locale (pl)', () => {
+    const future = new Date(NOW + 6 * 24 * 60 * 60 * 1000).toISOString();
+    const r = formatExpiryRelative(future, 'pl', NOW);
+    // pl renders "za 6 dni" - assert the number survives, not the exact phrasing.
+    expect(r?.text).toContain('6');
+  });
+});

--- a/apps/reborn-notes/src/lib/utils/expiry-format.ts
+++ b/apps/reborn-notes/src/lib/utils/expiry-format.ts
@@ -1,0 +1,34 @@
+/**
+ * Locale-aware relative expiry, e.g. "in 6 days" / "za 6 dni" / "tomorrow".
+ *
+ * Uses the platform `Intl.RelativeTimeFormat`, so the phrasing and plural rules
+ * come from the runtime per locale - no per-locale translation strings needed
+ * for the number itself. The caller renders a localized "Expired" label (in a
+ * destructive colour) when `expired` is true.
+ *
+ * `now` is injectable for deterministic tests; defaults to the current time.
+ */
+export function formatExpiryRelative(
+  iso: string | null,
+  locale: string,
+  now: number = Date.now()
+): { text: string; expired: boolean } | null {
+  if (!iso) return null;
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return null;
+
+  const diffMs = ts - now;
+  if (diffMs <= 0) return { text: '', expired: true };
+
+  const MINUTE = 60_000;
+  const HOUR = 60 * MINUTE;
+  const DAY = 24 * HOUR;
+
+  const rtf = new Intl.RelativeTimeFormat(locale || 'en', { numeric: 'auto' });
+  let text: string;
+  if (diffMs >= DAY) text = rtf.format(Math.round(diffMs / DAY), 'day');
+  else if (diffMs >= HOUR) text = rtf.format(Math.round(diffMs / HOUR), 'hour');
+  else text = rtf.format(Math.max(1, Math.round(diffMs / MINUTE)), 'minute');
+
+  return { text, expired: false };
+}

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -5,7 +5,7 @@
   import { base } from '$app/paths';
   import { copyText } from '$lib/utils/clipboard';
   import { SvelteSet, SvelteMap } from 'svelte/reactivity';
-  import { FolderPlus, Plus, ArrowLeft, Lock, ListTree, PinOff } from '@lucide/svelte';
+  import { FolderPlus, Plus, ArrowLeft, Lock, ListTree, PinOff, Share2 } from '@lucide/svelte';
 
   // Layout
   import IconNav, { type Section, isPeriodicSection } from '$lib/components/layout/IconNav.svelte';
@@ -46,9 +46,12 @@
   import TagSidebarSection from '$lib/components/tags/TagSidebarSection.svelte';
   import TagListMobile from '$lib/components/tags/TagListMobile.svelte';
   import TagActionSheet from '$lib/components/tags/TagActionSheet.svelte';
+  import SharesList from '$lib/components/shares/SharesList.svelte';
+  import ShareDetailPanel from '$lib/components/shares/ShareDetailPanel.svelte';
 
   // Stores / services
   import { notesStore, activeNoteId, type NoteListItem } from '$lib/stores/notes.store';
+  import { sharesStore, activeShareId } from '$lib/stores/shares.store';
   import * as NoteService from '$lib/services/note.service';
   import { exportNoteAsMarkdown, exportNoteAsPdf } from '$lib/services/export-import.service';
   import * as PeriodicNotesService from '$lib/services/periodic-notes.service';
@@ -511,9 +514,21 @@
     }
   }
 
+  /** Close the Shares detail pane, going through the mobile history stack so the
+   *  hardware back / swipe stays in sync (desktop just clears the selection). */
+  function closeShareDetail() {
+    if (isMobile && mobileHistoryDepth > 0) {
+      history.back();
+    } else {
+      activeShareId.set(null);
+    }
+  }
+
   /** Navigate one level up based on current app state. Called by popstate handler. */
   function navigateUp() {
-    if ($activeNoteId != null) {
+    if (activeSection === 'shares' && $activeShareId != null) {
+      activeShareId.set(null);
+    } else if ($activeNoteId != null) {
       noteDetailService.flushAndSnapshot();
       activeNoteId.set(null);
     } else if (mobileView === 'list' && activeSection === 'folders' && activeFolderId !== undefined) {
@@ -615,10 +630,25 @@
     prevNoteIdForHistory = id;
   });
 
+  // ── Mobile: push history when the share detail opens ───────────
+  let prevShareIdForHistory: string | null = null;
+  $effect(() => {
+    const id = $activeShareId;
+    if (isMobile && id != null && prevShareIdForHistory == null) {
+      pushMobileHistory();
+    }
+    prevShareIdForHistory = id;
+  });
+
   // ── Derived: should main area show note list? ──────────────────
   const showNoteListInMain = $derived(
     (activeSection === 'folders' && activeFolderId !== undefined) ||
       (activeSection === 'tags' && activeTagId !== null)
+  );
+
+  // Mobile detail pane (Panel 2) slides in for an open note OR a selected share.
+  const mobileDetailOpen = $derived(
+    $activeNoteId != null || (activeSection === 'shares' && $activeShareId != null)
   );
 
   /** Mobile-only: sections where NoteList renders its own prominent (h-12) header,
@@ -627,6 +657,7 @@
   const noteListOwnsMobileHeader = $derived(
     activeSection === 'starred' ||
       activeSection === 'trash' ||
+      activeSection === 'shares' ||
       isPeriodicSection(activeSection) ||
       (activeSection === 'folders' && activeFolderId !== undefined) ||
       (activeSection === 'tags' && activeTagId !== null)
@@ -700,6 +731,11 @@
         if (isMobile && (section === 'folders' || section === 'tags')) {
           pushMobileHistory();
         }
+
+        // Leaving any section drops the share selection; entering Shares pulls a
+        // fresh list (mirrors the old dialog's refresh-on-open).
+        activeShareId.set(null);
+        if (section === 'shares') void sharesStore.refresh();
       });
       prevSection = section;
     }
@@ -715,6 +751,9 @@
         notesStore.setTag(tagId);
       } else if (sectionUsesFolderId) {
         notesStore.setFolder(folderId);
+      } else if (section === 'shares') {
+        // Shares view is backed by its own store (sharesStore) - leave the
+        // notes filter as-is.
       } else {
         notesStore.setFolder(undefined);
       }
@@ -1681,6 +1720,21 @@
       isMobile = e.matches;
     });
 
+    // Deep-link: /?section=shares (used by the Settings → Security shortcut)
+    // opens the Shares view, then strips the param so a refresh / back doesn't
+    // re-trigger it. Read before the mobile history guard snapshots the URL.
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('section') === 'shares') {
+        activeSection = 'shares';
+      }
+      if (params.has('section')) {
+        history.replaceState(history.state, '', window.location.pathname + window.location.hash);
+      }
+    } catch {
+      // URL parsing / history access can throw in exotic embeds - non-fatal.
+    }
+
     // ── Mobile: virtual history guard entry ──────────────────────
     // Creates a "trampoline" entry so that native back gestures trigger
     // popstate instead of exiting the PWA.
@@ -1863,7 +1917,7 @@
       <!-- ── Panel 1: Icon Rail + List ──────────────────────────────── -->
       <div
         class="absolute inset-0 flex transition-transform duration-300 ease-in-out"
-        class:-translate-x-full={!!$activeNoteId}
+        class:-translate-x-full={mobileDetailOpen}
       >
         <!-- Icon rail (vertical, always visible) -->
         <IconNav
@@ -2005,6 +2059,8 @@
               </div>
             {:else if mobileView === 'tag-list'}
               <TagListMobile {activeTagId} onselect={handleTagSelect} bind:mobileNewTagInput />
+            {:else if activeSection === 'shares'}
+              <SharesList />
             {:else}
               <NoteList
                 {activeFolderName}
@@ -2053,7 +2109,7 @@
       <!-- ── Panel 2: Note Editor ───────────────────────────────────── -->
       <div
         class="absolute inset-0 flex flex-col bg-background transition-transform duration-300 ease-in-out"
-        class:translate-x-full={!$activeNoteId}
+        class:translate-x-full={!mobileDetailOpen}
         ontouchstart={handleSwipeStart}
         ontouchend={handleSwipeEnd}
         role="region"
@@ -2236,6 +2292,8 @@
               {/if}
             </div>
           {/if}
+        {:else if activeSection === 'shares' && $activeShareId}
+          <ShareDetailPanel shareId={$activeShareId} onback={closeShareDetail} />
         {:else if $isInitialSync}
           <InitialSyncState compact />
         {:else}
@@ -2350,6 +2408,8 @@
               searchOnly
               oncreate={handleNewNote}
             />
+          {:else if activeSection === 'shares'}
+            <SharesList />
           {:else}
             <NoteList
               {activeFolderName}
@@ -2540,6 +2600,22 @@
                 onclose={() => (showEncryptionXRay = false)}
               />
             {/if}
+          </div>
+        {/if}
+      {:else if activeSection === 'shares'}
+        {#if $activeShareId}
+          <ShareDetailPanel shareId={$activeShareId} onback={closeShareDetail} />
+        {:else}
+          <header
+            class="flex min-h-[calc(3rem+env(safe-area-inset-top,0px))] shrink-0 items-center gap-2 border-b border-border/60 px-6 pt-[env(safe-area-inset-top,0px)]"
+          >
+            <span class="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+              {$t('share.list.title')}
+            </span>
+          </header>
+          <div class="flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
+            <Share2 class="h-8 w-8 opacity-40" />
+            <p class="max-w-xs text-center text-sm">{$t('share.list.select_hint')}</p>
           </div>
         {/if}
       {:else if showNoteListInMain}

--- a/apps/reborn-notes/src/routes/settings/security/shares/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/shares/+page.svelte
@@ -1,134 +1,15 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { SvelteSet } from 'svelte/reactivity';
-  import {
-    RefreshCw,
-    Trash2,
-    Copy,
-    Share2,
-    Lock,
-    FileText,
-    Eye,
-    ChevronDown,
-    ChevronUp,
-    AlertTriangle
-  } from '@lucide/svelte';
+  import { Share2, ChevronRight } from '@lucide/svelte';
+  import { SettingsLayout } from '@reborn/ui';
   import { t } from '$lib/stores/i18n.store';
-  import { shareLink } from '$lib/utils/native-share';
-  import { copyText } from '$lib/utils/clipboard';
-  import {
-    SettingsLayout,
-    Button,
-    Alert,
-    AlertDescription,
-    Card,
-    CardContent,
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-    toastStore
-  } from '@reborn/ui';
-  import { type OwnShareListItem, type SharedSnapshotNotePayload } from '@reborn/types';
-  import NoteSnapshotView from '$lib/components/notes/NoteSnapshotView.svelte';
-  import {
-    sharesStore,
-    isShareInactive,
-    isShareExhausted
-  } from '$lib/stores/shares.store';
+  import { goto } from '$lib/utils/navigation';
+  import { sharesStore, activeSharesCount } from '$lib/stores/shares.store';
 
-  let urlsVisible = new SvelteSet<string>();
-  let previewing = $state<SharedSnapshotNotePayload | null>(null);
-  let previewOpen = $state(false);
-  let revoking = $state<string | null>(null);
-
-  const storeState = $derived($sharesStore);
-  const shares = $derived(storeState.shares);
-  const decoded = $derived(storeState.decoded);
-  const decryptErrors = $derived(storeState.decryptErrors);
-  const isLoading = $derived(storeState.loading);
-  const error = $derived(storeState.error);
-
-  function formatDate(iso: string | null) {
-    if (!iso) return '-';
-    try {
-      return new Date(iso).toLocaleString(undefined, {
-        dateStyle: 'medium',
-        timeStyle: 'short'
-      });
-    } catch {
-      return iso;
-    }
-  }
-
-  function formatOpens(s: OwnShareListItem): string {
-    return s.max_access_count !== null
-      ? `${s.access_count} / ${s.max_access_count}`
-      : String(s.access_count);
-  }
-
-  async function copyUrl(id: string) {
-    const url = decoded[id]?.url;
-    if (!url) return;
-    if (await copyText(url)) {
-      toastStore.success($t('share.create.copied'));
-    } else {
-      toastStore.error($t('share.create.copy_failed'));
-    }
-  }
-
-  // Native build only: open the OS share sheet. Web keeps copy-only (the button
-  // and `shareLink` are dead-code-eliminated on web).
-  const isNative = __REBORN_NATIVE__;
-
-  async function shareUrl(id: string) {
-    const entry = decoded[id];
-    if (!entry?.url) return;
-    const ok = await shareLink({
-      url: entry.url,
-      title: entry.payload.title || $t('share.list.untitled'),
-      dialogTitle: $t('share.create.share_sheet_title')
-    });
-    if (!ok) await copyUrl(id); // plugin unavailable -> fall back to clipboard
-  }
-
-  function toggleUrl(id: string) {
-    if (urlsVisible.has(id)) urlsVisible.delete(id);
-    else urlsVisible.add(id);
-  }
-
-  function openPreview(id: string) {
-    const item = decoded[id];
-    if (!item) return;
-    previewing = item.payload;
-    previewOpen = true;
-  }
-
-  async function revoke(share: OwnShareListItem) {
-    revoking = share.id;
-    const ok = await sharesStore.revoke(share.slug);
-    if (ok) {
-      toastStore.success($t('share.list.revoked_toast'));
-    } else {
-      toastStore.error($t('share.list.revoke_error'));
-    }
-    revoking = null;
-  }
-
-  // Defense-in-depth: server already filters by snapshot_type but the client
-  // double-checks against the actual payload type from the ciphertext.
-  const visibleShares = $derived(
-    shares.filter((s) => {
-      if (s.snapshot_type === 'note') return true;
-      if (s.snapshot_type === 'unknown') {
-        return decoded[s.id]?.payload.type === 'note' || decryptErrors.has(s.id);
-      }
-      return false;
-    })
-  );
-
+  // The full share list now lives in the in-app Shares view (icon rail). This
+  // settings entry is a thin shortcut into it - one source of truth, no
+  // duplicated list/preview/revoke markup to keep in sync.
   onMount(() => {
-    sharesStore.init();
     void sharesStore.refresh();
   });
 </script>
@@ -138,172 +19,22 @@
 </svelte:head>
 
 <SettingsLayout title={$t('share.list.title')} backHref="/settings">
-  {#snippet actions()}
-    <Button
-      variant="ghost"
-      size="icon"
-      onclick={() => sharesStore.refresh()}
-      disabled={isLoading}
-      aria-label="Refresh"
-    >
-      <RefreshCw class="h-4 w-4 {isLoading ? 'animate-spin' : ''}" />
-    </Button>
-  {/snippet}
-
   <div class="space-y-4">
-    {#if error}
-      <Alert variant="destructive">
-        <AlertDescription>{$t('share.list.error_load')}</AlertDescription>
-      </Alert>
-    {/if}
+    <p class="text-sm text-muted-foreground">{$t('share.list.settings_desc')}</p>
 
-    {#if isLoading && visibleShares.length === 0}
-      <div class="flex justify-center py-12">
-        <RefreshCw class="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    {:else if visibleShares.length === 0}
-      <Card>
-        <CardContent class="px-4 py-8 text-center text-sm text-muted-foreground">
-          {$t('share.list.empty')}
-        </CardContent>
-      </Card>
-    {:else}
-      {#each visibleShares as share (share.id)}
-        {@const entry = decoded[share.id]}
-        {@const hasDecryptError = decryptErrors.has(share.id)}
-        {@const exhausted = isShareExhausted(share)}
-        {@const inactive = isShareInactive(share)}
-        {@const urlShown = urlsVisible.has(share.id)}
-        <Card class={inactive ? 'opacity-60' : ''}>
-          <CardContent class="flex flex-col gap-3 px-4 py-3">
-            <div class="flex items-start justify-between gap-2">
-              <div class="flex min-w-0 flex-1 items-start gap-2">
-                <FileText class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-                <div class="min-w-0 flex-1">
-                  <div class="flex items-center gap-2">
-                    <span class="text-[10px] uppercase tracking-wider text-muted-foreground">
-                      {$t('share.list.type.note')}
-                    </span>
-                    {#if share.has_password}
-                      <span class="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-muted-foreground">
-                        <Lock class="h-3 w-3" />
-                        {$t('share.list.password_protected')}
-                      </span>
-                    {/if}
-                    {#if exhausted}
-                      <span class="text-[10px] uppercase tracking-wider text-destructive">{$t('share.list.exhausted_label')}</span>
-                    {:else if inactive}
-                      <span class="text-[10px] uppercase tracking-wider text-destructive">{$t('share.list.revoked_label')}</span>
-                    {/if}
-                  </div>
-                  {#if entry}
-                    <p class="truncate text-sm font-medium">
-                      {entry.payload.title || $t('share.list.untitled')}
-                    </p>
-                  {:else if hasDecryptError}
-                    <p class="inline-flex items-center gap-1 text-sm text-muted-foreground">
-                      <AlertTriangle class="h-3.5 w-3.5" />
-                      {$t('share.list.decrypt_failed')}
-                    </p>
-                  {:else}
-                    <p class="text-sm italic text-muted-foreground">{$t('share.list.decrypting')}</p>
-                  {/if}
-                </div>
-              </div>
-              <div class="flex shrink-0 gap-1">
-                {#if entry && !inactive}
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={$t('share.list.preview_action')}
-                    onclick={() => openPreview(share.id)}
-                  >
-                    <Eye class="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={$t('share.create.copy_link')}
-                    onclick={() => copyUrl(share.id)}
-                  >
-                    <Copy class="h-4 w-4" />
-                  </Button>
-                  {#if isNative}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label={$t('share.create.share_cta')}
-                      onclick={() => shareUrl(share.id)}
-                    >
-                      <Share2 class="h-4 w-4" />
-                    </Button>
-                  {/if}
-                {/if}
-                {#if !share.revoked_at}
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={$t('share.list.revoke_action')}
-                    disabled={revoking === share.id}
-                    onclick={() => revoke(share)}
-                  >
-                    <Trash2 class="h-4 w-4 text-destructive" />
-                  </Button>
-                {/if}
-              </div>
-            </div>
-
-            {#if entry && !inactive}
-              <div class="flex flex-col gap-1">
-                <button
-                  type="button"
-                  class="inline-flex w-fit items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
-                  onclick={() => toggleUrl(share.id)}
-                >
-                  {#if urlShown}
-                    <ChevronUp class="h-3 w-3" />
-                    {$t('share.list.hide_link')}
-                  {:else}
-                    <ChevronDown class="h-3 w-3" />
-                    {$t('share.list.show_link')}
-                  {/if}
-                </button>
-                {#if urlShown}
-                  <p class="break-all font-mono text-xs text-muted-foreground">{entry.url}</p>
-                {/if}
-              </div>
-            {/if}
-
-            <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-              <span>{$t('share.list.column.created')}: {formatDate(share.created_at)}</span>
-              <span>
-                {$t('share.list.column.expires')}:
-                {share.expires_at ? formatDate(share.expires_at) : $t('share.create.expires.never')}
-              </span>
-              <span>{$t('share.list.column.access_count')}: {formatOpens(share)}</span>
-              {#if share.last_accessed_at}
-                <span>
-                  {$t('share.list.column.last_accessed')}: {formatDate(share.last_accessed_at)}
-                </span>
-              {/if}
-            </div>
-          </CardContent>
-        </Card>
-      {/each}
-    {/if}
+    <button
+      type="button"
+      onclick={() => goto('/?section=shares')}
+      class="flex w-full items-center gap-3 rounded-lg border p-4 text-left transition-colors hover:bg-accent"
+    >
+      <Share2 class="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <span class="min-w-0 flex-1">
+        <span class="block text-sm font-medium">{$t('share.list.manage_cta')}</span>
+        <span class="block text-xs text-muted-foreground">
+          {$t('share.list.count', { values: { count: $activeSharesCount } })}
+        </span>
+      </span>
+      <ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+    </button>
   </div>
 </SettingsLayout>
-
-<Dialog bind:open={previewOpen}>
-  <DialogContent class="flex max-h-[85vh] max-w-2xl flex-col gap-0 overflow-hidden p-0">
-    <DialogHeader class="flex-shrink-0 border-b px-6 py-4 pr-12">
-      <DialogTitle>{$t('share.list.preview_dialog_title')}</DialogTitle>
-    </DialogHeader>
-    {#if previewing}
-      <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-6 py-4">
-        <NoteSnapshotView payload={previewing} />
-        <p class="text-xs italic text-muted-foreground">{$t('share.list.preview_hint')}</p>
-      </div>
-    {/if}
-  </DialogContent>
-</Dialog>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1435,6 +1435,13 @@
         "title": "Titel (A-Z)"
       },
       "manage_cta": "Aktive Freigaben verwalten",
+      "export_markdown": "Als Markdown exportieren",
+      "copy_markdown": "Als Markdown kopieren",
+      "copied_markdown": "Als Markdown kopiert",
+      "link_key_warning": "Dieser Link enthält den Entschlüsselungsschlüssel und gewährt vollen Zugriff auf den Snapshot. Teile ihn mit Bedacht.",
+      "opens_unlimited": "kein Limit",
+      "expired": "Abgelaufen",
+      "snapshot_stale": "Notiz seit dem Teilen geändert",
       "type": {
         "note": "Notiz",
         "task": "Aufgabe"

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1421,6 +1421,20 @@
       "preview_dialog_title": "Snapshot-Vorschau",
       "show_link": "Link anzeigen",
       "hide_link": "Link verbergen",
+      "count": "{count, plural, =0 {Keine Freigaben} one {1 Freigabe} other {# Freigaben}}",
+      "search_placeholder": "Freigaben suchen…",
+      "search_no_match": "Keine Freigabe entspricht deiner Suche.",
+      "select_hint": "Wähle eine Freigabe, um Details und Vorschau anzuzeigen.",
+      "expiring_soon": "Läuft bald ab",
+      "links_badge": "{count, plural, one {1 Link} other {# Links}}",
+      "sort_label": "Sortieren",
+      "sort": {
+        "created": "Neueste zuerst",
+        "expires": "Bald ablaufend",
+        "opens": "Meiste Aufrufe",
+        "title": "Titel (A-Z)"
+      },
+      "manage_cta": "Aktive Freigaben verwalten",
       "type": {
         "note": "Notiz",
         "task": "Aufgabe"

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1442,6 +1442,7 @@
       "opens_unlimited": "kein Limit",
       "expired": "Abgelaufen",
       "snapshot_stale": "Notiz seit dem Teilen geändert",
+      "snapshot_eyebrow": "Geteilter Snapshot",
       "type": {
         "note": "Notiz",
         "task": "Aufgabe"

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1442,6 +1442,7 @@
       "opens_unlimited": "no limit",
       "expired": "Expired",
       "snapshot_stale": "Note changed since shared",
+      "snapshot_eyebrow": "Shared snapshot",
       "type": {
         "note": "Note",
         "task": "Task"

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1435,6 +1435,13 @@
         "title": "Title (A-Z)"
       },
       "manage_cta": "Manage active shares",
+      "export_markdown": "Export as Markdown",
+      "copy_markdown": "Copy as Markdown",
+      "copied_markdown": "Copied as Markdown",
+      "link_key_warning": "This link contains the decryption key and grants full access to the snapshot. Share it carefully.",
+      "opens_unlimited": "no limit",
+      "expired": "Expired",
+      "snapshot_stale": "Note changed since shared",
       "type": {
         "note": "Note",
         "task": "Task"

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1421,6 +1421,20 @@
       "preview_dialog_title": "Snapshot preview",
       "show_link": "Show link",
       "hide_link": "Hide link",
+      "count": "{count, plural, =0 {No shares} one {1 share} other {# shares}}",
+      "search_placeholder": "Search shares…",
+      "search_no_match": "No shares match your search.",
+      "select_hint": "Select a share to view its details and preview.",
+      "expiring_soon": "Expiring soon",
+      "links_badge": "{count, plural, one {1 link} other {# links}}",
+      "sort_label": "Sort",
+      "sort": {
+        "created": "Newest first",
+        "expires": "Expiring soonest",
+        "opens": "Most opened",
+        "title": "Title (A-Z)"
+      },
+      "manage_cta": "Manage active shares",
       "type": {
         "note": "Note",
         "task": "Task"

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1442,6 +1442,7 @@
       "opens_unlimited": "sin límite",
       "expired": "Caducado",
       "snapshot_stale": "Nota modificada desde que se compartió",
+      "snapshot_eyebrow": "Snapshot compartido",
       "type": {
         "note": "Nota",
         "task": "Tarea"

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1435,6 +1435,13 @@
         "title": "Título (A-Z)"
       },
       "manage_cta": "Gestionar enlaces activos",
+      "export_markdown": "Exportar como Markdown",
+      "copy_markdown": "Copiar como Markdown",
+      "copied_markdown": "Copiado como Markdown",
+      "link_key_warning": "Este enlace contiene la clave de descifrado y da acceso completo al snapshot. Compártelo con cuidado.",
+      "opens_unlimited": "sin límite",
+      "expired": "Caducado",
+      "snapshot_stale": "Nota modificada desde que se compartió",
       "type": {
         "note": "Nota",
         "task": "Tarea"

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1421,6 +1421,20 @@
       "preview_dialog_title": "Vista previa del snapshot",
       "show_link": "Mostrar enlace",
       "hide_link": "Ocultar enlace",
+      "count": "{count, plural, =0 {Sin enlaces activos} one {1 enlace} other {# enlaces}}",
+      "search_placeholder": "Buscar enlaces…",
+      "search_no_match": "Ningún enlace coincide con tu búsqueda.",
+      "select_hint": "Selecciona un enlace para ver sus detalles y la vista previa.",
+      "expiring_soon": "Caduca pronto",
+      "links_badge": "{count, plural, one {1 enlace} other {# enlaces}}",
+      "sort_label": "Ordenar",
+      "sort": {
+        "created": "Más recientes",
+        "expires": "Caducan antes",
+        "opens": "Más abiertos",
+        "title": "Título (A-Z)"
+      },
+      "manage_cta": "Gestionar enlaces activos",
       "type": {
         "note": "Nota",
         "task": "Tarea"

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1421,6 +1421,20 @@
       "preview_dialog_title": "Aperçu du snapshot",
       "show_link": "Afficher le lien",
       "hide_link": "Masquer le lien",
+      "count": "{count, plural, =0 {Aucun partage actif} one {1 partage} other {# partages}}",
+      "search_placeholder": "Rechercher des partages…",
+      "search_no_match": "Aucun partage ne correspond à votre recherche.",
+      "select_hint": "Sélectionnez un partage pour voir ses détails et son aperçu.",
+      "expiring_soon": "Expire bientôt",
+      "links_badge": "{count, plural, one {1 lien} other {# liens}}",
+      "sort_label": "Trier",
+      "sort": {
+        "created": "Plus récents",
+        "expires": "Expirent bientôt",
+        "opens": "Plus ouverts",
+        "title": "Titre (A-Z)"
+      },
+      "manage_cta": "Gérer les partages actifs",
       "type": {
         "note": "Note",
         "task": "Tâche"

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1435,6 +1435,13 @@
         "title": "Titre (A-Z)"
       },
       "manage_cta": "Gérer les partages actifs",
+      "export_markdown": "Exporter en Markdown",
+      "copy_markdown": "Copier en Markdown",
+      "copied_markdown": "Copié en Markdown",
+      "link_key_warning": "Ce lien contient la clé de déchiffrement et donne un accès complet au snapshot. Partagez-le avec prudence.",
+      "opens_unlimited": "sans limite",
+      "expired": "Expiré",
+      "snapshot_stale": "Note modifiée depuis le partage",
       "type": {
         "note": "Note",
         "task": "Tâche"

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1442,6 +1442,7 @@
       "opens_unlimited": "sans limite",
       "expired": "Expiré",
       "snapshot_stale": "Note modifiée depuis le partage",
+      "snapshot_eyebrow": "Snapshot partagé",
       "type": {
         "note": "Note",
         "task": "Tâche"

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1442,6 +1442,7 @@
       "opens_unlimited": "bez limitu",
       "expired": "Wygasło",
       "snapshot_stale": "Notatka zmieniona od udostępnienia",
+      "snapshot_eyebrow": "Udostępniony snapshot",
       "type": {
         "note": "Notatka",
         "task": "Zadanie"

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1421,6 +1421,20 @@
       "preview_dialog_title": "Podgląd snapshotu",
       "show_link": "Pokaż link",
       "hide_link": "Ukryj link",
+      "count": "{count, plural, =0 {Brak udostępnień} one {1 udostępnienie} few {# udostępnienia} many {# udostępnień} other {# udostępnienia}}",
+      "search_placeholder": "Szukaj udostępnień…",
+      "search_no_match": "Brak udostępnień pasujących do wyszukiwania.",
+      "select_hint": "Wybierz udostępnienie, aby zobaczyć szczegóły i podgląd.",
+      "expiring_soon": "Wkrótce wygasa",
+      "links_badge": "{count, plural, one {1 link} few {# linki} many {# linków} other {# linku}}",
+      "sort_label": "Sortuj",
+      "sort": {
+        "created": "Najnowsze",
+        "expires": "Najbliższe wygaśnięcie",
+        "opens": "Najczęściej otwierane",
+        "title": "Tytuł (A-Z)"
+      },
+      "manage_cta": "Zarządzaj udostępnieniami",
       "type": {
         "note": "Notatka",
         "task": "Zadanie"

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1435,6 +1435,13 @@
         "title": "Tytuł (A-Z)"
       },
       "manage_cta": "Zarządzaj udostępnieniami",
+      "export_markdown": "Eksportuj jako Markdown",
+      "copy_markdown": "Kopiuj jako Markdown",
+      "copied_markdown": "Skopiowano jako Markdown",
+      "link_key_warning": "Ten link zawiera klucz deszyfrujący i daje pełny dostęp do snapshotu. Udostępniaj go ostrożnie.",
+      "opens_unlimited": "bez limitu",
+      "expired": "Wygasło",
+      "snapshot_stale": "Notatka zmieniona od udostępnienia",
       "type": {
         "note": "Notatka",
         "task": "Zadanie"


### PR DESCRIPTION
## Summary

Converts the global **"Active shares"** surface from a modal into a first-class **sidebar master-detail view**, matching the Starred pattern (list on the left, detail with snapshot preview on the right). The per-note "Shares for this note" modal is unchanged. A modal is the wrong container for a growing collection you manage over time (audit what is public, revoke, copy links); a view scales, is searchable/sortable, and reuses the existing master-detail mental model.

Decisions (agreed before implementation):
- **One row per active share link** (flat list), not grouped by note - matches the rail badge (which counts links) and avoids snapshot-divergence ambiguity (each link is its own point-in-time snapshot). Notes with several links show an "N links" pill.
- **Settings -> Security -> Shares folds into the view** - that page is now a thin shortcut (`/?section=shares`), removing duplicated list/preview/revoke markup.

Details:
- `IconNav`: `shares` is now a real `Section`; the rail button switches to it (keeping the local-only / session gate) instead of opening `ManageSharesDialog`. Badge unchanged.
- `SharesList.svelte` (new): rows over `activeShares` with search (title / display name), sort (created / expires / opens / title), and password + expiring-soon badges.
- `ShareDetailPanel.svelte` (new): `NoteSnapshotView` preview from the already-decrypted `decoded[id]` payload, metadata, link URL show/hide + copy + native share, and revoke with confirm.
- `+page.svelte`: `shares` branch in the desktop and mobile master-detail shells; `activeShareId` selection state; mobile detail panel with hardware-back / swipe wired.
- i18n: new `share.list.*` keys across all 5 locales (parity verified, 1235 keys).

**Zero Knowledge:** presentation-only. No new crypto, no server change, no visibility-model change. The preview reads `payload_encrypted` already decrypted client-side with the owner key; it does not call the public `/s` endpoint, so it consumes no access slot.

Deferred follow-ups (separate PR): "open source note" and "create another link" from the detail (need safe cross-section navigation), and an Active/All filter.

## Test plan

CI covers lint / check (svelte-check) / test / build. i18n parity verified locally (1235 keys, all 5 locales aligned).

Smoke (desktop + mobile):
- Rail "Shares" icon opens the Shares view (active state highlighted); badge count unchanged.
- List shows one row per active link; search filters by title; sort by created / expires / opens / title works; "N links" pill on a note shared more than once; password and expiring-soon badges render.
- Click a row -> detail shows the snapshot preview, metadata, URL show/hide, copy, (native) share, and revoke (with confirm; the row disappears after revoke).
- Mobile: list -> detail slides in; hardware back / swipe returns to the list.
- Settings -> Security -> Shares -> "Manage active shares" deep-links into the view.
- Per-note "Shares for this note" modal (note toolbar) still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)