### PR TITLE
fix(notes): exclude app data from OS device backups

### DIFF
--- a/apps/reborn-notes/android/app/src/main/AndroidManifest.xml
+++ b/apps/reborn-notes/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Zero Knowledge backup posture: the app's data directory holds DECRYPTED
+         state (WebView IndexedDB shadow indexes - note titles, folder names -
+         plus the localStorage access token), so it must never ride OS backups
+         off the device. allowBackup="false" disables cloud backup on every API
+         level, but on Android 12+ it no longer governs device-to-device
+         transfer - dataExtractionRules excludes everything from that (and from
+         cloud backup, belt and braces) too. The sanctioned backup is the app's
+         own phrase-encrypted portable backup (auto-backup service). Mirror this
+         posture in any future native shell (reborn-task). -->
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/apps/reborn-notes/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/apps/reborn-notes/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Read by Android 12+ (API 31+); older versions are covered in full by
+     allowBackup="false" in AndroidManifest.xml.
+
+     Exclude every domain from every transfer type: the data directory holds
+     decrypted shadow indexes (WebView IndexedDB) and the localStorage access
+     token, and the Zero Knowledge invariant is that only ciphertext ever
+     leaves the device. cloud-backup is already disabled by
+     allowBackup="false" (kept here as belt and braces); device-transfer and
+     cross-platform-transfer are NOT governed by allowBackup on Android 12+,
+     so these rules are what actually blocks them. path="." means the entire
+     domain directory, recursively.
+
+     Restore cost is nil by design: a new device gets a fresh login and
+     re-syncs ciphertext from the server; local-only data is covered by the
+     app's phrase-encrypted portable backup (auto-backup service). -->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </device-transfer>
+    <cross-platform-transfer platform="ios">
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </cross-platform-transfer>
+</data-extraction-rules>

--- a/apps/reborn-notes/ios/App/App/AppDelegate.swift
+++ b/apps/reborn-notes/ios/App/App/AppDelegate.swift
@@ -9,7 +9,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        AppDelegate.excludeWebDataFromBackup()
         return true
     }
 
@@ -84,6 +84,46 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             method_setImplementation(method, nilViewIMP)
         }
         didStripAccessory = true
+    }
+
+    /// Keep decrypted local state out of iCloud/Finder device backups.
+    ///
+    /// The Zero Knowledge invariant is that only ciphertext ever leaves the
+    /// device. WKWebView's store (Library/WebKit) holds IndexedDB with
+    /// decrypted shadow indexes (note titles, folder names used for
+    /// sort/filter) plus the access token in localStorage, and the shared
+    /// cookie jar (Library/Cookies) holds the refresh/session cookies the API
+    /// sets for native clients too. Both live inside the default backup scope,
+    /// so without the exclusion flag that plaintext would ride every backup.
+    ///
+    /// The flag is a per-item resource value and WebKit can recreate its
+    /// store, so it is re-applied on every launch; on a fresh install the
+    /// directories are created first so the flag lands before WebKit's first
+    /// write. Restore cost is nil by design: a restored device gets a fresh
+    /// login and re-syncs ciphertext from the server (the master key and
+    /// refresh token live in the Keychain as ThisDeviceOnly; the sanctioned
+    /// local backup is the app's phrase-encrypted portable backup).
+    private static func excludeWebDataFromBackup() {
+        let fileManager = FileManager.default
+        guard let library = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else { return }
+        for name in ["WebKit", "Cookies"] {
+            var directory = library.appendingPathComponent(name, isDirectory: true)
+            if !fileManager.fileExists(atPath: directory.path) {
+                do {
+                    try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+                } catch {
+                    NSLog("re/notes: could not create \(name) for backup exclusion: \(error)")
+                    continue
+                }
+            }
+            do {
+                var values = URLResourceValues()
+                values.isExcludedFromBackup = true
+                try directory.setResourceValues(values)
+            } catch {
+                NSLog("re/notes: could not exclude \(name) from backup: \(error)")
+            }
+        }
     }
 
     func applicationWillTerminate(_ application: UIApplication) {


### PR DESCRIPTION
## Summary

Security audit fix (S2) - the second and last native GA blocker. The native app's data directory holds decrypted state (WebView IndexedDB shadow indexes: note titles and folder names kept locally for sort/filter, plus the localStorage access token), and OS backup mechanisms would copy it off the device - breaking the Zero Knowledge invariant that only ciphertext ever leaves the device.

- **Android** (`AndroidManifest.xml` + new `res/xml/data_extraction_rules.xml`): `android:allowBackup="false"` plus exclude-all `dataExtractionRules` covering cloud backup, device-to-device transfer and cross-platform transfer. Both are needed: per the official Auto Backup docs, on Android 12+ `allowBackup="false"` no longer disables D2D transfer - only the extraction rules do.
- **iOS** (`AppDelegate.swift`): `Library/WebKit` (IndexedDB + localStorage) and `Library/Cookies` are flagged `isExcludedFromBackup` on every launch (the flag is per-item and WebKit can recreate its store); on a fresh install the directories are created first so the flag lands before WebKit's first write.

Decisions to review:

- The audit recommendation offered `allowBackup="false"` **or** extraction rules; implemented **both**, since the rules are required anyway for D2D transfer on Android 12+.
- iOS additionally excludes the cookie jar: `/api/auth/login` sets the `refresh_token`/`session_id` httpOnly cookies for native clients as well (they also receive the tokens in the response body), and `Library/Cookies` sits inside the default backup scope.
- Restore behavior is intentionally "fresh login + re-sync from server"; the sanctioned local backup remains the phrase-encrypted portable auto-backup. Master key and refresh token were already backup-safe (Keystore-wrapped / Keychain ThisDeviceOnly).

## Test plan

- No web code touched - CI re-runs the (unchanged) reborn-notes web targets.
- XML well-formedness verified with xmllint; `AppDelegate.swift` syntax-checked with `swiftc -parse`; Android backup semantics cross-checked against the official Auto Backup documentation.
- Native smoke (local builds): app launches and behaves as before on the Android emulator and iOS simulator; the iOS console shows no `could not exclude ... from backup` lines.
- Optional deeper Android check: `adb shell bmgr backupnow eu.reapps.notes` should report the package as not eligible for backup.