### PR TITLE
feat(notes): show snapshot rank and date in active shares list

### DIFF
--- a/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/SharesList.svelte
@@ -13,9 +13,10 @@
   import type { OwnShareListItem } from '@reborn/types';
 
   // One row per active share LINK (flat list). A note shared more than once shows
-  // one row per link, distinguished by expiry / opens and an "N links" pill -
-  // matches the rail badge (which counts links) and avoids the snapshot-divergence
-  // ambiguity of grouping by note (each link is its own point-in-time snapshot).
+  // one row per snapshot, distinguished by its creation date and a "k/n" ordinal
+  // pill ("snapshot k of n for this note"). k is the snapshot's 1-based position
+  // by created_at (stable across list re-sorts); n is the note's total active
+  // snapshot count - so two rows with the same title are no longer ambiguous.
   type ShareSort = 'created' | 'expires' | 'opens' | 'title';
 
   let searchInput = $state('');
@@ -75,17 +76,41 @@
     }
   }
 
+  // Full date + time - matches ShareDetailPanel's "Created" field. Used as the
+  // row tooltip so the compact date-only label still exposes the exact moment.
+  function formatDateTime(iso: string | null): string {
+    if (!iso) return '-';
+    try {
+      return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+    } catch {
+      return iso;
+    }
+  }
+
   function formatOpens(s: OwnShareListItem): string {
     return s.max_access_count !== null
       ? `${s.access_count} / ${s.max_access_count}`
       : String(s.access_count);
   }
 
-  // Number of active links pointing at the same source note (>1 => show a pill).
-  function linkCountFor(s: OwnShareListItem): number {
+  // Ordinal position of this snapshot among all active shares of the same source
+  // note: k = 1-based rank by created_at (oldest = 1), n = total snapshots for the
+  // note (same source as the former "N links" pill - presentation change only).
+  // k is derived from created_at alone, NOT the list's current sort, so badge
+  // numbers stay stable when the user re-sorts; id breaks created_at ties so every
+  // sibling keeps a distinct, stable k.
+  function snapshotRankFor(s: OwnShareListItem): { k: number; n: number } {
     const src = decoded[s.id]?.payload.source_id;
-    if (!src) return 1;
-    return $sharesBySourceId.get(src)?.length ?? 1;
+    const siblings = src ? $sharesBySourceId.get(src) : undefined;
+    const n = siblings?.length ?? 1;
+    if (!siblings || n < 2) return { k: 1, n };
+    const ordered = [...siblings].sort((a, b) => {
+      const da = new Date(a.created_at).getTime();
+      const db = new Date(b.created_at).getTime();
+      return da !== db ? da - db : a.id.localeCompare(b.id);
+    });
+    const k = ordered.findIndex((x) => x.id === s.id) + 1;
+    return { k: k || 1, n };
   }
 
   const SORT_OPTIONS: { value: ShareSort; label: string }[] = $derived([
@@ -217,7 +242,7 @@
         {#each rows as share (share.id)}
           {@const title = titleOf(share)}
           {@const expiringSoon = isExpiringSoon(share)}
-          {@const links = linkCountFor(share)}
+          {@const rank = snapshotRankFor(share)}
           {@const expRel = share.expires_at ? formatExpiryRelative(share.expires_at, $locale ?? 'en') : null}
           <li>
             <button
@@ -247,6 +272,10 @@
                       <Clock class="h-3 w-3" />{$t('share.list.expiring_soon')}
                     </span>
                   {/if}
+                  <span title={formatDateTime(share.created_at)}
+                    >{$t('share.list.column.created')}: {formatDate(share.created_at)}</span
+                  >
+                  <span aria-hidden="true">·</span>
                   <span
                     >{$t('share.list.column.expires')}: {share.expires_at
                       ? formatDate(share.expires_at)
@@ -254,11 +283,16 @@
                   >
                   <span aria-hidden="true">·</span>
                   <span>{$t('share.list.column.access_count')}: {formatOpens(share)}</span>
-                  {#if links > 1}
+                  {#if rank.n > 1}
+                    {@const rankLabel = $t('share.list.snapshot_rank_label', {
+                      values: { k: rank.k, n: rank.n }
+                    })}
                     <span
                       class="rounded-full border bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                      title={rankLabel}
+                      aria-label={rankLabel}
                     >
-                      {$t('share.list.links_badge', { values: { count: links } })}
+                      {rank.k}/{rank.n}
                     </span>
                   {/if}
                 </div>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1426,7 +1426,7 @@
       "search_no_match": "Keine Freigabe entspricht deiner Suche.",
       "select_hint": "Wähle eine Freigabe, um Details und Vorschau anzuzeigen.",
       "expiring_soon": "Läuft bald ab",
-      "links_badge": "{count, plural, one {1 Link} other {# Links}}",
+      "snapshot_rank_label": "Snapshot {k} von {n} für diese Notiz",
       "sort_label": "Sortieren",
       "sort": {
         "created": "Neueste zuerst",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1426,7 +1426,7 @@
       "search_no_match": "No shares match your search.",
       "select_hint": "Select a share to view its details and preview.",
       "expiring_soon": "Expiring soon",
-      "links_badge": "{count, plural, one {1 link} other {# links}}",
+      "snapshot_rank_label": "Snapshot {k} of {n} for this note",
       "sort_label": "Sort",
       "sort": {
         "created": "Newest first",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1426,7 +1426,7 @@
       "search_no_match": "Ningún enlace coincide con tu búsqueda.",
       "select_hint": "Selecciona un enlace para ver sus detalles y la vista previa.",
       "expiring_soon": "Caduca pronto",
-      "links_badge": "{count, plural, one {1 enlace} other {# enlaces}}",
+      "snapshot_rank_label": "Snapshot {k} de {n} para esta nota",
       "sort_label": "Ordenar",
       "sort": {
         "created": "Más recientes",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1426,7 +1426,7 @@
       "search_no_match": "Aucun partage ne correspond à votre recherche.",
       "select_hint": "Sélectionnez un partage pour voir ses détails et son aperçu.",
       "expiring_soon": "Expire bientôt",
-      "links_badge": "{count, plural, one {1 lien} other {# liens}}",
+      "snapshot_rank_label": "Snapshot {k} sur {n} pour cette note",
       "sort_label": "Trier",
       "sort": {
         "created": "Plus récents",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1426,7 +1426,7 @@
       "search_no_match": "Brak udostępnień pasujących do wyszukiwania.",
       "select_hint": "Wybierz udostępnienie, aby zobaczyć szczegóły i podgląd.",
       "expiring_soon": "Wkrótce wygasa",
-      "links_badge": "{count, plural, one {1 link} few {# linki} many {# linków} other {# linku}}",
+      "snapshot_rank_label": "Snapshot {k} z {n} dla tej notatki",
       "sort_label": "Sortuj",
       "sort": {
         "created": "Najnowsze",


### PR DESCRIPTION
## Summary

The Active shares list shows one row per snapshot (each link is its own point-in-time snapshot), and a note can be shared several times. The old `N links` badge read as if *that row* had N links and did nothing to tell apart two rows with the same note title. This swaps it for an ordinal indicator plus a per-row creation date.

- **Badge is now `k/n`** - `k` = this snapshot's 1-based position among the note's active snapshots ordered by creation date (oldest = 1), `n` = total active snapshots for the note. Rendered only when `n >= 2` (single shares show no badge, unchanged).
- **`n` keeps the exact same count source** as the old pill (`sharesBySourceId.get(source_id).length`) - this is a presentation change only, the counting logic is untouched.
- **`k` is computed from `created_at` alone**, independent of the list's current sort - so re-sorting the list (Newest / Expiring / Most opened / Title) never changes the badge numbers. `created_at` ties fall back to `id` so each sibling keeps a distinct, stable `k`.
- **Each row now shows the snapshot creation date.** Compact inline form is date-only (matching the adjacent `Expires` rhythm); the full date + time sits in the tooltip, matching `ShareDetailPanel`'s `Created` field and reusing the existing locale-aware formatting.
- **Badge tooltip + aria-label** expand to `Snapshot k of n for this note`, translated in all five locales. The now-unused `share.list.links_badge` key is replaced by `share.list.snapshot_rank_label` (uses the locale's established `snapshot`/`note` terms). i18n parity passes.

Scope: `SharesList.svelte` (Active shares sidebar) only. The per-note `ManageSharesDialog` is out of scope (it is already scoped to a single note). No schema / API / server-visibility change - `k` is read from the already-decrypted payload client-side, so no Zero-Knowledge impact.

One choice worth a glance at review: the inline date is **date-only with the full timestamp in the tooltip** (keeps the row compact and consistent with `Expires`); the `k/n` badge is the primary disambiguator, the date is secondary context.

## Test plan

Gates run locally (all green): `svelte-check` (0 errors / 0 warnings), ESLint on the changed component, `check-i18n-parity.mjs --namespace=notes`.

Smoke (Active shares panel, re/notes):
- A note shared once -> **no badge** (unchanged).
- A note shared twice -> rows show **`1/2`** and **`2/2`** by creation date; each row shows its own creation date.
- Change the list sort -> **badge numbers do not change**; row order does.
- Create another share of an already-shared note -> the new row gets the **highest** number (`k = n`), existing rows keep their `k`, denominator grows (e.g. `1/2` -> `1/3`).
- Revoke one snapshot -> remaining rows **renumber continuously** `1..n` by date.
- Hover the badge -> tooltip `Snapshot k of n for this note`; hover the date -> full date + time.
- Spot-check the tooltip copy in PL / DE / FR / ES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)