### PR TITLE
feat(notes): show progress while deleting a folder with many notes

### DIFF
--- a/apps/reborn-notes/src/lib/components/sidebar/DeleteFolderDialog.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/DeleteFolderDialog.svelte
@@ -7,13 +7,20 @@
     DialogHeader,
     DialogTitle,
     Button,
+    LoadingSpinner,
+    Progress,
     RadioGroup,
     RadioGroupItem,
     Label
   } from '@reborn/ui';
   import { t } from '$lib/stores/i18n.store';
   import { foldersStore } from '$lib/stores/folders.store';
-  import type { DeleteFolderMode, FolderDeleteSummary } from '$lib/services/folder.service';
+  import type {
+    DeleteFolderMode,
+    DeleteFolderProgress,
+    DeleteFolderProgressCallback,
+    FolderDeleteSummary
+  } from '$lib/services/folder.service';
 
   let {
     open = $bindable(false),
@@ -24,13 +31,19 @@
     open: boolean;
     folderId: string | null;
     folderName: string;
-    onConfirm: (mode: DeleteFolderMode) => void | Promise<void>;
+    onConfirm: (
+      mode: DeleteFolderMode,
+      onProgress: DeleteFolderProgressCallback
+    ) => void | Promise<void>;
   } = $props();
 
   let mode = $state<DeleteFolderMode>('detach');
   let summary = $state<FolderDeleteSummary | null>(null);
   let loadingSummary = $state(false);
   let isProcessing = $state(false);
+  // Live progress of the running delete - null until the service reports the
+  // first counted item (the dialog shows "Preparing…" in the meantime).
+  let progress = $state<DeleteFolderProgress | null>(null);
 
   // Refresh summary every time the dialog is opened for a folder.
   $effect(() => {
@@ -56,23 +69,55 @@
       : $t('folders.delete_dialog.confirm_detach')
   );
 
+  // Deleting a large subtree means seconds of sequential IndexedDB work - the
+  // label mirrors what is happening right now (mode-specific while notes are
+  // moved, then the folder records), the bar tracks the current phase.
+  const progressLabel = $derived.by(() => {
+    if (!progress) return $t('folders.delete_dialog.progress_preparing');
+    const { phase, current, total } = progress;
+    if (phase === 'folders') {
+      // All records are gone once current reaches total - the remaining tail
+      // (folder tree refresh) has no measurable progress of its own.
+      return current >= total
+        ? $t('folders.delete_dialog.progress_finishing')
+        : $t('folders.delete_dialog.progress_folders', { values: { current, total } });
+    }
+    return mode === 'cascade'
+      ? $t('folders.delete_dialog.progress_notes_cascade', { values: { current, total } })
+      : $t('folders.delete_dialog.progress_notes_detach', { values: { current, total } });
+  });
+
+  const showProgressBar = $derived.by(() => {
+    if (!progress || progress.total <= 1) return false;
+    return !(progress.phase === 'folders' && progress.current >= progress.total);
+  });
+
   async function handleConfirm() {
     isProcessing = true;
+    progress = null;
     try {
-      await onConfirm(mode);
+      await onConfirm(mode, (p) => {
+        progress = p;
+      });
       open = false;
     } finally {
       isProcessing = false;
+      progress = null;
     }
   }
 
   function handleCancel() {
+    if (isProcessing) return;
     open = false;
   }
 </script>
 
 <Dialog bind:open>
-  <DialogContent>
+  <DialogContent
+    showCloseButton={!isProcessing}
+    escapeKeydownBehavior={isProcessing ? 'ignore' : 'close'}
+    interactOutsideBehavior={isProcessing ? 'ignore' : 'close'}
+  >
     <DialogHeader>
       <DialogTitle>
         {$t('folders.delete_dialog.title', { values: { name: folderName } })}
@@ -98,7 +143,17 @@
       </DialogDescription>
     </DialogHeader>
 
-    {#if summary && summary.noteCount > 0}
+    {#if isProcessing}
+      <div class="space-y-2 py-2" role="status" aria-live="polite">
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <LoadingSpinner size="sm" />
+          <span>{progressLabel}</span>
+        </div>
+        {#if showProgressBar && progress}
+          <Progress value={progress.current} max={progress.total} class="h-1.5" />
+        {/if}
+      </div>
+    {:else if summary && summary.noteCount > 0}
       <RadioGroup bind:value={mode} class="gap-3 py-2">
         <div class="flex items-start gap-3">
           <RadioGroupItem value="detach" id="delete-mode-detach" class="mt-1" />

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderActionMenu.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderActionMenu.svelte
@@ -28,7 +28,10 @@
   import { syncedFolderConfigs, runFolderSync } from '$lib/services/folder-sync.service';
   import { t } from '$lib/stores/i18n.store';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
-  import type { DeleteFolderMode } from '$lib/services/folder.service';
+  import type {
+    DeleteFolderMode,
+    DeleteFolderProgressCallback
+  } from '$lib/services/folder.service';
   import DeleteFolderDialog from './DeleteFolderDialog.svelte';
   import ImportMarkdownToFolderDialog from '$lib/components/import/ImportMarkdownToFolderDialog.svelte';
 
@@ -52,7 +55,7 @@
     onNewSubfolder?: () => void;
     /** Parent owns the rename UI (e.g. inline input). */
     onStartRename: () => void;
-    /** Called after a successful delete — parent can navigate back to parent folder. */
+    /** Called after a successful delete - parent can navigate back to parent folder. */
     onAfterDelete?: () => void;
   } = $props();
 
@@ -138,9 +141,12 @@
     deleteDialogOpen = true;
   }
 
-  async function confirmDeleteFolder(mode: DeleteFolderMode) {
+  async function confirmDeleteFolder(
+    mode: DeleteFolderMode,
+    onProgress: DeleteFolderProgressCallback
+  ) {
     if (!folder) return;
-    await foldersStore.remove(folder.id, mode);
+    await foldersStore.remove(folder.id, mode, onProgress);
     if (mode === 'cascade') notesStore.refresh();
     onAfterDelete?.();
   }

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -46,7 +46,10 @@
   import { pendingNewFolderDraft } from '$lib/stores/new-folder-draft.store';
   import { t } from '$lib/stores/i18n.store';
   import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
-  import type { DeleteFolderMode } from '$lib/services/folder.service';
+  import type {
+    DeleteFolderMode,
+    DeleteFolderProgressCallback
+  } from '$lib/services/folder.service';
   import DeleteFolderDialog from './DeleteFolderDialog.svelte';
   import ImportMarkdownToFolderDialog from '$lib/components/import/ImportMarkdownToFolderDialog.svelte';
   import SavedSearchRow from '$lib/components/notes/SavedSearchRow.svelte';
@@ -92,7 +95,7 @@
     if (!pendingId) return;
     const found = nodes.find((n) => n.id === pendingId);
     if (found) {
-      pendingRenameId.set(null); // claim — clear so sibling instances don't also trigger
+      pendingRenameId.set(null); // claim - clear so sibling instances don't also trigger
       editingId = pendingId;
       editingName = found.name;
       setTimeout(() => editInputEl?.select(), 0);
@@ -241,10 +244,13 @@
     deleteFolderDialogOpen = true;
   }
 
-  async function confirmDeleteFolder(mode: DeleteFolderMode) {
+  async function confirmDeleteFolder(
+    mode: DeleteFolderMode,
+    onProgress: DeleteFolderProgressCallback
+  ) {
     if (folderToDelete) {
-      await foldersStore.remove(folderToDelete.id, mode);
-      // Cascade soft-deletes notes — refresh the visible note list so they
+      await foldersStore.remove(folderToDelete.id, mode, onProgress);
+      // Cascade soft-deletes notes - refresh the visible note list so they
       // disappear from the current folder/All-notes view immediately.
       if (mode === 'cascade') notesStore.refresh();
     }
@@ -301,7 +307,7 @@
     }
   });
 
-  // Single source of truth for a folder's actions — fed to both the desktop kebab
+  // Single source of truth for a folder's actions - fed to both the desktop kebab
   // (DropdownMenu) and the desktop right-click ContextMenu, so they can't drift.
   function folderActions(folder: FolderWithChildren, syncConfigId: string | null): RowAction[] {
     const actions: RowAction[] = [];
@@ -362,7 +368,7 @@
 
   // ── Drag & Drop ─────────────────────────────────────────────────
   // Folder rows are sorted alphabetically (see folder.service.getFolderTree),
-  // so sibling reorder is meaningless — drop on a row only ever means
+  // so sibling reorder is meaningless - drop on a row only ever means
   // "move dragged folder/note INTO this folder".
   let dragOverId = $state<string | null>(null);
 
@@ -386,7 +392,7 @@
     e.preventDefault();
     e.stopPropagation(); // prevent bubbling to AppSidebar root handler
 
-    // Handle note drop — move note into this folder
+    // Handle note drop - move note into this folder
     const noteId = e.dataTransfer!.getData('text/note-id');
     if (noteId) {
       await notesStore.move(noteId, target.id);

--- a/apps/reborn-notes/src/lib/services/folder-delete-progress.spec.ts
+++ b/apps/reborn-notes/src/lib/services/folder-delete-progress.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DeleteFolderProgress } from './folder.service';
+
+// ── Module mocks ─────────────────────────────────────────────────────────
+// deleteFolder is exercised against an in-memory note/folder fake; sync
+// pushes and the search index are spies. The spec locks the progress
+// contract (phase ordering, stable totals, clamping, opt-in count sweep),
+// not the storage internals.
+
+type NoteRow = {
+  id: string;
+  folder_id?: string | null;
+  is_archived?: boolean;
+  is_ephemeral?: boolean;
+  sync_status: string;
+};
+
+const notesById = new Map<string, NoteRow>();
+let descendantIds: string[] = [];
+const deletedFolderIds: string[] = [];
+
+// Call-observable so the "count sweep only when a listener asks" behavior
+// is testable via call counts.
+const byFolderSpy = vi.fn(async (fid: string) =>
+  [...notesById.values()].filter((n) => n.folder_id === fid && !n.is_archived)
+);
+
+vi.mock('@reborn/storage', () => ({
+  folderOperations: {
+    getDescendantIds: async () => [...descendantIds],
+    deleteFolder: async (fid: string) => {
+      deletedFolderIds.push(fid);
+    }
+  },
+  folderQueries: {},
+  folderStore: {},
+  noteOperations: {
+    archive: async (id: string) => {
+      const n = notesById.get(id);
+      if (n) n.is_archived = true;
+    },
+    moveToFolder: async (id: string, folderId: string | null) => {
+      const n = notesById.get(id);
+      if (n) n.folder_id = folderId;
+    }
+  },
+  noteQueries: { byFolder: (fid: string) => byFolderSpy(fid) },
+  noteStore: {
+    get: async (id: string) => {
+      const n = notesById.get(id);
+      return n ? { ...n } : undefined;
+    },
+    save: async (row: NoteRow) => {
+      notesById.set(row.id, { ...row });
+    }
+  },
+  savedSearchStore: { query: async () => [] }
+}));
+
+vi.mock('@reborn/crypto', () => ({
+  cryptoManager: {
+    isInitialized: () => true,
+    encryptText: async (s: string) => s,
+    decryptText: async (s: string) => s
+  }
+}));
+
+vi.mock('$lib/stores/auth.store', async () => {
+  const { writable } = await import('svelte/store');
+  return { authStore: writable({ userId: 'u1' }) };
+});
+
+const pushNoteUpdateSpy = vi.fn();
+const pushNoteDeleteSpy = vi.fn();
+const pushFolderDeleteSpy = vi.fn();
+vi.mock('./notes-sync.service', () => ({
+  pushFolder: vi.fn(),
+  pushFolderUpdate: vi.fn(),
+  pushFolderDelete: (id: string) => pushFolderDeleteSpy(id),
+  pushNoteUpdate: (...args: unknown[]) => pushNoteUpdateSpy(...args),
+  pushNoteDelete: (...args: unknown[]) => pushNoteDeleteSpy(...args),
+  pushSavedSearchUpdate: vi.fn()
+}));
+
+vi.mock('$lib/services/note-index.svelte', () => ({
+  noteIndex: { patch: vi.fn() }
+}));
+
+// Imported dynamically AFTER the mock/state declarations above so the mock
+// factories never touch an uninitialized module-scope binding (TDZ).
+const { deleteFolder } = await import('./folder.service');
+
+function seedNote(id: string, folderId: string, sync_status = 'synced'): void {
+  notesById.set(id, { id, folder_id: folderId, sync_status });
+}
+
+beforeEach(() => {
+  notesById.clear();
+  descendantIds = [];
+  deletedFolderIds.length = 0;
+  byFolderSpy.mockClear();
+  pushNoteUpdateSpy.mockClear();
+  pushNoteDeleteSpy.mockClear();
+  pushFolderDeleteSpy.mockClear();
+});
+
+describe('deleteFolder progress reporting', () => {
+  it('detach: notes phase 0..N, then folders phase 0..M bottom-up', async () => {
+    descendantIds = ['child'];
+    seedNote('n1', 'root');
+    seedNote('n2', 'root');
+    seedNote('n3', 'child');
+
+    const events: DeleteFolderProgress[] = [];
+    await deleteFolder('root', 'detach', (p) => events.push(p));
+
+    expect(events).toEqual([
+      { phase: 'notes', current: 0, total: 3 },
+      { phase: 'notes', current: 1, total: 3 },
+      { phase: 'notes', current: 2, total: 3 },
+      { phase: 'notes', current: 3, total: 3 },
+      { phase: 'folders', current: 0, total: 2 },
+      { phase: 'folders', current: 1, total: 2 },
+      { phase: 'folders', current: 2, total: 2 }
+    ]);
+    // Bottom-up: the descendant is deleted before the root.
+    expect(deletedFolderIds).toEqual(['child', 'root']);
+    // Every note was detached and its update pushed.
+    expect(pushNoteUpdateSpy).toHaveBeenCalledTimes(3);
+    expect([...notesById.values()].every((n) => n.folder_id == null)).toBe(true);
+  });
+
+  it('cascade: archives notes and reports the same progress shape', async () => {
+    seedNote('n1', 'root');
+    seedNote('n2', 'root', 'pending');
+
+    const events: DeleteFolderProgress[] = [];
+    await deleteFolder('root', 'cascade', (p) => events.push(p));
+
+    expect(events).toEqual([
+      { phase: 'notes', current: 0, total: 2 },
+      { phase: 'notes', current: 1, total: 2 },
+      { phase: 'notes', current: 2, total: 2 },
+      { phase: 'folders', current: 0, total: 1 },
+      { phase: 'folders', current: 1, total: 1 }
+    ]);
+    expect([...notesById.values()].every((n) => n.is_archived)).toBe(true);
+    // Only the already-synced note pushes a server DELETE.
+    expect(pushNoteDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(pushNoteDeleteSpy).toHaveBeenCalledWith('n1');
+  });
+
+  it('empty folder: skips the notes phase entirely', async () => {
+    const events: DeleteFolderProgress[] = [];
+    await deleteFolder('root', 'detach', (p) => events.push(p));
+
+    expect(events).toEqual([
+      { phase: 'folders', current: 0, total: 1 },
+      { phase: 'folders', current: 1, total: 1 }
+    ]);
+  });
+
+  it('without onProgress the extra count sweep is skipped', async () => {
+    descendantIds = ['child'];
+    seedNote('n1', 'root');
+
+    await deleteFolder('root', 'detach');
+
+    // One byFolder read per folder for processing - none for counting.
+    expect(byFolderSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('with onProgress each folder is read twice (count sweep + processing)', async () => {
+    descendantIds = ['child'];
+    seedNote('n1', 'root');
+
+    await deleteFolder('root', 'detach', () => {});
+
+    expect(byFolderSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('clamps current at total when notes appear between count and processing', async () => {
+    seedNote('n1', 'root');
+    seedNote('n2', 'root');
+    // The count sweep sees a stale single-note view (as if the second note
+    // landed from a concurrent sync pull right after counting).
+    byFolderSpy.mockImplementationOnce(async () => [
+      { id: 'n1', folder_id: 'root', sync_status: 'synced' }
+    ]);
+
+    const events: DeleteFolderProgress[] = [];
+    await deleteFolder('root', 'detach', (p) => events.push(p));
+
+    expect(events.filter((e) => e.phase === 'notes')).toEqual([
+      { phase: 'notes', current: 0, total: 1 },
+      { phase: 'notes', current: 1, total: 1 },
+      { phase: 'notes', current: 1, total: 1 }
+    ]);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/folder.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder.service.ts
@@ -174,6 +174,18 @@ export async function getFolderDeleteSummary(id: string): Promise<FolderDeleteSu
   return { subfolderCount: descendantIds.length, noteCount };
 }
 
+/** Progress of a long-running deleteFolder, reported once per processed item. */
+export interface DeleteFolderProgress {
+  /** 'notes' while notes are detached/trashed, 'folders' while folder records are deleted. */
+  phase: 'notes' | 'folders';
+  /** Items completed in the current phase. */
+  current: number;
+  /** Item count of the current phase (notes across the subtree, or folders incl. the root). */
+  total: number;
+}
+
+export type DeleteFolderProgressCallback = (progress: DeleteFolderProgress) => void;
+
 /**
  * Delete a folder, with control over what happens to the notes inside.
  *
@@ -183,12 +195,31 @@ export async function getFolderDeleteSummary(id: string): Promise<FolderDeleteSu
  * - `cascade`: notes are soft-deleted (moved to Trash) following the same
  *   path as `deleteNote`. They remain restorable from the trash for the
  *   normal retention window.
+ *
+ * `onProgress` reports per-item progress (notes first, then folders) so the
+ * UI can render a bar during large deletions - a subtree with hundreds of
+ * notes means many seconds of sequential IndexedDB work. When omitted, the
+ * up-front note count sweep is skipped entirely, so programmatic callers
+ * (e.g. the periodic-folder dedup) pay no extra reads.
  */
 export async function deleteFolder(
   id: string,
-  mode: DeleteFolderMode = 'detach'
+  mode: DeleteFolderMode = 'detach',
+  onProgress?: DeleteFolderProgressCallback
 ): Promise<void> {
   const folderIds = [id, ...(await folderOperations.getDescendantIds(id))];
+
+  // Count notes up front so the progress bar gets a stable total. The sweep
+  // re-reads what the loop below reads again, but these are cheap IndexedDB
+  // reads next to the per-note write+sync work that dominates the runtime.
+  let noteTotal = 0;
+  if (onProgress) {
+    for (const fid of folderIds) {
+      noteTotal += (await noteQueries.byFolder(fid)).length;
+    }
+    if (noteTotal > 0) onProgress({ phase: 'notes', current: 0, total: noteTotal });
+  }
+  let notesDone = 0;
 
   for (const fid of folderIds) {
     const notes = await noteQueries.byFolder(fid);
@@ -227,6 +258,13 @@ export async function deleteFolder(
         // to avoid a 404; it stays ephemeral and is cleaned up. #349
         if (!current?.is_ephemeral) pushNoteUpdate(note.id, { folder_id: null });
       }
+      notesDone += 1;
+      // Clamped: a note that appeared between the count sweep and this loop
+      // must not push `current` past `total` - the progress bar and the
+      // "{current} of {total}" copy both assume current <= total.
+      if (onProgress && noteTotal > 0) {
+        onProgress({ phase: 'notes', current: Math.min(notesDone, noteTotal), total: noteTotal });
+      }
     }
   }
 
@@ -256,12 +294,17 @@ export async function deleteFolder(
   }
 
   // Then delete folders bottom-up (descendants first, root last).
+  onProgress?.({ phase: 'folders', current: 0, total: folderIds.length });
+  let foldersDone = 0;
   for (const fid of folderIds.slice(1).reverse()) {
     await folderOperations.deleteFolder(fid);
     pushFolderDelete(fid);
+    foldersDone += 1;
+    onProgress?.({ phase: 'folders', current: foldersDone, total: folderIds.length });
   }
   await folderOperations.deleteFolder(id);
   pushFolderDelete(id);
+  onProgress?.({ phase: 'folders', current: folderIds.length, total: folderIds.length });
 }
 
 // `options.skipSync` defers the push to the caller (see renameFolder above).

--- a/apps/reborn-notes/src/lib/stores/folders.store.ts
+++ b/apps/reborn-notes/src/lib/stores/folders.store.ts
@@ -4,6 +4,7 @@ import type { FolderWithChildren } from '@reborn/types';
 import * as FolderService from '$lib/services/folder.service';
 import type {
   DeleteFolderMode,
+  DeleteFolderProgressCallback,
   FolderDeleteSummary
 } from '$lib/services/folder.service';
 
@@ -45,8 +46,12 @@ function createFoldersStore() {
     await refresh();
   }
 
-  async function remove(id: string, mode: DeleteFolderMode = 'detach'): Promise<void> {
-    await FolderService.deleteFolder(id, mode);
+  async function remove(
+    id: string,
+    mode: DeleteFolderMode = 'detach',
+    onProgress?: DeleteFolderProgressCallback
+  ): Promise<void> {
+    await FolderService.deleteFolder(id, mode, onProgress);
     await refresh();
   }
 

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -360,7 +360,12 @@
       "mode_cascade_hint": "Notizen (auch aus Unterordnern) werden in den Papierkorb verschoben und können von dort wiederhergestellt werden.",
       "confirm_detach": "Ordner löschen",
       "confirm_cascade": "Ordner und Notizen löschen",
-      "cancel": "Abbrechen"
+      "cancel": "Abbrechen",
+      "progress_preparing": "Wird vorbereitet…",
+      "progress_notes_detach": "Notiz {current} von {total} wird in „Alle Notizen“ verschoben…",
+      "progress_notes_cascade": "Notiz {current} von {total} wird in den Papierkorb verschoben…",
+      "progress_folders": "Ordner {current} von {total} wird gelöscht…",
+      "progress_finishing": "Wird abgeschlossen…"
     },
     "import_markdown": {
       "action": ".md hierher importieren",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -360,7 +360,12 @@
       "mode_cascade_hint": "Notes (including those in subfolders) will be moved to Trash and can be restored from there.",
       "confirm_detach": "Delete folder",
       "confirm_cascade": "Delete folder and notes",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "progress_preparing": "Preparing…",
+      "progress_notes_detach": "Moving note {current} of {total} to All Notes…",
+      "progress_notes_cascade": "Moving note {current} of {total} to Trash…",
+      "progress_folders": "Deleting folder {current} of {total}…",
+      "progress_finishing": "Finishing…"
     },
     "import_markdown": {
       "action": "Import .md here",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -360,7 +360,12 @@
       "mode_cascade_hint": "Las notas (incluidas las de las subcarpetas) se moverán a la papelera y se podrán restaurar desde allí.",
       "confirm_detach": "Eliminar carpeta",
       "confirm_cascade": "Eliminar carpeta y notas",
-      "cancel": "Cancelar"
+      "cancel": "Cancelar",
+      "progress_preparing": "Preparando…",
+      "progress_notes_detach": "Moviendo nota {current} de {total} a Todas las notas…",
+      "progress_notes_cascade": "Moviendo nota {current} de {total} a la papelera…",
+      "progress_folders": "Eliminando carpeta {current} de {total}…",
+      "progress_finishing": "Finalizando…"
     },
     "import_markdown": {
       "action": "Importar .md aquí",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -360,7 +360,12 @@
       "mode_cascade_hint": "Les notes (y compris celles des sous-dossiers) seront placées dans la corbeille et pourront y être restaurées.",
       "confirm_detach": "Supprimer le dossier",
       "confirm_cascade": "Supprimer le dossier et les notes",
-      "cancel": "Annuler"
+      "cancel": "Annuler",
+      "progress_preparing": "Préparation…",
+      "progress_notes_detach": "Déplacement de la note {current} sur {total} vers Toutes les notes…",
+      "progress_notes_cascade": "Déplacement de la note {current} sur {total} vers la corbeille…",
+      "progress_folders": "Suppression du dossier {current} sur {total}…",
+      "progress_finishing": "Finalisation…"
     },
     "import_markdown": {
       "action": "Importer .md ici",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -360,7 +360,12 @@
       "mode_cascade_hint": "Notatki (również z podfolderów) trafią do kosza i będzie można je stamtąd przywrócić.",
       "confirm_detach": "Usuń folder",
       "confirm_cascade": "Usuń folder i notatki",
-      "cancel": "Anuluj"
+      "cancel": "Anuluj",
+      "progress_preparing": "Przygotowywanie…",
+      "progress_notes_detach": "Przenoszenie notatki {current} z {total} do „Wszystkie notatki”…",
+      "progress_notes_cascade": "Przenoszenie notatki {current} z {total} do kosza…",
+      "progress_folders": "Usuwanie folderu {current} z {total}…",
+      "progress_finishing": "Kończenie…"
     },
     "import_markdown": {
       "action": "Importuj .md tutaj",


### PR DESCRIPTION
## Summary

- Deleting a folder with many notes/subfolders runs tens of seconds of sequential local IndexedDB work; the confirm dialog gave no feedback, so the app looked frozen.
- `deleteFolder()` in `folder.service.ts` now accepts an optional `onProgress` callback reporting two phases: `notes` (detach or trash each note; total counted up front for a stable bar) and `folders` (bottom-up record deletion). Without a listener the count sweep is skipped entirely, so programmatic callers (periodic-folder dedup) pay no extra reads.
- `DeleteFolderDialog` shows a spinner, a phase/mode-specific label ("Moving note 12 of 340 to Trash…", "Deleting folder 2 of 5…", then "Finishing…") and a progress bar, mirroring the import UI in settings/import-export. Closing the dialog (Esc, outside click, X) is blocked while the delete runs.
- New `folders.delete_dialog.progress_*` keys in all 5 locales (parity check green).
- New behavioral spec `folder-delete-progress.spec.ts` locks the progress contract: phase ordering, stable totals, clamping when notes appear mid-delete, opt-in count sweep.

## Test plan

- [x] Folder with a subfolder and many notes (e.g. via .md import) → Delete folder → "Move notes to Trash": spinner + "Moving note X of Y to Trash…" + advancing bar, brief folder phase, dialog closes; notes are in Trash.
- [x] Same with "Move notes to All Notes" (detach): label mentions All Notes and the notes land there.
- [x] While the delete runs: Esc, outside click and the X button do nothing; Cancel/Delete buttons are disabled.
- [x] Empty/small folder: deletion still completes immediately, no regression.
- [x] Local gates all green: app vitest suite (1175), i18n package tests, svelte-check, ESLint, `vite build`, `node scripts/check-i18n-parity.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016akfgjZGrSpEB4xsiot59P