### PR TITLE
fix(notes): unify mobile note-list header into a compact app-bar

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -652,9 +652,9 @@
 
   // Row 2 (count + actions, selection toolbar) always uses the prominent
   // sizing on mobile so the tap targets/icons match drill-in views like
-  // Favorites/Trash/Folder. Row 1 (title) still follows `prominentHeader`.
+  // Favorites/Trash/Folder. On mobile it sits mt-2 below the app-bar instead of
+  // owning a fixed-height band. Row 1 (title) still follows `prominentHeader`.
   const rowTwoProminent = $derived(prominentHeader || isMobileQuery.value);
-  const rowTwoHeight = $derived(rowTwoProminent ? 'h-14' : 'h-10');
   const rowTwoBtnClass = $derived(rowTwoProminent ? 'h-11 w-11' : 'h-9 w-9');
   const rowTwoIconClass = $derived(rowTwoProminent ? 'h-5 w-5' : 'h-4 w-4');
 
@@ -726,9 +726,9 @@
          also takes the iOS notch inset; min-h grows by the same amount so the
          content keeps its full 3.5rem box (env() is 0 elsewhere). -->
     <div
-      class="flex shrink-0 items-center gap-1 {prominentHeader
-        ? 'min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] pt-[env(safe-area-inset-top,0px)]'
-        : 'h-10'} {onback ? 'px-3' : 'px-5'}"
+      class="shrink-0 items-center gap-1 {prominentHeader
+        ? 'flex min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] px-4 pt-[env(safe-area-inset-top,0px)]'
+        : `hidden h-10 md:flex ${onback ? 'px-3' : 'px-5'}`}"
     >
       {#if onback}
         <button
@@ -755,12 +755,14 @@
           }}
           onblur={commitActiveFolderRename}
         />
+      {:else if prominentHeader}
+        <!-- Mobile app-bar title: single shared token across all views (logo
+             stands in for All Notes; see +page.svelte). -->
+        <h1 class="min-w-0 flex-1 truncate text-xl font-semibold tracking-tight">
+          {activeFolderName}
+        </h1>
       {:else}
-        <span
-          class="min-w-0 flex-1 truncate text-sm {prominentHeader
-            ? 'font-medium'
-            : 'font-normal'}">{activeFolderName}</span
-        >
+        <span class="min-w-0 flex-1 truncate text-sm font-normal">{activeFolderName}</span>
       {/if}
 
       {#if activeFolderSyncId && !editingActiveFolder}
@@ -820,7 +822,9 @@
     <!-- Row 2: count + per-list actions, swaps to selection toolbar in multi-select. -->
     {#if selectionMode}
       <div
-        class="flex shrink-0 items-center gap-1 {rowTwoHeight} {onback ? 'px-3' : 'px-5'}"
+        class="flex shrink-0 items-center gap-1 {rowTwoProminent
+          ? 'mt-2 px-4'
+          : `h-10 ${onback ? 'px-3' : 'px-5'}`}"
         role="toolbar"
         aria-label={$t('notes.multiselect.count', { values: { count: selectedIds.size } })}
       >
@@ -919,7 +923,9 @@
       </div>
     {:else}
       <div
-        class="flex {rowTwoHeight} shrink-0 items-center gap-1 pl-5 {onback ? 'pr-3' : 'pr-5'}"
+        class="flex shrink-0 items-center gap-1 {rowTwoProminent
+          ? 'mt-2 px-4'
+          : `h-10 pl-5 ${onback ? 'pr-3' : 'pr-5'}`}"
       >
         <span class="min-w-0 flex-1 truncate text-xs text-muted-foreground">
           {$t('notes.notes_count', { values: { count: $notesStore.length } })}
@@ -974,8 +980,11 @@
        (cleanTrash(30) in hooks.client.ts). Pinned above the list so the policy
        is visible whether trash is full or empty. -->
   {#if isTrash}
+    <!-- Mobile keeps the lineless header system (no border); desktop retains its
+         existing divider via md:border-b. py-2 + the list's py-1 gives the same
+         info-bar -> first card rhythm as search -> first card elsewhere. -->
     <div
-      class="flex items-start gap-1.5 border-b px-4 py-2 text-[11px] leading-snug text-muted-foreground"
+      class="flex items-start gap-1.5 px-4 py-2 text-[11px] leading-snug text-muted-foreground md:border-b"
     >
       <Info class="mt-px h-3.5 w-3.5 shrink-0" />
       <span>{$t('trash.auto_delete_notice', { values: { days: 30 } })}</span>

--- a/apps/reborn-notes/src/lib/components/notes/NoteListSearchBar.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListSearchBar.svelte
@@ -31,7 +31,9 @@
   }
 </script>
 
-<div class="shrink-0 px-3 pb-2 {searchOnly ? 'pt-3' : ''}">
+<!-- Mobile: px-4 + mt-2 places search in the unified app-bar/meta spacing rhythm;
+     desktop keeps the previous compact px-3 with no top margin via md:. -->
+<div class="shrink-0 px-4 pb-2 md:px-3 {searchOnly ? 'pt-3' : 'mt-2 md:mt-0'}">
   <div class="relative">
     <Search class="absolute left-2.5 top-1/2 h-4 w-4 md:h-3.5 md:w-3.5 -translate-y-1/2 text-muted-foreground" />
     <input

--- a/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
@@ -101,18 +101,21 @@
        search. Row 1 grows by the iOS notch inset on mobile (where this list owns
        the panel header) and is compact h-10 on desktop. -->
   <div
-    class="flex shrink-0 items-center gap-1 px-5
+    class="flex shrink-0 items-center gap-1 px-4 md:px-5
            min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] pt-[env(safe-area-inset-top,0px)]
            md:min-h-0 md:h-10 md:pt-0"
   >
-    <span class="min-w-0 flex-1 truncate text-sm font-medium md:font-normal">
+    <h1
+      class="min-w-0 flex-1 truncate text-xl font-semibold tracking-tight md:text-sm md:font-normal md:tracking-normal"
+    >
       {$t('share.list.title')}
-    </span>
+    </h1>
   </div>
 
-  <!-- Row 2: count + sort + refresh. Prominent sizing on mobile (h-14 / h-11),
-       compact on desktop (h-10 / h-9) - same tap targets as NoteList's row 2. -->
-  <div class="flex h-14 md:h-10 shrink-0 items-center gap-1 pl-5 pr-5">
+  <!-- Row 2 (meta): count + sort + refresh. Mobile sits mt-2 below the app-bar
+       (h-11 tap targets define its height); desktop stays the compact h-10 / h-9
+       band - same rhythm as NoteList's meta row. -->
+  <div class="flex shrink-0 items-center gap-1 mt-2 px-4 md:mt-0 md:h-10 md:px-5">
     <span class="min-w-0 flex-1 truncate text-xs text-muted-foreground">
       {$t('share.list.count', { values: { count: rows.length } })}
     </span>
@@ -162,8 +165,8 @@
     </button>
   </div>
 
-  <!-- Search (matches NoteListSearchBar) -->
-  <div class="shrink-0 px-3 pb-2">
+  <!-- Search (matches NoteListSearchBar): mobile px-4 + mt-2, desktop px-3. -->
+  <div class="shrink-0 px-4 pb-2 md:px-3 mt-2 md:mt-0">
     <div class="relative">
       <Search
         class="absolute left-2.5 top-1/2 h-4 w-4 md:h-3.5 md:w-3.5 -translate-y-1/2 text-muted-foreground"

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -1973,7 +1973,10 @@
                  keeps its full 3.5rem box and stays vertically centered
                  (env() is 0 elsewhere) -->
             <div
-              class="flex min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] shrink-0 items-center gap-1 border-b border-sidebar-border px-3 pt-[env(safe-area-inset-top,0px)]"
+              class="flex min-h-[calc(3.5rem+env(safe-area-inset-top,0px))] shrink-0 items-center gap-1 px-3 pt-[env(safe-area-inset-top,0px)] {activeSection ===
+                'all' || activeSection === 'search'
+                ? ''
+                : 'border-b border-sidebar-border'}"
             >
               {#if mobileView === 'folder-tree' || mobileView === 'tag-list'}
                 <button
@@ -2055,7 +2058,9 @@
                   {activeFolderName}
                 </span>
               {:else if activeSection === 'all' || activeSection === 'search'}
-                <span class="px-2">
+                <!-- px-1 inside the px-3 bar lands the logo at the same 16px inset
+                     as the px-4 title/meta rows in NoteList (unified app-bar). -->
+                <span class="px-1">
                   <img
                     src="{base}/logo-black.svg"
                     alt="re/notes"


### PR DESCRIPTION
## Summary

Unifies the note-list sidebar header on **mobile (`<md`) only** into one
consistent, lineless app-bar across all list views (All Notes, Starred,
Journal, Active shares, Trash). The desktop layout is unchanged.

- **One h-14 app-bar for every view.** All Notes keeps the re/notes logo;
  the other views render a single shared title token
  (`text-xl font-semibold tracking-tight` `<h1>`). Per-view actions
  (Journal's `+` / kebab) live in the app-bar's right slot; views with no
  actions keep the same h-14 height, so all headers line up.
- **No more redundant "All Notes" subtitle on mobile** - the logo *is* the
  header. The subtitle still renders on desktop.
- **Meta row** (`X notes` / `X shares` + checklist / sort / refresh, and
  `Empty Trash` for Trash) now sits `mt-2` under the app-bar instead of
  owning a fixed-height band. `Empty Trash` stays in the meta row, not the
  app-bar.
- **Search** moves to `mt-2` under the meta row.
- **Lineless header zone.** Removed the border under the All Notes logo and
  the full-width divider under the Trash retention notice on mobile (both
  retained on desktop via `md:`). The Trash notice stays as muted
  `text-[11px]` with an info icon; its spacing to the first card matches the
  search-to-first-card rhythm of the other views.

Touched: `NoteList.svelte`, `NoteListSearchBar.svelte`, `SharesList.svelte`,
`+page.svelte` (mobile wrapper logo header). No data/control logic changed -
layout, conditional logo-vs-title rendering, and separator removal only. No
new i18n keys. `svelte-check` and `eslint` are clean.

## Notes for review

- **Scope of the shared title token.** The brief named five views; I applied
  the same `text-xl/font-semibold` `<h1>` token to the folder/tag drill-in
  headers too, since they share `NoteList`'s row 1 - this keeps every mobile
  list view visually consistent. Easy to scope back to just the five if you
  want drill-in titles to differ.
- **Logo alignment.** Nudged the mobile logo inset from `px-2` to `px-1` so it
  lands at the same 16px (`px-4`) inset as the titles and meta rows.
- **Where the height is reclaimed.** The clear ~40px reclaim is on **All
  Notes** (redundant subtitle dropped). Starred / Trash / Journal / Active
  shares already used a single prominent title row, so their app-bar stays at
  the spec'd `h-14` - the win there is the de-floated big title, the lineless
  spacing, and consistent heights rather than a large pixel drop. If you want
  those even shorter we'd have to revisit the `h-14` token (flagging since the
  brief pinned it).

## Test plan

Smoke at a ~380px viewport (desktop regression at `>=768px`):

- [x] **All Notes**: logo header, no border under it, no "All Notes" subtitle;
      meta row (count + checklist + sort) sits just below; search below that.
- [x] **Starred / Journal**: big `<h1>` title in the app-bar (Journal shows
      `+` and kebab on the right); meta row + search below. App-bar height
      matches All Notes.
- [x] **Active shares**: `<h1>` title app-bar; meta row = count + sort +
      refresh; search below.
- [x] **Trash**: `<h1>` title app-bar; meta row = count + checklist +
      `Empty Trash` (red, trash icon); the retention notice shows as muted
      text with an info icon under search, **no** full-width line; first card
      starts at the same rhythm as other views.
- [x] All five app-bars are the same height; no empty band under any title.
- [x] **Desktop**: logo + per-view subtitle + meta + existing dividers all
      look exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)