### PR TITLE
fix(notes): restore last folder when entering Folders view

### DIFF
--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -707,10 +707,28 @@
   // non-periodic analogue of how handlePeriodic lets periodic sections keep their
   // freshly-opened note. Currently armed by "Open source note" from a share.
   let pendingOpenNoteId: string | null = null;
+
+  /**
+   * #384: entering the Folders section on desktop should land on a folder, not
+   * an empty pane. Prefer the last folder visited this session; if it was since
+   * deleted (or there is none yet), fall back to the first top-level folder;
+   * with no folders at all, stay unscoped (undefined) so the create/empty state
+   * shows. Session-scoped by design - it rides on `lastVisitedFolderId`, which
+   * is ephemeral and resets on reload.
+   */
+  function resolveFoldersEntryFolderId(): string | undefined {
+    if (
+      lastVisitedFolderId &&
+      flattenFolderTree($foldersStore).some((f) => f.id === lastVisitedFolderId)
+    ) {
+      return lastVisitedFolderId;
+    }
+    return $foldersStore[0]?.id;
+  }
+
   $effect(() => {
     const section = activeSection;
     const sectionUsesFolderId = section === 'folders' || isPeriodicSection(section);
-    const folderId = sectionUsesFolderId ? activeFolderId : undefined;
     const tagId = activeSection === 'tags' ? activeTagId : null;
 
     if (section !== prevSection) {
@@ -718,11 +736,24 @@
         // Reset mobile history stack when switching sections via IconNav
         if (isMobile) resetMobileHistory();
 
-        // Only periodic transitions arrive with an already-set activeFolderId
-        // (handlePeriodic sets it in the same batch). Clearing for everything else
-        // covers folders→folders is impossible (no transition), periodic→folders
-        // (must drop the periodic folder id), and any→all/starred/etc.
-        if (!isPeriodicSection(section)) activeFolderId = undefined;
+        // Entering a section resets the folder scope, with two exceptions.
+        // Periodic transitions arrive with activeFolderId already set
+        // (handlePeriodic, same batch), so they keep it. Entering Folders on
+        // desktop restores the last folder visited this session (fallback: first
+        // folder) so the main pane isn't an empty dead-end (#384); mobile keeps
+        // showing the folder tree, so it still clears. Everything else
+        // (all/starred/tags/...) clears to undefined.
+        //
+        // Note creation reads the store's currentFolderId (set by setFolder
+        // below), not activeFolderId directly - and every non-Folders section
+        // clears it - so a restored folder never leaks into notes made elsewhere.
+        if (isPeriodicSection(section)) {
+          // keep handlePeriodic's folder id
+        } else if (section === 'folders' && !isMobile) {
+          activeFolderId = resolveFoldersEntryFolderId();
+        } else {
+          activeFolderId = undefined;
+        }
         if (section !== 'tags') {
           activeTagId = null;
           tagManager.resetSection();
@@ -753,7 +784,11 @@
       prevSection = section;
     }
 
-    // untrack: store updates are write-only side effects —
+    // Read after the section-change reset above, so a restored Folders-entry id
+    // (#384) reaches the notes filter (setFolder) in this same pass.
+    const folderId = sectionUsesFolderId ? activeFolderId : undefined;
+
+    // untrack: store updates are write-only side effects -
     // this effect should only react to section/folder/tag changes, not store internals.
     untrack(() => {
       if (section === 'trash') {


### PR DESCRIPTION
## Summary

Entering the **Folders** section reset `activeFolderId` to `undefined`. On
desktop that made the main pane fall through to the empty "Select or create"
state - a dead-end with nothing to act on until you manually picked a folder
(#384).

- On **desktop**, entering Folders now restores the **last folder visited this session** (validated against the tree; falls back to the first folder, or stays unscoped when there are no folders). `showNoteListInMain` then renders that folder's notes right away.
- **Mobile** is unchanged: it still shows the full-screen folder tree (tap to drill), so the restore is gated on `\!isMobile`.
- Session-scoped by design - it rides on the existing `lastVisitedFolderId`, which resets on reload.

### Why note creation is safe

A restored `activeFolderId` does **not** leak into notes created elsewhere:
`createEphemeralNote()` resolves the target folder from the store's
`currentFolderId` (set by `setFolder`), not from `activeFolderId`, and **every
non-Folders section resets `currentFolderId` to `undefined`**. So a note made
from All Notes / Starred / Tags / Trash stays unfiled.

## Test plan

- Desktop: open folder X -> go to All Notes (or Search) -> click the Folders rail icon again -> lands back in folder X with its notes (no empty pane).
- Desktop, fresh session (no folder visited yet): entering Folders selects the first folder; with no folders at all, shows the create/empty state.
- Desktop: visit folder X, delete it, then re-enter Folders -> falls back to the first folder (no stale selection).
- New note from All Notes / Starred / Tags / Trash -> still unfiled (no folder), even right after visiting a folder.
- New note while inside folder X -> goes to X (unchanged).
- Mobile: Folders icon still opens the folder tree (tap to drill), no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)