### PR TITLE
fix(security): audit 012 W1 auto-backup isolation + S1 typed token gates

### DIFF
--- a/apps/reborn-notes/src/lib/server/auth.ts
+++ b/apps/reborn-notes/src/lib/server/auth.ts
@@ -11,11 +11,15 @@ export interface TokenInfo {
 /**
  * Extract and verify the user ID from an Authorization: Bearer <token> header.
  * Returns null if the token is missing, malformed, or invalid.
+ *
+ * Only ACCESS tokens are accepted: a refresh token is also a validly signed
+ * JWT (same issuer/audience, 30-day expiry) but bypasses rotation and
+ * family-reuse revocation, so it must never authenticate data endpoints.
  */
 export async function getUserFromToken(authorization: string | null): Promise<string | null> {
   if (!authorization?.startsWith('Bearer ')) return null;
   try {
-    const payload = await verifyToken(authorization.slice(7));
+    const payload = await verifyToken(authorization.slice(7), 'access');
     return payload?.userId ?? null;
   } catch (err: unknown) {
     logger.error('Token verification failed:', err);
@@ -26,11 +30,12 @@ export async function getUserFromToken(authorization: string | null): Promise<st
 /**
  * Extract user ID and session ID from an Authorization: Bearer <token> header.
  * Returns null if the token is missing, malformed, or invalid.
+ * Access tokens only - see getUserFromToken.
  */
 export async function getTokenInfo(authorization: string | null): Promise<TokenInfo | null> {
   if (!authorization?.startsWith('Bearer ')) return null;
   try {
-    const payload = await verifyToken(authorization.slice(7));
+    const payload = await verifyToken(authorization.slice(7), 'access');
     if (!payload?.userId) return null;
     return { userId: payload.userId, sessionId: payload.sessionId };
   } catch (err: unknown) {

--- a/apps/reborn-notes/src/lib/services/auto-backup/index.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/index.ts
@@ -12,10 +12,18 @@
 
 import { runAutoBackup, type AutoBackupOutcome } from '@reborn/backup';
 import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
 import { buildEncryptedBackup } from '$lib/services/export-import.service';
-import { loadAutoBackupConfig, loadAutoBackupState, saveAutoBackupState } from './prefs';
+import {
+  clearAutoBackupPrefs,
+  loadAutoBackupConfig,
+  loadAutoBackupState,
+  saveAutoBackupState
+} from './prefs';
 import { getLastDataChangeAt } from './watermark';
 import { verifyBackup } from './verify';
+
+const logger = createLogger('Notes-AutoBackup');
 
 /**
  * Run one "back up if due" cycle for reborn-notes.
@@ -54,6 +62,27 @@ export async function runNotesAutoBackupIfDue(
     saveState: async (next) => saveAutoBackupState(next),
     verifyBackup
   });
+}
+
+/**
+ * Wipe the CURRENT user's auto-backup footprint on this device: config +
+ * runtime state (localStorage) and the recovery phrase (OS vault). Called on
+ * logout and on the local-only wipe, BEFORE the session keys are removed -
+ * the entries are keyed by the session's user id, so this is the last moment
+ * they are addressable. Best-effort by design: a failed wipe is logged but
+ * must never block the logout flow (per-user keying already prevents another
+ * account from reading what might remain).
+ */
+export async function clearAutoBackupState(): Promise<void> {
+  try {
+    clearAutoBackupPrefs();
+    if (!__REBORN_NATIVE__) return;
+    // Lazy import keeps the native secure-storage bridge out of the web bundle.
+    const { clearRecoveryPhrase } = await import('./recovery-phrase-vault');
+    await clearRecoveryPhrase();
+  } catch (err) {
+    logger.error('Failed to clear auto-backup state:', err);
+  }
 }
 
 export {

--- a/apps/reborn-notes/src/lib/services/auto-backup/prefs.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/prefs.ts
@@ -15,6 +15,13 @@
  *
  * The recovery phrase is deliberately NOT stored here - it is a secret and
  * lives in the OS secure vault (`recovery-phrase-vault.ts`).
+ *
+ * Everything is keyed PER USER (account id or local-only pseudo id), never
+ * globally for the origin: a shared device must not let account B inherit
+ * account A's backup destination - A controls that folder and knows the
+ * phrase, so B's notes would land somewhere A can read them. The same scope id
+ * keys the phrase in the OS vault. Logout additionally wipes the current
+ * user's entries (see `clearAutoBackupState`).
  */
 
 import {
@@ -24,8 +31,16 @@ import {
   type AutoBackupState
 } from '@reborn/backup';
 
-const CONFIG_KEY = 'reborn-notes:autoBackup:config';
-const STATE_KEY = 'reborn-notes:autoBackup:state';
+const CONFIG_KEY_PREFIX = 'reborn-notes:autoBackup:config';
+const STATE_KEY_PREFIX = 'reborn-notes:autoBackup:state';
+
+// The shared cross-app session keys (duplicated string literals from
+// auth.store on purpose: they are a frozen cross-app storage contract, and
+// importing the store here would drag the whole svelte/crypto graph into this
+// otherwise dependency-free module).
+const CREDENTIALS_KEY = 'reborn_auth_credentials';
+const LOCAL_MODE_KEY = 'reborn_local_mode';
+const LOCAL_USER_ID_KEY = 'reborn_local_user_id';
 
 /**
  * Notes-side auto-backup config: the shared tunables plus the device-local
@@ -71,9 +86,37 @@ function safeLocalStorage(): KeyValueStore | null {
   }
 }
 
+/**
+ * The identity that scopes every auto-backup artifact on this device: the
+ * account user id when a session exists, the device-scoped local-only pseudo
+ * user id otherwise (both random UUIDs, so derived keys never collide). Null
+ * when there is no session at all - then there is nothing to read or write.
+ * Mirrors the precedence in auth.store's `readFromStorage` (account wins).
+ */
+export function autoBackupScopeId(store = safeLocalStorage()): string | null {
+  if (!store) return null;
+  try {
+    const raw = store.getItem(CREDENTIALS_KEY);
+    if (raw) {
+      const creds = JSON.parse(raw) as { id?: string };
+      if (creds?.id) return creds.id;
+    }
+  } catch {
+    // Malformed credentials - fall through to the local-only marker.
+  }
+  if (store.getItem(LOCAL_MODE_KEY) === '1') {
+    return store.getItem(LOCAL_USER_ID_KEY);
+  }
+  return null;
+}
+
+const configKey = (scopeId: string): string => `${CONFIG_KEY_PREFIX}:${scopeId}`;
+const stateKey = (scopeId: string): string => `${STATE_KEY_PREFIX}:${scopeId}`;
+
 /** Load the persisted config, merged over defaults. `store` is injectable for tests. */
 export function loadAutoBackupConfig(store = safeLocalStorage()): NotesAutoBackupConfig {
-  const raw = store?.getItem(CONFIG_KEY);
+  const scopeId = autoBackupScopeId(store);
+  const raw = scopeId ? store?.getItem(configKey(scopeId)) : null;
   if (!raw) return { ...DEFAULT_NOTES_AUTO_BACKUP_CONFIG };
   try {
     const parsed = JSON.parse(raw) as Partial<NotesAutoBackupConfig>;
@@ -88,17 +131,20 @@ export function loadAutoBackupConfig(store = safeLocalStorage()): NotesAutoBacku
   }
 }
 
-/** Persist the config. No-op when storage is unreachable. */
+/** Persist the config. No-op when storage is unreachable or no session exists. */
 export function saveAutoBackupConfig(
   config: NotesAutoBackupConfig,
   store = safeLocalStorage()
 ): void {
-  store?.setItem(CONFIG_KEY, JSON.stringify(config));
+  const scopeId = autoBackupScopeId(store);
+  if (!scopeId) return;
+  store?.setItem(configKey(scopeId), JSON.stringify(config));
 }
 
 /** Load the persisted runtime state, merged over defaults. */
 export function loadAutoBackupState(store = safeLocalStorage()): AutoBackupState {
-  const raw = store?.getItem(STATE_KEY);
+  const scopeId = autoBackupScopeId(store);
+  const raw = scopeId ? store?.getItem(stateKey(scopeId)) : null;
   if (!raw) return { ...DEFAULT_STATE };
   try {
     const parsed = JSON.parse(raw) as Partial<AutoBackupState>;
@@ -108,7 +154,28 @@ export function loadAutoBackupState(store = safeLocalStorage()): AutoBackupState
   }
 }
 
-/** Persist the runtime state. No-op when storage is unreachable. */
+/** Persist the runtime state. No-op when storage is unreachable or no session exists. */
 export function saveAutoBackupState(state: AutoBackupState, store = safeLocalStorage()): void {
-  store?.setItem(STATE_KEY, JSON.stringify(state));
+  const scopeId = autoBackupScopeId(store);
+  if (!scopeId) return;
+  store?.setItem(stateKey(scopeId), JSON.stringify(state));
+}
+
+/**
+ * Remove the persisted config and state of the CURRENT user. Called on logout
+ * and on the local-only wipe, while the session keys are still readable - the
+ * next account on this device must not inherit this user's backup target.
+ * Also sweeps the pre-scoping global keys (early native builds) so no stale
+ * folder bookmark survives the upgrade.
+ */
+export function clearAutoBackupPrefs(store = safeLocalStorage()): void {
+  if (!store) return;
+  const scopeId = autoBackupScopeId(store);
+  if (scopeId) {
+    store.removeItem(configKey(scopeId));
+    store.removeItem(stateKey(scopeId));
+  }
+  // Legacy unscoped keys from builds before per-user scoping.
+  store.removeItem(CONFIG_KEY_PREFIX);
+  store.removeItem(STATE_KEY_PREFIX);
 }

--- a/apps/reborn-notes/src/lib/services/auto-backup/recovery-phrase-vault.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/recovery-phrase-vault.ts
@@ -17,9 +17,20 @@
  */
 
 import { getSecureStorage } from '$lib/utils/native-secure-storage';
+import { autoBackupScopeId } from './prefs';
 
-/** Distinct from the master key's `'master_key'` - a separate vault entry. */
-const RECOVERY_PHRASE_KEY = 'recovery_phrase';
+/**
+ * Distinct from the master key's `'master_key'` - a separate vault entry,
+ * keyed per user (same scope id as the localStorage prefs): on a shared
+ * device the next account must never read - or unknowingly back up with -
+ * the previous owner's phrase.
+ */
+const RECOVERY_PHRASE_KEY_PREFIX = 'recovery_phrase';
+
+/** Pre-scoping global key (early native builds) - only ever deleted now. */
+const LEGACY_RECOVERY_PHRASE_KEY = 'recovery_phrase';
+
+const phraseKey = (scopeId: string): string => `${RECOVERY_PHRASE_KEY_PREFIX}_${scopeId}`;
 
 /**
  * Store the recovery phrase. Unlike load/clear this does NOT swallow errors:
@@ -29,27 +40,36 @@ const RECOVERY_PHRASE_KEY = 'recovery_phrase';
  */
 export async function saveRecoveryPhrase(phrase: string): Promise<void> {
   if (!__REBORN_NATIVE__) return;
+  const scopeId = autoBackupScopeId();
+  if (!scopeId) throw new Error('No session to scope the recovery phrase to');
   const storage = await getSecureStorage();
-  await storage.setItem(RECOVERY_PHRASE_KEY, phrase);
+  await storage.setItem(phraseKey(scopeId), phrase);
 }
 
-/** The stored recovery phrase, or null when absent / unreadable / on web. */
+/** The current user's stored recovery phrase, or null when absent / unreadable / on web. */
 export async function loadRecoveryPhrase(): Promise<string | null> {
   if (!__REBORN_NATIVE__) return null;
   try {
+    const scopeId = autoBackupScopeId();
+    if (!scopeId) return null;
     const storage = await getSecureStorage();
-    return await storage.getItem(RECOVERY_PHRASE_KEY);
+    return await storage.getItem(phraseKey(scopeId));
   } catch {
     return null;
   }
 }
 
-/** Remove the stored phrase (disabling backups / logout). Best-effort. */
+/**
+ * Remove the current user's stored phrase (disabling backups / logout), plus
+ * the legacy unscoped entry from builds before per-user scoping. Best-effort.
+ */
 export async function clearRecoveryPhrase(): Promise<void> {
   if (!__REBORN_NATIVE__) return;
   try {
     const storage = await getSecureStorage();
-    await storage.removeItem(RECOVERY_PHRASE_KEY);
+    const scopeId = autoBackupScopeId();
+    if (scopeId) await storage.removeItem(phraseKey(scopeId));
+    await storage.removeItem(LEGACY_RECOVERY_PHRASE_KEY);
   } catch {
     // A failed delete must not block the flow.
   }

--- a/apps/reborn-notes/src/lib/stores/auth.store.ts
+++ b/apps/reborn-notes/src/lib/stores/auth.store.ts
@@ -412,6 +412,19 @@ function createAuthStore() {
     // gate armed would strand the next account on a biometric lock screen with
     // no key to unlock. Re-enable is a one-tap opt-in after the next login.
     cryptoManager.setAppLockEnabled(false);
+
+    // Wipe this user's auto-backup config + recovery phrase BEFORE the session
+    // keys are removed (the entries are keyed by the current user id). Left in
+    // place, the next account could keep silently backing up into a folder the
+    // previous owner controls, encrypted with a phrase the previous owner
+    // knows. Never throws (best-effort inside), but the import can - guard it.
+    try {
+      const { clearAutoBackupState } = await import('$lib/services/auto-backup');
+      await clearAutoBackupState();
+    } catch (err) {
+      logger.error('Failed to clear auto-backup state on logout:', err);
+    }
+
     localStorage.removeItem(CREDENTIALS_KEY);
     localStorage.removeItem(ACCESS_TOKEN_KEY);
 

--- a/apps/reborn-notes/src/routes/api/auth/change-password/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/change-password/+server.ts
@@ -24,7 +24,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
       return json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }
 
-    const tokenData = await verifyToken(token);
+    const tokenData = await verifyToken(token, 'access');
     if (!tokenData?.userId) {
       return json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }

--- a/apps/reborn-notes/src/routes/api/auth/logout-all/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/logout-all/+server.ts
@@ -15,7 +15,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 
     if (token) {
       try {
-        const tokenData = await verifyToken(token);
+        const tokenData = await verifyToken(token, 'access');
         userId = tokenData?.userId;
       } catch {
         // Token might be expired but we still want to clear data

--- a/apps/reborn-notes/src/routes/api/auth/logout/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/logout/+server.ts
@@ -14,7 +14,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
     let userId: string | undefined;
     if (token) {
       try {
-        const tokenData = await verifyToken(token);
+        const tokenData = await verifyToken(token, 'access');
         userId = tokenData?.userId;
       } catch {
         logger.warn('Invalid token during logout');

--- a/apps/reborn-notes/src/routes/auth/lock/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/lock/+page.svelte
@@ -76,6 +76,14 @@
     } catch (err: unknown) {
       logger.error('Failed to wipe local data on passcode reset:', err);
     }
+    // Auto-backup config + recovery phrase are keyed by the local user id -
+    // wipe them while the marker below still resolves that id.
+    try {
+      const { clearAutoBackupState } = await import('$lib/services/auto-backup');
+      await clearAutoBackupState();
+    } catch (err: unknown) {
+      logger.error('Failed to clear auto-backup state on passcode reset:', err);
+    }
     localStorage.removeItem(LOCAL_MODE_KEY);
     localStorage.removeItem(LOCAL_USER_ID_KEY);
     // Hard redirect guarantees all in-memory state is dropped.

--- a/apps/reborn-task/src/lib/server/auth.ts
+++ b/apps/reborn-task/src/lib/server/auth.ts
@@ -11,11 +11,15 @@ export interface TokenInfo {
 /**
  * Extract and verify the user ID from an Authorization: Bearer <token> header.
  * Returns null if the token is missing, malformed, or invalid.
+ *
+ * Only ACCESS tokens are accepted: a refresh token is also a validly signed
+ * JWT (same issuer/audience, 30-day expiry) but bypasses rotation and
+ * family-reuse revocation, so it must never authenticate data endpoints.
  */
 export async function getUserFromToken(authorization: string | null): Promise<string | null> {
   if (!authorization?.startsWith('Bearer ')) return null;
   try {
-    const payload = await verifyToken(authorization.slice(7));
+    const payload = await verifyToken(authorization.slice(7), 'access');
     return payload?.userId ?? null;
   } catch (err: unknown) {
     logger.error('Token verification failed:', err);
@@ -26,11 +30,12 @@ export async function getUserFromToken(authorization: string | null): Promise<st
 /**
  * Extract user ID and session ID from an Authorization: Bearer <token> header.
  * Returns null if the token is missing, malformed, or invalid.
+ * Access tokens only - see getUserFromToken.
  */
 export async function getTokenInfo(authorization: string | null): Promise<TokenInfo | null> {
   if (!authorization?.startsWith('Bearer ')) return null;
   try {
-    const payload = await verifyToken(authorization.slice(7));
+    const payload = await verifyToken(authorization.slice(7), 'access');
     if (!payload?.userId) return null;
     return { userId: payload.userId, sessionId: payload.sessionId };
   } catch (err: unknown) {

--- a/apps/reborn-task/src/routes/api/auth/2fa/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/2fa/+server.ts
@@ -22,7 +22,7 @@ export const GET: RequestHandler = async ({ request }) => {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const tokenData = await verifyToken(token);
+		const tokenData = await verifyToken(token, 'access');
 		if (!tokenData?.userId) {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
@@ -56,7 +56,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const tokenData = await verifyToken(token);
+		const tokenData = await verifyToken(token, 'access');
 		if (!tokenData?.userId) {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
@@ -140,7 +140,7 @@ export const PUT: RequestHandler = async ({ request }) => {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const tokenData = await verifyToken(token);
+		const tokenData = await verifyToken(token, 'access');
 		if (!tokenData?.userId) {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
@@ -213,7 +213,7 @@ export const DELETE: RequestHandler = async ({ request }) => {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const tokenData = await verifyToken(token);
+		const tokenData = await verifyToken(token, 'access');
 		if (!tokenData?.userId) {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}

--- a/apps/reborn-task/src/routes/api/auth/change-password/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/change-password/+server.ts
@@ -24,7 +24,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}
 
-		const tokenData = await verifyToken(token);
+		const tokenData = await verifyToken(token, 'access');
 		if (!tokenData?.userId) {
 			return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 		}

--- a/apps/reborn-task/src/routes/api/auth/delete-account/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/delete-account/+server.ts
@@ -19,7 +19,7 @@ export const DELETE: RequestHandler = async ({ request, cookies }) => {
 
 		let userId: string;
 		try {
-			const tokenData = await verifyToken(token);
+			const tokenData = await verifyToken(token, 'access');
 			if (!tokenData?.userId) {
 				return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 			}

--- a/apps/reborn-task/src/routes/api/auth/logout-all/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/logout-all/+server.ts
@@ -15,7 +15,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 
 		if (token) {
 			try {
-				const tokenData = await verifyToken(token);
+				const tokenData = await verifyToken(token, 'access');
 				userId = tokenData?.userId;
 			} catch {
 				// Token might be expired but we still want to clear data

--- a/apps/reborn-task/src/routes/api/auth/logout/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/logout/+server.ts
@@ -16,7 +16,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 
 		if (token) {
 			try {
-				const tokenData = await verifyToken(token);
+				const tokenData = await verifyToken(token, 'access');
 				userId = tokenData?.userId;
 			} catch (error: unknown) {
 				// Token might be invalid, but we still want to clear cookies

--- a/apps/reborn-task/src/routes/api/auth/recovery-codes/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/recovery-codes/+server.ts
@@ -36,7 +36,7 @@ function hashCode(code: string): string {
 function getUserId(authHeader: string | null): Promise<string | null> {
 	const token = authHeader?.replace('Bearer ', '');
 	if (!token) return Promise.resolve(null);
-	return verifyToken(token)
+	return verifyToken(token, 'access')
 		.then((data) => data?.userId ?? null)
 		.catch(() => null);
 }

--- a/apps/reborn-task/src/routes/api/auth/sessions/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/sessions/+server.ts
@@ -12,7 +12,7 @@ async function getTokenInfo(
 	const token = authHeader?.replace('Bearer ', '');
 	if (!token) return null;
 	try {
-		const data = await verifyToken(token);
+		const data = await verifyToken(token, 'access');
 		if (!data?.userId) return null;
 		return { userId: data.userId, sessionId: data.sessionId };
 	} catch {

--- a/apps/reborn-task/src/routes/api/auth/sessions/[id]/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/sessions/[id]/+server.ts
@@ -11,7 +11,7 @@ export const DELETE: RequestHandler = async ({ request, params }) => {
 		const token = request.headers.get('authorization')?.replace('Bearer ', '');
 		if (!token) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
-		const tokenData = await verifyToken(token);
+		const tokenData = await verifyToken(token, 'access');
 		if (!tokenData?.userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
 		const sessionId = params.id;

--- a/apps/reborn-task/src/routes/api/auth/sessions/current/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/sessions/current/+server.ts
@@ -18,7 +18,7 @@ export const PATCH: RequestHandler = async ({ request, cookies }) => {
 		const token = request.headers.get('authorization')?.replace('Bearer ', '');
 		if (!token) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
-		const tokenData = await verifyToken(token);
+		const tokenData = await verifyToken(token, 'access');
 		if (!tokenData?.userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
 		const sessionId = cookies.get('session_id');

--- a/packages/auth/src/api/handlers.ts
+++ b/packages/auth/src/api/handlers.ts
@@ -70,7 +70,9 @@ export function createDefaultHandlerOptions(
     hashPassword,
     verifyPassword,
     generateTokens: generateJwtTokens,
-    verifyToken: (token: string) => verifyJwtToken(token),
+    // Access tokens only: refresh JWTs verify with the same secret but must
+    // not authenticate session/data reads (they bypass rotation + revocation).
+    verifyToken: (token: string) => verifyJwtToken(token, 'access'),
     generateEncryptionKey: async (password: string) => {
       const result = await generateMasterKeyForUser(password);
       return {
@@ -374,7 +376,8 @@ export async function handleSession(
     }
 
     const { dbClient } = options;
-    const verifyTokenFn = options.verifyToken || ((token: string) => verifyJwtToken(token));
+    const verifyTokenFn =
+      options.verifyToken || ((token: string) => verifyJwtToken(token, 'access'));
 
     // Verify token
     const tokenData = await verifyTokenFn(token);

--- a/packages/auth/src/middleware/authMiddleware.ts
+++ b/packages/auth/src/middleware/authMiddleware.ts
@@ -108,7 +108,9 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions) {
         return;
       }
 
-      // Verify token
+      // Verify token via the injected callback. Callers must supply a verifier
+      // that accepts ACCESS tokens only (refresh JWTs must not authenticate
+      // requests) - e.g. `(t) => verifyToken(t, 'access')` from utils/jwt.
       const tokenData = await verifyToken(token);
 
       if (!tokenData) {


### PR DESCRIPTION
## Summary

Implements the two top-priority fixes from internal security audit 012 (2026-07-02).

**W1 (high) - auto-backup must not survive logout / leak across accounts (native):**
- Auto-backup config + runtime state (localStorage) and the recovery phrase (OS vault) are now keyed per user - the account user id, or the local-only pseudo id - instead of origin-global keys. Another account on the same device can no longer read or unknowingly use the previous owner's backup folder and phrase.
- `logout()` and the local-only passcode wipe now call the new `clearAutoBackupState()`, wiping the current user's entries plus the legacy unscoped keys, before the session keys (which resolve the scope) are removed.
- No migration for pre-scoping entries (pre-GA native builds only): they get swept on the next logout; auto-backup needs a one-time re-enable. The local -> account upgrade also starts with a fresh scope (re-enable, documented trade-off).

**S1 (medium/high) - refresh JWT no longer works as a Bearer token:**
- Every auth gate now calls `verifyToken(token, 'access')`: `getUserFromToken`/`getTokenInfo` in both apps, the default verifier in `createDefaultHandlerOptions`/`handleSession`, and all inline verifications (logout, logout-all, change-password, delete-account, recovery-codes, sessions x3, 2fa x4).
- The refresh flow is unaffected - `handleRefreshToken` validates refresh tokens against the DB, never via `verifyToken` (verified before the change).
- The dead Express-style `authMiddleware` keeps its injected single-arg verifier (its options type takes `(token) => ...`); a comment now requires callers to supply an access-only verifier. Its removal is a separate cleanup (audit O48).

Decisions taken while implementing (flagged for review):
- Went straight to per-user scoping (audit lists it in the W1 priority row) instead of a wipe-only fix - it also covers session-expiry account switches, where no logout event exists.
- Session storage key literals are duplicated in `prefs.ts` rather than imported from `auth.store` to keep the module free of the svelte/crypto graph (they are a frozen cross-app contract).

## Test plan

- Green locally: eslint (auth, api-client, apps), svelte-check notes + task (0 errors), vitest: auth 59, notes 1175, task 87, tsup build of `@reborn/auth`, svelte compile of the changed page.
- Smoke (native build, two test accounts): as user A enable auto-backup (folder + phrase), log out; verify Settings > Backup for user B shows auto-backup disabled, no folder, no phrase; run a backup as B and confirm nothing lands in A's folder. Log back in as A - auto-backup is off (expected, needs re-enable).
- Smoke (web): logout/login still work; API calls still authenticate (access token); a refresh token pasted as `Authorization: Bearer` on e.g. `/api/notes` must now return 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016akfgjZGrSpEB4xsiot59P