### PR TITLE
fix(notes): stop version-sync 404s for a not-yet-created note

### DIFF
--- a/apps/reborn-notes/src/lib/services/note-version-baseline.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/note-version-baseline.regression.spec.ts
@@ -136,3 +136,51 @@ describe('note version history - baseline server-reconcile + write serialization
     expect(baseline).toMatch(/serializeVersionWrite\(\s*noteId\s*,/);
   });
 });
+
+/**
+ * Regression: a brand-new note is created lazily on its first edit (#349), so it
+ * has no server row until the debounced save POSTs it to /api/notes. The version
+ * paths target /api/notes/{id}/versions, which 404s while the parent note is
+ * missing - producing a swallowed GET 404 plus three doomed POST retries on the
+ * first keystroke of every new note. Two guards keep version sync from running
+ * before the note exists on the server:
+ *   1. saveBaselineSnapshot bails on an ephemeral note (its pristine state is an
+ *      empty blank - no baseline worth keeping, and the note has no server row).
+ *   2. pushNoteVersion runs inside the note's per-entity chain, so it queues
+ *      behind any in-flight create/update instead of overtaking it (closes the
+ *      leave-immediately-after-first-edit race where the note is promoted but its
+ *      POST /api/notes is still in flight).
+ */
+function notesSyncSrc(): string {
+  return readSource('./notes-sync.service.ts');
+}
+
+describe('note version history - no version push before the note exists on the server', () => {
+  it('saveBaselineSnapshot bails on an ephemeral (not-yet-created) note before any server contact', () => {
+    const fn = sliceServiceFn(
+      noteServiceSrc(),
+      'export async function saveBaselineSnapshot',
+      '\nexport '
+    );
+    const ephemeralGuardIdx = fn.search(/if\s*\(\s*entry\.is_ephemeral\s*\)\s*return/);
+    expect(ephemeralGuardIdx, 'must skip ephemeral notes').toBeGreaterThan(-1);
+    // The guard precedes BOTH the server-history pull and the version write/push,
+    // so a not-yet-created note makes zero /versions requests.
+    const realSyncCall = fn.search(/await\s+syncNoteVersionsFromServer\s*\(/);
+    const writeIdx = fn.search(/saveVersion\s*\(/);
+    expect(realSyncCall).toBeGreaterThan(ephemeralGuardIdx);
+    expect(writeIdx).toBeGreaterThan(ephemeralGuardIdx);
+  });
+
+  it('pushNoteVersion is serialized through the note per-entity chain, not a bare pushSilently', () => {
+    const fn = sliceServiceFn(notesSyncSrc(), 'export function pushNoteVersion', '\nexport ');
+    // Must enter the same FIFO as pushNote/pushNoteUpdate, keyed by the parent note,
+    // so the version push waits for an in-flight create/update to finish.
+    expect(fn).toMatch(/serializePerEntity\(\s*'note'\s*,\s*entry\.note_id\s*,/);
+    // The upload still runs through pushSilently (retry/backoff) INSIDE the chain.
+    const chainIdx = fn.search(/serializePerEntity\(/);
+    const silentIdx = fn.search(/pushSilently\(/);
+    expect(chainIdx).toBeGreaterThan(-1);
+    expect(silentIdx).toBeGreaterThan(chainIdx);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -747,6 +747,16 @@ export async function saveBaselineSnapshot(noteId: string): Promise<void> {
   const entry = await noteStore.get(noteId);
   if (!entry) return;
 
+  // A never-promoted ephemeral note (#349) has no server row yet — the debounced
+  // first-edit save creates it later (pushNoteMutation → POST /api/notes). Both
+  // the server-history pull (syncNoteVersionsFromServer) and the version push
+  // target /api/notes/{id}/versions, which 404s until the parent note exists, so
+  // capturing a baseline here only churns doomed requests. It is pointless anyway:
+  // the pristine state of a brand-new blank note is empty. The edited state still
+  // gets versioned by the later checkpoint/leave snapshot, once the note is on the
+  // server. See guideline 36 (version-push ordering).
+  if (entry.is_ephemeral) return;
+
   return serializeVersionWrite(noteId, async () => {
     // Materialize server history before deciding (best-effort, online-only).
     // Without this, a cold-start local miss makes us duplicate a server version.

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -1814,26 +1814,37 @@ export function pushSavedSearchDelete(id: string): void {
 
 // ── Note version sync ──────────────────────────────────────────────
 
-/** Push a single note version to server (fire-and-forget). Marks as synced on success. */
+/**
+ * Push a single note version to server (fire-and-forget). Marks as synced on success.
+ *
+ * Serialized through the note's per-entity chain (not a bare pushSilently): the
+ * versions endpoint requires the parent note to exist, so a version push must run
+ * AFTER any in-flight create/update for that note. Without this it can overtake a
+ * freshly-promoted note's POST /api/notes and 404 (the parent row is not there
+ * yet), churning three doomed retries. A failed push leaves the local row
+ * 'pending' for the next pushPendingVersions() sweep. See guideline 36.
+ */
 export function pushNoteVersion(entry: NoteHistoryEntry): void {
-  void pushSilently(async (idempotencyKey) => {
-    const res = await authFetch(`${API_BASE}/notes/${entry.note_id}/versions`, {
-      method: 'POST',
-      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-      body: JSON.stringify({
-        id: entry.id,
-        title_encrypted: entry.title_encrypted,
-        content_encrypted: entry.content_encrypted,
-        created_at: entry.created_at
-      })
-    });
-    if (!res.ok) throw new Error(`POST /api/notes/${entry.note_id}/versions: ${res.status}`);
-    // Mark as synced locally
-    const current = await noteHistoryStore.get(entry.id);
-    if (current) {
-      await noteHistoryStore.save({ ...current, sync_status: 'synced' });
-    }
-  });
+  void serializePerEntity('note', entry.note_id, () =>
+    pushSilently(async (idempotencyKey) => {
+      const res = await authFetch(`${API_BASE}/notes/${entry.note_id}/versions`, {
+        method: 'POST',
+        headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify({
+          id: entry.id,
+          title_encrypted: entry.title_encrypted,
+          content_encrypted: entry.content_encrypted,
+          created_at: entry.created_at
+        })
+      });
+      if (!res.ok) throw new Error(`POST /api/notes/${entry.note_id}/versions: ${res.status}`);
+      // Mark as synced locally
+      const current = await noteHistoryStore.get(entry.id);
+      if (current) {
+        await noteHistoryStore.save({ ...current, sync_status: 'synced' });
+      }
+    })
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

A brand-new note is created lazily on its first edit (#349): no server row exists until the debounced save POSTs it to `/api/notes`. But the version-history baseline snapshot fires **synchronously on the first keystroke**, hitting `/api/notes/{id}/versions` (a GET to pull server history + a POST to push the captured baseline) before the note exists. Both endpoints guard on the parent note (`prisma.note.findFirst → if (\!note) 404`), so both 404 - a swallowed GET 404 plus three doomed POST retries ("Push attempt N failed, retrying…") in the console on every "new note → start typing" flow.

It was benign and self-healing (the create lands ~2s after the last keystroke; the version retries / `pushPendingVersions` catch up), but the console noise looked alarming. Reported from a smoke session.

### Fix (two layers)
- **`saveBaselineSnapshot` bails on an ephemeral note** (`if (entry.is_ephemeral) return`), before any server contact. A brand-new note's pristine state is an empty blank - no baseline worth keeping. The edited state still gets versioned by the later checkpoint/leave snapshot, once the note is on the server.
- **`pushNoteVersion` now runs inside `serializePerEntity('note', note_id, …)`** (like `pushNote`/`pushNoteUpdate`), so a version push queues *behind* any in-flight create/update for that note instead of overtaking it. Closes the rarer "edit a new note → immediately leave" race where the note is promoted but its `POST /api/notes` is still in flight.

Rejected alternatives: gating `pushNoteVersion` on `sync_status==='pending'` (over-skips - a note is `pending` after *every* edit) or on `is_ephemeral` (cleared at promotion, so it misses the leave-immediately race). Serialization is the only thing that *guarantees* version-push-after-create ordering.

No schema / API / server-visibility / i18n / dependency changes - the versions endpoint and the ZK model are untouched.

## Test plan
- `vitest` reborn-notes: 1157/1157 green, incl. 2 new regression tests in `note-version-baseline.regression.spec.ts` ("no version push before the note exists on the server").
- `svelte-check` 0/0, `eslint` clean on the changed files.
- Smoke (the reported flow): create a new note, immediately type → **no** `GET`/`POST /api/notes/{id}/versions` 404s and no "Push attempt failed" warnings in the console.
- Reopen the note, open the version-history panel → versions present as before. Editing an existing (already-synced) note still snapshots its pre-edit baseline (no regression to #355).