### PR TITLE
fix(notes): show multiselect toolbar in search results

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -818,8 +818,14 @@
         />
       {/if}
     </div>
+    {@render listToolbar()}
+  {/if}
 
-    <!-- Row 2: count + per-list actions, swaps to selection toolbar in multi-select. -->
+  <!-- Row 2: count + per-list actions; swaps to the selection toolbar in
+       multi-select. Folder/all views render it under the title (above); the
+       dedicated search view renders it under the search box so bulk actions
+       (move/pin/star/delete) reach search results too (#374). -->
+  {#snippet listToolbar()}
     {#if selectionMode}
       <div
         class="flex shrink-0 items-center gap-1 {rowTwoProminent
@@ -964,7 +970,7 @@
         {/if}
       </div>
     {/if}
-  {/if}
+  {/snippet}
 
   <!-- Search bar. No save affordance in trash: the trash bucket has no query
        operator, so a saved view could never reproduce a trash-scoped result. -->
@@ -975,6 +981,13 @@
     {searchOnly}
     onsavesearch={isTrash ? undefined : () => (saveSearchDialogOpen = true)}
   />
+
+  <!-- Search view has no panel header, so the count + selection toolbar ride
+       under the search box instead. Gated on results (or an active selection)
+       so an empty search stays clean. -->
+  {#if searchOnly && ($notesStore.length > 0 || selectionMode)}
+    {@render listToolbar()}
+  {/if}
 
   <!-- Trash retention notice: trashed notes are auto-purged after 30 days
        (cleanTrash(30) in hooks.client.ts). Pinned above the list so the policy


### PR DESCRIPTION
## Summary

Multiselect (the "N selected" toolbar with move / pin / star / delete) was
unreachable in the **Search** view. The selection toolbar and its entry button
lived inside the panel header, which `searchOnly` hides - so Folder and All
Notes had it, but Search didn't, even though every `NoteListItem` already
received the selection props.

- Extracted the count / selection row into a `listToolbar` snippet.
- Folder / All Notes: unchanged (still rendered under the title).
- Search: now rendered **under the search box**, gated on `results > 0 || selectionMode` so an empty search stays clean.

This unblocks the `no:folder` -> multiselect -> **Move to folder** workflow for
organising notes that aren't in any folder (motivates #374).

## Test plan

- Search (desktop + mobile): run a query such as `no:folder` -> tap the multiselect icon -> select notes -> **Move to folder**; also try pin / star / delete.
- Empty search (no query / no results): no toolbar row, just the search box.
- Folder / All Notes: unchanged, toolbar still sits under the title.
- Mobile long-press to enter selection in search now shows the toolbar (previously it flipped state but stayed hidden).
- Leaving Search exits selection mode (no stale selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)