### PR TITLE
feat(notes): align per-note share dialog with share detail panel

### DIFF
--- a/apps/reborn-notes/src/lib/components/notes/ManageSharesDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/ManageSharesDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {
     RefreshCw,
-    Trash2,
+    Link2Off,
     Copy,
     Share2,
     Lock,
@@ -13,9 +13,10 @@
     Plus
   } from '@lucide/svelte';
   import { SvelteSet } from 'svelte/reactivity';
-  import { t } from '$lib/stores/i18n.store';
+  import { t, locale } from '$lib/stores/i18n.store';
   import { shareLink } from '$lib/utils/native-share';
   import { copyText } from '$lib/utils/clipboard';
+  import { formatExpiryRelative } from '$lib/utils/expiry-format';
   import {
     Dialog,
     DialogContent,
@@ -34,6 +35,8 @@
   } from '$lib/stores/shares.store';
   import type { OwnShareListItem, SharedSnapshotNotePayload } from '@reborn/types';
   import NoteSnapshotView from './NoteSnapshotView.svelte';
+  import ConfirmDialog from '../shared/ConfirmDialog.svelte';
+  import SnapshotStaleBadge from '../shares/SnapshotStaleBadge.svelte';
 
   let {
     open = $bindable(false),
@@ -55,6 +58,8 @@
   let previewOpen = $state(false);
   let previewScrollEl = $state<HTMLDivElement | null>(null);
   let revoking = $state<string | null>(null);
+  let confirmRevokeShare = $state<OwnShareListItem | null>(null);
+  let confirmRevokeOpen = $state(false);
 
   const storeState = $derived($sharesStore);
   const decoded = $derived(storeState.decoded);
@@ -92,7 +97,7 @@
   function formatOpens(s: OwnShareListItem): string {
     return s.max_access_count !== null
       ? `${s.access_count} / ${s.max_access_count}`
-      : String(s.access_count);
+      : `${s.access_count} (${$t('share.list.opens_unlimited')})`;
   }
 
   async function copyUrl(id: string) {
@@ -132,12 +137,22 @@
     previewOpen = true;
   }
 
-  async function revoke(share: OwnShareListItem) {
+  function askRevoke(share: OwnShareListItem) {
+    confirmRevokeShare = share;
+    confirmRevokeOpen = true;
+  }
+
+  // Revoke kills the public link permanently (not a recoverable trash), so it
+  // goes through a confirm step - matching the share detail panel.
+  async function doRevoke() {
+    const share = confirmRevokeShare;
+    if (!share) return;
     revoking = share.id;
     const ok = await sharesStore.revoke(share.slug);
     if (ok) toastStore.success($t('share.list.revoked_toast'));
     else toastStore.error($t('share.list.revoke_error'));
     revoking = null;
+    confirmRevokeShare = null;
   }
 
   $effect(() => {
@@ -249,10 +264,16 @@
                       {:else if inactive}
                         <span class="text-[10px] uppercase tracking-wider text-destructive">{$t('share.list.revoked_label')}</span>
                       {/if}
+                      {#if entry && !inactive}
+                        <SnapshotStaleBadge
+                          sourceId={entry.payload.source_id}
+                          sharedAt={entry.payload.shared_at}
+                        />
+                      {/if}
                     </div>
                     {#if entry}
                       <p class="truncate text-sm font-medium">
-                        {entry.payload.title || $t('share.list.untitled')}
+                        {entry.payload.display_name?.trim() || entry.payload.title || $t('share.list.untitled')}
                       </p>
                     {:else if hasDecryptError}
                       <p class="inline-flex items-center gap-1 text-sm text-muted-foreground">
@@ -299,9 +320,9 @@
                       size="icon"
                       aria-label={$t('share.list.revoke_action')}
                       disabled={revoking === share.id}
-                      onclick={() => revoke(share)}
+                      onclick={() => askRevoke(share)}
                     >
-                      <Trash2 class="h-4 w-4 text-destructive" />
+                      <Link2Off class="h-4 w-4 text-destructive" />
                     </Button>
                   {/if}
                 </div>
@@ -311,7 +332,7 @@
                 <div class="flex flex-col gap-1">
                   <button
                     type="button"
-                    class="inline-flex w-fit items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
+                    class="inline-flex w-fit cursor-pointer items-center gap-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground"
                     onclick={() => toggleUrl(share.id)}
                   >
                     {#if urlShown}
@@ -324,6 +345,10 @@
                   </button>
                   {#if urlShown}
                     <p class="break-all font-mono text-xs text-muted-foreground">{entry.url}</p>
+                    <p class="mt-1 flex items-start gap-1 text-[11px] leading-snug text-muted-foreground">
+                      <Lock class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+                      <span>{$t('share.list.link_key_warning')}</span>
+                    </p>
                   {/if}
                 </div>
               {/if}
@@ -332,7 +357,17 @@
                 <span>{$t('share.list.column.created')}: {formatDate(share.created_at)}</span>
                 <span>
                   {$t('share.list.column.expires')}:
-                  {share.expires_at ? formatDate(share.expires_at) : $t('share.create.expires.never')}
+                  {#if share.expires_at}
+                    {@const rel = formatExpiryRelative(share.expires_at, $locale ?? 'en')}
+                    {formatDate(share.expires_at)}
+                    {#if rel?.expired}
+                      <span class="text-destructive">({$t('share.list.expired')})</span>
+                    {:else if rel}
+                      <span>({rel.text})</span>
+                    {/if}
+                  {:else}
+                    {$t('share.create.expires.never')}
+                  {/if}
                 </span>
                 <span>{$t('share.list.column.access_count')}: {formatOpens(share)}</span>
                 {#if share.last_accessed_at}
@@ -368,3 +403,12 @@
     {/if}
   </DialogContent>
 </Dialog>
+
+<ConfirmDialog
+  bind:open={confirmRevokeOpen}
+  title={$t('share.list.confirm_revoke_title')}
+  description={$t('share.list.confirm_revoke_desc')}
+  confirmText={$t('share.list.revoke_action')}
+  destructive
+  onConfirm={doRevoke}
+/>

--- a/apps/reborn-notes/src/lib/components/notes/ManageSharesDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/ManageSharesDialog.svelte
@@ -251,7 +251,7 @@
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">
                       <span class="text-[10px] uppercase tracking-wider text-muted-foreground">
-                        {$t('share.list.type.note')}
+                        {$t('share.list.snapshot_eyebrow')}
                       </span>
                       {#if share.has_password}
                         <span class="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-muted-foreground">

--- a/apps/reborn-notes/src/lib/components/notes/ShareNoteDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/ShareNoteDialog.svelte
@@ -26,7 +26,7 @@
     encryptSnapshotPayload,
     buildShareUrl
   } from '@reborn/crypto';
-  import { Eye, EyeOff } from '@lucide/svelte';
+  import { Eye, EyeOff, Lock } from '@lucide/svelte';
   import {
     SHARE_EXPIRY_PRESETS,
     SHARE_MAX_ACCESS_COUNT_LIMIT,
@@ -363,7 +363,17 @@
     {:else if stage === 'success'}
       <div class="flex flex-col gap-4 py-2">
         <p class="text-sm text-muted-foreground">{$t('share.create.success_title')}</p>
-        <Input value={resultUrl} readonly class="font-mono text-xs" />
+        <div class="flex flex-col gap-2">
+          <Input value={resultUrl} readonly class="font-mono text-xs" />
+          <!-- The link carries the decryption key in its fragment, so anyone with
+               it can read the snapshot. Same warning shown on the share detail
+               surfaces - here it lands at the most critical moment: just before
+               the user copies / sends the link. -->
+          <p class="flex items-start gap-1 text-[11px] leading-snug text-muted-foreground">
+            <Lock class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+            <span>{$t('share.list.link_key_warning')}</span>
+          </p>
+        </div>
       </div>
       <DialogFooter>
         <Button variant="outline" onclick={close}>{$t('share.create.close_cta')}</Button>

--- a/apps/reborn-notes/src/lib/components/shares/SnapshotStaleBadge.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/SnapshotStaleBadge.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { FileClock } from '@lucide/svelte';
+  import { t } from '$lib/stores/i18n.store';
+  import { notesStore } from '$lib/stores/notes.store';
+
+  // The "note changed since shared" hint as a compact inline micro-label, for
+  // surfaces that list several shares at once (where a per-row $effect can't live
+  // in the parent's {#each}). Mirrors the share detail panel's staleness check:
+  // load the live note by the id baked into the snapshot payload only to read its
+  // updated_at, and compare it to when the snapshot was frozen. Reads IndexedDB
+  // (already-decrypted plaintext) - no server call, fully ZK-safe. A trashed
+  // (is_archived) or absent note yields no badge, same gate as the panel.
+  let {
+    sourceId,
+    sharedAt
+  }: {
+    sourceId: string | null | undefined;
+    sharedAt: string | null | undefined;
+  } = $props();
+
+  let sourceUpdatedAt = $state<string | null>(null);
+  $effect(() => {
+    const sid = sourceId;
+    sourceUpdatedAt = null;
+    if (!sid) return;
+    let cancelled = false;
+    void notesStore.loadNote(sid).then((n) => {
+      if (cancelled) return;
+      sourceUpdatedAt = n && !n.is_archived ? n.updated_at : null;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  // updated_at also moves on non-content edits (pin / move), so this is an
+  // informational hint, not proof the shared text changed.
+  const stale = $derived(
+    !!(
+      sourceUpdatedAt
+      && sharedAt
+      && new Date(sourceUpdatedAt).getTime() > new Date(sharedAt).getTime()
+    )
+  );
+</script>
+
+{#if stale}
+  <span
+    class="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400"
+  >
+    <FileClock class="h-3 w-3" aria-hidden="true" />
+    {$t('share.list.snapshot_stale')}
+  </span>
+{/if}


### PR DESCRIPTION
## Summary

The "Shares for this note" dialog (opened from a note via the share indicator) showed less information, and behaved differently, than the Shares section's detail panel for the same kind of data. This brings the per-share card to parity while keeping its compact list layout (scope chosen interactively: data + action parity, not a full per-card restyle).

- **Revoke affordance.** Swapped the red trash icon - which reads as a recoverable delete - for `Link2Off`, and gated it behind a confirm dialog. Revoking a public link is permanent, so this matches the panel (which already confirms) and closes a "permanent destructive action with no confirmation" gap.
- **Freshness badge.** Added the panel's "note changed since shared" hint, via a new presentational `SnapshotStaleBadge` component (so the per-row check can live inside the dialog's `{#each}`). It reads the live note from IndexedDB only to compare `updated_at` against the snapshot's `shared_at` - no server call, fully ZK-safe; a trashed/absent note yields no badge.
- **Decryption-key warning.** Shown under the expanded link, as in the panel.
- **Data parity.** Title falls back to `display_name`; expiry shows the relative `(in N days)` / `(Expired)`; opens show `(no limit)` when uncapped.
- **Affordance.** Pointer cursor on the show/hide-link toggle.

No new i18n keys - this reuses the panel's existing strings, verified present across all 5 locales.

The detail panel keeps its own inline staleness logic for now, to avoid touching the still-open share-detail PR; it can adopt `SnapshotStaleBadge` in a later DRY pass.

## Test plan

- Open a note that has at least one active share -> note header share indicator -> "Shares for this note".
- Card shows: title (display_name when set), the "note changed since shared" badge if you edit the note after sharing, expiry with a relative suffix, opens with "(no limit)" for an uncapped link.
- "Show link" -> URL plus the decryption-key warning; cursor is a pointer over the toggle.
- Revoke (unlink icon) -> a confirm dialog appears; confirming removes the link, cancelling leaves it.
- Cross-check side by side with the Shares section detail panel for the same share - the signals should read consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)