### PR TITLE
fix(notes): render search-view toolbar above the search box

### DIFF
--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -822,8 +822,8 @@
   {/if}
 
   <!-- Row 2: count + per-list actions; swaps to the selection toolbar in
-       multi-select. Folder/all views render it under the title (above); the
-       dedicated search view renders it under the search box so bulk actions
+       multi-select. Folder/all views render it under the title; the dedicated
+       search view renders it above the search box (same order) so bulk actions
        (move/pin/star/delete) reach search results too (#374). -->
   {#snippet listToolbar()}
     {#if selectionMode}
@@ -972,22 +972,22 @@
     {/if}
   {/snippet}
 
+  <!-- Search view has no panel header, so the count + selection toolbar ride
+       above the search box - same toolbar-over-filter order as every other
+       list view. Gated on results (or an active selection) so an empty
+       result set stays clean. -->
+  {#if searchOnly && ($notesStore.length > 0 || selectionMode)}
+    {@render listToolbar()}
+  {/if}
+
   <!-- Search bar. No save affordance in trash: the trash bucket has no query
        operator, so a saved view could never reproduce a trash-scoped result. -->
   <NoteListSearchBar
     bind:searchInput
     bind:searchInContent
     bind:searchInputEl
-    {searchOnly}
     onsavesearch={isTrash ? undefined : () => (saveSearchDialogOpen = true)}
   />
-
-  <!-- Search view has no panel header, so the count + selection toolbar ride
-       under the search box instead. Gated on results (or an active selection)
-       so an empty search stays clean. -->
-  {#if searchOnly && ($notesStore.length > 0 || selectionMode)}
-    {@render listToolbar()}
-  {/if}
 
   <!-- Trash retention notice: trashed notes are auto-purged after 30 days
        (cleanTrash(30) in hooks.client.ts). Pinned above the list so the policy

--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -974,9 +974,10 @@
 
   <!-- Search view has no panel header, so the count + selection toolbar ride
        above the search box - same toolbar-over-filter order as every other
-       list view. Gated on results (or an active selection) so an empty
-       result set stays clean. -->
-  {#if searchOnly && ($notesStore.length > 0 || selectionMode)}
+       list view. Always rendered in search mode (even at 0 matches, where it
+       reads "0 notes", like an empty folder) so the search box keeps a fixed
+       row and never jumps as results appear or disappear. -->
+  {#if searchOnly}
     {@render listToolbar()}
   {/if}
 

--- a/apps/reborn-notes/src/lib/components/notes/NoteListSearchBar.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListSearchBar.svelte
@@ -6,13 +6,11 @@
     searchInput = $bindable(''),
     searchInContent = $bindable(false),
     searchInputEl = $bindable<HTMLInputElement | null>(null),
-    searchOnly = false,
     onsavesearch
   }: {
     searchInput: string;
     searchInContent: boolean;
     searchInputEl?: HTMLInputElement | null;
-    searchOnly?: boolean;
     /** Optional "save this search" affordance (shown when a query is typed). */
     onsavesearch?: () => void;
   } = $props();
@@ -32,8 +30,10 @@
 </script>
 
 <!-- Mobile: px-4 + mt-2 places search in the unified app-bar/meta spacing rhythm;
-     desktop keeps the previous compact px-3 with no top margin via md:. -->
-<div class="shrink-0 px-4 pb-2 md:px-3 {searchOnly ? 'pt-3' : 'mt-2 md:mt-0'}">
+     desktop keeps the previous compact px-3 with no top margin via md:. The
+     count/sort toolbar always sits above this box, so the rhythm is identical
+     across every list view (including the dedicated search view). -->
+<div class="shrink-0 px-4 pb-2 md:px-3 mt-2 md:mt-0">
   <div class="relative">
     <Search class="absolute left-2.5 top-1/2 h-4 w-4 md:h-3.5 md:w-3.5 -translate-y-1/2 text-muted-foreground" />
     <input


### PR DESCRIPTION
## Summary

The shared count + multiselect + sort toolbar (`listToolbar`) rendered *below* the search box only in the dedicated **Search** view, while every other list view (All Notes, Starred, Folders, Trash, and the separate Active-shares list) renders it *above* the search/filter input. Search was the lone outlier, so the sort and multiselect controls shifted position between views (reported by Michał from the live app).

- Move the search-mode toolbar render above `NoteListSearchBar`, so the order is `[count + tools] -> [search box] -> [results]` in every view.
- Drop the search bar's `pt-3` top-padding special-case (and the now-unused `searchOnly` prop): it only existed because the box used to be the topmost element in search mode. The bar now uses the same `mt-2 md:mt-0` rhythm as everywhere else.
- Mobile notch handling is unaffected - in search mode the external master header owns the safe-area inset, not `NoteList`.

No new keys, deps, schema, or encryption-model changes; pure layout. Independent of #389.

## Test plan

Smoke (desktop sidebar + mobile):
- Open the **Search** view: the "N notes" count with the multiselect (checklist) and sort icons now sits **above** the search box, matching All Notes / Starred / Folders / Trash / Active shares.
- Type a query: results render below; the search box stays put (no vertical jump).
- Empty query: toolbar still shows over the box, SAVED SEARCHES list below - same behavior, new position.
- Enter multiselect from the Search view and confirm bulk actions still reach search results.
- Check spacing on both desktop and mobile: no doubled gap above the box, no flush-to-top oddity; rhythm matches the other views.