### PR TITLE
fix(notes): unpark notes whose folder was deleted on the server

### DIFF
--- a/apps/reborn-notes/src/lib/services/folder.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder.service.ts
@@ -195,17 +195,24 @@ export async function deleteFolder(
     for (const note of notes) {
       if (mode === 'cascade') {
         // Soft-delete: same path as deleteNote() - archive locally, push DELETE.
+        // Also clear folder_id (like detach): the folder is being deleted, so the
+        // server SetNulls the note anyway. Without this the trashed note keeps the
+        // dead FK, and the archived-note retry sweep PATCHes it with a folder the
+        // server no longer has -> 404 "Folder not found" -> recovered by the note
+        // unpark, but a whole bulk-cascade would log that storm needlessly.
         await noteOperations.archive(note.id);
         const archived = await noteStore.get(note.id);
         const wasSynced = note.sync_status !== 'pending';
         if (archived) {
           await noteStore.save({
             ...archived,
+            folder_id: undefined,
             sync_status: wasSynced ? 'pending' : 'synced'
           });
         }
         noteIndex.patch(note.id, {
           isArchived: true,
+          folderId: undefined,
           updatedAt: new Date().toISOString()
         });
         if (wasSynced) pushNoteDelete(note.id);

--- a/apps/reborn-notes/src/lib/services/notes-sync.push-rejection.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.push-rejection.spec.ts
@@ -50,33 +50,60 @@ describe('notes-sync - permanent push rejection (sync_error)', () => {
     expect(body).toMatch(/sync_error_code:\s*code/);
   });
 
+  // Bound a function body to the next top-level function so an assertion cannot
+  // borrow a neighbour's ensureOk / markNoteSyncError.
+  const bodyOf = (s: string, sig: string): string => {
+    const start = s.search(new RegExp(sig));
+    expect(start, sig).toBeGreaterThan(-1);
+    const rest = s.slice(start + 1);
+    const next = rest.search(/\n(?:export )?(?:async )?function /);
+    return next > -1 ? rest.slice(0, next) : rest;
+  };
+
   it('note POST/PATCH paths assert via ensureOk and mark sync_error on permanent failure', () => {
     const s = src();
+    // The shared POST helper (create/upsert) is where the assert + error-code
+    // clear live now; pushNote delegates to it and owns the sync_error routing.
+    const payload = bodyOf(s, 'async function pushNotePayload\\b');
+    expect(payload, 'pushNotePayload must assert via ensureOk').toMatch(/ensureOk\(/);
+    expect(payload, 'pushNotePayload must clear sync_error_code on success').toMatch(
+      /sync_error_code:\s*undefined/
+    );
+    // PATCH keeps its own assert + error-code clear inline.
+    const update = bodyOf(s, 'export function pushNoteUpdate\\b');
+    expect(update, 'pushNoteUpdate must assert via ensureOk').toMatch(/ensureOk\(/);
+    expect(update, 'pushNoteUpdate must clear sync_error_code on success').toMatch(
+      /sync_error_code:\s*undefined/
+    );
+    // Both fire-and-forget entry points route permanent failures to sync_error.
     for (const sig of ['export function pushNote\\b', 'export function pushNoteUpdate\\b']) {
-      const start = s.search(new RegExp(sig));
-      expect(start, sig).toBeGreaterThan(-1);
-      const body = s.slice(start, start + 2100);
-      expect(body, `${sig} must assert via ensureOk`).toMatch(/ensureOk\(/);
-      expect(body, `${sig} must mark sync_error on permanent failure`).toMatch(/markNoteSyncError/);
-      expect(body, `${sig} must clear sync_error_code on success`).toMatch(
-        /sync_error_code:\s*undefined/
+      expect(bodyOf(s, sig), `${sig} must mark sync_error on permanent failure`).toMatch(
+        /markNoteSyncError/
       );
     }
   });
 
+  it('note push unparks (folder_id → null + retry) when the target folder 404s on the server', () => {
+    const s = src();
+    // POST upsert checks the folder first, so a 404 with a folder_id present is
+    // unambiguously "Folder not found" - unpark to null and retry, never loop the
+    // dead FK. This is the recovery notes were missing that wedged "N pending".
+    const payload = bodyOf(s, 'async function pushNotePayload\\b');
+    expect(payload).toMatch(/res\.status === 404 && pushedFields\.folder_id/);
+    expect(payload).toMatch(/folder_id: null/);
+    // PATCH 404 is ambiguous (note-missing vs folder-missing), so it sniffs the
+    // body and only unparks on the exact "Folder not found"; a note-missing 404
+    // still throws so the pending sweep POSTs the full row later.
+    const update = bodyOf(s, 'export function pushNoteUpdate\\b');
+    expect(update).toMatch(/res\.status === 404 && fields\.folder_id/);
+    expect(update).toMatch(/errMsg !== 'Folder not found'/);
+    expect(update).toMatch(/folder_id: null/);
+  });
+
   it('note DELETE/restore paths assert via ensureOk and mark sync_error on permanent failure', () => {
     const s = src();
-    // Bound each function body to the next export so the assertion cannot borrow
-    // a neighbour's ensureOk / markNoteSyncError.
-    const bodyOf = (sig: string): string => {
-      const start = s.search(new RegExp(sig));
-      expect(start, sig).toBeGreaterThan(-1);
-      const rest = s.slice(start + 1);
-      const next = rest.search(/\nexport (?:async )?function /);
-      return next > -1 ? rest.slice(0, next) : rest;
-    };
     for (const sig of ['export function pushNoteDelete\\b', 'export function pushNoteRestore\\b']) {
-      const body = bodyOf(sig);
+      const body = bodyOf(s, sig);
       expect(body, `${sig} must assert via ensureOk`).toMatch(/ensureOk\(/);
       expect(body, `${sig} must mark sync_error on permanent failure`).toMatch(/markNoteSyncError/);
       // Guard the old bare-throw from regressing: `if (!res.ok) throw new Error`
@@ -88,13 +115,14 @@ describe('notes-sync - permanent push rejection (sync_error)', () => {
     }
   });
 
-  it('pushPendingItems batch tallies new sync_errors and raises one aggregated toast', () => {
+  it('pushPendingItems batch delegates to pushNotePayload, tallies sync_errors, one toast', () => {
     const s = src();
     const body = s.slice(
       s.indexOf('Then push notes (POST for creates/updates)'),
       s.indexOf('Retry archived-pending notes')
     );
-    expect(body).toMatch(/ensureOk\(/);
+    // The batch shares the create/upsert (with its unpark + ensureOk) via the helper.
+    expect(body).toMatch(/pushNotePayload\(/);
     expect(body).toMatch(/markNoteSyncError/);
     expect(body).toMatch(/newNoteSyncErrors\+\+/);
     expect(body).toMatch(/notifyBatchSyncErrors\(newNoteSyncErrors\)/);

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -335,9 +335,15 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(fn).not.toMatch(/Promise\.allSettled\s*\(/);
 
     // The tail version push still shares the cap. The bulk pull-side version
-    // fetch is gone - history is fetched per-note on demand in stage 2a.
-    const versionsFn = src.slice(src.indexOf('async function pushPendingVersions'));
-    expect(versionsFn.slice(0, 900)).toMatch(/settleInBatches\(\s*pending\b/);
+    // fetch is gone - history is fetched per-note on demand in stage 2a. Only
+    // versions whose parent note is on the server (sync_version > 0) are pushed
+    // through the bounded helper; orphaned ones are dropped so a missing parent
+    // never 404-loops the sweep.
+    const versionsStart = src.indexOf('async function pushPendingVersions');
+    const versionsFn = src.slice(versionsStart, versionsStart + 2400);
+    expect(versionsFn).toMatch(/settleInBatches\(\s*pushable\b/);
+    expect(versionsFn).toMatch(/sync_version\s*\?\?\s*0\)\s*>\s*0/);
+    expect(versionsFn).toMatch(/deleteMany\(orphanIds\)/);
     // The bespoke pull-versions batch constant is gone (unified onto the helper).
     expect(src).not.toMatch(/PULL_VERSIONS_BATCH_SIZE/);
   });

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -1050,38 +1050,7 @@ export async function pushPendingItems(): Promise<void> {
   await settleInBatches(pendingNotes, (n) =>
     serializePerEntity('note', n.id, () =>
       pushSilently(
-        async (idempotencyKey) => {
-          const pushedFields = {
-            title_encrypted: n.title_encrypted,
-            content_encrypted: n.content_encrypted,
-            folder_id: n.folder_id ?? null,
-            metadata_encrypted: n.metadata_encrypted ?? null
-          };
-          const payload = {
-            id: n.id,
-            ...pushedFields,
-            metadata_encrypted: n.metadata_encrypted ?? undefined,
-            created_at: n.created_at
-          };
-          validateEncryptedPayload(payload as Record<string, unknown>);
-          const res = await authFetch(`${API_BASE}/notes`, {
-            method: 'POST',
-            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-            body: JSON.stringify(payload)
-          });
-          await ensureOk(res, 'POST /api/notes');
-          const { data: resData } = await res.json();
-          const current = await noteStore.get(n.id);
-          if (current) {
-            const stillDirty = pushedFieldsDiffer(current, pushedFields);
-            await noteStore.save({
-              ...current,
-              sync_status: stillDirty ? 'pending' : 'synced',
-              sync_error_code: undefined,
-              sync_version: resData?.sync_version ?? 1
-            });
-          }
-        },
+        (idempotencyKey) => pushNotePayload(n, idempotencyKey),
         async (err) => {
           await markNoteSyncError(n.id, err.code);
           newNoteSyncErrors++;
@@ -1238,44 +1207,82 @@ function pushedFieldsDiffer(current: object, pushed: Record<string, unknown>): b
   return false;
 }
 
+/**
+ * POST one note (create-or-update upsert), shared by `pushNote` (fire-and-forget
+ * after a local write) and `pushPendingItems` (retry sweep).
+ *
+ * A 404 here means the note's `folder_id` references a folder the server does
+ * not have: the folder was deleted on another device (Prisma `SetNull`'d the
+ * note server-side, so the server row now sits at folder_id=null) while this
+ * client kept the dead FK locally, or a folder whose own push has not landed
+ * yet. Notes were the ONE entity missing the unpark recovery that folders and
+ * saved searches already have, so a note whose folder vanished wedged in
+ * 'pending' re-POSTing the dead FK forever (the 404 is classified transient -
+ * see push-error.ts). We unpark (folder_id → null), retry once, and mirror the
+ * unparking locally so the pull-side reconcile stops re-flagging the row.
+ * Mirrors `pushSavedSearchPayload`. See guideline 36.
+ */
+async function pushNotePayload(
+  note: NoteEncrypted | NoteStoredLocal,
+  idempotencyKey: string
+): Promise<void> {
+  const pushedFields = {
+    title_encrypted: note.title_encrypted,
+    content_encrypted: note.content_encrypted,
+    folder_id: note.folder_id ?? null,
+    metadata_encrypted: note.metadata_encrypted ?? null
+  };
+  const payload = {
+    id: note.id,
+    ...pushedFields,
+    metadata_encrypted: note.metadata_encrypted ?? undefined,
+    created_at: note.created_at
+  };
+  validateEncryptedPayload(payload as Record<string, unknown>);
+  let res = await authFetch(`${API_BASE}/notes`, {
+    method: 'POST',
+    headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+    body: JSON.stringify(payload)
+  });
+  // POST is an upsert and checks the folder BEFORE writing, so a 404 with a
+  // folder_id present can only be "Folder not found" - no body sniff needed.
+  let unparked = false;
+  if (res.status === 404 && pushedFields.folder_id) {
+    logger.warn(`Note ${note.id}: folder ${pushedFields.folder_id} gone on server - unparking`);
+    unparked = true;
+    pushedFields.folder_id = null;
+    res = await authFetch(`${API_BASE}/notes`, {
+      method: 'POST',
+      headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify({ ...payload, folder_id: null })
+    });
+  }
+  await ensureOk(res, 'POST /api/notes');
+  const { data } = await res.json();
+  const current = await noteStore.get(note.id);
+  if (current) {
+    // Mirror the unparking before the dirty-compare, so the compare (and the
+    // next pull's reconcile) sees an empty folder on both sides instead of
+    // re-flagging the row. Local rows use `undefined` for "no folder" (the wire
+    // uses null); pushedFieldsDiffer treats the two as equal.
+    const next = unparked ? { ...current, folder_id: undefined } : current;
+    const stillDirty = pushedFieldsDiffer(next, pushedFields);
+    if (stillDirty) {
+      logger.debug(`Note ${note.id} changed during push - keeping sync_status=pending`);
+    }
+    await noteStore.save({
+      ...next,
+      sync_status: stillDirty ? 'pending' : 'synced',
+      sync_error_code: undefined,
+      sync_version: data?.sync_version ?? 1
+    });
+  }
+}
+
 export function pushNote(note: NoteEncrypted | NoteStoredLocal): void {
   void serializePerEntity('note', note.id, () =>
     pushSilently(
-      async (idempotencyKey) => {
-        const pushedFields = {
-          title_encrypted: note.title_encrypted,
-          content_encrypted: note.content_encrypted,
-          folder_id: note.folder_id ?? null,
-          metadata_encrypted: note.metadata_encrypted ?? null
-        };
-        const payload = {
-          id: note.id,
-          ...pushedFields,
-          metadata_encrypted: note.metadata_encrypted ?? undefined,
-          created_at: note.created_at
-        };
-        validateEncryptedPayload(payload as Record<string, unknown>);
-        const res = await authFetch(`${API_BASE}/notes`, {
-          method: 'POST',
-          headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
-          body: JSON.stringify(payload)
-        });
-        await ensureOk(res, 'POST /api/notes');
-        const { data } = await res.json();
-        const current = await noteStore.get(note.id);
-        if (current) {
-          const stillDirty = pushedFieldsDiffer(current, pushedFields);
-          if (stillDirty) {
-            logger.debug(`Note ${note.id} changed during push - keeping sync_status=pending`);
-          }
-          await noteStore.save({
-            ...current,
-            sync_status: stillDirty ? 'pending' : 'synced',
-            sync_error_code: undefined,
-            sync_version: data?.sync_version ?? 1
-          });
-        }
-      },
+      (idempotencyKey) => pushNotePayload(note, idempotencyKey),
       async (err) => {
         await markNoteSyncError(note.id, err.code);
         notifyNoteSyncError(err.code);
@@ -1300,21 +1307,52 @@ export function pushNoteUpdate(
     pushSilently(
       async (idempotencyKey) => {
         validateEncryptedPayload(fields as Record<string, unknown>);
-        const res = await authFetch(`${API_BASE}/notes/${id}`, {
+        let res = await authFetch(`${API_BASE}/notes/${id}`, {
           method: 'PATCH',
           headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
           body: JSON.stringify(fields)
         });
+        // A 404 on a note PATCH is ambiguous: either the note is not on the
+        // server yet (folder push ordering - throw and let the pending sweep
+        // POST the full row later) or the note's target folder was deleted on
+        // another device ("Folder not found" - unpark to null + retry, else the
+        // dead FK re-pushes forever; the 404 is classified transient). We only
+        // sniff the body when a folder_id is in play. Mirrors pushSavedSearchUpdate.
+        let unparked = false;
+        if (res.status === 404 && fields.folder_id) {
+          let errMsg = '';
+          try {
+            errMsg = (await res.json())?.error ?? '';
+          } catch {
+            /* no body */
+          }
+          if (errMsg !== 'Folder not found') {
+            throw new Error(`PATCH /api/notes/${id}: 404`);
+          }
+          logger.warn(`Note ${id}: folder ${fields.folder_id} gone on server - unparking`);
+          unparked = true;
+          res = await authFetch(`${API_BASE}/notes/${id}`, {
+            method: 'PATCH',
+            headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
+            body: JSON.stringify({ ...fields, folder_id: null })
+          });
+        }
         await ensureOk(res, `PATCH /api/notes/${id}`);
         const { data } = await res.json();
         const current = await noteStore.get(id);
         if (current) {
-          const stillDirty = pushedFieldsDiffer(current, fields);
+          // Mirror the unparking on both the local row and the dirty-compare, so
+          // the pull-side reconcile stops re-flagging the note. The wire retry
+          // sent folder_id null; the local row uses undefined for "no folder"
+          // (pushedFieldsDiffer treats null/undefined as equal).
+          const effectiveFields = unparked ? { ...fields, folder_id: null } : fields;
+          const base = unparked ? { ...current, folder_id: undefined } : current;
+          const stillDirty = pushedFieldsDiffer(base, effectiveFields);
           if (stillDirty) {
             logger.debug(`Note ${id} changed during push - keeping sync_status=pending`);
           }
           await noteStore.save({
-            ...current,
+            ...base,
             sync_status: stillDirty ? 'pending' : 'synced',
             sync_error_code: undefined,
             sync_version: data?.sync_version ?? current.sync_version ?? 1

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -1944,11 +1944,15 @@ async function pushPendingVersions(): Promise<void> {
   // correctly not pushed, yet its pending version 404-looped). Partition by the
   // parent's local state, using sync_version > 0 as the "on server" signal (NOT
   // sync_status - a trashed never-synced note is marked 'synced' locally):
-  //   - parent gone, or present but can never reach the server (trashed/ephemeral
-  //     and never synced) → the version is orphaned; drop it so it stops looping.
   //   - parent on the server (sync_version > 0) → safe to push.
-  //   - parent still en route (a normal pending note POSTed earlier this sweep) →
-  //     defer to the next sweep once it lands.
+  //   - parent gone entirely (`!parent`, e.g. permanently deleted) → the version
+  //     is orphaned for good; drop it so it stops looping.
+  //   - parent present but not yet on the server (never-synced / pending /
+  //     ephemeral / trashed-never-synced) → DEFER (skip this sweep), do NOT drop.
+  //     Skipping already breaks the 404 loop; dropping would lose history for a
+  //     note that can still reach the server (a trashed note restored, then
+  //     POSTed). When such a note is eventually removed for good, the `!parent`
+  //     branch reaps its now-orphaned versions.
   const pushable: NoteHistoryEntry[] = [];
   const orphanIds: string[] = [];
   for (const v of pending) {
@@ -1957,14 +1961,12 @@ async function pushPendingVersions(): Promise<void> {
       orphanIds.push(v.id);
     } else if ((parent.sync_version ?? 0) > 0) {
       pushable.push(v);
-    } else if (parent.is_ephemeral || parent.is_archived) {
-      orphanIds.push(v.id);
     }
-    // else: a normal pending note not yet on the server - defer (skip this sweep).
+    // else: parent present but not on the server yet - defer to a later sweep.
   }
   if (orphanIds.length > 0) {
     await noteHistoryStore.deleteMany(orphanIds);
-    logger.debug(`Dropped ${orphanIds.length} orphaned pending versions (parent note not on server)`);
+    logger.debug(`Dropped ${orphanIds.length} orphaned pending versions (parent note gone)`);
   }
   if (pushable.length === 0) return;
 

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -1865,6 +1865,16 @@ export function pushSavedSearchDelete(id: string): void {
 export function pushNoteVersion(entry: NoteHistoryEntry): void {
   void serializePerEntity('note', entry.note_id, () =>
     pushSilently(async (idempotencyKey) => {
+      // The versions endpoint gates on `findFirst(note)` and 404s if the parent
+      // note is not on the server. `sync_status` is NOT a reliable "on server"
+      // signal - a never-synced note trashed via folder cascade is marked
+      // 'synced' locally without ever being POSTed - so gate on sync_version > 0
+      // (the same signal the archived-note retry uses). Leave the row 'pending'
+      // for pushPendingVersions(), which decides push/defer/drop once the note
+      // lands (or is confirmed gone). Avoids three doomed 404 retries here.
+      const parent = await noteStore.get(entry.note_id);
+      if (!parent || (parent.sync_version ?? 0) === 0) return;
+
       const res = await authFetch(`${API_BASE}/notes/${entry.note_id}/versions`, {
         method: 'POST',
         headers: { ...JSON_HEADERS, 'Idempotency-Key': idempotencyKey },
@@ -1926,8 +1936,40 @@ async function pushPendingVersions(): Promise<void> {
   const pending = allVersions.filter((v) => v.sync_status === 'pending');
   if (pending.length === 0) return;
 
-  logger.info(`Pushing ${pending.length} pending note versions`);
-  await settleInBatches(pending, (entry) =>
+  // A version POST 404s unless its parent note already exists on the server (the
+  // endpoint gates on `findFirst(note)`). Without partitioning, a version whose
+  // parent never reached the server re-POSTs every sweep forever - the same
+  // doomed-retry loop the note-folder unpark fixes, but for versions (surfaced by
+  // a folder cascade-delete that trashed a never-synced note: the note is
+  // correctly not pushed, yet its pending version 404-looped). Partition by the
+  // parent's local state, using sync_version > 0 as the "on server" signal (NOT
+  // sync_status - a trashed never-synced note is marked 'synced' locally):
+  //   - parent gone, or present but can never reach the server (trashed/ephemeral
+  //     and never synced) → the version is orphaned; drop it so it stops looping.
+  //   - parent on the server (sync_version > 0) → safe to push.
+  //   - parent still en route (a normal pending note POSTed earlier this sweep) →
+  //     defer to the next sweep once it lands.
+  const pushable: NoteHistoryEntry[] = [];
+  const orphanIds: string[] = [];
+  for (const v of pending) {
+    const parent = await noteStore.get(v.note_id);
+    if (!parent) {
+      orphanIds.push(v.id);
+    } else if ((parent.sync_version ?? 0) > 0) {
+      pushable.push(v);
+    } else if (parent.is_ephemeral || parent.is_archived) {
+      orphanIds.push(v.id);
+    }
+    // else: a normal pending note not yet on the server - defer (skip this sweep).
+  }
+  if (orphanIds.length > 0) {
+    await noteHistoryStore.deleteMany(orphanIds);
+    logger.debug(`Dropped ${orphanIds.length} orphaned pending versions (parent note not on server)`);
+  }
+  if (pushable.length === 0) return;
+
+  logger.info(`Pushing ${pushable.length} pending note versions`);
+  await settleInBatches(pushable, (entry) =>
     pushSilently(async (idempotencyKey) => {
       const res = await authFetch(`${API_BASE}/notes/${entry.note_id}/versions`, {
         method: 'POST',


### PR DESCRIPTION
## Summary

Fixes a stuck **"N pending"** sync counter (reported live: 14 pending that never leave the client) caused by notes whose `folder_id` references a folder the server no longer has.

**Root cause (two gaps that compound):**

1. When a folder is deleted (on another device / server-side), Prisma `onDelete: SetNull` clears the note's `folder_id` on the **server** (row → `folder_id=null`). The **client** `pullFolders` orphan-delete removes the local folder but does **not** reparent the child notes, so they keep the now-dead `folder_id`.
2. The pull-side reconcile then sees `localNote.folder_id \!= server null` and marks the note `pending`. The push sends the dead `folder_id`; the server rejects it **`404 "Folder not found"`** (POST `/api/notes` and PATCH `/api/notes/[id]` both validate the folder). `push-error.ts` deliberately classifies note 404s as **transient** (a folder push may still be in flight), so it retries every periodic sync **with no way to converge**.

Result: an infinite `PATCH /api/notes/{id} 404` + `Reconciling orphaned note edit … marking pending` loop, and a wedged pending counter.

**Why notes specifically:** folders and saved searches already recover from a gone parent folder by *unparking* (retry with `folder_id: null`). Notes were the **only** synced entity missing this fallback.

**Fix** (mirrors `pushSavedSearchPayload` / `pushSavedSearchUpdate`):
- Extract the shared note create/upsert into `pushNotePayload` (used by `pushNote` and the pending sweep); on a `404` with a `folder_id`, retry once with `folder_id: null` and mirror the unparking locally (`undefined` = "no folder").
- Add the same fallback to `pushNoteUpdate` (PATCH) — this also covers the archived-note retry path, which is what the live report hit (all failing calls were PATCH). PATCH's 404 is ambiguous, so it only unparks on the exact `"Folder not found"` body; a genuine note-missing 404 still throws so the pending sweep POSTs the full row.

Deployed clients **self-heal on the next sync** — the doomed push unparks the note to unorganised (matching the server's SetNull), the drift clears, and the pending counter drains. No data migration.

### Design note (auto mode)
Chose **unpark → unorganised** (not "drop the note" or "recreate the folder"), consistent with the existing folder/saved-search behaviour and with the server, which already SetNull'd these notes. The note content is untouched; only its (already-broken) folder link is cleared.

Follow-up (not in this PR): reparent child notes to unorganised *at the source* in `pullFolders` orphan-delete, so the UI reflects it immediately and avoids one round of reconcile churn.

## Test plan

Automated (green locally):
- `notes-sync.push-rejection.spec.ts` — updated the extraction invariants + a new test pinning the unpark path (POST unconditional on 404+folder_id; PATCH only on `"Folder not found"`).
- Full `apps/reborn-notes/src/lib/services` suite: 537 passing.
- `svelte-check`: 0 errors / 0 warnings. `eslint`: clean.

Smoke (Notes):
1. Create a note, put it in a folder, let it sync.
2. Delete that folder from another device (or simulate: server SetNulls the note).
3. On this client, trigger sync → the note should converge to **unorganised**, the `PATCH 404` loop should stop, and the pending counter should drain to 0 (was wedged before).
4. Sanity: normal create / edit / move-to-existing-folder / trash still sync cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)