### PR TITLE
feat(notes): open source note from share detail

### DIFF
--- a/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
@@ -14,8 +14,7 @@
     ClipboardCopy,
     FileClock,
     FileText,
-    FileX2,
-    ArrowRight
+    FileX2
   } from '@lucide/svelte';
   import { t, locale } from '$lib/stores/i18n.store';
   import { shareLink } from '$lib/utils/native-share';
@@ -261,6 +260,21 @@
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" class="min-w-48">
           {#if entry}
+            <!-- Navigational: jump to the live source note. Top of the menu,
+                 separated from the snapshot/content actions below it and the
+                 destructive Revoke at the bottom. When the note was deleted or
+                 trashed the item is disabled and its label becomes the reason, so
+                 it reads in the open menu without a hover-only tooltip. -->
+            {#if sourceNoteState === 'gone'}
+              <DropdownMenuItem disabled>
+                <FileX2 class="mr-2 h-4 w-4" />{$t('share.list.source_note_deleted')}
+              </DropdownMenuItem>
+            {:else}
+              <DropdownMenuItem disabled={sourceNoteState !== 'open'} onclick={openSourceNote}>
+                <FileText class="mr-2 h-4 w-4" />{$t('share.list.open_source_note')}
+              </DropdownMenuItem>
+            {/if}
+            <DropdownMenuSeparator />
             {#if isNative}
               <DropdownMenuItem onclick={shareUrl}>
                 <Share2 class="mr-2 h-4 w-4" />{$t('share.create.share_cta')}
@@ -301,55 +315,17 @@
       </div>
     {:else}
       <div class="mx-auto flex max-w-3xl flex-col gap-4 px-4 md:px-6 py-4">
-        <!-- Jump from this frozen snapshot to the live source note. Only shown
-             once the snapshot is decoded (we have the payload's source_id). When
-             the note is gone the same slot shows a visible reason rather than a
-             disabled control with a hover-only tooltip. -->
-        {#if entry}
-          {#if sourceNoteState === 'gone'}
-            <div
-              class="flex items-center gap-2 rounded-lg border border-dashed bg-muted/20 px-3 py-2.5
-                     text-sm text-muted-foreground"
-            >
-              <FileX2 class="h-4 w-4 shrink-0" aria-hidden="true" />
-              <span class="min-w-0 flex-1">{$t('share.list.source_note_deleted')}</span>
-            </div>
-          {:else}
-            <button
-              type="button"
-              onclick={openSourceNote}
-              disabled={sourceNoteState !== 'open'}
-              class="group flex w-full items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2.5
-                     text-left text-sm transition-colors hover:bg-accent
-                     disabled:opacity-60 disabled:hover:bg-muted/30"
-            >
-              <FileText class="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-              <span class="min-w-0 flex-1 truncate font-medium">
-                {$t('share.list.open_source_note')}
-              </span>
-              <ArrowRight
-                class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-                aria-hidden="true"
-              />
-            </button>
-          {/if}
-        {/if}
-
         <!-- Public link URL (hidden by default) -->
         {#if entry}
-          <div class="relative flex flex-col gap-1.5 rounded-lg border bg-muted/30 p-3">
-            <button
-              type="button"
-              class="inline-flex w-fit items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
-              onclick={() => (urlShown = !urlShown)}
-            >
-              {#if urlShown}
+          {#if urlShown}
+            <div class="relative flex flex-col gap-1.5 rounded-lg border bg-muted/30 p-3">
+              <button
+                type="button"
+                class="inline-flex w-fit cursor-pointer items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
+                onclick={() => (urlShown = false)}
+              >
                 <ChevronUp class="h-3 w-3" />{$t('share.list.hide_link')}
-              {:else}
-                <ChevronDown class="h-3 w-3" />{$t('share.list.show_link')}
-              {/if}
-            </button>
-            {#if urlShown}
+              </button>
               <!-- Copy affordance pinned top-right, mirroring note code blocks. -->
               <button
                 type="button"
@@ -368,8 +344,21 @@
                 <Lock class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
                 <span>{$t('share.list.link_key_warning')}</span>
               </p>
-            {/if}
-          </div>
+            </div>
+          {:else}
+            <!-- Collapsed: the whole block is the expand affordance (full-width,
+                 pointer cursor + hover), not just the small label - bigger target
+                 and signals interactivity like a link. -->
+            <button
+              type="button"
+              onclick={() => (urlShown = true)}
+              class="flex w-full cursor-pointer items-center gap-1 rounded-lg border bg-muted/30 p-3
+                     text-[11px] uppercase tracking-wider text-muted-foreground transition-colors
+                     hover:bg-muted/50 hover:text-foreground"
+            >
+              <ChevronDown class="h-3 w-3" />{$t('share.list.show_link')}
+            </button>
+          {/if}
         {/if}
 
         <!-- Source note changed since the snapshot was frozen (informational). -->

--- a/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
@@ -12,7 +12,10 @@
     Ellipsis,
     Download,
     ClipboardCopy,
-    FileClock
+    FileClock,
+    FileText,
+    FileX2,
+    ArrowRight
   } from '@lucide/svelte';
   import { t, locale } from '$lib/stores/i18n.store';
   import { shareLink } from '$lib/utils/native-share';
@@ -33,7 +36,15 @@
   import { formatExpiryRelative } from '$lib/utils/expiry-format';
   import type { OwnShareListItem } from '@reborn/types';
 
-  let { shareId, onback }: { shareId: string; onback?: () => void } = $props();
+  let {
+    shareId,
+    onback,
+    onopensource
+  }: {
+    shareId: string;
+    onback?: () => void;
+    onopensource?: (sourceId: string) => void;
+  } = $props();
 
   const storeState = $derived($sharesStore);
   const share = $derived<OwnShareListItem | null>(
@@ -67,18 +78,45 @@
   // the shared text changed.
   const sourceId = $derived(entry?.payload.source_id ?? null);
   let sourceUpdatedAt = $state<string | null>(null);
+  // 'loading' until the lookup resolves, then 'open' (live note present on this
+  // device, can jump to it) or 'gone' (deleted, never synced here, or trashed).
+  // Same gate as the stale hint above: a trashed note is treated as gone. Drives
+  // the "Open source note" row - an enabled jump vs a visible "no longer
+  // available" reason (shown inline, not hover-only, so it reads on mobile).
+  let sourceNoteState = $state<'loading' | 'open' | 'gone'>('loading');
   $effect(() => {
     const sid = sourceId;
     sourceUpdatedAt = null;
-    if (!sid) return;
+    sourceNoteState = 'loading';
+    if (!sid) {
+      sourceNoteState = 'gone';
+      return;
+    }
     let cancelled = false;
     void notesStore.loadNote(sid).then((n) => {
-      if (!cancelled) sourceUpdatedAt = n && !n.is_archived ? n.updated_at : null;
+      if (cancelled) return;
+      if (n && !n.is_archived) {
+        sourceUpdatedAt = n.updated_at;
+        sourceNoteState = 'open';
+      } else {
+        sourceUpdatedAt = null;
+        sourceNoteState = 'gone';
+      }
     });
     return () => {
       cancelled = true;
     };
   });
+
+  // Delegate the actual navigation to the page (activeSection/activeNoteId live
+  // there): switch to All notes and open the live source note. Guarded so a click
+  // during the brief 'loading' window or on a gone note is a no-op here - the
+  // page handler also re-validates as the source of truth.
+  function openSourceNote() {
+    const sid = sourceId;
+    if (!sid || sourceNoteState !== 'open') return;
+    onopensource?.(sid);
+  }
   const snapshotStale = $derived(
     !!(
       sourceUpdatedAt
@@ -263,6 +301,40 @@
       </div>
     {:else}
       <div class="mx-auto flex max-w-3xl flex-col gap-4 px-4 md:px-6 py-4">
+        <!-- Jump from this frozen snapshot to the live source note. Only shown
+             once the snapshot is decoded (we have the payload's source_id). When
+             the note is gone the same slot shows a visible reason rather than a
+             disabled control with a hover-only tooltip. -->
+        {#if entry}
+          {#if sourceNoteState === 'gone'}
+            <div
+              class="flex items-center gap-2 rounded-lg border border-dashed bg-muted/20 px-3 py-2.5
+                     text-sm text-muted-foreground"
+            >
+              <FileX2 class="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span class="min-w-0 flex-1">{$t('share.list.source_note_deleted')}</span>
+            </div>
+          {:else}
+            <button
+              type="button"
+              onclick={openSourceNote}
+              disabled={sourceNoteState !== 'open'}
+              class="group flex w-full items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2.5
+                     text-left text-sm transition-colors hover:bg-accent
+                     disabled:opacity-60 disabled:hover:bg-muted/30"
+            >
+              <FileText class="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <span class="min-w-0 flex-1 truncate font-medium">
+                {$t('share.list.open_source_note')}
+              </span>
+              <ArrowRight
+                class="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                aria-hidden="true"
+              />
+            </button>
+          {/if}
+        {/if}
+
         <!-- Public link URL (hidden by default) -->
         {#if entry}
           <div class="relative flex flex-col gap-1.5 rounded-lg border bg-muted/30 p-3">

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -701,6 +701,12 @@
 
   // ── Sync store filters to nav state ─────────────────────────────
   let prevSection: Section | null = null;
+  // Cross-section "open this note" request. A handler sets this id right before
+  // switching to a (non-periodic) destination section; the section-sync effect
+  // below adopts it after its flush instead of clearing activeNoteId. The
+  // non-periodic analogue of how handlePeriodic lets periodic sections keep their
+  // freshly-opened note. Currently armed by "Open source note" from a share.
+  let pendingOpenNoteId: string | null = null;
   $effect(() => {
     const section = activeSection;
     const sectionUsesFolderId = section === 'folders' || isPeriodicSection(section);
@@ -721,10 +727,17 @@
           activeTagId = null;
           tagManager.resetSection();
         }
-        // Periodic sections own activeNoteId via handlePeriodic — don't clear it
+        // Periodic sections own activeNoteId via handlePeriodic - don't clear it
         // here or the freshly-opened periodic note would deselect on first paint.
+        // A pending cross-section open (pendingOpenNoteId, e.g. "open source note"
+        // from a share) is adopted after the flush instead of cleared, so the
+        // requested note survives the transition. The clear is async (.then), so
+        // setting activeNoteId here before the flush resolves would lose the race -
+        // adopting inside the same continuation is what makes it deterministic.
         if (!isPeriodicSection(section)) {
-          noteDetailService.flushAndSnapshot().then(() => activeNoteId.set(null));
+          const adoptNoteId = pendingOpenNoteId;
+          pendingOpenNoteId = null;
+          noteDetailService.flushAndSnapshot().then(() => activeNoteId.set(adoptNoteId));
         }
 
         // Push history entry for drill-down sections (folders/tags)
@@ -1223,6 +1236,29 @@
     // fire the recorder, so don't leave the flag armed for the next open.
     extendNavTrailOnce = noteId !== $activeNoteId;
     activeNoteId.set(noteId);
+  }
+
+  /** "Open source note" from a share's detail panel: jump from the frozen
+   *  snapshot to the live note it was created from. Re-validate first (the note
+   *  may have been deleted or trashed since the panel rendered - the panel
+   *  disables the action proactively, this is the render→click safety net), then
+   *  arm pendingOpenNoteId and switch to All notes. The section-sync effect adopts
+   *  the id after its flush. Only ever called from the Shares section, so the
+   *  section transition (and thus the adopt) is guaranteed to fire. */
+  async function handleOpenSourceNote(sourceId: string) {
+    const note = await notesStore.loadNote(sourceId);
+    if (!note) {
+      toastStore.error($t('notes.note_not_found'));
+      return;
+    }
+    if (note.is_archived) {
+      toastStore.info($t('notes.note_in_trash'));
+      return;
+    }
+    pendingOpenNoteId = sourceId;
+    activeSection = 'all';
+    activeFolderId = undefined;
+    activeTagId = null;
   }
 
   // ── Note link picker ─────────────────────────────────────────────
@@ -2293,7 +2329,11 @@
             </div>
           {/if}
         {:else if activeSection === 'shares' && $activeShareId}
-          <ShareDetailPanel shareId={$activeShareId} onback={closeShareDetail} />
+          <ShareDetailPanel
+            shareId={$activeShareId}
+            onback={closeShareDetail}
+            onopensource={handleOpenSourceNote}
+          />
         {:else if $isInitialSync}
           <InitialSyncState compact />
         {:else}
@@ -2604,7 +2644,11 @@
         {/if}
       {:else if activeSection === 'shares'}
         {#if $activeShareId}
-          <ShareDetailPanel shareId={$activeShareId} onback={closeShareDetail} />
+          <ShareDetailPanel
+            shareId={$activeShareId}
+            onback={closeShareDetail}
+            onopensource={handleOpenSourceNote}
+          />
         {:else}
           <header
             class="flex min-h-[calc(3rem+env(safe-area-inset-top,0px))] shrink-0 items-center gap-2 border-b border-border/60 px-6 pt-[env(safe-area-inset-top,0px)]"

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1443,6 +1443,8 @@
       "expired": "Abgelaufen",
       "snapshot_stale": "Notiz seit dem Teilen geändert",
       "snapshot_eyebrow": "Geteilter Snapshot",
+      "open_source_note": "Quellnotiz öffnen",
+      "source_note_deleted": "Quellnotiz nicht mehr verfügbar",
       "type": {
         "note": "Notiz",
         "task": "Aufgabe"

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1443,6 +1443,8 @@
       "expired": "Expired",
       "snapshot_stale": "Note changed since shared",
       "snapshot_eyebrow": "Shared snapshot",
+      "open_source_note": "Open source note",
+      "source_note_deleted": "Source note no longer available",
       "type": {
         "note": "Note",
         "task": "Task"

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1443,6 +1443,8 @@
       "expired": "Caducado",
       "snapshot_stale": "Nota modificada desde que se compartió",
       "snapshot_eyebrow": "Snapshot compartido",
+      "open_source_note": "Abrir la nota original",
+      "source_note_deleted": "Nota original no disponible",
       "type": {
         "note": "Nota",
         "task": "Tarea"

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1443,6 +1443,8 @@
       "expired": "Expiré",
       "snapshot_stale": "Note modifiée depuis le partage",
       "snapshot_eyebrow": "Snapshot partagé",
+      "open_source_note": "Ouvrir la note source",
+      "source_note_deleted": "Note source indisponible",
       "type": {
         "note": "Note",
         "task": "Tâche"

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1443,6 +1443,8 @@
       "expired": "Wygasło",
       "snapshot_stale": "Notatka zmieniona od udostępnienia",
       "snapshot_eyebrow": "Udostępniony snapshot",
+      "open_source_note": "Otwórz notatkę źródłową",
+      "source_note_deleted": "Notatka źródłowa już niedostępna",
       "type": {
         "note": "Notatka",
         "task": "Zadanie"


### PR DESCRIPTION
## Summary

Adds an **Open source note** action to the note share detail panel (`ShareDetailPanel`), bridging from the frozen shared snapshot to the live note it was created from. It wires into existing navigation rather than adding a new link surface.

- **Placement (UX decision):** a labelled row at the top of the detail body. When the source note is gone, the same slot shows a visible "no longer available" reason inline instead of a disabled control with a hover-only tooltip - so the reason reads on mobile touch.
- **Cross-section navigation (architectural decision):** opening the note means leaving the Shares section for All notes and setting `activeNoteId`. The section-sync effect (`+page.svelte`) clears `activeNoteId` for non-periodic sections, and that clear is asynchronous (`flushAndSnapshot().then(...)`), so a plain `tick()` ordering loses the race. Introduced a `pendingOpenNoteId` baton that the effect adopts after its flush instead of clearing - the non-periodic analogue of how `handlePeriodic` exempts periodic sections. Reusable for future cross-section jumps (backlinks, search results).
- **Deleted / trashed handling:** the panel disables the row proactively (treats a trashed note as gone, consistent with the existing stale-hint). The page handler re-validates on click as the source of truth (`note_not_found` error toast / `note_in_trash` info toast), reusing existing keys.
- **i18n:** two new keys across all 5 locales - `share.list.open_source_note`, `share.list.source_note_deleted`.

## Test plan

Smoke (Reborn Notes):
- [ ] Create a share for a note, open Shares, select it. The "Open source note" row shows at the top of the detail. Click: switches to All notes and opens the live note with no deselect flicker.
- [ ] Mobile: tapping the row slides in the note detail; hardware back returns to the All notes list.
- [ ] Trash the source note, reopen the share: the row is replaced by a visible "Source note no longer available" line (no hover needed).
- [ ] Confirm the opened note stays open and does not deselect on first paint (the race the baton fixes).
- [ ] Spot-check the row label + gone-reason in pl/de/fr/es.

Green locally: eslint, svelte-check (0 errors / 0 warnings), i18n parity, i18n vitest (27/27). CI runs the authoritative lint/check/test/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)