### PR TITLE
feat(notes): saved-search UX - reveal, edit query, menu highlight

### DIFF
--- a/apps/reborn-notes/src/app.css
+++ b/apps/reborn-notes/src/app.css
@@ -177,6 +177,23 @@
     background-color: var(--rn-list-row-active);
     box-shadow: inset 3px 0 0 0 var(--rn-list-row-accent);
   }
+
+  /* Momentary flash on a saved-search row right after it is created, so a
+     first-time user spots where the new saved view landed. One-shot: fades from
+     the active-row tint to transparent, then the row's normal hover/active rules
+     take back over (the class is dropped by a timer once the flash ends). */
+  .saved-search-just-saved {
+    animation: rn-saved-search-flash 2.2s ease-out;
+  }
+
+  @keyframes rn-saved-search-flash {
+    0% {
+      background-color: var(--rn-list-row-active);
+    }
+    100% {
+      background-color: transparent;
+    }
+  }
 }
 
 /* CodeMirror base styles */

--- a/apps/reborn-notes/src/lib/components/NoteList.svelte
+++ b/apps/reborn-notes/src/lib/components/NoteList.svelte
@@ -236,6 +236,12 @@
 
   // ── Saved searches ─────────────────────────────────────────────
   let saveSearchDialogOpen = $state(false);
+  // Id of a just-saved search, flashed in the saved-searches list so a first-time
+  // user sees where the saved view landed. The list only renders on an empty
+  // query, so a save also clears the box (see handleSearchSaved) to reveal it.
+  let justSavedSearchId = $state<string | null>(null);
+  let justSavedResetTimer: ReturnType<typeof setTimeout> | undefined;
+  onDestroy(() => clearTimeout(justSavedResetTimer));
 
   // Searches pinned to the folder being browsed - shown alongside the
   // subfolder cards so a pin made from this very view doesn't "vanish"
@@ -250,6 +256,20 @@
     // content-phrase view silently returns a different (usually empty) result
     // set than the one the user saved.
     searchInContent = search.search_in_content;
+  }
+
+  function handleSearchSaved(id: string) {
+    // Only meaningful in the search section, where the saved-searches list is the
+    // empty-query view. Clearing the box drops the user onto that list with the
+    // new entry flashed at the top, so it never "vanishes" behind the results.
+    // Elsewhere the list isn't shown, so leave the current query untouched.
+    if (!searchOnly) return;
+    clearSearch();
+    justSavedSearchId = id;
+    clearTimeout(justSavedResetTimer);
+    justSavedResetTimer = setTimeout(() => {
+      justSavedSearchId = null;
+    }, 2500);
   }
 
   function onWindowClick() {
@@ -1020,7 +1040,7 @@
     {/if}
     {#if searchOnly && !searchInput}
       {#if $savedSearchesStore.length > 0}
-        <SavedSearchList onselect={applySavedSearch} />
+        <SavedSearchList onselect={applySavedSearch} highlightId={justSavedSearchId} />
       {:else}
         <div class="px-4 py-12 text-center">
           <Search class="mx-auto mb-3 h-8 w-8 text-muted-foreground/40" />
@@ -1137,6 +1157,7 @@
   {searchInContent}
   scope={saveScope}
   inSearchSection={searchOnly}
+  onsaved={handleSearchSaved}
 />
 
 <ConfirmDialog

--- a/apps/reborn-notes/src/lib/components/notes/EditSavedSearchQueryDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/EditSavedSearchQueryDialog.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Button,
+    toastStore
+  } from '@reborn/ui';
+  import { MAX_SAVED_SEARCH_QUERY_CHARS } from '@reborn/types';
+  import type { SavedSearchDecrypted } from '@reborn/types';
+  import { t } from '$lib/stores/i18n.store';
+  import { savedSearchesStore } from '$lib/stores/saved-searches.store';
+
+  let {
+    open = $bindable(false),
+    search
+  }: {
+    open: boolean;
+    /** The saved search whose query is being edited. */
+    search: SavedSearchDecrypted | null;
+  } = $props();
+
+  let query = $state('');
+  let searchInContent = $state(false);
+  let queryInputEl = $state<HTMLTextAreaElement | null>(null);
+  let isSaving = $state(false);
+
+  // Re-seed the fields from the target every time the dialog opens - the same
+  // component instance is reused across rows, so stale values must not leak in.
+  $effect(() => {
+    if (open && search) {
+      query = search.query;
+      searchInContent = search.search_in_content;
+      setTimeout(() => queryInputEl?.focus(), 0);
+    }
+  });
+
+  const canSave = $derived(query.trim().length > 0);
+
+  async function handleSave() {
+    if (!canSave || isSaving || !search) return;
+    isSaving = true;
+    try {
+      await savedSearchesStore.updateQuery(search.id, query.trim(), searchInContent);
+      toastStore.success(
+        $t('saved_searches.query_updated_toast', { values: { name: search.name } })
+      );
+      open = false;
+    } catch {
+      toastStore.error($t('saved_searches.query_update_failed_toast'));
+    } finally {
+      isSaving = false;
+    }
+  }
+</script>
+
+<Dialog bind:open>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>{$t('saved_searches.edit_dialog.title')}</DialogTitle>
+      <DialogDescription>{$t('saved_searches.edit_dialog.description')}</DialogDescription>
+    </DialogHeader>
+
+    <div class="flex flex-col gap-3 py-2">
+      <label class="flex flex-col gap-1.5">
+        <span class="text-sm font-medium">{$t('saved_searches.dialog.query_label')}</span>
+        <!-- Textarea (not a single-line input): queries can run long with several
+             operators, and wrapping keeps the whole query readable while editing.
+             Cmd/Ctrl+Enter saves so a bare Enter can still insert a newline. -->
+        <textarea
+          bind:this={queryInputEl}
+          bind:value={query}
+          rows="2"
+          maxlength={MAX_SAVED_SEARCH_QUERY_CHARS}
+          class="w-full resize-y rounded-md border bg-background px-3 py-2 font-mono text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+          onkeydown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSave();
+          }}
+        ></textarea>
+      </label>
+      <label class="flex cursor-pointer items-center gap-2.5 text-sm">
+        <input type="checkbox" bind:checked={searchInContent} class="h-4 w-4 accent-primary" />
+        {$t('notes.search_in_content')}
+      </label>
+    </div>
+
+    <DialogFooter>
+      <Button variant="outline" onclick={() => (open = false)} disabled={isSaving}>
+        {$t('saved_searches.dialog.cancel')}
+      </Button>
+      <Button onclick={handleSave} disabled={!canSave || isSaving}>
+        {$t('saved_searches.dialog.save')}
+      </Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>

--- a/apps/reborn-notes/src/lib/components/notes/SaveSearchDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/SaveSearchDialog.svelte
@@ -19,7 +19,8 @@
     query,
     searchInContent = false,
     scope = null,
-    inSearchSection = false
+    inSearchSection = false,
+    onsaved
   }: {
     open: boolean;
     /** The query string currently in the search bar. */
@@ -34,6 +35,8 @@
     scope?: SaveScope | null;
     /** Picks the toast variant: outside the search section, hint where saved views live. */
     inSearchSection?: boolean;
+    /** Called with the new saved-search id after a successful save. */
+    onsaved?: (id: string) => void;
   } = $props();
 
   let name = $state('');
@@ -59,7 +62,12 @@
     const trimmedName = name.trim();
     const pinFolderId = scope?.kind === 'folder' && pinToFolder ? scope.folderId : undefined;
     try {
-      await savedSearchesStore.create(trimmedName, composedQuery, searchInContent, pinFolderId);
+      const newId = await savedSearchesStore.create(
+        trimmedName,
+        composedQuery,
+        searchInContent,
+        pinFolderId
+      );
       if (pinFolderId && scope?.kind === 'folder') {
         toastStore.success(
           $t('saved_searches.saved_toast_pinned', {
@@ -74,6 +82,7 @@
         toastStore.success($t('saved_searches.saved_toast', { values: { name: trimmedName } }));
       }
       open = false;
+      onsaved?.(newId);
     } catch {
       toastStore.error($t('saved_searches.save_failed_toast'));
     } finally {

--- a/apps/reborn-notes/src/lib/components/notes/SavedSearchList.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/SavedSearchList.svelte
@@ -6,9 +6,12 @@
   import MoveToFolderMenu from './MoveToFolderMenu.svelte';
 
   let {
-    onselect
+    onselect,
+    highlightId = null
   }: {
     onselect: (search: SavedSearchDecrypted) => void;
+    /** Id of a just-saved search to flash momentarily so the user spots the new row. */
+    highlightId?: string | null;
   } = $props();
 
   // ── Park in folder (shared picker, sheet variant on all breakpoints -
@@ -40,7 +43,13 @@
   </p>
   <ul class="select-none">
     {#each $savedSearchesStore as search (search.id)}
-      <SavedSearchRow {search} context="panel" {onselect} onrequestmove={requestMove} />
+      <SavedSearchRow
+        {search}
+        context="panel"
+        highlight={search.id === highlightId}
+        {onselect}
+        onrequestmove={requestMove}
+      />
     {/each}
   </ul>
 </div>

--- a/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { SearchCheck, MoreHorizontal, Pencil, Trash2, FolderInput, FolderX } from '@lucide/svelte';
+  import {
+    SearchCheck,
+    SearchCode,
+    MoreHorizontal,
+    Pencil,
+    Trash2,
+    FolderInput,
+    FolderX
+  } from '@lucide/svelte';
   import {
     Button,
     DropdownMenu,
@@ -17,12 +25,14 @@
   import { t } from '$lib/stores/i18n.store';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
   import ConfirmDialog from '../shared/ConfirmDialog.svelte';
+  import EditSavedSearchQueryDialog from './EditSavedSearchQueryDialog.svelte';
 
   let {
     search,
     context,
     depth = 0,
     active = false,
+    highlight = false,
     onselect,
     onrequestmove
   }: {
@@ -33,6 +43,8 @@
     depth?: number;
     /** Tree context: this smart folder is the one currently open in the main list. */
     active?: boolean;
+    /** Momentary flash after this search was just saved, so the new row stands out. */
+    highlight?: boolean;
     onselect: (search: SavedSearchDecrypted) => void;
     /** Panel only: open the folder picker for parking this search. */
     onrequestmove?: (search: SavedSearchDecrypted) => void;
@@ -47,6 +59,9 @@
 
   function startRename(e?: Event) {
     e?.stopPropagation();
+    // Clear the menu open-state before the kebab unmounts under the rename input,
+    // so it can't spuriously re-open when rename ends and the kebab remounts.
+    menuOpen = false;
     actionSheetOpen = false;
     editing = true;
     editingName = search.name;
@@ -64,10 +79,22 @@
   // ── Actions ─────────────────────────────────────────────────────
   let actionSheetOpen = $state(false);
   let deleteDialogOpen = $state(false);
+  let editQueryDialogOpen = $state(false);
+  // Desktop kebab open state - held so the row keeps a background while its menu
+  // is open (otherwise moving the pointer onto the menu drops the hover, and you
+  // lose track of which row the menu belongs to).
+  let menuOpen = $state(false);
+  const rowMenuActive = $derived(menuOpen || actionSheetOpen);
 
   function handleMenuButton(e: Event) {
     e.stopPropagation();
     actionSheetOpen = true;
+  }
+
+  function startEditQuery(e?: Event) {
+    e?.stopPropagation();
+    actionSheetOpen = false;
+    editQueryDialogOpen = true;
   }
 
   function requestMove(e?: Event) {
@@ -94,7 +121,10 @@
     class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm cursor-pointer transition-colors
       {active
       ? 'list-row-active text-accent-foreground font-medium'
-      : 'text-foreground hover:bg-accent/50'}"
+      : rowMenuActive
+        ? 'bg-accent/50 text-foreground'
+        : 'text-foreground hover:bg-accent/50'}"
+    class:saved-search-just-saved={highlight}
     style="padding-left: {depth * 0.75 + 0.5}rem"
     role="button"
     tabindex="0"
@@ -138,7 +168,7 @@
           <MoreHorizontal class="h-3.5 w-3.5" />
         </button>
       {:else}
-        <DropdownMenu>
+        <DropdownMenu bind:open={menuOpen}>
           <DropdownMenuTrigger>
             {#snippet child({ props })}
               <button
@@ -157,6 +187,10 @@
             <DropdownMenuItem onclick={startRename}>
               <Pencil class="h-3.5 w-3.5" />
               {$t('saved_searches.rename')}
+            </DropdownMenuItem>
+            <DropdownMenuItem onclick={startEditQuery}>
+              <SearchCode class="h-3.5 w-3.5" />
+              {$t('saved_searches.edit_query')}
             </DropdownMenuItem>
             {#if context === 'panel'}
               <DropdownMenuItem onclick={requestMove}>
@@ -197,6 +231,10 @@
           <Pencil class="mr-2 h-4 w-4" />
           {$t('saved_searches.rename')}
         </Button>
+        <Button variant="ghost" class="w-full justify-start" onclick={() => startEditQuery()}>
+          <SearchCode class="mr-2 h-4 w-4" />
+          {$t('saved_searches.edit_query')}
+        </Button>
         {#if context === 'panel'}
           <Button variant="ghost" class="w-full justify-start" onclick={() => requestMove()}>
             <FolderInput class="mr-2 h-4 w-4" />
@@ -221,6 +259,8 @@
     </SheetContent>
   </Sheet>
 {/if}
+
+<EditSavedSearchQueryDialog bind:open={editQueryDialogOpen} {search} />
 
 <ConfirmDialog
   bind:open={deleteDialogOpen}

--- a/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
@@ -10,6 +10,11 @@
   } from '@lucide/svelte';
   import {
     Button,
+    ContextMenu,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuSeparator,
+    ContextMenuTrigger,
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -21,6 +26,7 @@
     SheetTitle
   } from '@reborn/ui';
   import type { SavedSearchDecrypted } from '@reborn/types';
+  import type { RowAction } from '$lib/utils/row-action';
   import { savedSearchesStore } from '$lib/stores/saved-searches.store';
   import { t } from '$lib/stores/i18n.store';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
@@ -80,9 +86,11 @@
   let actionSheetOpen = $state(false);
   let deleteDialogOpen = $state(false);
   let editQueryDialogOpen = $state(false);
-  // Desktop kebab open state - held so the row keeps a background while its menu
-  // is open (otherwise moving the pointer onto the menu drops the hover, and you
-  // lose track of which row the menu belongs to).
+  // Desktop menu open state (kebab OR right-click) - held so the row keeps a
+  // background while its menu is open (otherwise moving the pointer onto the menu
+  // drops the hover, and you lose track of which row the menu belongs to). Both
+  // menus are uncontrolled and only *report* their open state here, so neither
+  // ever drives the other open.
   let menuOpen = $state(false);
   const rowMenuActive = $derived(menuOpen || actionSheetOpen);
 
@@ -114,109 +122,152 @@
     actionSheetOpen = false;
     deleteDialogOpen = true;
   }
+
+  // Single source of truth for the desktop actions - feeds both the kebab
+  // (DropdownMenu) and the right-click ContextMenu, so they can't drift (mirrors
+  // FolderTree.folderActions). The mobile Sheet lists the same actions by hand.
+  const rowActions = $derived<RowAction[]>([
+    { key: 'rename', icon: Pencil, label: $t('saved_searches.rename'), run: startRename },
+    {
+      key: 'edit-query',
+      icon: SearchCode,
+      label: $t('saved_searches.edit_query'),
+      run: startEditQuery
+    },
+    ...(context === 'panel'
+      ? [
+          {
+            key: 'move',
+            icon: FolderInput,
+            label: $t('saved_searches.move_to_folder'),
+            run: requestMove
+          }
+        ]
+      : []),
+    ...(search.folder_id || search.pinned_to_root
+      ? [{ key: 'unpark', icon: FolderX, label: $t('saved_searches.unpark'), run: unpark }]
+      : []),
+    {
+      key: 'delete',
+      icon: Trash2,
+      label: $t('saved_searches.delete'),
+      run: requestDelete,
+      destructive: true,
+      separatorBefore: true
+    }
+  ]);
 </script>
 
 <li role={context === 'tree' ? 'treeitem' : 'listitem'} aria-selected={context === 'tree' ? false : undefined}>
-  <div
-    class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm cursor-pointer transition-colors
-      {active
-      ? 'list-row-active text-accent-foreground font-medium'
-      : rowMenuActive
-        ? 'bg-accent/50 text-foreground'
-        : 'text-foreground hover:bg-accent/50'}"
-    class:saved-search-just-saved={highlight}
-    style="padding-left: {depth * 0.75 + 0.5}rem"
-    role="button"
-    tabindex="0"
-    onclick={() => !editing && onselect(search)}
-    onkeydown={(e) => e.key === 'Enter' && !editing && onselect(search)}
-    aria-label={$t('saved_searches.item_label', { values: { name: search.name } })}
-    title={search.query}
-  >
-    <SearchCheck class="h-4 w-4 shrink-0 text-muted-foreground" />
-
-    {#if editing}
-      <input
-        bind:this={editInputEl}
-        bind:value={editingName}
-        class="min-w-0 flex-1 rounded-md border bg-background px-2 py-0.5 text-sm caret-primary focus:outline-none focus:ring-1 focus:ring-primary"
-        onclick={(e) => e.stopPropagation()}
-        onkeydown={(e) => {
-          if (e.key === 'Enter') commitRename();
-          if (e.key === 'Escape') editing = false;
-        }}
-        onblur={commitRename}
-      />
-    {:else}
-      <span class="min-w-0 flex-1 truncate">{search.name}</span>
-      {#if context === 'panel'}
-        <span class="hidden max-w-[40%] shrink-0 truncate text-xs text-muted-foreground md:inline">
-          {search.query}
-        </span>
-      {/if}
-    {/if}
-
-    {#if !editing}
-      {#if isMobileQuery.value}
-        <button
-          type="button"
-          onclick={handleMenuButton}
-          class="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-          aria-label={$t('saved_searches.actions')}
-          tabindex="-1"
+  <!-- Desktop right-click opens the same actions as the kebab (parity with folder
+       rows). Disabled on mobile (uses the action Sheet) and while renaming inline. -->
+  <ContextMenu onOpenChange={(o) => (menuOpen = o)}>
+    <ContextMenuTrigger disabled={isMobileQuery.value || editing}>
+      {#snippet child({ props: triggerProps })}
+        <div
+          {...triggerProps}
+          class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm cursor-pointer transition-colors
+            {active
+            ? 'list-row-active text-accent-foreground font-medium'
+            : rowMenuActive
+              ? 'bg-accent/50 text-foreground'
+              : 'text-foreground hover:bg-accent/50'}"
+          class:saved-search-just-saved={highlight}
+          style="padding-left: {depth * 0.75 + 0.5}rem"
+          role="button"
+          tabindex="0"
+          onclick={() => !editing && onselect(search)}
+          onkeydown={(e) => e.key === 'Enter' && !editing && onselect(search)}
+          aria-label={$t('saved_searches.item_label', { values: { name: search.name } })}
+          title={search.query}
         >
-          <MoreHorizontal class="h-3.5 w-3.5" />
-        </button>
-      {:else}
-        <DropdownMenu bind:open={menuOpen}>
-          <DropdownMenuTrigger>
-            {#snippet child({ props })}
+          <SearchCheck class="h-4 w-4 shrink-0 text-muted-foreground" />
+
+          {#if editing}
+            <input
+              bind:this={editInputEl}
+              bind:value={editingName}
+              class="min-w-0 flex-1 rounded-md border bg-background px-2 py-0.5 text-sm caret-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              onclick={(e) => e.stopPropagation()}
+              onkeydown={(e) => {
+                if (e.key === 'Enter') commitRename();
+                if (e.key === 'Escape') editing = false;
+              }}
+              onblur={commitRename}
+            />
+          {:else}
+            <span class="min-w-0 flex-1 truncate">{search.name}</span>
+            {#if context === 'panel'}
+              <span class="hidden max-w-[40%] shrink-0 truncate text-xs text-muted-foreground md:inline">
+                {search.query}
+              </span>
+            {/if}
+          {/if}
+
+          {#if !editing}
+            {#if isMobileQuery.value}
               <button
-                {...props}
                 type="button"
-                onclick={(e) => e.stopPropagation()}
-                class="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-opacity md:opacity-0 md:group-hover:opacity-100 hover:bg-accent hover:text-foreground"
+                onclick={handleMenuButton}
+                class="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
                 aria-label={$t('saved_searches.actions')}
                 tabindex="-1"
               >
                 <MoreHorizontal class="h-3.5 w-3.5" />
               </button>
-            {/snippet}
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" class="min-w-36">
-            <DropdownMenuItem onclick={startRename}>
-              <Pencil class="h-3.5 w-3.5" />
-              {$t('saved_searches.rename')}
-            </DropdownMenuItem>
-            <DropdownMenuItem onclick={startEditQuery}>
-              <SearchCode class="h-3.5 w-3.5" />
-              {$t('saved_searches.edit_query')}
-            </DropdownMenuItem>
-            {#if context === 'panel'}
-              <DropdownMenuItem onclick={requestMove}>
-                <FolderInput class="h-3.5 w-3.5" />
-                {$t('saved_searches.move_to_folder')}
-              </DropdownMenuItem>
+            {:else}
+              <DropdownMenu onOpenChange={(o) => (menuOpen = o)}>
+                <DropdownMenuTrigger>
+                  {#snippet child({ props })}
+                    <button
+                      {...props}
+                      type="button"
+                      onclick={(e) => e.stopPropagation()}
+                      class="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-opacity md:opacity-0 md:group-hover:opacity-100 hover:bg-accent hover:text-foreground"
+                      aria-label={$t('saved_searches.actions')}
+                      tabindex="-1"
+                    >
+                      <MoreHorizontal class="h-3.5 w-3.5" />
+                    </button>
+                  {/snippet}
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" class="min-w-44">
+                  {#each rowActions as { key, icon: Icon, label, run, destructive, separatorBefore } (key)}
+                    {#if separatorBefore}
+                      <DropdownMenuSeparator />
+                    {/if}
+                    <DropdownMenuItem
+                      class={destructive ? 'text-destructive focus:text-destructive' : ''}
+                      onclick={run}
+                    >
+                      <Icon class="h-3.5 w-3.5" />
+                      {label}
+                    </DropdownMenuItem>
+                  {/each}
+                </DropdownMenuContent>
+              </DropdownMenu>
             {/if}
-            {#if search.folder_id || search.pinned_to_root}
-              <DropdownMenuItem onclick={unpark}>
-                <FolderX class="h-3.5 w-3.5" />
-                {$t('saved_searches.unpark')}
-              </DropdownMenuItem>
-            {/if}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              class="text-destructive focus:text-destructive"
-              onclick={requestDelete}
-            >
-              <Trash2 class="h-3.5 w-3.5" />
-              {$t('saved_searches.delete')}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      {/if}
+          {/if}
+        </div>
+      {/snippet}
+    </ContextMenuTrigger>
+    {#if !isMobileQuery.value && !editing}
+      <ContextMenuContent class="min-w-44">
+        {#each rowActions as { key, icon: Icon, label, run, destructive, separatorBefore } (key)}
+          {#if separatorBefore}
+            <ContextMenuSeparator />
+          {/if}
+          <ContextMenuItem
+            class={destructive ? 'text-destructive focus:text-destructive' : ''}
+            onclick={run}
+          >
+            <Icon class="h-3.5 w-3.5" />
+            {label}
+          </ContextMenuItem>
+        {/each}
+      </ContextMenuContent>
     {/if}
-  </div>
+  </ContextMenu>
 </li>
 
 <!-- Mobile: action Sheet -->

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -133,10 +133,6 @@
 
   function startRename(folder: FolderWithChildren, e?: Event) {
     e?.stopPropagation();
-    // Clear the menu open-state before the kebab unmounts under the rename input,
-    // so the controlled dropdown can't spuriously re-open when rename ends and the
-    // kebab remounts.
-    menuOpenId = null;
     editingId = folder.id;
     editingName = folder.name;
     // Focus after DOM update
@@ -558,10 +554,7 @@
                     <MoreHorizontal class="h-3.5 w-3.5" />
                   </button>
                 {:else}
-                  <DropdownMenu
-                    open={menuOpenId === folder.id}
-                    onOpenChange={(o) => setFolderMenuOpen(folder.id, o)}
-                  >
+                  <DropdownMenu onOpenChange={(o) => setFolderMenuOpen(folder.id, o)}>
                     <DropdownMenuTrigger>
                       {#snippet child({ props })}
                         <button

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -133,6 +133,10 @@
 
   function startRename(folder: FolderWithChildren, e?: Event) {
     e?.stopPropagation();
+    // Clear the menu open-state before the kebab unmounts under the rename input,
+    // so the controlled dropdown can't spuriously re-open when rename ends and the
+    // kebab remounts.
+    menuOpenId = null;
     editingId = folder.id;
     editingName = folder.name;
     // Focus after DOM update
@@ -200,6 +204,14 @@
     } else {
       menuOpenId = menuOpenId === id ? null : id;
     }
+  }
+
+  // Keep menuOpenId in sync with the desktop kebab / right-click menu open state
+  // so the owning row can hold a background while its menu is open (otherwise the
+  // hover is lost the moment the pointer moves onto the menu, and it's unclear
+  // which row the menu belongs to).
+  function setFolderMenuOpen(id: string, isOpen: boolean) {
+    menuOpenId = isOpen ? id : menuOpenId === id ? null : menuOpenId;
   }
 
   function handleCreateNote(folderId: string, e?: Event) {
@@ -459,7 +471,7 @@
     >
       <!-- Desktop right-click opens the same folder actions as the kebab (#348).
            Disabled on mobile and while renaming inline. -->
-      <ContextMenu>
+      <ContextMenu onOpenChange={(o) => setFolderMenuOpen(folder.id, o)}>
         <ContextMenuTrigger disabled={isMobileQuery.value || editingId === folder.id}>
           {#snippet child({ props: triggerProps })}
             <div
@@ -474,7 +486,9 @@
                 cursor-pointer transition-colors
                 {isActive
                 ? 'list-row-active text-accent-foreground font-medium'
-                : 'text-foreground hover:bg-accent/50'}
+                : menuOpenId === folder.id
+                  ? 'bg-accent/50 text-foreground'
+                  : 'text-foreground hover:bg-accent/50'}
                 {isDragTarget ? 'ring-1 ring-primary bg-accent/30' : ''}"
               style="padding-left: {depth * 0.75 + 0.5}rem"
               role="button"
@@ -544,7 +558,10 @@
                     <MoreHorizontal class="h-3.5 w-3.5" />
                   </button>
                 {:else}
-                  <DropdownMenu>
+                  <DropdownMenu
+                    open={menuOpenId === folder.id}
+                    onOpenChange={(o) => setFolderMenuOpen(folder.id, o)}
+                  >
                     <DropdownMenuTrigger>
                       {#snippet child({ props })}
                         <button

--- a/apps/reborn-notes/src/lib/services/saved-search.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/saved-search.service.spec.ts
@@ -55,6 +55,7 @@ const {
   createSavedSearch,
   getAllSavedSearches,
   renameSavedSearch,
+  updateSavedSearchQuery,
   moveSavedSearchToFolder,
   pinSavedSearchToRoot,
   deleteSavedSearch
@@ -185,6 +186,56 @@ describe('renameSavedSearch', () => {
     expect(updated.name_encrypted).toBe('enc:New Name');
     expect(updated.sync_status).toBe('pending');
     expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', { name_encrypted: 'enc:New Name' });
+  });
+});
+
+describe('updateSavedSearchQuery', () => {
+  it('re-encrypts the query, marks pending and pushes only the query when the toggle is unchanged', async () => {
+    seed({
+      id: 's-1',
+      query_encrypted: 'enc:tag:old',
+      metadata_encrypted: 'encobj:{"search_in_content":false,"pinned_to_root":false}'
+    });
+
+    await updateSavedSearchQuery('s-1', '  tag:new is:starred  ', false);
+
+    const updated = rows.find((r) => r.id === 's-1')!;
+    expect(updated.query_encrypted).toBe('enc:tag:new is:starred');
+    expect(updated.sync_status).toBe('pending');
+    // Toggle unchanged → bundle untouched and left out of the PATCH payload.
+    expect(updated.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":false,"pinned_to_root":false}'
+    );
+    expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', {
+      query_encrypted: 'enc:tag:new is:starred'
+    });
+  });
+
+  it('re-encodes the metadata bundle and pushes it when the content toggle flips (root-pin preserved)', async () => {
+    seed({
+      id: 's-1',
+      query_encrypted: 'enc:tag:x',
+      metadata_encrypted: 'encobj:{"search_in_content":false,"pinned_to_root":true}'
+    });
+
+    await updateSavedSearchQuery('s-1', '"phrase"', true);
+
+    const updated = rows.find((r) => r.id === 's-1')!;
+    expect(updated.query_encrypted).toBe('enc:"phrase"');
+    expect(updated.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":true,"pinned_to_root":true}'
+    );
+    expect(pushUpdateSpy).toHaveBeenCalledWith('s-1', {
+      query_encrypted: 'enc:"phrase"',
+      metadata_encrypted: 'encobj:{"search_in_content":true,"pinned_to_root":true}'
+    });
+  });
+
+  it('rejects an empty query and does not push', async () => {
+    seed({ id: 's-1' });
+
+    await expect(updateSavedSearchQuery('s-1', '   ', false)).rejects.toThrow();
+    expect(pushUpdateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/reborn-notes/src/lib/services/saved-search.service.ts
+++ b/apps/reborn-notes/src/lib/services/saved-search.service.ts
@@ -167,6 +167,45 @@ export async function renameSavedSearch(id: string, name: string): Promise<void>
 }
 
 /**
+ * Update an existing saved search's query (and the body-search toggle it was
+ * saved with). The query is re-encrypted just like the name; the toggle lives in
+ * the encrypted metadata bundle, so it is only re-encoded when it actually flips
+ * (avoids needless ciphertext churn / pushes when only the query text changed).
+ */
+export async function updateSavedSearchQuery(
+  id: string,
+  query: string,
+  searchInContent: boolean
+): Promise<void> {
+  const existing = await savedSearchStore.get(id);
+  if (!existing) throw new Error('Saved search not found');
+  const trimmedQuery = query.trim().slice(0, MAX_SAVED_SEARCH_QUERY_CHARS);
+  if (!trimmedQuery) throw new Error('Saved search query must not be empty');
+  const query_encrypted = await encode(trimmedQuery, 'query');
+
+  const meta = await decodeMetadata(existing.metadata_encrypted);
+  const contentChanged = meta.search_in_content !== searchInContent;
+  if (contentChanged && !cryptoManager.isInitialized()) {
+    throw new Error('[E2E] encode saved-search metadata called without master key loaded');
+  }
+  const metadata_encrypted = contentChanged
+    ? await cryptoManager.encryptObject({ ...meta, search_in_content: searchInContent })
+    : existing.metadata_encrypted;
+
+  await savedSearchStore.save({
+    ...existing,
+    query_encrypted,
+    metadata_encrypted,
+    updated_at: new Date().toISOString(),
+    sync_status: 'pending'
+  });
+  pushSavedSearchUpdate(id, {
+    query_encrypted,
+    ...(contentChanged ? { metadata_encrypted } : {})
+  });
+}
+
+/**
  * Set a saved search's pin location. The three states are mutually exclusive:
  *   - `{ folderId }` parks it under a folder (plaintext FK, clears root-pin)
  *   - `{ root: true }` pins it to the top level as a smart folder (root-pin

--- a/apps/reborn-notes/src/lib/stores/saved-searches.store.ts
+++ b/apps/reborn-notes/src/lib/stores/saved-searches.store.ts
@@ -38,6 +38,15 @@ function createSavedSearchesStore() {
     await refresh();
   }
 
+  async function updateQuery(
+    id: string,
+    query: string,
+    searchInContent: boolean
+  ): Promise<void> {
+    await SavedSearchService.updateSavedSearchQuery(id, query, searchInContent);
+    await refresh();
+  }
+
   async function move(id: string, folderId: string | null): Promise<void> {
     await SavedSearchService.moveSavedSearchToFolder(id, folderId);
     await refresh();
@@ -60,6 +69,7 @@ function createSavedSearchesStore() {
     refresh,
     create,
     rename,
+    updateQuery,
     move,
     pinToRoot,
     remove

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -132,6 +132,14 @@
       ? ($savedSearchesStore.find((s) => s.id === activeSavedSearchId) ?? null)
       : null
   );
+  // The open smart folder's query + toggle, funnelled through their own $derived so
+  // value-equality memoization applies: editing the active smart folder's query
+  // changes these (re-running the section effect to refresh the list in place),
+  // while an unrelated saved-searches store tick that reproduces the same string
+  // does not. Reading the whole activeSavedSearch object in the effect instead
+  // would re-fire on every tick (refresh() yields freshly decrypted objects).
+  const activeSmartFolderQuery = $derived(activeSavedSearch?.query ?? null);
+  const activeSmartFolderInContent = $derived(activeSavedSearch?.search_in_content ?? false);
   // Last folder the user visited — used to scroll the folder tree back to that
   // node after exiting all the way up to the tree root, so deep trees keep context.
   let lastVisitedFolderId = $state<string | null>(null);
@@ -753,6 +761,12 @@
     // Only the Folders section hosts smart folders. Tracked here so opening one
     // (activeSavedSearchId set by handleSavedSearchSelect) re-runs this effect.
     const savedSearchId = section === 'folders' ? activeSavedSearchId : null;
+    // Track the open smart folder's query + toggle too, so editing the currently
+    // open smart folder's query re-runs this effect and refreshes the list in
+    // place. The $derived above give value-equality memoization, so this fires on
+    // an actual edit, not on every saved-searches store tick.
+    const smartQuery = savedSearchId ? activeSmartFolderQuery : null;
+    const smartInContent = savedSearchId ? activeSmartFolderInContent : false;
 
     if (section !== prevSection) {
       untrack(() => {
@@ -824,11 +838,10 @@
       } else if (section === 'tags' && tagId) {
         notesStore.setTag(tagId);
       } else if (savedSearchId) {
-        // Smart folder: membership = the saved query, scope = whole vault. Read
-        // the query untracked (activeSavedSearch is store-derived) so this effect
-        // tracks only nav state, not every saved-searches store tick.
-        const search = activeSavedSearch;
-        if (search) notesStore.setSmartFolder(search.query, search.search_in_content);
+        // Smart folder: membership = the saved query, scope = whole vault. Uses
+        // the tracked smartQuery/smartInContent (read above) so both opening a
+        // smart folder AND editing the open one's query refresh the list in place.
+        if (smartQuery !== null) notesStore.setSmartFolder(smartQuery, smartInContent);
         else notesStore.setFolder(undefined);
       } else if (sectionUsesFolderId) {
         notesStore.setFolder(folderId);

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -518,6 +518,13 @@
       "save": "Speichern",
       "cancel": "Abbrechen"
     },
+    "edit_query": "Abfrage bearbeiten",
+    "query_updated_toast": "Abfrage für \"{name}\" aktualisiert",
+    "query_update_failed_toast": "Die Abfrage konnte nicht aktualisiert werden",
+    "edit_dialog": {
+      "title": "Abfrage bearbeiten",
+      "description": "Ändern Sie, was diese gespeicherte Ansicht erfasst. Die Ergebnisse bleiben dynamisch und übernehmen die neue Abfrage."
+    },
     "item_label": "Gespeicherte Suche: {name}",
     "actions": "Aktionen für gespeicherte Suche",
     "rename": "Umbenennen",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -518,6 +518,13 @@
       "save": "Save",
       "cancel": "Cancel"
     },
+    "edit_query": "Edit query",
+    "query_updated_toast": "Query updated for \"{name}\"",
+    "query_update_failed_toast": "Could not update the query",
+    "edit_dialog": {
+      "title": "Edit query",
+      "description": "Change what this saved view matches. Results stay live and update to the new query."
+    },
     "item_label": "Saved search: {name}",
     "actions": "Saved search actions",
     "rename": "Rename",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -518,6 +518,13 @@
       "save": "Guardar",
       "cancel": "Cancelar"
     },
+    "edit_query": "Editar consulta",
+    "query_updated_toast": "Consulta actualizada para \"{name}\"",
+    "query_update_failed_toast": "No se pudo actualizar la consulta",
+    "edit_dialog": {
+      "title": "Editar consulta",
+      "description": "Cambia lo que coincide con esta vista guardada. Los resultados se mantienen al día y reflejan la nueva consulta."
+    },
     "item_label": "Búsqueda guardada: {name}",
     "actions": "Acciones de la búsqueda guardada",
     "rename": "Renombrar",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -518,6 +518,13 @@
       "save": "Enregistrer",
       "cancel": "Annuler"
     },
+    "edit_query": "Modifier la requête",
+    "query_updated_toast": "Requête mise à jour pour \"{name}\"",
+    "query_update_failed_toast": "Impossible de mettre à jour la requête",
+    "edit_dialog": {
+      "title": "Modifier la requête",
+      "description": "Modifiez ce que cette vue enregistrée renvoie. Les résultats restent dynamiques et reflètent la nouvelle requête."
+    },
     "item_label": "Recherche enregistrée : {name}",
     "actions": "Actions de la recherche enregistrée",
     "rename": "Renommer",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -518,6 +518,13 @@
       "save": "Zapisz",
       "cancel": "Anuluj"
     },
+    "edit_query": "Edytuj zapytanie",
+    "query_updated_toast": "Zaktualizowano zapytanie dla \"{name}\"",
+    "query_update_failed_toast": "Nie udało się zaktualizować zapytania",
+    "edit_dialog": {
+      "title": "Edytuj zapytanie",
+      "description": "Zmień, co dopasowuje ten zapisany widok. Wyniki są zawsze aktualne i odzwierciedlą nowe zapytanie."
+    },
     "item_label": "Zapisane wyszukiwanie: {name}",
     "actions": "Akcje zapisanego wyszukiwania",
     "rename": "Zmień nazwę",


### PR DESCRIPTION
## Summary

Three UX fixes for the Notes "saved searches" feature, all reported from smoke testing the Search section:

1. **Reveal on save.** The saved-searches list only renders on an empty query, so after saving, the new entry stayed hidden behind the results until the box was cleared - first-time users couldn't find it. Saving from the Search section now clears the box and flashes the new entry at the top of the list. Outside the Search section the query is left untouched.
2. **Edit query.** A new "Edit query" action (in both the Search-panel and pinned/smart-folder menus) opens a dialog to edit the query string and the "search in content" toggle. New service `updateSavedSearchQuery` re-encrypts the query and only re-encodes the encrypted metadata bundle when the toggle actually flips (churn-free). Closes the long-standing "update query" follow-up. No schema or Zero-Knowledge change - the query was already E2E-encrypted; this re-encrypts it exactly like rename does for the name.
3. **Menu-open highlight.** A row now keeps a subtle background while its kebab / right-click menu (or mobile action sheet) is open - for saved-search rows and folder rows alike - so it stays clear which row the menu belongs to. Coexists with the active-row highlight.

The three UX forks were confirmed with the PO via a decision prompt (all recommended options chosen).

## Test plan

Automated (green locally): `svelte-check` 0 errors / 0 warnings, eslint clean, `saved-search.service.spec.ts` 17/17 (3 new: query re-encrypt, churn-free metadata when the toggle is unchanged, reject empty query), i18n parity PASSED across all namespaces.

Smoke (Notes app):
- Search section: type a query, Save -> the box clears and the saved-searches list appears with the new entry briefly highlighted at the top.
- Row menu (desktop kebab + right-click, mobile sheet): "Edit query" opens a dialog; change the query and/or the "search in content" toggle, Save -> the toast confirms and re-running the search reflects the new query and remembered toggle.
- Open a row's kebab/context menu on a saved-search row and on a folder row: the row keeps a subtle background while the menu is open; the active folder / smart folder keeps its own highlight.
- Rename a saved search or folder via its menu, then cancel: the menu does not spuriously re-open.