### PR TITLE
fix(security): audit 012 S4 challenge token + N1/N2/N8 hardening

### DIFF
--- a/apps/reborn-notes/src/hooks.server.ts
+++ b/apps/reborn-notes/src/hooks.server.ts
@@ -17,7 +17,12 @@ import { getAppLoadingStrings } from '$lib/server/app-loading-strings';
 
 const BASE = process.env.PUBLIC_BASE_PATH ?? '';
 const RATE_LIMITED_AUTH = new Set([`${BASE}/api/auth/login`, `${BASE}/api/auth/2fa/verify`]);
-const RATE_LIMITED_REFRESH = new Set([`${BASE}/api/auth/refresh`]);
+const RATE_LIMITED_REFRESH = new Set([
+  `${BASE}/api/auth/refresh`,
+  // Native (Capacitor) refresh takes the token in the body instead of the
+  // cookie but is the same unauthenticated DB-hitting operation (audit 012 N1).
+  `${BASE}/api/auth/refresh-native`
+]);
 const RATE_LIMITED_REGISTER = new Set([`${BASE}/api/auth/register`]);
 const RATE_LIMITED_POW = new Set([`${BASE}/api/auth/pow`]);
 

--- a/apps/reborn-notes/src/lib/services/notes-auth.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-auth.service.ts
@@ -29,7 +29,8 @@ export interface LoginResult {
   success: boolean;
   message?: string;
   twoFactorRequired?: boolean;
-  userId?: string;
+  /** Short-lived signed token proving the password step passed - required by /2fa/verify. */
+  challengeToken?: string;
   encryptedMasterKey?: string;
   masterKeySalt?: string;
 }
@@ -40,7 +41,7 @@ interface ReAuthResponseBody {
   error?: string;
   data?: {
     twoFactorRequired?: boolean;
-    userId?: string;
+    challengeToken?: string;
     access_token?: string;
     /** Present only for native clients (sent the native header). */
     refresh_token?: string;
@@ -75,7 +76,7 @@ export async function loginInNotes(username: string, password: string): Promise<
       return {
         success: false,
         twoFactorRequired: true,
-        userId: data.userId,
+        challengeToken: data.challengeToken,
         encryptedMasterKey: data.encryptedMasterKey,
         masterKeySalt: data.masterKeySalt
       };
@@ -266,8 +267,9 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
   const { data } = body;
 
   if (data?.twoFactorRequired) {
-    if (!data.userId) return { kind: 'error', message: 'Missing userId in 2FA response' };
-    return { kind: 'two_factor_required', userId: data.userId };
+    if (!data.challengeToken)
+      return { kind: 'error', message: 'Missing challenge token in 2FA response' };
+    return { kind: 'two_factor_required', challengeToken: data.challengeToken };
   }
 
   if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
@@ -294,13 +296,16 @@ export async function reAuthenticate(password: string): Promise<ReAuthResult> {
  * Re-authenticate after session expiry - TOTP step (invoked from ReAuthModal
  * after {@link reAuthenticate} returned `two_factor_required`).
  */
-export async function verifyTotpForReauth(userId: string, code: string): Promise<ReAuthResult> {
+export async function verifyTotpForReauth(
+  challengeToken: string,
+  code: string
+): Promise<ReAuthResult> {
   let res: Response;
   try {
     res = await fetch(`${API_BASE}/auth/2fa/verify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...nativeAuthHeaders() },
-      body: JSON.stringify({ userId, code })
+      body: JSON.stringify({ challengeToken, code })
     });
   } catch (err) {
     return { kind: 'error', message: err instanceof Error ? err.message : 'Network error' };
@@ -311,6 +316,10 @@ export async function verifyTotpForReauth(userId: string, code: string): Promise
     const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 0;
     return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
   }
+
+  // Challenge token expired or already consumed - the modal returns to the
+  // password step so a fresh one can be minted.
+  if (res.status === 401) return { kind: 'challenge_expired' };
 
   let body: ReAuthResponseBody;
   try {

--- a/apps/reborn-notes/src/routes/api/auth/2fa/verify/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/2fa/verify/+server.ts
@@ -1,7 +1,14 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createLogger } from '@reborn/utils';
-import { generateTokens, REFRESH_TOKEN_TTL_SECONDS, refreshTokenExpiryDate } from '@reborn/auth/server';
+import {
+  consumeSingleUseToken,
+  generateTokens,
+  REFRESH_TOKEN_TTL_SECONDS,
+  refreshTokenExpiryDate,
+  TWO_FACTOR_CHALLENGE_PURPOSE,
+  verifySingleUseToken
+} from '@reborn/auth/server';
 import { prisma } from '@reborn/database';
 import { v4 as uuidv4 } from 'uuid';
 import * as OTPAuth from 'otpauth';
@@ -18,14 +25,25 @@ const ISSUER = 'Reborn Apps';
 export const POST: RequestHandler = async ({ request, cookies }) => {
   try {
     const body = await request.json();
-    const { userId, code } = body ?? {};
+    const { challengeToken, code } = body ?? {};
 
-    if (!userId || typeof userId !== 'string' || userId.length > 36) {
-      return json({ success: false, error: 'Missing userId' }, { status: 400 });
+    if (!challengeToken || typeof challengeToken !== 'string' || challengeToken.length > 2048) {
+      return json({ success: false, error: 'Missing challenge token' }, { status: 400 });
     }
     if (!code || typeof code !== 'string' || code.length > 20) {
       return json({ success: false, error: 'Invalid verification code' }, { status: 400 });
     }
+
+    // The challenge token (issued by /login after a successful password step)
+    // is the only accepted proof of identity here - a bare userId is not,
+    // so the second factor cannot be attempted without the password
+    // (audit 012 S4). Consumed only after a SUCCESSFUL code check below:
+    // a typo in the TOTP must not force the user back to the password step.
+    const challenge = await verifySingleUseToken(challengeToken, TWO_FACTOR_CHALLENGE_PURPOSE);
+    if (!challenge) {
+      return json({ success: false, error: 'Invalid or expired challenge' }, { status: 401 });
+    }
+    const userId = challenge.userId;
 
     // Per-userId lockout check
     if (twoFactorLockout.isLocked(userId)) {
@@ -82,7 +100,8 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
       }
     }
 
-    // 2FA verified, clear lockout
+    // 2FA verified - consume the challenge (single-use) and clear lockout
+    consumeSingleUseToken(challenge.jti, challenge.expiresAt);
     twoFactorLockout.reset(userId);
 
     // Generate tokens

--- a/apps/reborn-notes/src/routes/api/auth/2fa/verify/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/auth/2fa/verify/server.spec.ts
@@ -21,13 +21,21 @@ const mockLockout = {
 
 vi.mock('$lib/server/rate-limit', () => ({ twoFactorLockout: mockLockout }));
 
+const mockChallenge = {
+	verifySingleUseToken: vi.fn(),
+	consumeSingleUseToken: vi.fn()
+};
+
 vi.mock('@reborn/auth/server', () => ({
 	generateTokens: vi.fn().mockResolvedValue({
 		accessToken: 'mock-access',
 		refreshToken: 'mock-refresh'
 	}),
 	REFRESH_TOKEN_TTL_SECONDS: 60 * 60 * 24 * 30,
-	refreshTokenExpiryDate: () => new Date(Date.now() + 60 * 60 * 24 * 30 * 1000)
+	refreshTokenExpiryDate: () => new Date(Date.now() + 60 * 60 * 24 * 30 * 1000),
+	TWO_FACTOR_CHALLENGE_PURPOSE: '2fa_challenge',
+	verifySingleUseToken: mockChallenge.verifySingleUseToken,
+	consumeSingleUseToken: mockChallenge.consumeSingleUseToken
 }));
 
 vi.mock('@reborn/utils', () => ({
@@ -52,6 +60,9 @@ vi.mock('otpauth', () => {
 // ── Helpers ──────────────────────────────────────────────────────
 
 const MOCK_USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+/** Opaque challenge token from /login (audit 012 S4) - verified via the mocked verifySingleUseToken. */
+const CHALLENGE = 'mock-challenge-token';
+const CHALLENGE_JTI = 'mock-jti';
 
 const mockUser = {
 	id: MOCK_USER_ID,
@@ -109,6 +120,13 @@ beforeEach(() => {
 
 	mockLockout.isLocked.mockReturnValue(false);
 	mockLockout.retryAfter.mockReturnValue(0);
+
+	// Default: valid, unconsumed challenge token resolving to MOCK_USER_ID
+	mockChallenge.verifySingleUseToken.mockResolvedValue({
+		userId: MOCK_USER_ID,
+		jti: CHALLENGE_JTI,
+		expiresAt: Math.floor(Date.now() / 1000) + 300
+	});
 });
 
 // ── Tests ────────────────────────────────────────────────────────
@@ -126,7 +144,7 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		});
 		mockPrisma.recoveryCode.update.mockResolvedValue({});
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code });
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
@@ -162,7 +180,10 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		});
 		mockPrisma.recoveryCode.update.mockResolvedValue({});
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: 'abcde-fghij' });
+		const { status, data } = await callEndpoint({
+			challengeToken: CHALLENGE,
+			code: 'abcde-fghij'
+		});
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
@@ -187,7 +208,7 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		});
 		mockPrisma.recoveryCode.update.mockResolvedValue({});
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code });
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
@@ -197,7 +218,10 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 	it('should reject invalid recovery code not found in DB', async () => {
 		mockPrisma.recoveryCode.findFirst.mockResolvedValue(null);
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: 'XXXXX-YYYYY' });
+		const { status, data } = await callEndpoint({
+			challengeToken: CHALLENGE,
+			code: 'XXXXX-YYYYY'
+		});
 
 		expect(status).toBe(400);
 		expect(data.success).toBe(false);
@@ -208,7 +232,10 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 	it('should reject already-used recovery code', async () => {
 		mockPrisma.recoveryCode.findFirst.mockResolvedValue(null);
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: 'USED1-CODE2' });
+		const { status, data } = await callEndpoint({
+			challengeToken: CHALLENGE,
+			code: 'USED1-CODE2'
+		});
 
 		expect(status).toBe(400);
 		expect(data.success).toBe(false);
@@ -216,7 +243,7 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 
 	// (f) Empty code → 400
 	it('should reject empty code', async () => {
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: '' });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code: '' });
 
 		expect(status).toBe(400);
 		expect(data.error).toBe('Invalid verification code');
@@ -225,7 +252,7 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 	// (g) Code > 20 characters → 400
 	it('should reject code exceeding 20 characters', async () => {
 		const { status, data } = await callEndpoint({
-			userId: MOCK_USER_ID,
+			challengeToken: CHALLENGE,
 			code: 'A'.repeat(21)
 		});
 
@@ -233,12 +260,33 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		expect(data.error).toBe('Invalid verification code');
 	});
 
-	// (h) Missing userId → 400
-	it('should reject request without userId', async () => {
+	// (h) Missing challenge token → 400 (audit 012 S4: raw userId no longer accepted)
+	it('should reject request without challengeToken', async () => {
 		const { status, data } = await callEndpoint({ code: '123456' });
 
 		expect(status).toBe(400);
-		expect(data.error).toBe('Missing userId');
+		expect(data.error).toBe('Missing challenge token');
+	});
+
+	// (h2) Legacy body shape {userId, code} → 400 (contract hardening regression guard)
+	it('should reject legacy userId-based request', async () => {
+		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: '123456' });
+
+		expect(status).toBe(400);
+		expect(data.error).toBe('Missing challenge token');
+		expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+	});
+
+	// (h3) Invalid / expired / consumed challenge → 401, no code evaluation
+	it('should reject invalid or expired challenge token with 401', async () => {
+		mockChallenge.verifySingleUseToken.mockResolvedValue(null);
+
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code: '123456' });
+
+		expect(status).toBe(401);
+		expect(data.error).toBe('Invalid or expired challenge');
+		expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+		expect(mockChallenge.consumeSingleUseToken).not.toHaveBeenCalled();
 	});
 
 	// (i) Locked user (rate limit) → 429
@@ -247,7 +295,7 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		mockLockout.retryAfter.mockReturnValue(600);
 
 		const { status, data, response } = await callEndpoint({
-			userId: MOCK_USER_ID,
+			challengeToken: CHALLENGE,
 			code: '123456'
 		});
 
@@ -258,7 +306,7 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 
 	// (j) TOTP 6-digit code → 200 (sanity, no regression)
 	it('should accept valid 6-digit TOTP code', async () => {
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: '123456' });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code: '123456' });
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
@@ -267,6 +315,20 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		// the JSON body (byte-identical to before the native path was added).
 		expect(data.data.refresh_token).toBeUndefined();
 		expect(mockLockout.reset).toHaveBeenCalledWith(MOCK_USER_ID);
+		// Challenge consumed exactly once, on success (single-use)
+		expect(mockChallenge.consumeSingleUseToken).toHaveBeenCalledWith(
+			CHALLENGE_JTI,
+			expect.any(Number)
+		);
+	});
+
+	// (j2) Failed TOTP keeps the challenge unconsumed (typo must not burn it)
+	it('should NOT consume the challenge on a failed TOTP attempt', async () => {
+		const { status } = await callEndpoint({ challengeToken: CHALLENGE, code: '654321' });
+
+		expect(status).toBe(400);
+		expect(mockChallenge.consumeSingleUseToken).not.toHaveBeenCalled();
+		expect(mockLockout.recordFailure).toHaveBeenCalledWith(MOCK_USER_ID);
 	});
 
 	// (m) Native client (x-reborn-client: native) → refresh_token ALSO in body so
@@ -274,7 +336,7 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 	//     still set too; native simply ignores it.
 	it('returns refresh_token in the body for the native client', async () => {
 		const { status, data } = await callEndpoint(
-			{ userId: MOCK_USER_ID, code: '123456' },
+			{ challengeToken: CHALLENGE, code: '123456' },
 			{ 'x-reborn-client': 'native' }
 		);
 
@@ -284,22 +346,22 @@ describe('POST /api/auth/2fa/verify (reborn-notes)', () => {
 		expect(data.data.refresh_token).toBe('mock-refresh');
 	});
 
-	// (k) userId > 36 characters → 400 (notes-specific validation)
-	it('should reject userId exceeding 36 characters', async () => {
+	// (k) challengeToken > 2048 characters → 400 (bound the JWT-shaped input)
+	it('should reject challengeToken exceeding 2048 characters', async () => {
 		const { status, data } = await callEndpoint({
-			userId: 'x'.repeat(37),
+			challengeToken: 'x'.repeat(2049),
 			code: '123456'
 		});
 
 		expect(status).toBe(400);
-		expect(data.error).toBe('Missing userId');
+		expect(data.error).toBe('Missing challenge token');
 	});
 
 	// (l) TOTP code != 6 digits → 400 (notes has explicit length check in TOTP branch)
 	it('should reject TOTP code that is not exactly 6 digits', async () => {
-		// 5-digit code (not a recovery code: no dash, length <= 6... wait, length is 5 which is ≤ 6)
+		// 5-digit code (not a recovery code: no dash, length <= 6)
 		// Notes checks trimmedCode.length !== 6 in the TOTP branch
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: '12345' });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code: '12345' });
 
 		expect(status).toBe(400);
 		expect(data.error).toBe('Invalid verification code');

--- a/apps/reborn-notes/src/routes/api/auth/login/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/login/+server.ts
@@ -3,8 +3,11 @@ import { json } from '@sveltejs/kit';
 import {
   handleLogin,
   createDefaultHandlerOptions,
+  generateSingleUseToken,
   REFRESH_TOKEN_TTL_SECONDS,
-  refreshTokenExpiryDate
+  refreshTokenExpiryDate,
+  TWO_FACTOR_CHALLENGE_PURPOSE,
+  TWO_FACTOR_CHALLENGE_TTL_MINUTES
 } from '@reborn/auth/server';
 import { prisma } from '@reborn/database';
 import { loginLockout } from '$lib/server/rate-limit';
@@ -87,11 +90,20 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
               where: { token: result.data.refreshToken }
             });
           }
+          // Short-lived challenge token binds /2fa/verify to this password-
+          // verified login: the second factor cannot be attempted with a bare
+          // userId (audit 012 S4).
+          const challengeToken = await generateSingleUseToken(
+            result.data.user.id,
+            TWO_FACTOR_CHALLENGE_PURPOSE,
+            TWO_FACTOR_CHALLENGE_TTL_MINUTES
+          );
           return json({
             success: true,
             data: {
               twoFactorRequired: true,
               userId: result.data.user.id,
+              challengeToken,
               encryptedMasterKey: result.data.encryptedMasterKey,
               masterKeySalt: result.data.masterKeySalt
             }

--- a/apps/reborn-notes/src/routes/api/auth/refresh-native/+server.ts
+++ b/apps/reborn-notes/src/routes/api/auth/refresh-native/+server.ts
@@ -37,7 +37,7 @@ export const POST: RequestHandler = async ({ request }) => {
     }
 
     const refreshToken = body?.refresh_token;
-    if (!refreshToken || typeof refreshToken !== 'string') {
+    if (!refreshToken || typeof refreshToken !== 'string' || refreshToken.length > 2048) {
       return json({ success: false, error: 'No refresh token provided' }, { status: 401 });
     }
 

--- a/apps/reborn-notes/src/routes/api/folders/+server.ts
+++ b/apps/reborn-notes/src/routes/api/folders/+server.ts
@@ -14,6 +14,10 @@ export const GET: RequestHandler = async ({ request, url }) => {
     if (!userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
     const since = url.searchParams.get('since');
+    // Unparseable `since` → 400, not an Invalid-Date Prisma 500 (audit 012 N8).
+    if (since && Number.isNaN(Date.parse(since))) {
+      return json({ success: false, error: 'Invalid since parameter' }, { status: 400 });
+    }
     const where: Prisma.FolderWhereInput = { user_id: userId, is_archived: false };
     if (since) where.updated_at = { gt: new Date(since) };
 

--- a/apps/reborn-notes/src/routes/api/notes/+server.ts
+++ b/apps/reborn-notes/src/routes/api/notes/+server.ts
@@ -95,6 +95,13 @@ export const GET: RequestHandler = async ({ request, url }) => {
     const wantReconcile = url.searchParams.get('reconcile') === 'true';
     const paginated = limitRaw !== null || cursorRaw !== null;
 
+    // Unparseable `since` would reach Prisma as Invalid Date and 500; a 500
+    // reads as transient to the sync client and would be retried forever
+    // (audit 012 N8).
+    if (since && Number.isNaN(Date.parse(since))) {
+      return json({ success: false, error: 'Invalid since parameter' }, { status: 400 });
+    }
+
     // Filter shared by the page query, the delta count and the all_ids scan.
     const baseWhere: Prisma.NoteWhereInput = { user_id: userId };
     if (!includeArchived) baseWhere.deleted_at = null;

--- a/apps/reborn-notes/src/routes/api/notes/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/notes/server.spec.ts
@@ -103,6 +103,16 @@ describe('GET /api/notes - legacy (un-paginated) mode', () => {
     const args = mockPrisma.note.findMany.mock.calls[0][0];
     expect(args.where.updated_at).toEqual({ gt: new Date('2026-02-01T00:00:00.000Z') });
   });
+
+  // Audit 012 N8: unparseable since must 400 instead of reaching Prisma as an
+  // Invalid Date (500 reads as transient to the sync client → endless retry).
+  it('rejects an unparseable `since` with 400', async () => {
+    const { status, body } = await callGet('?since=not-a-date');
+
+    expect(status).toBe(400);
+    expect(body.error).toBe('Invalid since parameter');
+    expect(mockPrisma.note.findMany).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/notes - paginated delta mode', () => {

--- a/apps/reborn-notes/src/routes/api/saved-searches/+server.ts
+++ b/apps/reborn-notes/src/routes/api/saved-searches/+server.ts
@@ -7,6 +7,14 @@ import { getUserFromToken } from '$lib/server/auth';
 
 const logger = createLogger('Notes-API-SavedSearches');
 
+/**
+ * Hard cap on saved-search rows per user (audit 012 N2): SavedSearch sits
+ * outside the byte-based storage quota, so without a cap an authenticated
+ * client could grow the table without bound. 100 is far above real usage
+ * (the UI lists them in a flat sidebar section).
+ */
+const MAX_SAVED_SEARCHES_PER_USER = 100;
+
 /** GET /api/saved-searches — fetch all saved searches for the authenticated user. */
 export const GET: RequestHandler = async ({ request, url }) => {
   try {
@@ -14,6 +22,10 @@ export const GET: RequestHandler = async ({ request, url }) => {
     if (!userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
     const since = url.searchParams.get('since');
+    // Unparseable `since` → 400, not an Invalid-Date Prisma 500 (audit 012 N8).
+    if (since && Number.isNaN(Date.parse(since))) {
+      return json({ success: false, error: 'Invalid since parameter' }, { status: 400 });
+    }
     const where: Prisma.SavedSearchWhereInput = { user_id: userId };
     if (since) where.updated_at = { gt: new Date(since) };
 
@@ -68,6 +80,23 @@ export const POST: RequestHandler = async ({ request }) => {
     });
     if (existingSearch && existingSearch.user_id !== userId) {
       return json({ success: false, error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Row cap applies to creates only - updates of existing rows stay allowed.
+    // 422 (not 5xx) so the offline push marks the item sync_error instead of
+    // retrying forever.
+    if (!existingSearch) {
+      const count = await prisma.savedSearch.count({ where: { user_id: userId } });
+      if (count >= MAX_SAVED_SEARCHES_PER_USER) {
+        return json(
+          {
+            success: false,
+            error: 'SAVED_SEARCH_LIMIT_EXCEEDED',
+            limit: MAX_SAVED_SEARCHES_PER_USER
+          },
+          { status: 422 }
+        );
+      }
     }
 
     // Folder FK must exist and belong to the user. 404 lets the client push

--- a/apps/reborn-notes/src/routes/api/tags/+server.ts
+++ b/apps/reborn-notes/src/routes/api/tags/+server.ts
@@ -14,6 +14,10 @@ export const GET: RequestHandler = async ({ request, url }) => {
     if (!userId) return json({ success: false, error: 'Unauthorized' }, { status: 401 });
 
     const since = url.searchParams.get('since');
+    // Unparseable `since` → 400, not an Invalid-Date Prisma 500 (audit 012 N8).
+    if (since && Number.isNaN(Date.parse(since))) {
+      return json({ success: false, error: 'Invalid since parameter' }, { status: 400 });
+    }
     const where: Prisma.TagWhereInput = { user_id: userId };
     if (since) where.updated_at = { gt: new Date(since) };
 

--- a/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/2fa/+page.svelte
@@ -24,7 +24,7 @@
 	import { Shield, RefreshCw, KeyRound } from '@lucide/svelte';
 	import { untrack } from 'svelte';
 
-	let userId = $state('');
+	let challengeToken = $state('');
 	let encryptedMasterKey = $state('');
 	let masterKeySalt = $state('');
 	let returnTo = $state('/');
@@ -38,12 +38,14 @@
 	$effect(() => {
 		if (browser) {
 			const url = new URL($page.url);
-			userId = url.searchParams.get('userId') ?? '';
+			// The challenge token (proof of the password step, audit 012 S4) is a
+			// credential - it travels via sessionStorage, not the URL.
+			challengeToken = sessionStorage.getItem('2fa_challenge_token') ?? '';
 			encryptedMasterKey = url.searchParams.get('emk') ?? '';
 			masterKeySalt = url.searchParams.get('ms') ?? '';
 			returnTo = url.searchParams.get('returnTo') ?? '/';
 
-			if (!userId) {
+			if (!challengeToken) {
 				untrack(() => goto('/auth/login'));
 			}
 		}
@@ -69,19 +71,28 @@
 			const res = await fetch(`${API_BASE}/auth/2fa/verify`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json', ...nativeAuthHeaders() },
-				body: JSON.stringify({ userId, code: codeToVerify })
+				body: JSON.stringify({ challengeToken, code: codeToVerify })
 			});
 			const body = await res.json();
 
 			if (!res.ok || !body.success) {
-				error =
-					body.error === 'Invalid verification code'
-						? $t('auth.two_factor.invalid_code')
-						: (body.error ?? $t('auth.two_factor.failed'));
+				if (res.status === 401) {
+					// Challenge token expired (5-min TTL) or already used - the user
+					// must restart from the password step. The back-to-login link is
+					// right below the form.
+					sessionStorage.removeItem('2fa_challenge_token');
+					error = $t('auth.two_factor.challenge_expired');
+				} else {
+					error =
+						body.error === 'Invalid verification code'
+							? $t('auth.two_factor.invalid_code')
+							: (body.error ?? $t('auth.two_factor.failed'));
+				}
 				isLoading = false;
 				return;
 			}
 
+			sessionStorage.removeItem('2fa_challenge_token');
 			const { data } = body;
 
 			// Save credentials to localStorage (same format as reborn-task - SSO-compatible)

--- a/apps/reborn-notes/src/routes/auth/login/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/login/+page.svelte
@@ -67,9 +67,17 @@
     }
 
     if (result.twoFactorRequired) {
+      if (!result.challengeToken) {
+        error = $t('auth.login.errors.server_error');
+        loading = false;
+        return;
+      }
       sessionStorage.setItem('2fa_pending_password', password);
+      // The challenge token is a credential - keep it out of the URL
+      // (browser history); the 2FA page reads it from sessionStorage.
+      sessionStorage.setItem('2fa_challenge_token', result.challengeToken);
       // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp variable
-      const params = new URLSearchParams({ userId: result.userId ?? '', returnTo });
+      const params = new URLSearchParams({ returnTo });
       if (result.encryptedMasterKey) params.set('emk', result.encryptedMasterKey);
       if (result.masterKeySalt) params.set('ms', result.masterKeySalt);
       await goto(`/auth/2fa?${params.toString()}`);

--- a/apps/reborn-task/src/lib/auth/adapters/authApi.ts
+++ b/apps/reborn-task/src/lib/auth/adapters/authApi.ts
@@ -49,6 +49,7 @@ export class AuthApiAdapter implements IAuthApiClient {
 			if (data.data.twoFactorRequired) {
 				result.twoFactorRequired = true;
 				result.userId = data.data.userId;
+				result.challengeToken = data.data.challengeToken;
 			}
 
 			// IMPORTANT: Set token in sync service immediately

--- a/apps/reborn-task/src/lib/services/auth-operations.service.ts
+++ b/apps/reborn-task/src/lib/services/auth-operations.service.ts
@@ -28,7 +28,7 @@ interface ReAuthResponseBody {
 	error?: string;
 	data?: {
 		twoFactorRequired?: boolean;
-		userId?: string;
+		challengeToken?: string;
 		access_token?: string;
 	};
 }
@@ -1133,9 +1133,9 @@ export class AuthOperationsService {
 		const { data } = body;
 
 		if (data?.twoFactorRequired) {
-			if (!data.userId)
-				return { kind: 'error', message: 'Missing userId in 2FA response' };
-			return { kind: 'two_factor_required', userId: data.userId };
+			if (!data.challengeToken)
+				return { kind: 'error', message: 'Missing challenge token in 2FA response' };
+			return { kind: 'two_factor_required', challengeToken: data.challengeToken };
 		}
 
 		if (!data?.access_token) return { kind: 'error', message: 'Missing access token' };
@@ -1148,7 +1148,7 @@ export class AuthOperationsService {
 	 * Re-authenticate after session expiry — TOTP step (invoked from
 	 * ReAuthModal after {@link reAuthenticate} returned `two_factor_required`).
 	 */
-	async verifyTotpForReauth(userId: string, code: string): Promise<ReAuthResult> {
+	async verifyTotpForReauth(challengeToken: string, code: string): Promise<ReAuthResult> {
 		if (!browser) return { kind: 'error', message: 'Not in browser' };
 
 		const { PUBLIC_BASE_PATH } = await import('$env/static/public');
@@ -1157,7 +1157,7 @@ export class AuthOperationsService {
 			res = await fetch(`${PUBLIC_BASE_PATH}/api/auth/2fa/verify`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ userId, code })
+				body: JSON.stringify({ challengeToken, code })
 			});
 		} catch (err) {
 			return {
@@ -1171,6 +1171,10 @@ export class AuthOperationsService {
 			const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 0;
 			return { kind: 'locked', retryAfter: Number.isFinite(retryAfter) ? retryAfter : 0 };
 		}
+
+		// Challenge token expired or already consumed - the modal returns to the
+		// password step so a fresh one can be minted.
+		if (res.status === 401) return { kind: 'challenge_expired' };
 
 		let body: ReAuthResponseBody;
 		try {

--- a/apps/reborn-task/src/routes/+layout.svelte
+++ b/apps/reborn-task/src/routes/+layout.svelte
@@ -317,12 +317,14 @@
 		visible={$sessionExpired && navigator.onLine}
 		username={$session?.user?.username ?? ''}
 		onReAuth={(password) => authOperationsService.reAuthenticate(password)}
-		onVerifyTotp={(userId, code) => authOperationsService.verifyTotpForReauth(userId, code)}
+		onVerifyTotp={(challengeToken, code) =>
+			authOperationsService.verifyTotpForReauth(challengeToken, code)}
 	/>
 	<RequireSessionModal
 		username={$session?.user?.username ?? ''}
 		onReAuth={(password) => authOperationsService.reAuthenticate(password)}
-		onVerifyTotp={(userId, code) => authOperationsService.verifyTotpForReauth(userId, code)}
+		onVerifyTotp={(challengeToken, code) =>
+			authOperationsService.verifyTotpForReauth(challengeToken, code)}
 	/>
 	<div class="svelte-app-ready min-h-screen bg-background text-foreground transition-colors">
 		{#if children}

--- a/apps/reborn-task/src/routes/api/auth/2fa/verify/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/2fa/verify/+server.ts
@@ -1,7 +1,14 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createLogger } from '@reborn/utils';
-import { generateTokens, REFRESH_TOKEN_TTL_SECONDS, refreshTokenExpiryDate } from '@reborn/auth/server';
+import {
+	consumeSingleUseToken,
+	generateTokens,
+	REFRESH_TOKEN_TTL_SECONDS,
+	refreshTokenExpiryDate,
+	TWO_FACTOR_CHALLENGE_PURPOSE,
+	verifySingleUseToken
+} from '@reborn/auth/server';
 import { prisma } from '@reborn/database';
 import { v4 as uuidv4 } from 'uuid';
 import * as OTPAuth from 'otpauth';
@@ -17,15 +24,26 @@ const ISSUER = 'Reborn Apps';
 export const POST: RequestHandler = async ({ request, cookies }) => {
 	try {
 		const body = await request.json();
-		const { userId, code } = body;
+		const { challengeToken, code } = body;
 
-		if (!userId || typeof userId !== 'string') {
-			return json({ success: false, error: 'Missing userId' }, { status: 400 });
+		if (!challengeToken || typeof challengeToken !== 'string' || challengeToken.length > 2048) {
+			return json({ success: false, error: 'Missing challenge token' }, { status: 400 });
 		}
 
 		if (!code || typeof code !== 'string' || code.trim().length === 0 || code.trim().length > 20) {
 			return json({ success: false, error: 'Invalid verification code' }, { status: 400 });
 		}
+
+		// The challenge token (issued by /login after a successful password step)
+		// is the only accepted proof of identity here - a bare userId is not,
+		// so the second factor cannot be attempted without the password
+		// (audit 012 S4). Consumed only after a SUCCESSFUL code check below:
+		// a typo in the TOTP must not force the user back to the password step.
+		const challenge = await verifySingleUseToken(challengeToken, TWO_FACTOR_CHALLENGE_PURPOSE);
+		if (!challenge) {
+			return json({ success: false, error: 'Invalid or expired challenge' }, { status: 401 });
+		}
+		const userId = challenge.userId;
 
 		// Per-userId lockout check
 		if (twoFactorLockout.isLocked(userId)) {
@@ -93,7 +111,8 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 			}
 		}
 
-		// 2FA verified, clear lockout
+		// 2FA verified - consume the challenge (single-use) and clear lockout
+		consumeSingleUseToken(challenge.jti, challenge.expiresAt);
 		twoFactorLockout.reset(userId);
 
 		// Generate tokens

--- a/apps/reborn-task/src/routes/api/auth/2fa/verify/server.spec.ts
+++ b/apps/reborn-task/src/routes/api/auth/2fa/verify/server.spec.ts
@@ -21,13 +21,21 @@ const mockLockout = {
 
 vi.mock('$lib/server/rate-limit', () => ({ twoFactorLockout: mockLockout }));
 
+const mockChallenge = {
+	verifySingleUseToken: vi.fn(),
+	consumeSingleUseToken: vi.fn()
+};
+
 vi.mock('@reborn/auth/server', () => ({
 	generateTokens: vi.fn().mockResolvedValue({
 		accessToken: 'mock-access',
 		refreshToken: 'mock-refresh'
 	}),
 	REFRESH_TOKEN_TTL_SECONDS: 60 * 60 * 24 * 30,
-	refreshTokenExpiryDate: () => new Date(Date.now() + 60 * 60 * 24 * 30 * 1000)
+	refreshTokenExpiryDate: () => new Date(Date.now() + 60 * 60 * 24 * 30 * 1000),
+	TWO_FACTOR_CHALLENGE_PURPOSE: '2fa_challenge',
+	verifySingleUseToken: mockChallenge.verifySingleUseToken,
+	consumeSingleUseToken: mockChallenge.consumeSingleUseToken
 }));
 
 vi.mock('@reborn/utils', () => ({
@@ -53,6 +61,9 @@ vi.mock('otpauth', () => {
 // ── Helpers ──────────────────────────────────────────────────────
 
 const MOCK_USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+/** Opaque challenge token from /login (audit 012 S4) - verified via the mocked verifySingleUseToken. */
+const CHALLENGE = 'mock-challenge-token';
+const CHALLENGE_JTI = 'mock-jti';
 
 const mockUser = {
 	id: MOCK_USER_ID,
@@ -111,6 +122,13 @@ beforeEach(() => {
 
 	mockLockout.isLocked.mockReturnValue(false);
 	mockLockout.retryAfter.mockReturnValue(0);
+
+	// Default: valid, unconsumed challenge token resolving to MOCK_USER_ID
+	mockChallenge.verifySingleUseToken.mockResolvedValue({
+		userId: MOCK_USER_ID,
+		jti: CHALLENGE_JTI,
+		expiresAt: Math.floor(Date.now() / 1000) + 300
+	});
 });
 
 // ── Tests ────────────────────────────────────────────────────────
@@ -128,7 +146,7 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 		});
 		mockPrisma.recoveryCode.update.mockResolvedValue({});
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code });
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
@@ -167,7 +185,10 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 		});
 		mockPrisma.recoveryCode.update.mockResolvedValue({});
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: 'abcde-fghij' });
+		const { status, data } = await callEndpoint({
+			challengeToken: CHALLENGE,
+			code: 'abcde-fghij'
+		});
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
@@ -192,7 +213,7 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 		});
 		mockPrisma.recoveryCode.update.mockResolvedValue({});
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code });
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
@@ -202,7 +223,10 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 	it('should reject invalid recovery code not found in DB', async () => {
 		mockPrisma.recoveryCode.findFirst.mockResolvedValue(null);
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: 'XXXXX-YYYYY' });
+		const { status, data } = await callEndpoint({
+			challengeToken: CHALLENGE,
+			code: 'XXXXX-YYYYY'
+		});
 
 		expect(status).toBe(400);
 		expect(data.success).toBe(false);
@@ -214,7 +238,10 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 		// findFirst returns null because query filters is_used: false
 		mockPrisma.recoveryCode.findFirst.mockResolvedValue(null);
 
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: 'USED1-CODE2' });
+		const { status, data } = await callEndpoint({
+			challengeToken: CHALLENGE,
+			code: 'USED1-CODE2'
+		});
 
 		expect(status).toBe(400);
 		expect(data.success).toBe(false);
@@ -222,7 +249,7 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 
 	// (f) Empty code → 400
 	it('should reject empty code', async () => {
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: '' });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code: '' });
 
 		expect(status).toBe(400);
 		expect(data.error).toBe('Invalid verification code');
@@ -231,7 +258,7 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 	// (g) Code > 20 characters → 400
 	it('should reject code exceeding 20 characters', async () => {
 		const { status, data } = await callEndpoint({
-			userId: MOCK_USER_ID,
+			challengeToken: CHALLENGE,
 			code: 'A'.repeat(21)
 		});
 
@@ -239,12 +266,33 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 		expect(data.error).toBe('Invalid verification code');
 	});
 
-	// (h) Missing userId → 400
-	it('should reject request without userId', async () => {
+	// (h) Missing challenge token → 400 (audit 012 S4: raw userId no longer accepted)
+	it('should reject request without challengeToken', async () => {
 		const { status, data } = await callEndpoint({ code: '123456' });
 
 		expect(status).toBe(400);
-		expect(data.error).toBe('Missing userId');
+		expect(data.error).toBe('Missing challenge token');
+	});
+
+	// (h2) Legacy body shape {userId, code} → 400 (contract hardening regression guard)
+	it('should reject legacy userId-based request', async () => {
+		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: '123456' });
+
+		expect(status).toBe(400);
+		expect(data.error).toBe('Missing challenge token');
+		expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+	});
+
+	// (h3) Invalid / expired / consumed challenge → 401, no code evaluation
+	it('should reject invalid or expired challenge token with 401', async () => {
+		mockChallenge.verifySingleUseToken.mockResolvedValue(null);
+
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code: '123456' });
+
+		expect(status).toBe(401);
+		expect(data.error).toBe('Invalid or expired challenge');
+		expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+		expect(mockChallenge.consumeSingleUseToken).not.toHaveBeenCalled();
 	});
 
 	// (i) Locked user (rate limit) → 429
@@ -253,7 +301,7 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 		mockLockout.retryAfter.mockReturnValue(600);
 
 		const { status, data, response } = await callEndpoint({
-			userId: MOCK_USER_ID,
+			challengeToken: CHALLENGE,
 			code: '123456'
 		});
 
@@ -264,12 +312,26 @@ describe('POST /api/auth/2fa/verify (reborn-task)', () => {
 
 	// (j) TOTP 6-digit code → 200 (sanity, no regression)
 	it('should accept valid 6-digit TOTP code', async () => {
-		const { status, data } = await callEndpoint({ userId: MOCK_USER_ID, code: '123456' });
+		const { status, data } = await callEndpoint({ challengeToken: CHALLENGE, code: '123456' });
 
 		expect(status).toBe(200);
 		expect(data.success).toBe(true);
 		expect(data.data.access_token).toBe('mock-access');
 		// refresh_token is sent as httpOnly cookie, not in JSON body
 		expect(mockLockout.reset).toHaveBeenCalledWith(MOCK_USER_ID);
+		// Challenge consumed exactly once, on success (single-use)
+		expect(mockChallenge.consumeSingleUseToken).toHaveBeenCalledWith(
+			CHALLENGE_JTI,
+			expect.any(Number)
+		);
+	});
+
+	// (j2) Failed TOTP keeps the challenge unconsumed (typo must not burn it)
+	it('should NOT consume the challenge on a failed TOTP attempt', async () => {
+		const { status } = await callEndpoint({ challengeToken: CHALLENGE, code: '654321' });
+
+		expect(status).toBe(400);
+		expect(mockChallenge.consumeSingleUseToken).not.toHaveBeenCalled();
+		expect(mockLockout.recordFailure).toHaveBeenCalledWith(MOCK_USER_ID);
 	});
 });

--- a/apps/reborn-task/src/routes/api/auth/login/+server.ts
+++ b/apps/reborn-task/src/routes/api/auth/login/+server.ts
@@ -3,8 +3,11 @@ import { json } from '@sveltejs/kit';
 import {
 	handleLogin,
 	createDefaultHandlerOptions,
+	generateSingleUseToken,
 	REFRESH_TOKEN_TTL_SECONDS,
-	refreshTokenExpiryDate
+	refreshTokenExpiryDate,
+	TWO_FACTOR_CHALLENGE_PURPOSE,
+	TWO_FACTOR_CHALLENGE_TTL_MINUTES
 } from '@reborn/auth/server';
 import { prisma } from '@reborn/database';
 import { loginLockout } from '$lib/server/rate-limit';
@@ -92,11 +95,21 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 						});
 					}
 
+					// Short-lived challenge token binds /2fa/verify to this password-
+					// verified login: the second factor cannot be attempted with a
+					// bare userId (audit 012 S4).
+					const challengeToken = await generateSingleUseToken(
+						result.data.user.id,
+						TWO_FACTOR_CHALLENGE_PURPOSE,
+						TWO_FACTOR_CHALLENGE_TTL_MINUTES
+					);
+
 					return json({
 						success: true,
 						data: {
 							twoFactorRequired: true,
 							userId: result.data.user.id,
+							challengeToken,
 							encryptedMasterKey: result.data.encryptedMasterKey,
 							masterKeySalt: result.data.masterKeySalt
 						}

--- a/apps/reborn-task/src/routes/auth/2fa/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/2fa/+page.svelte
@@ -25,7 +25,7 @@
 
 	const logger = createLogger('2FAVerifyPage');
 
-	let userId = $state('');
+	let challengeToken = $state('');
 	let returnTo = $state('/all');
 	let encryptedMasterKey = $state('');
 	let masterKeySalt = $state('');
@@ -39,12 +39,14 @@
 	$effect(() => {
 		if (browser) {
 			const url = new URL($page.url);
-			userId = url.searchParams.get('userId') || '';
+			// The challenge token (proof of the password step, audit 012 S4) is a
+			// credential - it travels via sessionStorage, not the URL.
+			challengeToken = sessionStorage.getItem('2fa_challenge_token') || '';
 			returnTo = url.searchParams.get('returnTo') || '/all';
 			encryptedMasterKey = url.searchParams.get('emk') || '';
 			masterKeySalt = url.searchParams.get('ms') || '';
 
-			if (!userId) {
+			if (!challengeToken) {
 				untrack(() => goto('/auth/login'));
 			}
 		}
@@ -70,19 +72,29 @@
 			const response = await fetch(`${PUBLIC_BASE_PATH}/api/auth/2fa/verify`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ userId, code: codeToVerify })
+				body: JSON.stringify({ challengeToken, code: codeToVerify })
 			});
 
 			const data = await response.json();
 
 			if (!response.ok || !data.success) {
-				error =
-					data.error === 'Invalid verification code'
-						? $t('settings.profile.verification_code_invalid') || 'Invalid verification code'
-						: data.error || '2FA verification failed';
+				if (response.status === 401) {
+					// Challenge token expired (5-min TTL) or already used - the user
+					// must restart from the password step. The back-to-login link is
+					// right below the form.
+					sessionStorage.removeItem('2fa_challenge_token');
+					error = $t('auth.2fa.errors.challenge_expired');
+				} else {
+					error =
+						data.error === 'Invalid verification code'
+							? $t('settings.profile.verification_code_invalid') || 'Invalid verification code'
+							: data.error || '2FA verification failed';
+				}
 				isLoading = false;
 				return;
 			}
+
+			sessionStorage.removeItem('2fa_challenge_token');
 
 			// Store access token (refresh token is managed via httpOnly cookie)
 			if (data.data.access_token) {

--- a/apps/reborn-task/src/routes/auth/login/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/login/+page.svelte
@@ -76,11 +76,17 @@
 			if (result.twoFactorRequired) {
 				logger.info('2FA required, redirecting...');
 				loading = false;
+				if (!result.challengeToken) {
+					error = 'Login failed';
+					return;
+				}
 				// Save password temporarily for E2E decryption after 2FA verification
 				sessionStorage.setItem('2fa_pending_password', password);
+				// The challenge token is a credential - keep it out of the URL
+				// (browser history); the 2FA page reads it from sessionStorage.
+				sessionStorage.setItem('2fa_challenge_token', result.challengeToken);
 				// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp variable
 				const params = new URLSearchParams({
-					userId: result.userId || '',
 					returnTo: returnTo
 				});
 				if (result.encryptedMasterKey) {

--- a/packages/auth/src/__tests__/jwt.spec.ts
+++ b/packages/auth/src/__tests__/jwt.spec.ts
@@ -4,14 +4,17 @@ import {
   verifyToken,
   generateSingleUseToken,
   verifySingleUseToken,
+  consumeSingleUseToken,
   extractTokenFromHeader,
   getTokenConfig
 } from '../utils/jwt';
+import { clearBlacklist } from '../utils/tokenBlacklist';
 import { REFRESH_TOKEN_TTL_TIMESPAN } from '../config/token-ttl';
 
 // Mock environment variable
 beforeEach(() => {
   vi.stubEnv('JWT_SECRET', 'test-secret-key-for-testing');
+  clearBlacklist();
 });
 
 describe('JWT Utils', () => {
@@ -116,6 +119,7 @@ describe('JWT Utils', () => {
       expect(result).toBeTruthy();
       expect(result?.userId).toBe(userId);
       expect(result?.jti).toBeTruthy();
+      expect(result?.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
     });
 
     it('should reject token with wrong purpose', async () => {
@@ -133,6 +137,24 @@ describe('JWT Utils', () => {
       const result = await verifySingleUseToken(accessToken, 'password-reset');
 
       expect(result).toBeNull();
+    });
+
+    it('should reject a consumed token but allow retries before consumption', async () => {
+      const userId = 'user-123';
+      const purpose = '2fa_challenge';
+      const token = await generateSingleUseToken(userId, purpose, 5);
+
+      // Multiple verifications succeed while the token is unconsumed
+      // (a failed TOTP attempt must not burn the challenge)
+      const first = await verifySingleUseToken(token, purpose);
+      const second = await verifySingleUseToken(token, purpose);
+      expect(first).toBeTruthy();
+      expect(second).toBeTruthy();
+
+      consumeSingleUseToken(first!.jti, first!.expiresAt);
+
+      const afterConsume = await verifySingleUseToken(token, purpose);
+      expect(afterConsume).toBeNull();
     });
   });
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -13,9 +13,12 @@ export {
   verifyToken,
   generateSingleUseToken,
   verifySingleUseToken,
+  consumeSingleUseToken,
   extractTokenFromHeader,
   getTokenConfig,
-  blacklistAccessToken
+  blacklistAccessToken,
+  TWO_FACTOR_CHALLENGE_PURPOSE,
+  TWO_FACTOR_CHALLENGE_TTL_MINUTES
 } from './utils/jwt';
 export type { TokenPair, TokenPayload } from './utils/jwt';
 

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -38,6 +38,8 @@ export interface LoginResult {
   refreshToken?: string;
   twoFactorRequired?: boolean;
   userId?: string;
+  /** Short-lived signed token proving the password step passed - required by /2fa/verify. */
+  challengeToken?: string;
   message?: string;
 }
 

--- a/packages/auth/src/utils/authApiClient.ts
+++ b/packages/auth/src/utils/authApiClient.ts
@@ -59,6 +59,7 @@ export function createAuthApiClient(options: AuthApiClientOptions = {}): IAuthAp
         refreshToken: data.refreshToken,
         twoFactorRequired: data.twoFactorRequired,
         userId: data.userId,
+        challengeToken: data.challengeToken,
         message: data.message
       };
     },

--- a/packages/auth/src/utils/jwt.ts
+++ b/packages/auth/src/utils/jwt.ts
@@ -63,6 +63,12 @@ export interface TokenPair {
   refreshToken: string;
 }
 
+// 2FA challenge token (audit 012 S4): issued by /login after the password step
+// when 2FA is enabled, required by /2fa/verify instead of a raw userId - so the
+// second factor cannot be attempted without first proving password knowledge.
+export const TWO_FACTOR_CHALLENGE_PURPOSE = '2fa_challenge';
+export const TWO_FACTOR_CHALLENGE_TTL_MINUTES = 5;
+
 export interface TokenPayload extends JWTPayload {
   userId: string;
   tokenType: 'access' | 'refresh';
@@ -236,12 +242,14 @@ export async function generateSingleUseToken(
  * Verify a single-use token
  * @param token - Token to verify
  * @param expectedPurpose - Expected token purpose
- * @returns Promise<{userId: string, jti: string} | null> - User ID and token ID if valid
+ * @returns Promise<{userId, jti, expiresAt} | null> - Token identity if valid
+ *          and not yet consumed. Pass `jti` + `expiresAt` to
+ *          {@link consumeSingleUseToken} once the token has served its purpose.
  */
 export async function verifySingleUseToken(
   token: string,
   expectedPurpose: string
-): Promise<{ userId: string; jti: string } | null> {
+): Promise<{ userId: string; jti: string; expiresAt: number } | null> {
   try {
     const secret = getJwtSecret();
     const verifyOptions = { issuer: JWT_CONFIG.issuer };
@@ -262,20 +270,44 @@ export async function verifySingleUseToken(
     }
 
     // Ensure required fields are present
-    if (!payload.userId || typeof payload.userId !== 'string' || !payload.jti) {
+    if (
+      !payload.userId ||
+      typeof payload.userId !== 'string' ||
+      !payload.jti ||
+      typeof payload.exp !== 'number'
+    ) {
       logger.warn('Single-use token missing required fields');
+      return null;
+    }
+
+    // Reject tokens already consumed via consumeSingleUseToken
+    if (isTokenBlacklisted(payload.jti)) {
+      logger.debug('Single-use token already consumed:', { jti: payload.jti });
       return null;
     }
 
     logger.debug('Single-use token verified successfully');
     return {
       userId: payload.userId as string,
-      jti: payload.jti
+      jti: payload.jti,
+      expiresAt: payload.exp
     };
   } catch (error) {
     logger.debug('Single-use token verification failed:', error);
     return null;
   }
+}
+
+/**
+ * Consume a single-use token: blacklist its jti until the token's natural
+ * expiry, so every subsequent verifySingleUseToken() for it returns null.
+ * Call only AFTER the action the token authorizes has succeeded - a failed
+ * attempt keeps the token valid for a retry within its TTL.
+ * @param jti - Token ID from verifySingleUseToken
+ * @param expiresAt - Token expiry (seconds since epoch) from verifySingleUseToken
+ */
+export function consumeSingleUseToken(jti: string, expiresAt: number): void {
+  blacklistToken(jti, expiresAt);
 }
 
 /**

--- a/packages/i18n/src/translations/common/de.json
+++ b/packages/i18n/src/translations/common/de.json
@@ -124,6 +124,7 @@
       "totp_submit_button": "Verifizieren",
       "totp_verifying": "Verifizierung...",
       "totp_error_invalid": "Ungültiger Code. Bitte versuchen Sie es erneut.",
+      "challenge_expired": "Die Verifizierungssitzung ist abgelaufen. Geben Sie Ihr Passwort erneut ein.",
       "use_recovery": "Wiederherstellungscode verwenden",
       "use_app": "Authenticator-App verwenden",
       "recovery_label": "Wiederherstellungscode",
@@ -140,6 +141,7 @@
         "code_required": "2FA-Code ist erforderlich.",
         "recovery_required": "Wiederherstellungscode ist erforderlich.",
         "verification_failed": "Überprüfung fehlgeschlagen.",
+        "challenge_expired": "Ihre Verifizierungssitzung ist abgelaufen. Bitte melden Sie sich erneut an.",
         "decrypt_failed": "2FA-Geheimnis konnte nicht verarbeitet werden. Bitte stellen Sie sicher, dass Ihr Passwort korrekt ist.",
         "secret_format": "Ungültiges 2FA-Geheimnisformat."
       }

--- a/packages/i18n/src/translations/common/en.json
+++ b/packages/i18n/src/translations/common/en.json
@@ -124,6 +124,7 @@
       "totp_submit_button": "Verify",
       "totp_verifying": "Verifying...",
       "totp_error_invalid": "Invalid code. Please try again.",
+      "challenge_expired": "Verification session expired. Enter your password again.",
       "use_recovery": "Use a recovery code",
       "use_app": "Use authenticator app",
       "recovery_label": "Recovery code",
@@ -140,6 +141,7 @@
         "code_required": "2FA code is required.",
         "recovery_required": "Recovery code is required.",
         "verification_failed": "Verification failed.",
+        "challenge_expired": "Your verification session has expired. Please sign in again.",
         "decrypt_failed": "Failed to process 2FA secret. Please ensure your password is correct.",
         "secret_format": "Invalid 2FA secret format."
       }

--- a/packages/i18n/src/translations/common/es.json
+++ b/packages/i18n/src/translations/common/es.json
@@ -124,6 +124,7 @@
       "totp_submit_button": "Verificar",
       "totp_verifying": "Verificando...",
       "totp_error_invalid": "Código no válido. Inténtelo de nuevo.",
+      "challenge_expired": "La sesión de verificación ha expirado. Introduzca su contraseña de nuevo.",
       "use_recovery": "Usar código de recuperación",
       "use_app": "Usar aplicación de autenticación",
       "recovery_label": "Código de recuperación",
@@ -140,6 +141,7 @@
         "code_required": "El código 2FA es obligatorio.",
         "recovery_required": "El código de recuperación es obligatorio.",
         "verification_failed": "La verificación falló.",
+        "challenge_expired": "Su sesión de verificación ha expirado. Inicie sesión de nuevo.",
         "decrypt_failed": "No se pudo procesar el secreto 2FA. Por favor, asegúrese de que su contraseña sea correcta.",
         "secret_format": "Formato de secreto 2FA no válido."
       }

--- a/packages/i18n/src/translations/common/fr.json
+++ b/packages/i18n/src/translations/common/fr.json
@@ -124,6 +124,7 @@
       "totp_submit_button": "Vérifier",
       "totp_verifying": "Vérification...",
       "totp_error_invalid": "Code invalide. Veuillez réessayer.",
+      "challenge_expired": "La session de vérification a expiré. Entrez à nouveau votre mot de passe.",
       "use_recovery": "Utiliser un code de récupération",
       "use_app": "Utiliser l'application d'authentification",
       "recovery_label": "Code de récupération",
@@ -140,6 +141,7 @@
         "code_required": "Le code 2FA est requis.",
         "recovery_required": "Le code de récupération est requis.",
         "verification_failed": "La vérification a échoué.",
+        "challenge_expired": "Votre session de vérification a expiré. Veuillez vous reconnecter.",
         "decrypt_failed": "Impossible de traiter le secret 2FA. Veuillez vérifier que votre mot de passe est correct.",
         "secret_format": "Format du secret 2FA invalide."
       }

--- a/packages/i18n/src/translations/common/pl.json
+++ b/packages/i18n/src/translations/common/pl.json
@@ -124,6 +124,7 @@
       "totp_submit_button": "Zweryfikuj",
       "totp_verifying": "Weryfikacja...",
       "totp_error_invalid": "Nieprawidłowy kod. Spróbuj ponownie.",
+      "challenge_expired": "Sesja weryfikacji wygasła. Wprowadź hasło ponownie.",
       "use_recovery": "Użyj kodu zapasowego",
       "use_app": "Użyj kodu z aplikacji",
       "recovery_label": "Kod zapasowy",
@@ -140,6 +141,7 @@
         "code_required": "Kod 2FA jest wymagany.",
         "recovery_required": "Kod zapasowy jest wymagany.",
         "verification_failed": "Weryfikacja nie powiodła się.",
+        "challenge_expired": "Sesja weryfikacji wygasła. Zaloguj się ponownie.",
         "decrypt_failed": "Nie udało się przetworzyć sekretu 2FA. Upewnij się, że hasło jest poprawne.",
         "secret_format": "Nieprawidłowy format sekretu 2FA."
       }

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -1127,6 +1127,7 @@
       "code_6_digits": "Der Code muss 6 Ziffern haben",
       "invalid_code": "Ungültiger Bestätigungscode. Bitte versuchen Sie es erneut.",
       "failed": "2FA-Verifizierung fehlgeschlagen",
+      "challenge_expired": "Ihre Verifizierungssitzung ist abgelaufen. Bitte melden Sie sich erneut an.",
       "verifying": "Überprüfung…",
       "verify": "Überprüfen",
       "code_label": "Bestätigungscode",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -1127,6 +1127,7 @@
       "code_6_digits": "Code must be 6 digits",
       "invalid_code": "Invalid verification code. Please try again.",
       "failed": "2FA verification failed",
+      "challenge_expired": "Your verification session has expired. Please sign in again.",
       "verifying": "Verifying…",
       "verify": "Verify",
       "code_label": "Verification code",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -1127,6 +1127,7 @@
       "code_6_digits": "El código debe tener 6 dígitos",
       "invalid_code": "Código de verificación no válido. Inténtelo de nuevo.",
       "failed": "Error en la verificación 2FA",
+      "challenge_expired": "Su sesión de verificación ha expirado. Inicie sesión de nuevo.",
       "verifying": "Verificando…",
       "verify": "Verificar",
       "code_label": "Código de verificación",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -1127,6 +1127,7 @@
       "code_6_digits": "Le code doit comporter 6 chiffres",
       "invalid_code": "Code de vérification invalide. Veuillez réessayer.",
       "failed": "Échec de la vérification 2FA",
+      "challenge_expired": "Votre session de vérification a expiré. Veuillez vous reconnecter.",
       "verifying": "Vérification…",
       "verify": "Vérifier",
       "code_label": "Code de vérification",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -1127,6 +1127,7 @@
       "code_6_digits": "Kod musi mieć 6 cyfr",
       "invalid_code": "Nieprawidłowy kod weryfikacyjny. Spróbuj ponownie.",
       "failed": "Weryfikacja 2FA nie powiodła się",
+      "challenge_expired": "Sesja weryfikacji wygasła. Zaloguj się ponownie.",
       "verifying": "Weryfikacja…",
       "verify": "Zweryfikuj",
       "code_label": "Kod weryfikacyjny",

--- a/packages/types/src/schemas/api/crud-requests.ts
+++ b/packages/types/src/schemas/api/crud-requests.ts
@@ -86,13 +86,21 @@ export const DeleteListRequestSchema = z.object({
 
 // ─── reborn-notes: Notes ─────────────────────────────────────────────
 
+// Any Date.parse-able timestamp (offline-first clients send ISO strings).
+// Guards the server against `new Date(garbage)` → Invalid Date → Prisma 500
+// (audit 012 N8): unparseable input now fails validation with a 400.
+const parseableDate = z
+  .string()
+  .max(64)
+  .refine((v) => !Number.isNaN(Date.parse(v)), { message: 'Invalid date format' });
+
 export const CreateNoteRequestSchema = z.object({
   id: z.string().uuid(),
   title_encrypted: z.string().min(1).max(MAX_ENCRYPTED_NOTE_TITLE_BYTES),
   content_encrypted: z.string().max(MAX_ENCRYPTED_CONTENT_BYTES).optional(),
   metadata_encrypted: z.string().max(MAX_ENCRYPTED_NOTE_METADATA_BYTES).optional(),
   folder_id: z.string().uuid().optional().nullable(),
-  created_at: z.string().optional()
+  created_at: parseableDate.optional()
 });
 
 export const UpdateNoteRequestSchema = z.object({
@@ -143,7 +151,7 @@ export const CreateSavedSearchRequestSchema = z.object({
     .nullable(),
   folder_id: z.string().uuid().optional().nullable(),
   position: z.number().int().min(0).optional(),
-  created_at: z.string().optional()
+  created_at: parseableDate.optional()
 });
 
 export const UpdateSavedSearchRequestSchema = z.object({

--- a/packages/types/src/schemas/api/requests.ts
+++ b/packages/types/src/schemas/api/requests.ts
@@ -55,14 +55,16 @@ export const RegisterRequestSchema = z.object({
  * Refresh token request schema
  */
 export const RefreshTokenRequestSchema = z.object({
-  refresh_token: z.string()
+  refresh_token: z.string().max(2048)
 });
 
 /**
- * Two-factor verification request schema
+ * Two-factor verification request schema.
+ * `challengeToken` is the short-lived single-use token issued by /login after
+ * the password step (audit 012 S4) - a raw userId is no longer accepted.
  */
 export const TwoFactorVerifyRequestSchema = z.object({
-  userId: z.string(),
+  challengeToken: z.string().max(2048),
   code: z.string().length(6)
 });
 

--- a/packages/ui/src/components/auth/ReAuthModal.svelte
+++ b/packages/ui/src/components/auth/ReAuthModal.svelte
@@ -37,8 +37,8 @@
     description?: string;
     /** Called with the password. Returns a ReAuthResult. */
     onSubmitPassword?: (password: string) => Promise<ReAuthResult>;
-    /** Called with a TOTP or recovery code once 2FA is required. */
-    onSubmitTotp?: (userId: string, code: string) => Promise<ReAuthResult>;
+    /** Called with the password-step challenge token and a TOTP or recovery code once 2FA is required. */
+    onSubmitTotp?: (challengeToken: string, code: string) => Promise<ReAuthResult>;
     /** Called when the dialog closes. Receives `true` if a re-auth succeeded, `false` if cancelled. */
     onClose?: (success: boolean) => void;
   }>();
@@ -50,7 +50,7 @@
   let showPassword = $state(false);
   let totpCode = $state('');
   let useRecovery = $state(false);
-  let pendingUserId = $state<string | null>(null);
+  let pendingChallenge = $state<string | null>(null);
   let loading = $state(false);
   let error = $state<string | null>(null);
   let succeeded = $state(false);
@@ -61,7 +61,7 @@
     showPassword = false;
     totpCode = '';
     useRecovery = false;
-    pendingUserId = null;
+    pendingChallenge = null;
     loading = false;
     error = null;
     succeeded = false;
@@ -92,6 +92,8 @@
         return $t('auth.session.error_auth_failed');
       case 'invalid_totp':
         return $t('auth.session.totp_error_invalid');
+      case 'challenge_expired':
+        return $t('auth.session.challenge_expired');
       case 'locked':
         return $t('auth.session.error_locked', { values: { seconds: result.retryAfter } });
       case 'two_factor_required':
@@ -123,7 +125,7 @@
       }
 
       if (result.kind === 'two_factor_required') {
-        pendingUserId = result.userId;
+        pendingChallenge = result.challengeToken;
         step = 'totp';
         totpCode = '';
         error = null;
@@ -141,7 +143,7 @@
   async function handleTotpSubmit(event: Event) {
     event.preventDefault();
     const trimmed = totpCode.trim();
-    if (!trimmed || loading || !pendingUserId) return;
+    if (!trimmed || loading || !pendingChallenge) return;
 
     if (!useRecovery && trimmed.length !== 6) {
       error = $t('auth.session.totp_error_invalid');
@@ -152,7 +154,7 @@
     error = null;
 
     try {
-      const result = (await onSubmitTotp?.(pendingUserId, trimmed)) ?? {
+      const result = (await onSubmitTotp?.(pendingChallenge, trimmed)) ?? {
         kind: 'error',
         message: $t('auth.session.error_unknown')
       };
@@ -161,6 +163,14 @@
         succeeded = true;
         open = false;
         return;
+      }
+
+      // The challenge token has a short TTL - when it expires mid-step, send
+      // the user back to the password step to mint a fresh one.
+      if (result.kind === 'challenge_expired') {
+        pendingChallenge = null;
+        step = 'password';
+        totpCode = '';
       }
 
       error = describeResult(result);

--- a/packages/ui/src/components/auth/RequireSessionModal.svelte
+++ b/packages/ui/src/components/auth/RequireSessionModal.svelte
@@ -19,7 +19,7 @@
   } = $props<{
     username?: string;
     onReAuth?: (password: string) => Promise<ReAuthResult>;
-    onVerifyTotp?: (userId: string, code: string) => Promise<ReAuthResult>;
+    onVerifyTotp?: (challengeToken: string, code: string) => Promise<ReAuthResult>;
   }>();
 
   let open = $state(false);

--- a/packages/ui/src/components/auth/SessionExpiredBanner.svelte
+++ b/packages/ui/src/components/auth/SessionExpiredBanner.svelte
@@ -23,8 +23,8 @@
     visible?: boolean;
     /** Submit password — may return `two_factor_required` to trigger TOTP step. */
     onReAuth?: (password: string) => Promise<ReAuthResult>;
-    /** Submit TOTP / recovery code after `two_factor_required`. */
-    onVerifyTotp?: (userId: string, code: string) => Promise<ReAuthResult>;
+    /** Submit the challenge token + TOTP / recovery code after `two_factor_required`. */
+    onVerifyTotp?: (challengeToken: string, code: string) => Promise<ReAuthResult>;
   }>();
 
   let modalOpen = $state(false);

--- a/packages/ui/src/components/auth/reauth-types.ts
+++ b/packages/ui/src/components/auth/reauth-types.ts
@@ -3,12 +3,17 @@
  *
  * `two_factor_required` is returned when the account has 2FA enabled and the
  * password has been verified — the UI must then collect a TOTP/recovery code
- * and call the TOTP verify callback with `userId`.
+ * and call the TOTP verify callback with the `challengeToken` issued by the
+ * password step (audit 012 S4: /2fa/verify no longer accepts a raw userId).
+ *
+ * `challenge_expired` is returned when that token has expired (5-minute TTL)
+ * or was already consumed — the UI must return to the password step.
  */
 export type ReAuthResult =
   | { kind: 'ok' }
   | { kind: 'invalid_password' }
-  | { kind: 'two_factor_required'; userId: string }
+  | { kind: 'two_factor_required'; challengeToken: string }
   | { kind: 'invalid_totp' }
+  | { kind: 'challenge_expired' }
   | { kind: 'locked'; retryAfter: number }
   | { kind: 'error'; message?: string };


### PR DESCRIPTION
## Summary

Closes the last MEDIUM finding of security audit 012 (S4 = O26 from audit 008) plus three LOW findings (N1, N2, N8). Two commits, reviewable independently.

**Commit 1 - S4: 2FA challenge token.** `POST /api/auth/2fa/verify` no longer accepts a bare `{userId, code}`. `/login` (both apps) now returns a signed single-use `challengeToken` (JWT, purpose `2fa_challenge`, 5-minute TTL) in the `twoFactorRequired` branch, and `/2fa/verify` derives the userId from that token - so the second factor cannot be attempted without first passing the password step. Full client chain updated: login/2FA pages (token rides in sessionStorage, not the URL), re-auth modal flow in `@reborn/ui` (new `challenge_expired` result returns the modal to the password step), 3 new i18n keys x 5 locales.

**Commit 2 - N1/N2/N8.** `refresh-native` joins the refresh rate limiter (was completely unlimited); SavedSearch gets a 100-rows-per-user cap on create (422, outside the byte quota until now); unparseable `since`/`created_at` dates now 400 instead of an Invalid-Date Prisma 500 (which the sync client would retry forever).

### Decisions needing review (auto mode)

1. **Challenge token = stateless JWT + in-memory consumed-jti blacklist** (existing `tokenBlacklist` infra), no DB table - consistent with the in-memory lockouts on the single-instance deploy. Multi-instance deployment would need a shared store, same as every other limiter here.
2. **Consume-on-success-only**: a TOTP typo does not burn the challenge (no forced password re-entry); brute force stays bounded by the 5/15min per-user 2FA lockout. OAuth `mfa_token` semantics.
3. **Hard cutover, no legacy dual-accept**: a stale PWA bundle mid-rollout fails 2FA login until reload. Dual-accept would keep the bypass alive; today's 2FA user count makes the window acceptable.
4. **SavedSearch cap = 100** (folders/tags share the same pre-existing gap - tracked in the docs backlog as a uniform row-cap pass).
5. **Date validation via `Date.parse` refine**, not `z.string().datetime()` - `.datetime()` rejects timezone offsets and could break legitimate offline payloads.

## Test plan

- [ ] 2FA login (web): password -> TOTP code -> lands in the app; wrong code shows "invalid code" and a retry works without re-entering the password
- [ ] 2FA login with a recovery code
- [ ] Wait >5 min on the 2FA screen, then submit: "verification session expired" message appears, back-to-login works
- [ ] Session-expired re-auth with a 2FA account (banner -> password -> TOTP); also let the TOTP step idle >5 min: modal returns to the password step with the expired message
- [ ] Non-2FA login unaffected
- [ ] `GET /api/notes?since=garbage` returns 400 (was 500)
- [ ] Suites: auth 61, types 80, i18n 27, notes 1188, task 85 tests green; svelte-check 0/0 both apps; i18n parity PASSED