### PR TITLE
chore(build): resolve @reborn/* from source for typecheck

### DIFF
--- a/apps/reborn-notes/tsconfig.json
+++ b/apps/reborn-notes/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    "customConditions": ["reborn-source"],
     "allowJs": true,
     "checkJs": false,
     "esModuleInterop": true,

--- a/apps/reborn-task/tsconfig.json
+++ b/apps/reborn-task/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+		"customConditions": ["reborn-source"],
 		"allowJs": true,
 		"checkJs": false,
 		"esModuleInterop": true,

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,10 +6,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./server": {
+      "reborn-source": "./src/server.ts",
       "types": "./dist/server.d.ts",
       "import": "./dist/server.js"
     }

--- a/packages/backup/package.json
+++ b/packages/backup/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -15,6 +15,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "reborn-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }


### PR DESCRIPTION
## Summary

App `svelte-check` (CLI) and the IDE TS server resolved `@reborn/*` via `node_modules → dist/*.d.ts` (the apps extend `.svelte-kit/tsconfig.json`, not `tsconfig.base.json` which carries the `src` paths). A **stale dist** produced phantom type errors unrelated to the change; and since `dist/` is gitignored it doesn't revert on `git checkout`, so a branch switch could leave dist **ahead** of source (inverse-stale). Hit twice in June 2026 (`pinned_to_root` from #389). CI and `nx check` were immune (`check` has `dependsOn: ["^build"]`); only bare `svelte-check` saw the phantoms. Follow-up logged after #392.

### Fix
Typecheck now resolves `@reborn/*` from **source** via a TS custom export condition:
- Each dist-based package's `exports` gains `"reborn-source": "./src/index.ts"` as the **first** condition (auth's split barrel also maps `./server → ./src/server.ts`).
- Both apps' `tsconfig.json` set `compilerOptions.customConditions: ["reborn-source"]` (works via the inherited `moduleResolution: "bundler"`).
- `@reborn/ui` already resolves its exports to `src`, so it needs no condition.

**Runtime/build/vitest deliberately stay on `dist`** (`import`/`types` conditions) - `reborn-source` is inert for Vite/Node/pnpm (they never request it), so the bundle and what ships are unchanged. Typecheck-vs-shipped cannot diverge (matters for the native build).

### Decision (PO delegated "pick the best")
Chose `customConditions` over:
- **`paths` in the app tsconfig** - TS does NOT merge `paths` across `extends`, so it would clobber svelte-kit's generated `$lib`/`$app` paths, forcing a brittle re-declaration that drifts on every svelte-kit upgrade.
- **`kit.alias`** - also changes *runtime* resolution (Vite would bundle from source, incl. `@reborn/ui` svelte / `@reborn/crypto` wasm) - too broad, risky for native.
- **build-before-check wrapper** - band-aid, slow, duplicates nx's `^build`.

`customConditions` scales best: a new shared package needs one line in its own `package.json`, no app edits. Guideline 01 documents the rule.

Files: 10 `package.json` (`exports`) + 2 app `tsconfig.json`. No source / schema / API / i18n / dependency changes.

## Test plan
- `svelte-check` **0/0 on both apps** - now resolving `@reborn/*` to source, type-checking all package source under each app's config (reborn-notes processes 5695 files vs 5559 before).
- **Staleness-immunity proof**: with `@reborn/types/dist` deleted entirely, both apps' `svelte-check` stay 0/0.
- **Runtime unaffected**: both app test suites green (reborn-notes 1157, reborn-task 87) - vitest resolves via dist as before.
- CI `build` is the final gate that runtime/build resolution (dist) is intact.

Optional follow-up (not here): drop `dependsOn: ["^build"]` from the `check` target (now unnecessary for typecheck → faster CI); separate because it touches the CI build graph.