### PR TITLE
fix(ui): use pointer cursor on dropdown items and share-detail buttons

### DIFF
--- a/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
+++ b/apps/reborn-notes/src/lib/components/shares/ShareDetailPanel.svelte
@@ -209,7 +209,7 @@
     <button
       type="button"
       onclick={close}
-      class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground
+      class="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground
              transition-colors hover:bg-accent hover:text-foreground"
       aria-label={$t('nav.back')}
     >
@@ -234,7 +234,7 @@
       <button
         type="button"
         onclick={copyUrl}
-        class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-sm
+        class="inline-flex h-9 shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2.5 text-sm
                text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         aria-label={$t('share.create.copy_link')}
       >
@@ -251,7 +251,7 @@
               type="button"
               title={$t('share.list.column.actions')}
               aria-label={$t('share.list.column.actions')}
-              class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground
+              class="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground
                      transition-colors hover:bg-accent hover:text-foreground"
             >
               <Ellipsis class="h-5 w-5" />
@@ -330,7 +330,7 @@
               <button
                 type="button"
                 onclick={copyUrl}
-                class="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-md border
+                class="absolute right-2 top-2 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border
                        bg-background text-muted-foreground opacity-70 transition hover:text-foreground hover:opacity-100"
                 aria-label={$t('share.create.copy_link')}
                 title={$t('share.create.copy_link')}

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -23,7 +23,7 @@
 	bind:indeterminate
 	data-slot="dropdown-menu-checkbox-item"
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-pointer select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className
 	)}
 	{...restProps}

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-item.svelte
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-item.svelte
@@ -20,7 +20,7 @@
   data-inset={inset}
   data-variant={variant}
   class={cn(
-    "data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-highlighted:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2.5 sm:py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-highlighted:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-2.5 sm:py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     className
   )}
   {...restProps}

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="dropdown-menu-radio-item"
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-pointer select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className
 	)}
 	{...restProps}

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -19,7 +19,7 @@
 	data-slot="dropdown-menu-sub-trigger"
 	data-inset={inset}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground outline-hidden [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground outline-hidden [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
## Summary

Interactive elements showed the default arrow cursor on hover instead of a pointer, so they did not read as clickable. Reported in the Notes share-detail panel (copy-link icons + kebab menu options).

- **Shared `@reborn/ui` dropdown primitives** (`dropdown-menu-item`, `-checkbox-item`, `-radio-item`, `-sub-trigger`): shadcn ships these with `cursor-default` (native-desktop-menu convention). Switched to `cursor-pointer` so **every dropdown across both apps** (Notes + Task) matches the app's buttons, which already use pointer. Chosen over a panel-local fix (confirmed with @rerefu) to avoid a pointer/arrow split between the kebab and e.g. the sort menus.
- **Notes share detail panel** (`ShareDetailPanel.svelte`): added the missing `cursor-pointer` to the four raw icon buttons - back, header copy-link, kebab trigger, and the in-link-block copy button. Their siblings (show/hide link) already had it, so this just makes the panel internally consistent.

Purely cosmetic - a Tailwind cursor utility swap inside existing class strings. No logic, type, or API change. `@reborn/ui` is consumed from source (`exports` -> `src/index.ts`), so no package rebuild is needed.

## Test plan

Gates run locally (green): `svelte-check` on reborn-notes (0 errors / 0 warnings); ESLint on `ShareDetailPanel` (clean; the vendored shadcn dropdown files are excluded from lint by config).

Smoke (re/notes; restart/refresh dev server):
- Open a share in **Active shares -> detail**. Hover the **copy-link icon** in the header, the **kebab (⋯) trigger**, the **back** arrow, and the **copy icon inside the expanded link block** -> cursor is a **pointer**.
- Open the **kebab menu** and hover its options (Open source note / Export / Copy / Revoke) -> **pointer**.
- Spot-check other dropdowns still feel right: the **sort menu** in Active shares / note list, and any menu in **Task** -> **pointer** on items (global change), no visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)