### PR TITLE
feat(notes): pin saved searches to top level as smart folders

### DIFF
--- a/apps/reborn-notes/src/lib/components/notes/MoveToFolderMenu.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/MoveToFolderMenu.svelte
@@ -5,6 +5,7 @@
     ChevronRight,
     Folder as FolderIcon,
     Search,
+    SearchCheck,
     Check,
     FileText,
     X
@@ -25,16 +26,26 @@
    * Move target — single note keeps the "already here" disabled state and auto-navigates
    * to the parent of the current folder on open; multi-note skips both (selected notes
    * may span folders, and there's no single "current folder" to compare against).
+   *
+   * `currentPinnedToRoot` is only meaningful in pin mode (saved searches): it lets the
+   * picker show the top-level pin as the current state and disable the redundant actions.
    */
   export type MoveSelection =
-    | { kind: 'single'; id: string; currentFolderId: string | null }
+    | {
+        kind: 'single';
+        id: string;
+        currentFolderId: string | null;
+        currentPinnedToRoot?: boolean;
+      }
     | { kind: 'multi'; count: number };
 
   let {
     selection,
     open = $bindable(false),
     forceSheet = false,
+    mode = 'move',
     onmove,
+    onpinroot,
     onclose
   }: {
     selection: MoveSelection | null;
@@ -42,12 +53,22 @@
     /** Force the bottom-sheet variant on desktop too — used by bulk move which has no
      *  anchoring button for the absolute desktop popup. */
     forceSheet?: boolean;
+    /** `'pin'` repurposes the picker for parking a saved search (smart folder): the
+     *  title becomes "Pin to folder", a "Pin to top level" action appears, and the
+     *  "No folder" row becomes "Don't pin". Default `'move'` keeps note-move wording. */
+    mode?: 'move' | 'pin';
     onmove: (folderId: string | null, e?: Event) => void;
+    /** Pin mode only: pin the saved search to the top level (root smart folder). */
+    onpinroot?: () => void;
     onclose?: () => void;
   } = $props();
 
   const isMobileQuery = useIsMobile();
   const useSheet = $derived(forceSheet || isMobileQuery.value);
+  const isPin = $derived(mode === 'pin');
+  const pickerTitle = $derived(
+    isPin ? $t('saved_searches.pin_picker_title') : $t('notes.move_to')
+  );
 
   let currentParentId = $state<string | null>(null);
   let searchQuery = $state('');
@@ -73,6 +94,16 @@
   // different folders, so no single folder can be highlighted as "current".
   const currentFolderId = $derived(
     selection?.kind === 'single' ? selection.currentFolderId : null
+  );
+  // Pin mode only: is the saved search currently pinned to the top level?
+  const currentRoot = $derived(
+    selection?.kind === 'single' ? !!selection.currentPinnedToRoot : false
+  );
+  // The "No folder" / "Don't pin" row reflects the current state. In move mode that's
+  // "note has no folder"; in pin mode it's "search is not pinned anywhere" (neither a
+  // folder nor the top level), so a folder- or root-pinned search keeps it actionable.
+  const noneIsCurrent = $derived(
+    isPin ? currentFolderId === null && !currentRoot : currentFolderId === null
   );
 
   // Auto-navigate to the parent of the note's current folder when opened (single mode only).
@@ -123,12 +154,29 @@
 
   function doMove(folderId: string | null, e?: Event) {
     if (!selection) return;
-    if (selection.kind === 'single' && folderId === (selection.currentFolderId ?? null)) {
+    // The "already here" no-op only maps cleanly to move mode, where pin state is
+    // fully captured by folder_id. In pin mode the disabled states guard redundancy.
+    if (
+      mode === 'move' &&
+      selection.kind === 'single' &&
+      folderId === (selection.currentFolderId ?? null)
+    ) {
       // no-op: already in this folder
       closeMenu();
       return;
     }
     onmove(folderId, e);
+    closeMenu();
+  }
+
+  function doPinRoot(e?: Event) {
+    e?.stopPropagation();
+    if (currentRoot) {
+      // no-op: already pinned to the top level
+      closeMenu();
+      return;
+    }
+    onpinroot?.();
     closeMenu();
   }
 
@@ -227,21 +275,41 @@
       </div>
     {/if}
 
-    <!-- Primary action row: "No folder" at root, "Move here" otherwise -->
-    <div class="mt-2 px-2">
+    <!-- Primary action row: "No folder"/"Don't pin" at root, "Move/Pin here" otherwise -->
+    <div class="mt-2 space-y-1 px-2">
       {#if isRoot}
+        {#if isPin}
+          <!-- Pin to top level (smart folder) - pin mode only -->
+          <button
+            type="button"
+            role="menuitem"
+            class="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-accent disabled:cursor-default disabled:hover:bg-transparent
+              {currentRoot ? 'text-muted-foreground' : 'text-foreground'}"
+            onclick={doPinRoot}
+            disabled={currentRoot}
+            aria-current={currentRoot ? 'true' : undefined}
+          >
+            <SearchCheck class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span class="min-w-0 flex-1 truncate">{$t('saved_searches.pin_to_top_level')}</span>
+            {#if currentRoot}
+              <Check class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            {/if}
+          </button>
+        {/if}
         <button
           type="button"
           role="menuitem"
           class="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-accent disabled:cursor-default disabled:hover:bg-transparent
-            {currentFolderId === null ? 'text-muted-foreground' : 'text-foreground'}"
+            {noneIsCurrent ? 'text-muted-foreground' : 'text-foreground'}"
           onclick={(e) => doMove(null, e)}
-          disabled={currentFolderId === null}
-          aria-current={currentFolderId === null ? 'true' : undefined}
+          disabled={noneIsCurrent}
+          aria-current={noneIsCurrent ? 'true' : undefined}
         >
           <FileText class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <span class="min-w-0 flex-1 truncate">{$t('notes.no_folder')}</span>
-          {#if currentFolderId === null}
+          <span class="min-w-0 flex-1 truncate">
+            {isPin ? $t('saved_searches.dont_pin') : $t('notes.no_folder')}
+          </span>
+          {#if noneIsCurrent}
             <Check class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           {/if}
         </button>
@@ -256,7 +324,9 @@
           aria-current={currentFolderId === currentParentId ? 'true' : undefined}
         >
           <Check class="h-3.5 w-3.5 shrink-0" />
-          <span class="min-w-0 flex-1 truncate">{$t('notes.move_here')}</span>
+          <span class="min-w-0 flex-1 truncate">
+            {isPin ? $t('saved_searches.pin_here') : $t('notes.move_here')}
+          </span>
         </button>
       {/if}
     </div>
@@ -349,14 +419,14 @@
     class="absolute right-0 top-7 z-50 w-[300px] overflow-hidden rounded-md border bg-popover shadow-md"
     role="dialog"
     tabindex="-1"
-    aria-label={$t('notes.move_to')}
+    aria-label={pickerTitle}
     onkeydown={handleContainerKeydown}
     onclick={(e) => e.stopPropagation()}
   >
     <p
       class="border-b px-3 pb-1.5 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
     >
-      {$t('notes.move_to')}
+      {pickerTitle}
     </p>
     <div class="max-h-[min(60vh,26rem)] overflow-y-auto">
       {@render body()}
@@ -369,7 +439,7 @@
   <Sheet bind:open>
     <SheetContent side="bottom" class="flex h-auto max-h-[75dvh] flex-col p-0">
       <SheetHeader class="border-b px-4 py-3">
-        <SheetTitle class="text-left text-sm">{$t('notes.move_to')}</SheetTitle>
+        <SheetTitle class="text-left text-sm">{pickerTitle}</SheetTitle>
       </SheetHeader>
       <div class="flex-1 overflow-y-auto pb-4">
         {@render body()}

--- a/apps/reborn-notes/src/lib/components/notes/SavedSearchList.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/SavedSearchList.svelte
@@ -26,6 +26,12 @@
     await savedSearchesStore.move(movingSearch.id, folderId);
     movingSearch = null;
   }
+
+  async function handlePinRoot() {
+    if (!movingSearch) return;
+    await savedSearchesStore.pinToRoot(movingSearch.id);
+    movingSearch = null;
+  }
 </script>
 
 <div class="py-2">
@@ -41,10 +47,17 @@
 
 <MoveToFolderMenu
   selection={movingSearch
-    ? { kind: 'single', id: movingSearch.id, currentFolderId: movingSearch.folder_id ?? null }
+    ? {
+        kind: 'single',
+        id: movingSearch.id,
+        currentFolderId: movingSearch.folder_id ?? null,
+        currentPinnedToRoot: movingSearch.pinned_to_root
+      }
     : null}
   bind:open={moveOpen}
   forceSheet
+  mode="pin"
   onmove={(folderId) => handleMove(folderId)}
+  onpinroot={handlePinRoot}
   onclose={() => (movingSearch = null)}
 />

--- a/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
@@ -158,7 +158,7 @@
                 {$t('saved_searches.move_to_folder')}
               </DropdownMenuItem>
             {/if}
-            {#if search.folder_id}
+            {#if search.folder_id || search.pinned_to_root}
               <DropdownMenuItem onclick={unpark}>
                 <FolderX class="h-3.5 w-3.5" />
                 {$t('saved_searches.unpark')}
@@ -197,7 +197,7 @@
             {$t('saved_searches.move_to_folder')}
           </Button>
         {/if}
-        {#if search.folder_id}
+        {#if search.folder_id || search.pinned_to_root}
           <Button variant="ghost" class="w-full justify-start" onclick={() => unpark()}>
             <FolderX class="mr-2 h-4 w-4" />
             {$t('saved_searches.unpark')}

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -592,20 +592,11 @@
         {/if}
       </ContextMenu>
 
-      <!-- Children (recursive) + saved searches parked in this folder -->
+      <!-- Saved searches parked in this folder render ABOVE its subfolders -
+           same "searches before folders" rule as root-pin and the folder
+           drill-down view, and keeps a parked search visible without scrolling
+           past a deep subtree. -->
       {#if isExpanded && hasChildren}
-        {#if (folder.children?.length ?? 0) > 0}
-          <FolderTree
-            nodes={folder.children ?? []}
-            depth={depth + 1}
-            {activeFolderId}
-            {expandedIds}
-            {onselect}
-            {onnewnote}
-            {savedSearchesByFolder}
-            {onsavedsearchselect}
-          />
-        {/if}
         {#if parkedSearches.length > 0}
           <ul class="select-none" role="group">
             {#each parkedSearches as search (search.id)}
@@ -617,6 +608,18 @@
               />
             {/each}
           </ul>
+        {/if}
+        {#if (folder.children?.length ?? 0) > 0}
+          <FolderTree
+            nodes={folder.children ?? []}
+            depth={depth + 1}
+            {activeFolderId}
+            {expandedIds}
+            {onselect}
+            {onnewnote}
+            {savedSearchesByFolder}
+            {onsavedsearchselect}
+          />
         {/if}
       {/if}
     </li>

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -60,6 +60,7 @@
     onselect,
     onnewnote = undefined,
     savedSearchesByFolder = undefined,
+    rootPinnedSearches = undefined,
     onsavedsearchselect = undefined
   }: {
     nodes: FolderWithChildren[];
@@ -71,6 +72,9 @@
     onnewnote?: (folderId: string) => void;
     /** Saved searches parked per folder id - rendered as leaf nodes under the folder. */
     savedSearchesByFolder?: Map<string, SavedSearchDecrypted[]>;
+    /** Searches pinned to the top level (smart folders) - rendered above the folder
+     *  list at the root instance only (ignored for depth > 0). */
+    rootPinnedSearches?: SavedSearchDecrypted[];
     onsavedsearchselect?: (search: SavedSearchDecrypted) => void;
   } = $props();
 
@@ -421,6 +425,18 @@
         />
       </div>
     </li>
+  {/if}
+  <!-- Top-level smart folders (root-pinned saved searches) render above the folder
+       list. Root instance only; not a drop target (a leaf, not a real folder). -->
+  {#if depth === 0 && rootPinnedSearches && rootPinnedSearches.length > 0}
+    {#each rootPinnedSearches as search (search.id)}
+      <SavedSearchRow
+        {search}
+        context="tree"
+        depth={0}
+        onselect={(s) => onsavedsearchselect?.(s)}
+      />
+    {/each}
   {/if}
   {#each nodes as folder (folder.id)}
     {@const isExpanded = expandedIds.has(folder.id)}

--- a/apps/reborn-notes/src/lib/services/saved-search.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/saved-search.service.spec.ts
@@ -56,6 +56,7 @@ const {
   getAllSavedSearches,
   renameSavedSearch,
   moveSavedSearchToFolder,
+  pinSavedSearchToRoot,
   deleteSavedSearch
 } = await import('./saved-search.service');
 
@@ -110,8 +111,13 @@ describe('createSavedSearch', () => {
 
     const withContent = rows.find((r) => r.id === idOn)!;
     const titlesOnly = rows.find((r) => r.id === idOff)!;
-    expect(withContent.metadata_encrypted).toBe('encobj:{"search_in_content":true}');
-    expect(titlesOnly.metadata_encrypted).toBe('encobj:{"search_in_content":false}');
+    // New searches are never pinned, so the bundle carries pinned_to_root: false.
+    expect(withContent.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":true,"pinned_to_root":false}'
+    );
+    expect(titlesOnly.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":false,"pinned_to_root":false}'
+    );
   });
 
   it('rejects empty name or query', async () => {
@@ -146,6 +152,26 @@ describe('getAllSavedSearches', () => {
     expect(byId.get('off')).toBe(false);
     expect(byId.get('legacy')).toBe(false);
     expect(byId.get('corrupt')).toBe(false);
+  });
+
+  it('derives pinned_to_root from metadata, with folder_id winning over the flag', async () => {
+    seed({ id: 'root', metadata_encrypted: 'encobj:{"pinned_to_root":true}' });
+    // Both set (legacy/inconsistent row): folder-pin wins, never shown at root.
+    seed({
+      id: 'both',
+      folder_id: 'f1',
+      metadata_encrypted: 'encobj:{"pinned_to_root":true}'
+    });
+    seed({ id: 'plain' }); // no metadata
+    seed({ id: 'flag-false', metadata_encrypted: 'encobj:{"pinned_to_root":false}' });
+
+    const all = await getAllSavedSearches();
+    const byId = new Map(all.map((s) => [s.id, s.pinned_to_root]));
+
+    expect(byId.get('root')).toBe(true);
+    expect(byId.get('both')).toBe(false);
+    expect(byId.get('plain')).toBe(false);
+    expect(byId.get('flag-false')).toBe(false);
   });
 });
 
@@ -182,6 +208,79 @@ describe('moveSavedSearchToFolder', () => {
     const updated = rows.find((r) => r.id === 's-1')!;
     expect('folder_id' in updated).toBe(false);
     expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', { folder_id: null });
+  });
+
+  it('pinning to a folder clears an existing root-pin and pushes the new bundle', async () => {
+    seed({
+      id: 's-1',
+      metadata_encrypted: 'encobj:{"search_in_content":false,"pinned_to_root":true}'
+    });
+
+    await moveSavedSearchToFolder('s-1', 'folder-9');
+
+    const updated = rows.find((r) => r.id === 's-1')!;
+    expect(updated.folder_id).toBe('folder-9');
+    expect(updated.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":false,"pinned_to_root":false}'
+    );
+    expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', {
+      folder_id: 'folder-9',
+      metadata_encrypted: 'encobj:{"search_in_content":false,"pinned_to_root":false}'
+    });
+  });
+
+  it('does not re-encode metadata when the root flag is unchanged (folder-pin churn-free)', async () => {
+    seed({
+      id: 's-1',
+      metadata_encrypted: 'encobj:{"search_in_content":true,"pinned_to_root":false}'
+    });
+
+    await moveSavedSearchToFolder('s-1', 'folder-9');
+
+    const updated = rows.find((r) => r.id === 's-1')!;
+    // Bundle untouched, and metadata_encrypted stays out of the PATCH payload.
+    expect(updated.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":true,"pinned_to_root":false}'
+    );
+    expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', { folder_id: 'folder-9' });
+  });
+});
+
+describe('pinSavedSearchToRoot', () => {
+  it('sets the root flag, clears the folder, and pushes bundle + null folder_id', async () => {
+    seed({
+      id: 's-1',
+      folder_id: 'folder-9',
+      metadata_encrypted: 'encobj:{"search_in_content":true,"pinned_to_root":false}'
+    });
+
+    await pinSavedSearchToRoot('s-1');
+
+    const updated = rows.find((r) => r.id === 's-1')!;
+    expect('folder_id' in updated).toBe(false);
+    expect(updated.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":true,"pinned_to_root":true}'
+    );
+    expect(updated.sync_status).toBe('pending');
+    expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', {
+      folder_id: null,
+      metadata_encrypted: 'encobj:{"search_in_content":true,"pinned_to_root":true}'
+    });
+  });
+
+  it('backfills a missing bundle when pinning a legacy row to root', async () => {
+    seed({ id: 's-1' }); // no metadata bundle at all
+
+    await pinSavedSearchToRoot('s-1');
+
+    const updated = rows.find((r) => r.id === 's-1')!;
+    expect(updated.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":false,"pinned_to_root":true}'
+    );
+    expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', {
+      folder_id: null,
+      metadata_encrypted: 'encobj:{"search_in_content":false,"pinned_to_root":true}'
+    });
   });
 });
 

--- a/apps/reborn-notes/src/lib/services/saved-search.service.ts
+++ b/apps/reborn-notes/src/lib/services/saved-search.service.ts
@@ -55,18 +55,21 @@ async function decode(stored: string): Promise<string> {
   }
 }
 
-async function decodeMetadata(stored?: string): Promise<SavedSearchSensitiveMetadata> {
-  // Missing or undecryptable metadata degrades to the conservative default
-  // (title-only search) instead of erroring - same posture as the name/query codec.
-  if (!stored) return { search_in_content: false };
+async function decodeMetadata(
+  stored?: string
+): Promise<Required<SavedSearchSensitiveMetadata>> {
+  // Missing or undecryptable metadata degrades to the conservative defaults
+  // (title-only search, not root-pinned) instead of erroring - same posture as
+  // the name/query codec.
+  if (!stored) return { search_in_content: false, pinned_to_root: false };
   if (!cryptoManager.isInitialized()) {
     throw new Error('[E2E] decode saved-search metadata called without master key loaded');
   }
   try {
     const meta = await cryptoManager.decryptObject<SavedSearchSensitiveMetadata>(stored);
-    return { search_in_content: !!meta.search_in_content };
+    return { search_in_content: !!meta.search_in_content, pinned_to_root: !!meta.pinned_to_root };
   } catch {
-    return { search_in_content: false };
+    return { search_in_content: false, pinned_to_root: false };
   }
 }
 
@@ -77,6 +80,10 @@ async function toDecrypted(enc: SavedSearchEncrypted): Promise<SavedSearchDecryp
     name: await decode(enc.name_encrypted),
     query: await decode(enc.query_encrypted),
     search_in_content: meta.search_in_content,
+    // Folder-pin wins over root-pin: a search with a live folder_id is shown in
+    // the folder tree, never duplicated at the top level (mutual exclusivity is
+    // enforced on write, this is defense in depth for any legacy both-set row).
+    pinned_to_root: meta.pinned_to_root && !enc.folder_id,
     folder_id: enc.folder_id,
     position: enc.position,
     created_at: enc.created_at,
@@ -118,7 +125,11 @@ export async function createSavedSearch(
   // Always store the bundle, even for the default false - a row where
   // metadata_encrypted is only present when the toggle is on would leak the
   // toggle state to the server through the mere existence of the ciphertext.
-  const metadata: SavedSearchSensitiveMetadata = { search_in_content: searchInContent };
+  // New searches are never pinned, so root-pin starts false.
+  const metadata: SavedSearchSensitiveMetadata = {
+    search_in_content: searchInContent,
+    pinned_to_root: false
+  };
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
   const search: SavedSearchEncrypted = {
@@ -156,23 +167,71 @@ export async function renameSavedSearch(id: string, name: string): Promise<void>
 }
 
 /**
+ * Set a saved search's pin location. The three states are mutually exclusive:
+ *   - `{ folderId }` parks it under a folder (plaintext FK, clears root-pin)
+ *   - `{ root: true }` pins it to the top level as a smart folder (root-pin
+ *     flag in the encrypted bundle, clears folder_id)
+ *   - `{ none: true }` unpins it entirely (search-panel list only)
+ *
+ * The root-pin flag lives inside `metadata_encrypted`, so flipping it re-encrypts
+ * the bundle and the change rides the existing metadata reconciliation/push path
+ * (notes-sync.service compares metadata_encrypted). The bundle is only re-encoded
+ * when the flag actually flips, to avoid needless ciphertext churn / pushes when
+ * merely re-parking between folders.
+ */
+async function setSavedSearchPin(
+  id: string,
+  target: { folderId: string } | { root: true } | { none: true }
+): Promise<void> {
+  const existing = await savedSearchStore.get(id);
+  if (!existing) throw new Error('Saved search not found');
+
+  const nextFolderId = 'folderId' in target ? target.folderId : null;
+  const nextRoot = 'root' in target;
+
+  const meta = await decodeMetadata(existing.metadata_encrypted);
+  const rootChanged = meta.pinned_to_root !== nextRoot;
+  if (rootChanged && !cryptoManager.isInitialized()) {
+    throw new Error('[E2E] encode saved-search metadata called without master key loaded');
+  }
+  const metadata_encrypted = rootChanged
+    ? await cryptoManager.encryptObject({ ...meta, pinned_to_root: nextRoot })
+    : existing.metadata_encrypted;
+
+  const { folder_id: _previous, ...rest } = existing;
+  await savedSearchStore.save({
+    ...rest,
+    ...(nextFolderId ? { folder_id: nextFolderId } : {}),
+    metadata_encrypted,
+    updated_at: new Date().toISOString(),
+    sync_status: 'pending'
+  });
+  // folder_id always goes on the wire (server needs `'folder_id' in data` to act);
+  // metadata only when the root flag flipped (otherwise its ciphertext is unchanged).
+  pushSavedSearchUpdate(id, {
+    folder_id: nextFolderId,
+    ...(rootChanged ? { metadata_encrypted } : {})
+  });
+}
+
+/**
  * Park a saved search in a folder (renders as a node in the folder tree),
- * or unpark it with `null` (search-panel list only).
+ * or unpark it with `null` (search-panel list only). Setting a folder clears
+ * any top-level pin; `null` clears every pin (folder and root alike).
  */
 export async function moveSavedSearchToFolder(
   id: string,
   folderId: string | null
 ): Promise<void> {
-  const existing = await savedSearchStore.get(id);
-  if (!existing) throw new Error('Saved search not found');
-  const { folder_id: _previous, ...rest } = existing;
-  await savedSearchStore.save({
-    ...rest,
-    ...(folderId ? { folder_id: folderId } : {}),
-    updated_at: new Date().toISOString(),
-    sync_status: 'pending'
-  });
-  pushSavedSearchUpdate(id, { folder_id: folderId });
+  await setSavedSearchPin(id, folderId ? { folderId } : { none: true });
+}
+
+/**
+ * Pin a saved search to the top level of the folder tree as a smart folder.
+ * Clears any folder-pin (mutually exclusive).
+ */
+export async function pinSavedSearchToRoot(id: string): Promise<void> {
+  await setSavedSearchPin(id, { root: true });
 }
 
 /** Delete a saved search (local hard delete + server push). */

--- a/apps/reborn-notes/src/lib/services/saved-searches-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/saved-searches-sync.regression.spec.ts
@@ -84,6 +84,9 @@ describe('saved searches - push sync', () => {
     expect(fn).toMatch(/res\.status === 404 && fields\.folder_id/);
     expect(fn).toMatch(/Folder not found/);
     expect(fn).toMatch(/throw new Error\(`PATCH \/api\/saved-searches/);
+    // The PATCH must carry metadata_encrypted, otherwise toggling the root-pin
+    // flag (it lives in the encrypted bundle) would never reach the server.
+    expect(fn).toMatch(/metadata_encrypted\?:\s*string/);
   });
 
   it('pushSavedSearchDelete does not clobber sync_version (same bug class as folders/tags)', () => {

--- a/apps/reborn-notes/src/lib/stores/saved-searches.store.ts
+++ b/apps/reborn-notes/src/lib/stores/saved-searches.store.ts
@@ -43,6 +43,11 @@ function createSavedSearchesStore() {
     await refresh();
   }
 
+  async function pinToRoot(id: string): Promise<void> {
+    await SavedSearchService.pinSavedSearchToRoot(id);
+    await refresh();
+  }
+
   async function remove(id: string): Promise<void> {
     await SavedSearchService.deleteSavedSearch(id);
     await refresh();
@@ -56,6 +61,7 @@ function createSavedSearchesStore() {
     create,
     rename,
     move,
+    pinToRoot,
     remove
   };
 }

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -1089,6 +1089,12 @@
     return map;
   });
 
+  // Searches pinned to the top level (smart folders) render above the folder list.
+  // folder_id wins over the root flag, so a folder-pinned search never shows here.
+  const rootPinnedSearches = $derived(
+    $savedSearchesStore.filter((s) => s.pinned_to_root && !s.folder_id)
+  );
+
   /**
    * Clicking a parked saved search jumps to the search section and replays
    * its query. The handoff store is set AFTER a tick so NoteList's
@@ -2128,6 +2134,7 @@
                       onselect={handleFolderSelect}
                       onnewnote={handleNewNoteInFolder}
                       {savedSearchesByFolder}
+                      {rootPinnedSearches}
                       onsavedsearchselect={handleSavedSearchSelect}
                     />
                   {/if}
@@ -2467,6 +2474,7 @@
                     onselect={handleFolderSelect}
                     onnewnote={handleNewNoteInFolder}
                     {savedSearchesByFolder}
+                    {rootPinnedSearches}
                     onsavedsearchselect={handleSavedSearchSelect}
                   />
                 {/if}

--- a/apps/reborn-notes/src/routes/api/saved-searches/[id]/+server.ts
+++ b/apps/reborn-notes/src/routes/api/saved-searches/[id]/+server.ts
@@ -8,9 +8,11 @@ import { getUserFromToken } from '$lib/server/auth';
 const logger = createLogger('Notes-API-SavedSearch');
 
 /**
- * PATCH /api/saved-searches/[id] — update name, query, folder parking and/or position.
- * Body: { name_encrypted?, query_encrypted?, folder_id?, position? }
- * `folder_id: null` explicitly unparks the search from the folder tree.
+ * PATCH /api/saved-searches/[id] - update name, query, metadata, folder parking
+ * and/or position.
+ * Body: { name_encrypted?, query_encrypted?, metadata_encrypted?, folder_id?, position? }
+ * `folder_id: null` explicitly unparks the search from the folder tree;
+ * `metadata_encrypted` carries the behavioral bundle (search-in-content + root-pin).
  */
 export const PATCH: RequestHandler = async ({ request, params }) => {
   try {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -522,7 +522,11 @@
     "actions": "Aktionen für gespeicherte Suche",
     "rename": "Umbenennen",
     "move_to_folder": "An Ordner anheften…",
-    "unpark": "Vom Ordner lösen",
+    "pin_picker_title": "An Ordner anheften",
+    "pin_to_top_level": "Auf oberster Ebene anheften",
+    "pin_here": "Hier anheften",
+    "dont_pin": "Nicht anheften",
+    "unpark": "Lösen",
     "delete": "Löschen",
     "delete_confirm_title": "„{name}“ löschen?",
     "delete_confirm_desc": "Nur die gespeicherte Ansicht wird entfernt - Ihre Notizen bleiben unberührt."

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -522,7 +522,11 @@
     "actions": "Saved search actions",
     "rename": "Rename",
     "move_to_folder": "Pin to folder…",
-    "unpark": "Unpin from folder",
+    "pin_picker_title": "Pin to folder",
+    "pin_to_top_level": "Pin to top level",
+    "pin_here": "Pin here",
+    "dont_pin": "Don't pin",
+    "unpark": "Unpin",
     "delete": "Delete",
     "delete_confirm_title": "Delete \"{name}\"?",
     "delete_confirm_desc": "Only the saved view is removed - your notes are not affected."

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -522,7 +522,11 @@
     "actions": "Acciones de la búsqueda guardada",
     "rename": "Renombrar",
     "move_to_folder": "Fijar en carpeta…",
-    "unpark": "Quitar de la carpeta",
+    "pin_picker_title": "Fijar en carpeta",
+    "pin_to_top_level": "Fijar en el nivel superior",
+    "pin_here": "Fijar aquí",
+    "dont_pin": "No fijar",
+    "unpark": "Desfijar",
     "delete": "Eliminar",
     "delete_confirm_title": "¿Eliminar \"{name}\"?",
     "delete_confirm_desc": "Solo se elimina la vista guardada: sus notas no se ven afectadas."

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -522,7 +522,11 @@
     "actions": "Actions de la recherche enregistrée",
     "rename": "Renommer",
     "move_to_folder": "Épingler au dossier…",
-    "unpark": "Détacher du dossier",
+    "pin_picker_title": "Épingler au dossier",
+    "pin_to_top_level": "Épingler au niveau supérieur",
+    "pin_here": "Épingler ici",
+    "dont_pin": "Ne pas épingler",
+    "unpark": "Détacher",
     "delete": "Supprimer",
     "delete_confirm_title": "Supprimer « {name} » ?",
     "delete_confirm_desc": "Seule la vue enregistrée est supprimée - vos notes ne sont pas affectées."

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -522,7 +522,11 @@
     "actions": "Akcje zapisanego wyszukiwania",
     "rename": "Zmień nazwę",
     "move_to_folder": "Przypnij do folderu…",
-    "unpark": "Odepnij od folderu",
+    "pin_picker_title": "Przypnij do folderu",
+    "pin_to_top_level": "Przypnij do głównego poziomu",
+    "pin_here": "Przypnij tutaj",
+    "dont_pin": "Nie przypinaj",
+    "unpark": "Odepnij",
     "delete": "Usuń",
     "delete_confirm_title": "Usunąć \"{name}\"?",
     "delete_confirm_desc": "Usuwany jest tylko zapisany widok - notatki pozostają nietknięte."

--- a/packages/types/src/entities/saved-search.ts
+++ b/packages/types/src/entities/saved-search.ts
@@ -15,6 +15,13 @@ export interface SavedSearchDecrypted {
   query: string;
   /** Whether the "search in content" toggle was on when the search was saved. */
   search_in_content: boolean;
+  /**
+   * Whether the search is pinned to the top level of the folder tree as a
+   * "smart folder". Mutually exclusive with `folder_id` (folder-pin) - a search
+   * with a `folder_id` is treated as folder-pinned regardless of this flag.
+   * Derived from the encrypted metadata bundle, so the server never learns it.
+   */
+  pinned_to_root: boolean;
   folder_id?: string;
   position: number;
   created_at: string;
@@ -24,10 +31,14 @@ export interface SavedSearchDecrypted {
 /**
  * Behavioral metadata bundle, encrypted as one JSON object (same pattern as
  * NoteSensitiveMetadata). The server must not learn which saved searches scan
- * note bodies - that correlates with how sensitive the underlying query is.
+ * note bodies - that correlates with how sensitive the underlying query is - nor
+ * which are pinned to the top level (root-pin is an encrypted flag, unlike the
+ * plaintext `folder_id` FK that folder-pins must use for the SetNull relation).
  */
 export interface SavedSearchSensitiveMetadata {
   search_in_content: boolean;
+  /** Pinned to the top level of the folder tree (smart folder). Absent ⇒ false. */
+  pinned_to_root?: boolean;
 }
 
 export interface SavedSearchEncrypted extends SyncableEncryptedEntity {


### PR DESCRIPTION
## Summary

Pin any saved search to the top level of the folder tree as a **smart folder** (e.g. a `no:folder` search becomes a virtual "unfiled notes" folder, always visible in the Folders panel). Closes the intent of #374 with the right pattern - no artificial folder in the data.

**Data model (Zero Knowledge).** The pin is an encrypted `pinned_to_root` flag inside the existing `metadata_encrypted` bundle - no migration, no schema/API change. Deliberate asymmetry: folder-pin stays a plaintext FK (relation + SetNull need it), root-pin is encrypted (the server has no reason to see it). States are mutually exclusive, enforced client-side in `setSavedSearchPin`; on read `folder_id` wins (`pinned_to_root && \!folder_id`) as defense in depth. The bundle is re-encoded only when the flag actually flips, so re-parking between folders adds no churn.

**Sync.** Reconciliation in `pullSavedSearches` already compares `metadata_encrypted`, so flipping the flag changes the ciphertext and pushes via the existing `pushSavedSearchUpdate` PATCH (which carries `metadata_encrypted`). Verified - no guideline-36 rule-9 gap.

**UX decisions (agreed with reviewer in this session):**
- Smart folders render **above** the folder list (root instance only; no section header - the `SearchCheck` icon differentiates them from real folders).
- The folder picker gains a `pin` mode: title becomes **"Pin to folder"** (fixes the stale "Move to" header when reused for pinning), with "Pin to top level" + "Don't pin" + "Pin here", and disabled states driven by a new optional `currentPinnedToRoot` on `MoveSelection` (ignored in `move` mode, so note-move callers are unchanged).
- No per-smart-folder count in v1.

**Files:** `packages/types` (flag in bundle + derived `pinned_to_root`), `saved-search.service` (`setSavedSearchPin` + `pinSavedSearchToRoot`), `saved-searches.store` (`pinToRoot`), `MoveToFolderMenu` (pin mode), `SavedSearchList` / `SavedSearchRow`, `FolderTree` (+`rootPinnedSearches`), `+page.svelte`, i18n x5 (4 new keys; `unpark` generalized to "Unpin").

## Test plan

Automated: 66 tests green (service codec + both sync regression specs); eslint, svelte-check, and a single-file svelte-compile build-proxy all clean.

Smoke (please verify in the browser):
- [ ] Panel "Pin to folder…" -> "Pin to top level": the search appears above the folder list with a SearchCheck icon; clicking it jumps to Search and replays the query.
- [ ] Pinning to a folder clears a root-pin and vice versa (mutually exclusive); "Unpin" in the row menu removes it from the tree entirely.
- [ ] Picker disabled states: "Pin to top level" greyed when already root-pinned; "Don't pin" greyed when the search is unpinned.
- [ ] Mobile bottom-sheet picker shows the same actions and the "Pin to folder" title.
- [ ] Dragging a note onto a smart-folder row is a no-op.
- [ ] Cross-device: toggling the pin propagates (metadata ciphertext changes -> push, other device reconciles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)