### PR TITLE
fix(security): audit 012 N3-N7 client-side hardening batch

### DIFF
--- a/apps/reborn-notes/ios/App/App/FolderFsPlugin.swift
+++ b/apps/reborn-notes/ios/App/App/FolderFsPlugin.swift
@@ -233,7 +233,7 @@ public class FolderFsPlugin: CAPPlugin, CAPBridgedPlugin, UIDocumentPickerDelega
                     return
                 }
 
-                let fileURL = self.resolveChild(root: root, relativePath: relPath)
+                let fileURL = try self.resolveChild(root: root, relativePath: relPath)
                 try self.ensureDownloaded(fileURL)
                 let content = try self.coordinatedRead(fileURL)
                 let mtimeMs = ((try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]))?
@@ -245,15 +245,35 @@ public class FolderFsPlugin: CAPPlugin, CAPBridgedPlugin, UIDocumentPickerDelega
         }
     }
 
+    /// Error for a relative path that tries to leave the bookmarked folder.
+    private struct PathTraversalError: LocalizedError {
+        let path: String
+        var errorDescription: String? { "Path escapes the bookmarked folder: \(path)" }
+    }
+
     /// Map a `<leaf>/<sub>/<file>` relative path (leaf == root.lastPathComponent) to a
-    /// child URL under `root` by dropping the leaf segment.
-    private func resolveChild(root: URL, relativePath: String) -> URL {
+    /// child URL under `root` by dropping the leaf segment. Every path reaching this
+    /// comes from our own JS (listFiles results / backupFilename()), which never emits
+    /// dot segments or absolute paths - so reject them outright rather than resolve
+    /// them: a `..` would climb OUT of the security-scoped folder (defense-in-depth,
+    /// audit 012 N3; Android is already immune via leafName()/documentId).
+    private func resolveChild(root: URL, relativePath: String) throws -> URL {
+        guard !relativePath.hasPrefix("/") else {
+            throw PathTraversalError(path: relativePath)
+        }
+        // split(separator:) drops empty subsequences, so "a//b" cannot smuggle
+        // an empty segment through.
         var segments = relativePath.split(separator: "/").map(String.init)
         if let first = segments.first, first == root.lastPathComponent {
             segments.removeFirst()
         }
         var url = root
-        for seg in segments { url.appendPathComponent(seg) }
+        for seg in segments {
+            guard seg != "." && seg != ".." else {
+                throw PathTraversalError(path: relativePath)
+            }
+            url.appendPathComponent(seg)
+        }
         return url
     }
 
@@ -348,7 +368,7 @@ public class FolderFsPlugin: CAPPlugin, CAPBridgedPlugin, UIDocumentPickerDelega
                     staleBookmark = fresh.base64EncodedString()
                 }
 
-                let fileURL = self.resolveChild(root: root, relativePath: relPath)
+                let fileURL = try self.resolveChild(root: root, relativePath: relPath)
                 try self.coordinatedWrite(fileURL, content: content)
 
                 var result: [String: Any] = [:]
@@ -409,7 +429,7 @@ public class FolderFsPlugin: CAPPlugin, CAPBridgedPlugin, UIDocumentPickerDelega
                     staleBookmark = fresh.base64EncodedString()
                 }
 
-                let fileURL = self.resolveChild(root: root, relativePath: relPath)
+                let fileURL = try self.resolveChild(root: root, relativePath: relPath)
                 if FileManager.default.fileExists(atPath: fileURL.path) {
                     try self.coordinatedRemove(fileURL)
                 }

--- a/apps/reborn-notes/src/lib/services/export-import.sanitize.spec.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.sanitize.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ── sanitizeFilename hardening (audit 012 N5) ───────────────────────────────
+// A note title / folder name becomes a path segment in ZIP entries and
+// downloads. Dot-only names must not survive (a folder named ".." yields a
+// "../note.md" entry - zip-slip on naive extractors), and Windows-reserved
+// device names / trailing dots would make the archive fail to extract there.
+//
+// The heavy service layer is faked the same way the link-rewrite integration
+// spec fakes its deps (no IndexedDB / crypto in vitest) - we only need the
+// module to load.
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('$lib/stores/auth.store', async () => {
+  const { writable } = await import('svelte/store');
+  return { authStore: writable({ isAuthenticated: true, hasE2E: true }) };
+});
+
+vi.mock('@reborn/storage', () => ({
+  noteStore: {},
+  folderStore: {},
+  tagStore: {},
+  noteTagStore: {},
+  noteTagOperations: {},
+  noteTagQueries: {}
+}));
+
+vi.mock('./note.service', () => ({}));
+vi.mock('./folder.service', () => ({}));
+vi.mock('./tag.service', () => ({}));
+vi.mock('./notes-sync.service', () => ({ pushNote: () => {}, pushPendingItems: () => {} }));
+vi.mock('./note-index.svelte', () => ({ noteIndex: {} }));
+
+import { sanitizeFilename } from './export-import.service';
+
+describe('sanitizeFilename (audit 012 N5)', () => {
+  it('keeps ordinary titles intact', () => {
+    expect(sanitizeFilename('Meeting notes 2026')).toBe('Meeting notes 2026');
+    expect(sanitizeFilename('Zażółć gęślą jaźń')).toBe('Zażółć gęślą jaźń');
+  });
+
+  it('replaces path separators and control characters (existing behavior)', () => {
+    expect(sanitizeFilename('a/b\\c:d')).toBe('a_b_c_d');
+    expect(sanitizeFilename('tab\there')).toBe('tab_here');
+  });
+
+  it('neutralizes dot-only names instead of emitting traversal segments', () => {
+    expect(sanitizeFilename('..')).toBe('untitled');
+    expect(sanitizeFilename('.')).toBe('untitled');
+    expect(sanitizeFilename('...')).toBe('untitled');
+  });
+
+  it('strips trailing dots and spaces (unextractable on Windows)', () => {
+    expect(sanitizeFilename('notes.')).toBe('notes');
+    expect(sanitizeFilename('notes... ')).toBe('notes');
+    // Leading dots are preserved - a hidden file is valid, only the tail breaks.
+    expect(sanitizeFilename('.hidden')).toBe('.hidden');
+  });
+
+  it('defuses Windows reserved device names, with or without an extension', () => {
+    expect(sanitizeFilename('CON')).toBe('_CON');
+    expect(sanitizeFilename('con')).toBe('_con');
+    expect(sanitizeFilename('PRN.notes')).toBe('_PRN.notes');
+    expect(sanitizeFilename('LPT1')).toBe('_LPT1');
+    // Not reserved: the device name must be the whole base name.
+    expect(sanitizeFilename('CONTRACT')).toBe('CONTRACT');
+    expect(sanitizeFilename('conference')).toBe('conference');
+  });
+
+  it('still falls back to "untitled" for empty input and caps the length', () => {
+    expect(sanitizeFilename('')).toBe('untitled');
+    expect(sanitizeFilename('   ')).toBe('untitled');
+    expect(sanitizeFilename('x'.repeat(300))).toHaveLength(100);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -35,9 +35,7 @@ import { createMarkdownListRenderers } from '$lib/utils/markdown-to-html';
 import { get } from 'svelte/store';
 import { authStore } from '$lib/stores/auth.store';
 import {
-  deriveKeyFromPassword,
-  decryptData,
-  base64ToArrayBuffer,
+  decryptWithPasswordOrPhrase,
   encryptWithPassword,
   cryptoManager,
   isEncryptedDataReadable
@@ -161,8 +159,31 @@ async function downloadBlob(blob: Blob, filename: string): Promise<void> {
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
-function sanitizeFilename(name: string): string {
-  return (name.replace(/[\\/:*?"<>|\n\r\t]/g, '_').trim() || 'untitled').slice(0, 100);
+/**
+ * Windows reserved device names - refused by the OS as a file's base name
+ * (the part before the first dot), in any casing, so `con.md` is as broken
+ * as `CON`.
+ */
+const WINDOWS_RESERVED_NAME_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+
+/**
+ * Make a note title / folder name safe as a single path segment in a download
+ * or ZIP entry. Beyond stripping separator and control characters, dot-only
+ * names must not survive: a folder named ".." becomes a `../note.md` ZIP entry
+ * that a naive extractor writes OUTSIDE the target directory (zip-slip), and
+ * "." vanishes. Trailing dots and Windows reserved device names would make the
+ * archive fail to extract on Windows. (Audit 012 N5.)
+ *
+ * Exported for unit tests.
+ */
+export function sanitizeFilename(name: string): string {
+  let safe = name
+    .replace(/[\\/:*?"<>|\n\r\t]/g, '_')
+    .trim()
+    .slice(0, 100)
+    .replace(/[\s.]+$/, '');
+  if (WINDOWS_RESERVED_NAME_RE.test(safe)) safe = `_${safe}`;
+  return safe || 'untitled';
 }
 
 function buildFrontmatter(note: NoteDecrypted, tagNames: string[]): string {
@@ -928,15 +949,17 @@ export async function importJsonBackup(
   if (parsed.version === 2 || parsed.version === 3) {
     // Password-encrypted envelope. Both versions share the same PBKDF2 +
     // AES-GCM wrapper; they differ only in what the ciphertext decrypts to.
+    // Phrase-tolerant decrypt: an auto-backup is keyed by the recovery phrase,
+    // which the restoring user re-types from paper - the helper retries with
+    // the normalized phrase form when the raw input fails (audit 012 N4).
     if (!password) throw new Error('Ten backup jest zaszyfrowany. Podaj hasło.');
     const envelope = parsed as BackupV2 | BackupV3;
-    const salt = base64ToArrayBuffer(envelope.salt);
-    const iv = base64ToArrayBuffer(envelope.iv);
-    const ciphertext = base64ToArrayBuffer(envelope.data);
-    const key = await deriveKeyFromPassword(password, salt);
     let decrypted: string;
     try {
-      decrypted = (await decryptData(ciphertext, key, iv, 'string')) as string;
+      decrypted = await decryptWithPasswordOrPhrase(
+        { salt: envelope.salt, iv: envelope.iv, data: envelope.data },
+        password
+      );
     } catch {
       throw new Error('Nieprawidłowe hasło lub uszkodzony plik backupu.');
     }

--- a/apps/reborn-notes/src/routes/auth/lock/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/lock/+page.svelte
@@ -19,7 +19,7 @@
   } from '@reborn/ui';
   import { Eye, EyeOff, Lock } from '@lucide/svelte';
   import { t } from '$lib/stores/i18n.store';
-  import { cryptoManager } from '@reborn/crypto';
+  import { cryptoManager, LocalPasscodeThrottledError } from '@reborn/crypto';
   import { authStore, LOCAL_MODE_KEY, LOCAL_USER_ID_KEY } from '$lib/stores/auth.store';
   import { createLogger } from '@reborn/utils';
 
@@ -33,6 +33,32 @@
   let resetting = $state(false);
   let isRedirecting = false;
 
+  // Failure-throttle countdown (audit 012 N6): after repeated wrong passcodes
+  // the crypto layer refuses attempts for a growing window - surface it as a
+  // ticking "try again in m:ss" instead of a misleading "wrong passcode".
+  let retryDelayMs = $state(0);
+  let retryTimer: ReturnType<typeof setInterval> | null = null;
+
+  const retryTimeLabel = $derived.by(() => {
+    const total = Math.ceil(retryDelayMs / 1000);
+    return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+  });
+
+  function syncRetryDelay() {
+    retryDelayMs = cryptoManager.getLocalPasscodeRetryDelayMs();
+    if (retryDelayMs <= 0 && retryTimer) {
+      clearInterval(retryTimer);
+      retryTimer = null;
+    }
+  }
+
+  function watchRetryDelay() {
+    syncRetryDelay();
+    if (retryDelayMs > 0 && !retryTimer) {
+      retryTimer = setInterval(syncRetryDelay, 500);
+    }
+  }
+
   const returnTo = $derived.by(() => $page.url.searchParams.get('returnTo') || '/');
 
   // Nothing to unlock (no passcode set) or the key is already in memory → leave.
@@ -41,11 +67,16 @@
       isRedirecting = true;
       goto(returnTo);
     }
+    // A reload inside an open throttle window resumes the countdown.
+    watchRetryDelay();
+    return () => {
+      if (retryTimer) clearInterval(retryTimer);
+    };
   });
 
   async function handleUnlock(event: Event) {
     event.preventDefault();
-    if (!passcode || loading) return;
+    if (!passcode || loading || retryDelayMs > 0) return;
     loading = true;
     error = null;
     try {
@@ -56,10 +87,15 @@
       } else {
         error = $t('local_mode.passcode.wrong');
         passcode = '';
+        watchRetryDelay();
       }
     } catch (err: unknown) {
-      logger.error('Passcode unlock failed:', err);
-      error = $t('local_mode.passcode.wrong');
+      if (err instanceof LocalPasscodeThrottledError) {
+        watchRetryDelay();
+      } else {
+        logger.error('Passcode unlock failed:', err);
+        error = $t('local_mode.passcode.wrong');
+      }
     } finally {
       loading = false;
     }
@@ -115,7 +151,13 @@
     </div>
 
     <form onsubmit={handleUnlock} class="space-y-4">
-      {#if error}
+      {#if retryDelayMs > 0}
+        <Alert variant="destructive">
+          <AlertDescription>
+            {$t('local_mode.passcode.throttled', { values: { time: retryTimeLabel } })}
+          </AlertDescription>
+        </Alert>
+      {:else if error}
         <Alert variant="destructive">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
@@ -143,7 +185,7 @@
         </div>
       </div>
 
-      <Button type="submit" disabled={loading || !passcode} class="w-full">
+      <Button type="submit" disabled={loading || !passcode || retryDelayMs > 0} class="w-full">
         {loading
           ? $t('local_mode.passcode.unlocking')
           : $t('local_mode.passcode.unlock_cta')}

--- a/apps/reborn-notes/src/routes/settings/security/passcode/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/security/passcode/+page.svelte
@@ -24,12 +24,18 @@
   import { t } from '$lib/stores/i18n.store';
   import { goto } from '$lib/utils/navigation';
   import { authStore } from '$lib/stores/auth.store';
-  import { cryptoManager } from '@reborn/crypto';
+  import {
+    cryptoManager,
+    LOCAL_PASSCODE_MIN_LENGTH,
+    isTriviallyGuessablePasscode
+  } from '@reborn/crypto';
   import { createLogger } from '@reborn/utils';
   import { get } from 'svelte/store';
 
   const logger = createLogger('PasscodeSettingsPage');
-  const MIN_LENGTH = 6;
+  // Enforced by the crypto layer (enable/change throw below it) - the UI just
+  // mirrors the shared constant for validation copy (audit 012 N6).
+  const MIN_LENGTH = LOCAL_PASSCODE_MIN_LENGTH;
 
   let enabled = $state(false);
 
@@ -66,6 +72,14 @@
     if (confirmPasscode !== newPasscode) return $t('local_mode.passcode.mismatch');
     return null;
   });
+
+  // Soft quality nudge, never a blocker: flags repeated / sequential patterns
+  // ("111111", "123456") while typing (audit 012 N6).
+  const weakWarning = $derived(
+    newPasscode.length >= MIN_LENGTH && isTriviallyGuessablePasscode(newPasscode)
+      ? $t('local_mode.passcode.weak_warning')
+      : null
+  );
 
   function resetForm() {
     currentPasscode = '';
@@ -204,6 +218,8 @@
             </div>
             {#if newError}
               <p class="text-sm text-destructive">{newError}</p>
+            {:else if weakWarning}
+              <p class="text-xs text-amber-600 dark:text-amber-400">{weakWarning}</p>
             {:else}
               <p class="text-xs text-muted-foreground">
                 {$t('local_mode.passcode.min_length', { values: { min: MIN_LENGTH } })}

--- a/apps/reborn-task/src/lib/services/data-import.service.ts
+++ b/apps/reborn-task/src/lib/services/data-import.service.ts
@@ -1,11 +1,5 @@
 import { taskStore, listStore, subtaskStore, addOperation } from '@reborn/storage';
-import {
-	cryptoManager,
-	deriveKeyFromPassword,
-	decryptData,
-	base64ToArrayBuffer,
-	isEncryptedDataReadable
-} from '@reborn/crypto';
+import { cryptoManager, decryptWithPasswordOrPhrase, isEncryptedDataReadable } from '@reborn/crypto';
 import { createLogger } from '@reborn/utils';
 import { schemas } from '@reborn/types';
 import { get } from 'svelte/store';
@@ -222,13 +216,16 @@ export class DataImportService {
 		envelope: PortableEncryptedExport,
 		password: string
 	): Promise<unknown> {
-		const salt = base64ToArrayBuffer(envelope.salt);
-		const iv = base64ToArrayBuffer(envelope.iv);
-		const ciphertext = base64ToArrayBuffer(envelope.data);
-		const key = await deriveKeyFromPassword(password, salt);
+		// Phrase-tolerant decrypt: when the typed secret parses as a recovery
+		// phrase, the helper retries with its normalized form after the raw input
+		// fails - a phrase re-typed from paper with numbering/capitals must not
+		// read as "wrong password" (audit 012 N4; mirrors the notes importer).
 		let decrypted: string;
 		try {
-			decrypted = (await decryptData(ciphertext, key, iv, 'string')) as string;
+			decrypted = await decryptWithPasswordOrPhrase(
+				{ salt: envelope.salt, iv: envelope.iv, data: envelope.data },
+				password
+			);
 		} catch {
 			throw new Error('Nieprawidłowe hasło lub uszkodzony plik backupu.');
 		}

--- a/apps/reborn-task/src/routes/auth/lock/+page.svelte
+++ b/apps/reborn-task/src/routes/auth/lock/+page.svelte
@@ -19,7 +19,7 @@
 	} from '@reborn/ui';
 	import { Eye, EyeOff, Lock } from '@lucide/svelte';
 	import { t } from '$lib/stores/i18n.store';
-	import { cryptoManager } from '@reborn/crypto';
+	import { cryptoManager, LocalPasscodeThrottledError } from '@reborn/crypto';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
 	import { createLogger } from '@reborn/utils';
 
@@ -33,6 +33,32 @@
 	let resetting = $state(false);
 	let isRedirecting = false;
 
+	// Failure-throttle countdown (audit 012 N6): after repeated wrong passcodes
+	// the crypto layer refuses attempts for a growing window - surface it as a
+	// ticking "try again in m:ss" instead of a misleading "wrong passcode".
+	let retryDelayMs = $state(0);
+	let retryTimer: ReturnType<typeof setInterval> | null = null;
+
+	const retryTimeLabel = $derived.by(() => {
+		const total = Math.ceil(retryDelayMs / 1000);
+		return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+	});
+
+	function syncRetryDelay() {
+		retryDelayMs = cryptoManager.getLocalPasscodeRetryDelayMs();
+		if (retryDelayMs <= 0 && retryTimer) {
+			clearInterval(retryTimer);
+			retryTimer = null;
+		}
+	}
+
+	function watchRetryDelay() {
+		syncRetryDelay();
+		if (retryDelayMs > 0 && !retryTimer) {
+			retryTimer = setInterval(syncRetryDelay, 500);
+		}
+	}
+
 	const returnTo = $derived.by(() => $page.url.searchParams.get('returnTo') || '/');
 
 	// Nothing to unlock (no passcode set) or the key is already in memory → leave.
@@ -41,11 +67,16 @@
 			isRedirecting = true;
 			goto(returnTo);
 		}
+		// A reload inside an open throttle window resumes the countdown.
+		watchRetryDelay();
+		return () => {
+			if (retryTimer) clearInterval(retryTimer);
+		};
 	});
 
 	async function handleUnlock(event: Event) {
 		event.preventDefault();
-		if (!passcode || loading) return;
+		if (!passcode || loading || retryDelayMs > 0) return;
 		loading = true;
 		error = null;
 		try {
@@ -57,10 +88,15 @@
 			} else {
 				error = $t('local_mode.passcode.wrong');
 				passcode = '';
+				watchRetryDelay();
 			}
 		} catch (err: unknown) {
-			logger.error('Passcode unlock failed:', err);
-			error = $t('local_mode.passcode.wrong');
+			if (err instanceof LocalPasscodeThrottledError) {
+				watchRetryDelay();
+			} else {
+				logger.error('Passcode unlock failed:', err);
+				error = $t('local_mode.passcode.wrong');
+			}
 		} finally {
 			loading = false;
 		}
@@ -112,7 +148,13 @@
 		</div>
 
 		<form onsubmit={handleUnlock} class="space-y-4">
-			{#if error}
+			{#if retryDelayMs > 0}
+				<Alert variant="destructive">
+					<AlertDescription>
+						{$t('local_mode.passcode.throttled', { values: { time: retryTimeLabel } })}
+					</AlertDescription>
+				</Alert>
+			{:else if error}
 				<Alert variant="destructive">
 					<AlertDescription>{error}</AlertDescription>
 				</Alert>
@@ -140,7 +182,7 @@
 				</div>
 			</div>
 
-			<Button type="submit" disabled={loading || !passcode} class="w-full">
+			<Button type="submit" disabled={loading || !passcode || retryDelayMs > 0} class="w-full">
 				{loading
 					? $t('local_mode.passcode.unlocking')
 					: $t('local_mode.passcode.unlock_cta')}

--- a/apps/reborn-task/src/routes/settings/security/passcode/+page.svelte
+++ b/apps/reborn-task/src/routes/settings/security/passcode/+page.svelte
@@ -25,12 +25,18 @@
 	import { goto } from '$lib/utils/navigation';
 	import { isLocalOnly } from '$lib/stores/auth.store';
 	import { authOperationsService } from '$lib/services/auth-operations.service';
-	import { cryptoManager } from '@reborn/crypto';
+	import {
+		cryptoManager,
+		LOCAL_PASSCODE_MIN_LENGTH,
+		isTriviallyGuessablePasscode
+	} from '@reborn/crypto';
 	import { createLogger } from '@reborn/utils';
 	import { get } from 'svelte/store';
 
 	const logger = createLogger('PasscodeSettingsPage');
-	const MIN_LENGTH = 6;
+	// Enforced by the crypto layer (enable/change throw below it) - the UI just
+	// mirrors the shared constant for validation copy (audit 012 N6).
+	const MIN_LENGTH = LOCAL_PASSCODE_MIN_LENGTH;
 
 	let enabled = $state(false);
 
@@ -68,6 +74,14 @@
 		if (confirmPasscode !== newPasscode) return $t('local_mode.passcode.mismatch');
 		return null;
 	});
+
+	// Soft quality nudge, never a blocker: flags repeated / sequential patterns
+	// ("111111", "123456") while typing (audit 012 N6).
+	const weakWarning = $derived(
+		newPasscode.length >= MIN_LENGTH && isTriviallyGuessablePasscode(newPasscode)
+			? $t('local_mode.passcode.weak_warning')
+			: null
+	);
 
 	function resetForm() {
 		currentPasscode = '';
@@ -207,6 +221,8 @@
 						</div>
 						{#if newError}
 							<p class="text-sm text-destructive">{newError}</p>
+						{:else if weakWarning}
+							<p class="text-xs text-amber-600 dark:text-amber-400">{weakWarning}</p>
 						{:else}
 							<p class="text-xs text-muted-foreground">
 								{$t('local_mode.passcode.min_length', { values: { min: MIN_LENGTH } })}

--- a/packages/crypto/src/__tests__/cryptoManager.passcode.spec.ts
+++ b/packages/crypto/src/__tests__/cryptoManager.passcode.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { CryptoManager } from '../cryptoManager';
+import { CryptoManager, type MasterKeyVault } from '../cryptoManager';
+import { LocalPasscodeThrottledError, LOCAL_PASSCODE_FREE_ATTEMPTS } from '../local-passcode';
 
 /**
  * Local-mode passcode: optional at-rest wrap of the local master key.
@@ -67,6 +68,13 @@ describe('CryptoManager - local passcode', () => {
       const m = freshManager();
       await m.setMasterKey(await m.generateMasterKey());
       await expect(m.enableLocalPasscode('')).rejects.toThrow('Passcode must not be empty');
+    });
+
+    it('enforces the shared minimum length below the UI (audit 012 N6)', async () => {
+      const m = freshManager();
+      await m.setMasterKey(await m.generateMasterKey());
+      await expect(m.enableLocalPasscode('12345')).rejects.toThrow('at least 6 characters');
+      expect(m.isLocalPasscodeEnabled()).toBe(false);
     });
   });
 
@@ -162,6 +170,15 @@ describe('CryptoManager - local passcode', () => {
       const cold = freshManager();
       await cold.waitForRestore();
       expect(await cold.unlockWithLocalPasscode(PASSCODE)).toBe(true);
+    });
+
+    it('rejects a too-short new passcode (audit 012 N6)', async () => {
+      const m = freshManager();
+      await m.setMasterKey(await m.generateMasterKey());
+      await m.enableLocalPasscode(PASSCODE);
+      await expect(m.changeLocalPasscode(PASSCODE, '123')).rejects.toThrow(
+        'at least 6 characters'
+      );
     });
   });
 
@@ -262,6 +279,122 @@ describe('CryptoManager - local passcode', () => {
 
       expect(await m.decryptString(before)).toBe('before passcode');
       expect(await m.decryptString(during)).toBe('after enabling');
+    });
+  });
+
+  describe('failure throttle (audit 012 N6)', () => {
+    const ATTEMPTS_KEY = 'reborn_local_passcode_attempts';
+
+    /** A cold, locked instance with a wrap for PASSCODE already persisted. */
+    async function lockedManager() {
+      const setup = freshManager();
+      await setup.setMasterKey(await setup.generateMasterKey());
+      await setup.enableLocalPasscode(PASSCODE);
+      const cold = freshManager();
+      await cold.waitForRestore();
+      return cold;
+    }
+
+    it('throttles after the free attempts, even for the correct passcode', async () => {
+      const cold = await lockedManager();
+      for (let i = 0; i < LOCAL_PASSCODE_FREE_ATTEMPTS; i++) {
+        expect(await cold.unlockWithLocalPasscode(WRONG)).toBe(false);
+      }
+      expect(cold.getLocalPasscodeRetryDelayMs()).toBeGreaterThan(0);
+      await expect(cold.unlockWithLocalPasscode(PASSCODE)).rejects.toThrow(
+        LocalPasscodeThrottledError
+      );
+      expect(cold.isInitialized()).toBe(false);
+    });
+
+    it('allows the attempt again once the window passes, and success clears the counter', async () => {
+      const cold = await lockedManager();
+      for (let i = 0; i < LOCAL_PASSCODE_FREE_ATTEMPTS; i++) {
+        await cold.unlockWithLocalPasscode(WRONG);
+      }
+      // Rewind the persisted window instead of faking timers - also proves the
+      // record is read from storage, not process memory.
+      const rec = JSON.parse(ls().getItem(ATTEMPTS_KEY) as string);
+      ls().setItem(ATTEMPTS_KEY, JSON.stringify({ ...rec, lockedUntil: Date.now() - 1 }));
+
+      expect(await cold.unlockWithLocalPasscode(PASSCODE)).toBe(true);
+      expect(ls().getItem(ATTEMPTS_KEY)).toBeNull();
+      expect(cold.getLocalPasscodeRetryDelayMs()).toBe(0);
+    });
+
+    it('drops the counter with the wrap (reset path)', async () => {
+      const cold = await lockedManager();
+      for (let i = 0; i < LOCAL_PASSCODE_FREE_ATTEMPTS; i++) {
+        await cold.unlockWithLocalPasscode(WRONG);
+      }
+      expect(ls().getItem(ATTEMPTS_KEY)).not.toBeNull();
+      cold.forgetLocalPasscode();
+      expect(ls().getItem(ATTEMPTS_KEY)).toBeNull();
+    });
+  });
+
+  describe('purge verification on enable (audit 012 N7)', () => {
+    /** Vault whose clear() resolves but silently leaves the entry behind. */
+    function stickyVault(): MasterKeyVault {
+      let stored: string | null = null;
+      return {
+        save: async (raw: string) => {
+          stored = raw;
+        },
+        load: async () => stored,
+        clear: async () => {
+          /* pretends to succeed without deleting */
+        }
+      };
+    }
+
+    it('rolls back and throws when a raw key copy survives the purge', async () => {
+      const m = freshManager();
+      m.setMasterKeyVault(stickyVault());
+      await m.setMasterKey(await m.generateMasterKey());
+
+      await expect(m.enableLocalPasscode(PASSCODE)).rejects.toThrow('passcode not enabled');
+      // Consistent no-passcode baseline: wrap rolled back, session key intact.
+      expect(m.isLocalPasscodeEnabled()).toBe(false);
+      expect(ls().getItem(WRAP_KEY)).toBeNull();
+      expect(m.isInitialized()).toBe(true);
+    });
+
+    it('propagates a vault clear() failure instead of reporting success', async () => {
+      const m = freshManager();
+      let stored: string | null = null;
+      m.setMasterKeyVault({
+        save: async (raw: string) => {
+          stored = raw;
+        },
+        load: async () => stored,
+        clear: async () => {
+          throw new Error('keystore unavailable');
+        }
+      });
+      await m.setMasterKey(await m.generateMasterKey());
+
+      await expect(m.enableLocalPasscode(PASSCODE)).rejects.toThrow('passcode not enabled');
+      expect(m.isLocalPasscodeEnabled()).toBe(false);
+    });
+
+    it('succeeds with a vault that really deletes', async () => {
+      const m = freshManager();
+      let stored: string | null = null;
+      m.setMasterKeyVault({
+        save: async (raw: string) => {
+          stored = raw;
+        },
+        load: async () => stored,
+        clear: async () => {
+          stored = null;
+        }
+      });
+      await m.setMasterKey(await m.generateMasterKey());
+
+      await m.enableLocalPasscode(PASSCODE);
+      expect(m.isLocalPasscodeEnabled()).toBe(true);
+      expect(stored).toBeNull();
     });
   });
 });

--- a/packages/crypto/src/__tests__/cryptoManager.passcode.spec.ts
+++ b/packages/crypto/src/__tests__/cryptoManager.passcode.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CryptoManager, type MasterKeyVault } from '../cryptoManager';
-import { LocalPasscodeThrottledError, LOCAL_PASSCODE_FREE_ATTEMPTS } from '../local-passcode';
+import { LocalPasscodeThrottledError, UNLOCK_THROTTLE_FREE_ATTEMPTS } from '../local-passcode';
 
 /**
  * Local-mode passcode: optional at-rest wrap of the local master key.
@@ -297,7 +297,7 @@ describe('CryptoManager - local passcode', () => {
 
     it('throttles after the free attempts, even for the correct passcode', async () => {
       const cold = await lockedManager();
-      for (let i = 0; i < LOCAL_PASSCODE_FREE_ATTEMPTS; i++) {
+      for (let i = 0; i < UNLOCK_THROTTLE_FREE_ATTEMPTS; i++) {
         expect(await cold.unlockWithLocalPasscode(WRONG)).toBe(false);
       }
       expect(cold.getLocalPasscodeRetryDelayMs()).toBeGreaterThan(0);
@@ -309,7 +309,7 @@ describe('CryptoManager - local passcode', () => {
 
     it('allows the attempt again once the window passes, and success clears the counter', async () => {
       const cold = await lockedManager();
-      for (let i = 0; i < LOCAL_PASSCODE_FREE_ATTEMPTS; i++) {
+      for (let i = 0; i < UNLOCK_THROTTLE_FREE_ATTEMPTS; i++) {
         await cold.unlockWithLocalPasscode(WRONG);
       }
       // Rewind the persisted window instead of faking timers - also proves the
@@ -324,7 +324,7 @@ describe('CryptoManager - local passcode', () => {
 
     it('drops the counter with the wrap (reset path)', async () => {
       const cold = await lockedManager();
-      for (let i = 0; i < LOCAL_PASSCODE_FREE_ATTEMPTS; i++) {
+      for (let i = 0; i < UNLOCK_THROTTLE_FREE_ATTEMPTS; i++) {
         await cold.unlockWithLocalPasscode(WRONG);
       }
       expect(ls().getItem(ATTEMPTS_KEY)).not.toBeNull();

--- a/packages/crypto/src/__tests__/local-passcode.spec.ts
+++ b/packages/crypto/src/__tests__/local-passcode.spec.ts
@@ -1,30 +1,30 @@
 import { describe, it, expect } from 'vitest';
 import {
   LOCAL_PASSCODE_MIN_LENGTH,
-  LOCAL_PASSCODE_FREE_ATTEMPTS,
-  LOCAL_PASSCODE_MAX_DELAY_MS,
-  localPasscodeRetryDelayMs,
+  UNLOCK_THROTTLE_FREE_ATTEMPTS,
+  UNLOCK_THROTTLE_MAX_DELAY_MS,
+  unlockThrottleDelayMs,
   isTriviallyGuessablePasscode,
   LocalPasscodeThrottledError
 } from '../local-passcode';
 
 describe('local passcode policy (audit 012 N6)', () => {
-  describe('localPasscodeRetryDelayMs', () => {
+  describe('unlockThrottleDelayMs', () => {
     it('gives no delay for the free attempts', () => {
-      for (let count = 0; count < LOCAL_PASSCODE_FREE_ATTEMPTS; count++) {
-        expect(localPasscodeRetryDelayMs(count)).toBe(0);
+      for (let count = 0; count < UNLOCK_THROTTLE_FREE_ATTEMPTS; count++) {
+        expect(unlockThrottleDelayMs(count)).toBe(0);
       }
     });
 
     it('starts at 10 s and doubles per failure', () => {
-      expect(localPasscodeRetryDelayMs(LOCAL_PASSCODE_FREE_ATTEMPTS)).toBe(10_000);
-      expect(localPasscodeRetryDelayMs(LOCAL_PASSCODE_FREE_ATTEMPTS + 1)).toBe(20_000);
-      expect(localPasscodeRetryDelayMs(LOCAL_PASSCODE_FREE_ATTEMPTS + 2)).toBe(40_000);
+      expect(unlockThrottleDelayMs(UNLOCK_THROTTLE_FREE_ATTEMPTS)).toBe(10_000);
+      expect(unlockThrottleDelayMs(UNLOCK_THROTTLE_FREE_ATTEMPTS + 1)).toBe(20_000);
+      expect(unlockThrottleDelayMs(UNLOCK_THROTTLE_FREE_ATTEMPTS + 2)).toBe(40_000);
     });
 
     it('caps at 15 minutes and survives absurd counts without overflow', () => {
-      expect(localPasscodeRetryDelayMs(50)).toBe(LOCAL_PASSCODE_MAX_DELAY_MS);
-      expect(localPasscodeRetryDelayMs(10_000)).toBe(LOCAL_PASSCODE_MAX_DELAY_MS);
+      expect(unlockThrottleDelayMs(50)).toBe(UNLOCK_THROTTLE_MAX_DELAY_MS);
+      expect(unlockThrottleDelayMs(10_000)).toBe(UNLOCK_THROTTLE_MAX_DELAY_MS);
     });
   });
 

--- a/packages/crypto/src/__tests__/local-passcode.spec.ts
+++ b/packages/crypto/src/__tests__/local-passcode.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LOCAL_PASSCODE_MIN_LENGTH,
+  LOCAL_PASSCODE_FREE_ATTEMPTS,
+  LOCAL_PASSCODE_MAX_DELAY_MS,
+  localPasscodeRetryDelayMs,
+  isTriviallyGuessablePasscode,
+  LocalPasscodeThrottledError
+} from '../local-passcode';
+
+describe('local passcode policy (audit 012 N6)', () => {
+  describe('localPasscodeRetryDelayMs', () => {
+    it('gives no delay for the free attempts', () => {
+      for (let count = 0; count < LOCAL_PASSCODE_FREE_ATTEMPTS; count++) {
+        expect(localPasscodeRetryDelayMs(count)).toBe(0);
+      }
+    });
+
+    it('starts at 10 s and doubles per failure', () => {
+      expect(localPasscodeRetryDelayMs(LOCAL_PASSCODE_FREE_ATTEMPTS)).toBe(10_000);
+      expect(localPasscodeRetryDelayMs(LOCAL_PASSCODE_FREE_ATTEMPTS + 1)).toBe(20_000);
+      expect(localPasscodeRetryDelayMs(LOCAL_PASSCODE_FREE_ATTEMPTS + 2)).toBe(40_000);
+    });
+
+    it('caps at 15 minutes and survives absurd counts without overflow', () => {
+      expect(localPasscodeRetryDelayMs(50)).toBe(LOCAL_PASSCODE_MAX_DELAY_MS);
+      expect(localPasscodeRetryDelayMs(10_000)).toBe(LOCAL_PASSCODE_MAX_DELAY_MS);
+    });
+  });
+
+  describe('isTriviallyGuessablePasscode', () => {
+    it('flags repeated single characters', () => {
+      expect(isTriviallyGuessablePasscode('111111')).toBe(true);
+      expect(isTriviallyGuessablePasscode('aaaaaa')).toBe(true);
+    });
+
+    it('flags straight runs in both directions', () => {
+      expect(isTriviallyGuessablePasscode('123456')).toBe(true);
+      expect(isTriviallyGuessablePasscode('987654')).toBe(true);
+      expect(isTriviallyGuessablePasscode('abcdef')).toBe(true);
+    });
+
+    it('accepts ordinary passcodes', () => {
+      expect(isTriviallyGuessablePasscode('correct horse')).toBe(false);
+      expect(isTriviallyGuessablePasscode('a1b2c3')).toBe(false);
+      // Known limitation, documented on the helper: alternating patterns pass.
+      expect(isTriviallyGuessablePasscode('121212')).toBe(false);
+    });
+  });
+
+  it('exposes the shared minimum the UIs and crypto layer both enforce', () => {
+    expect(LOCAL_PASSCODE_MIN_LENGTH).toBe(6);
+  });
+
+  it('LocalPasscodeThrottledError carries the remaining wait', () => {
+    const err = new LocalPasscodeThrottledError(12_345);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('LocalPasscodeThrottledError');
+    expect(err.retryAfterMs).toBe(12_345);
+  });
+});

--- a/packages/crypto/src/__tests__/password-envelope.spec.ts
+++ b/packages/crypto/src/__tests__/password-envelope.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   encryptWithPassword,
   decryptWithPassword,
+  decryptWithPasswordOrPhrase,
   PASSWORD_ENVELOPE_ALGORITHM
 } from '../password-envelope';
 import {
@@ -68,5 +69,39 @@ describe('Password envelope', () => {
 
   it('exposes the algorithm marker used by existing envelopes', () => {
     expect(PASSWORD_ENVELOPE_ALGORITHM).toBe('aes-256-gcm-pbkdf2');
+  });
+});
+
+describe('decryptWithPasswordOrPhrase (audit 012 N4)', () => {
+  // 12 valid BIP-0039 words in canonical (normalized) form - the exact string
+  // the auto-backup engine feeds the KDF.
+  const PHRASE =
+    'abandon ability able about above absent absorb abstract absurd abuse access accident';
+  // The same phrase as a user re-types it from paper: numbered lines, capitals.
+  const RETYPED = PHRASE.split(' ')
+    .map((w, i) => `${i + 1}. ${w[0].toUpperCase()}${w.slice(1)}`)
+    .join('\n');
+
+  it('accepts a re-typed recovery phrase (numbering, capitals, line breaks)', async () => {
+    const envelope = await encryptWithPassword('backup payload', PHRASE);
+    expect(await decryptWithPasswordOrPhrase(envelope, RETYPED)).toBe('backup payload');
+  });
+
+  it('keeps a deliberate password working even when it parses as a phrase', async () => {
+    // Raw input is tried FIRST: a password that merely looks like a
+    // denormalized phrase must not be silently rewritten.
+    const envelope = await encryptWithPassword('payload', RETYPED);
+    expect(await decryptWithPasswordOrPhrase(envelope, RETYPED)).toBe('payload');
+  });
+
+  it('behaves exactly like decryptWithPassword for a non-phrase password', async () => {
+    const envelope = await encryptWithPassword('payload', 'just a password');
+    expect(await decryptWithPasswordOrPhrase(envelope, 'just a password')).toBe('payload');
+  });
+
+  it('still rejects a wrong phrase (both candidates fail)', async () => {
+    const envelope = await encryptWithPassword('payload', PHRASE);
+    const wrong = RETYPED.replace('Abandon', 'Zebra');
+    await expect(decryptWithPasswordOrPhrase(envelope, wrong)).rejects.toThrow();
   });
 });

--- a/packages/crypto/src/cryptoManager.ts
+++ b/packages/crypto/src/cryptoManager.ts
@@ -20,7 +20,7 @@ import { assertEncrypted } from './encryption-validation';
 import {
   LOCAL_PASSCODE_MIN_LENGTH,
   LocalPasscodeThrottledError,
-  localPasscodeRetryDelayMs
+  unlockThrottleDelayMs
 } from './local-passcode';
 import { createLogger } from '@reborn/utils';
 
@@ -1202,9 +1202,13 @@ export class CryptoManager {
   }
 
   // ── Local-passcode failure throttle (audit 012 N6) ───────────
+  //
+  // Identifiers feeding the stored record avoid the word "passcode" - CodeQL's
+  // clear-text-storage query taints setItem VALUES by name heuristics (see
+  // local-passcode.ts naming note). The record itself is non-secret counters.
 
   /** Parsed failure record, or the zero state when absent/invalid. */
-  private readLocalPasscodeAttempts(): { count: number; lockedUntil: number } {
+  private readUnlockThrottleRecord(): { count: number; lockedUntil: number } {
     const zero = { count: 0, lockedUntil: 0 };
     if (typeof window === 'undefined' || !window.localStorage) return zero;
     const raw = window.localStorage.getItem(this.LOCAL_PASSCODE_ATTEMPTS_KEY);
@@ -1221,10 +1225,10 @@ export class CryptoManager {
   }
 
   /** Record one failed unlock and (past the free attempts) open a delay window. */
-  private recordLocalPasscodeFailure(): void {
+  private recordUnlockThrottleFailure(): void {
     if (typeof window === 'undefined' || !window.localStorage) return;
-    const count = this.readLocalPasscodeAttempts().count + 1;
-    const delayMs = localPasscodeRetryDelayMs(count);
+    const count = this.readUnlockThrottleRecord().count + 1;
+    const delayMs = unlockThrottleDelayMs(count);
     window.localStorage.setItem(
       this.LOCAL_PASSCODE_ATTEMPTS_KEY,
       JSON.stringify({ count, lockedUntil: delayMs > 0 ? Date.now() + delayMs : 0 })
@@ -1243,7 +1247,7 @@ export class CryptoManager {
    * {@link LocalPasscodeThrottledError} inside the window.
    */
   public getLocalPasscodeRetryDelayMs(): number {
-    return Math.max(0, this.readLocalPasscodeAttempts().lockedUntil - Date.now());
+    return Math.max(0, this.readUnlockThrottleRecord().lockedUntil - Date.now());
   }
 
   /**
@@ -1366,7 +1370,7 @@ export class CryptoManager {
       logger.warn('Local passcode unlock failed (wrong passcode or corrupt wrap)');
       this.masterKey = null;
       this.initialized = false;
-      this.recordLocalPasscodeFailure();
+      this.recordUnlockThrottleFailure();
       return false;
     }
   }

--- a/packages/crypto/src/cryptoManager.ts
+++ b/packages/crypto/src/cryptoManager.ts
@@ -17,6 +17,11 @@ import {
   importKey
 } from './encryption';
 import { assertEncrypted } from './encryption-validation';
+import {
+  LOCAL_PASSCODE_MIN_LENGTH,
+  LocalPasscodeThrottledError,
+  localPasscodeRetryDelayMs
+} from './local-passcode';
 import { createLogger } from '@reborn/utils';
 
 const logger = createLogger('CryptoManager');
@@ -84,6 +89,15 @@ export class CryptoManager {
    */
   private readonly LOCAL_PASSCODE_WRAP_KEY = 'reborn_local_passcode_wrap';
   private readonly WRAP_FORMAT_VERSION = 1;
+  /**
+   * localStorage key for the local-passcode failure throttle:
+   * `{ count, lockedUntil }` - consecutive failed unlock attempts and the epoch
+   * ms before which the next attempt is refused. Same storage tier as the wrap
+   * it protects (and the same caveat: same-origin script can clear it - this is
+   * on-device friction against typed guesses, not a cryptographic boundary).
+   * See audit 012 N6.
+   */
+  private readonly LOCAL_PASSCODE_ATTEMPTS_KEY = 'reborn_local_passcode_attempts';
   /**
    * localStorage flag for the native App Lock (biometric gate). When set on a
    * native build, the master key is NOT auto-read from the vault at cold start:
@@ -298,8 +312,14 @@ export class CryptoManager {
     }
   }
 
-  private async clearKeyFromIDB(): Promise<void> {
-    if (typeof indexedDB === 'undefined') return;
+  /**
+   * Best-effort by default (errors are logged, not thrown) - most callers are
+   * defensive sweeps where a failed delete must not break logout/lock. Returns
+   * whether the delete transaction actually completed so paths that PROMISE the
+   * raw key is gone (enableLocalPasscode) can refuse to report success.
+   */
+  private async clearKeyFromIDB(): Promise<boolean> {
+    if (typeof indexedDB === 'undefined') return true;
     try {
       const db = await this.openIDB();
       await new Promise<void>((resolve, reject) => {
@@ -310,8 +330,10 @@ export class CryptoManager {
       });
       db.close();
       logger.debug('Master key cleared from IndexedDB');
+      return true;
     } catch (error) {
       logger.error('Failed to clear master key from IndexedDB:', error);
+      return false;
     }
   }
 
@@ -1174,6 +1196,54 @@ export class CryptoManager {
   private removeLocalPasscodeWrap(): void {
     if (typeof window === 'undefined' || !window.localStorage) return;
     window.localStorage.removeItem(this.LOCAL_PASSCODE_WRAP_KEY);
+    // No wrap, nothing to guess - a stale counter would otherwise throttle the
+    // next passcode the user sets.
+    this.clearLocalPasscodeAttempts();
+  }
+
+  // ── Local-passcode failure throttle (audit 012 N6) ───────────
+
+  /** Parsed failure record, or the zero state when absent/invalid. */
+  private readLocalPasscodeAttempts(): { count: number; lockedUntil: number } {
+    const zero = { count: 0, lockedUntil: 0 };
+    if (typeof window === 'undefined' || !window.localStorage) return zero;
+    const raw = window.localStorage.getItem(this.LOCAL_PASSCODE_ATTEMPTS_KEY);
+    if (!raw) return zero;
+    try {
+      const rec = JSON.parse(raw) as { count?: number; lockedUntil?: number };
+      return {
+        count: typeof rec.count === 'number' && rec.count > 0 ? Math.floor(rec.count) : 0,
+        lockedUntil: typeof rec.lockedUntil === 'number' ? rec.lockedUntil : 0
+      };
+    } catch {
+      return zero;
+    }
+  }
+
+  /** Record one failed unlock and (past the free attempts) open a delay window. */
+  private recordLocalPasscodeFailure(): void {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    const count = this.readLocalPasscodeAttempts().count + 1;
+    const delayMs = localPasscodeRetryDelayMs(count);
+    window.localStorage.setItem(
+      this.LOCAL_PASSCODE_ATTEMPTS_KEY,
+      JSON.stringify({ count, lockedUntil: delayMs > 0 ? Date.now() + delayMs : 0 })
+    );
+  }
+
+  private clearLocalPasscodeAttempts(): void {
+    if (typeof window === 'undefined' || !window.localStorage) return;
+    window.localStorage.removeItem(this.LOCAL_PASSCODE_ATTEMPTS_KEY);
+  }
+
+  /**
+   * Milliseconds until the next local-passcode unlock attempt is allowed - 0
+   * when an attempt is allowed now. Lock screens poll this for the countdown;
+   * `unlockWithLocalPasscode` enforces it by throwing
+   * {@link LocalPasscodeThrottledError} inside the window.
+   */
+  public getLocalPasscodeRetryDelayMs(): number {
+    return Math.max(0, this.readLocalPasscodeAttempts().lockedUntil - Date.now());
   }
 
   /**
@@ -1223,6 +1293,9 @@ export class CryptoManager {
       throw new Error('Cannot set a local passcode without an unlocked master key');
     }
     if (!passcode) throw new Error('Passcode must not be empty');
+    if (passcode.length < LOCAL_PASSCODE_MIN_LENGTH) {
+      throw new Error(`Passcode must be at least ${LOCAL_PASSCODE_MIN_LENGTH} characters`);
+    }
     if (typeof window === 'undefined' || !window.localStorage) {
       throw new Error('Local passcode requires a browser environment');
     }
@@ -1230,15 +1303,32 @@ export class CryptoManager {
     const { encryptedMasterKey, salt } = await this.encryptMasterKey(this.masterKey, passcode);
     this.writeLocalPasscodeWrap(encryptedMasterKey, salt);
 
-    // Purge every cleartext at-rest copy - the wrap is now the only on-disk form.
-    await this.clearKeyFromIDB();
-    if (this.vault) {
-      await this.vault.clear().catch((err) => {
-        logger.error('Failed to clear vault while enabling local passcode:', err);
+    // Purge every cleartext at-rest copy - the wrap must become the only
+    // on-disk form. Unlike the defensive sweeps elsewhere this purge is the
+    // very promise being made to the user, so a failed or silently no-op'd
+    // delete must NOT report success: verify by reading back, and on any
+    // surviving copy roll the wrap back so the device stays in the consistent
+    // no-passcode baseline instead of a half-enabled state (audit 012 N7).
+    try {
+      const idbCleared = await this.clearKeyFromIDB();
+      if (!idbCleared || (await this.restoreKeyFromIDB()) !== null) {
+        throw new Error('raw master key still present in IndexedDB');
+      }
+      if (this.vault) {
+        await this.vault.clear();
+        if ((await this.vault.load().catch(() => null)) !== null) {
+          throw new Error('raw master key still present in the platform vault');
+        }
+      }
+      if (typeof window !== 'undefined' && window.sessionStorage) {
+        window.sessionStorage.removeItem(this.TEMP_KEY_STORAGE_KEY);
+      }
+    } catch (error) {
+      this.removeLocalPasscodeWrap();
+      logger.error('Failed to purge raw key copies - local passcode NOT enabled:', error);
+      throw new Error('Failed to remove the unprotected key copy - passcode not enabled', {
+        cause: error
       });
-    }
-    if (typeof window !== 'undefined' && window.sessionStorage) {
-      window.sessionStorage.removeItem(this.TEMP_KEY_STORAGE_KEY);
     }
 
     logger.info('Local passcode enabled - master key wrapped at-rest');
@@ -1255,6 +1345,13 @@ export class CryptoManager {
       logger.warn('unlockWithLocalPasscode called with no passcode wrap present');
       return false;
     }
+    // Failure throttle: refuse attempts inside the delay window so repeated
+    // on-device guessing costs real time on top of PBKDF2 (audit 012 N6).
+    const waitMs = this.getLocalPasscodeRetryDelayMs();
+    if (waitMs > 0) {
+      logger.warn('Local passcode unlock throttled after repeated failures');
+      throw new LocalPasscodeThrottledError(waitMs);
+    }
     try {
       const key = await this.decryptMasterKey(record.wrapped, record.salt, passcode);
       this.masterKey = key;
@@ -1262,12 +1359,14 @@ export class CryptoManager {
       // Memory-only on purpose: do NOT persist to IndexedDB/sessionStorage/vault,
       // and do NOT broadcast `unlocked` (peers have no at-rest key to read).
       await this.verifyEncryption();
+      this.clearLocalPasscodeAttempts();
       logger.info('Local master key unlocked with passcode');
       return true;
     } catch {
       logger.warn('Local passcode unlock failed (wrong passcode or corrupt wrap)');
       this.masterKey = null;
       this.initialized = false;
+      this.recordLocalPasscodeFailure();
       return false;
     }
   }
@@ -1285,6 +1384,9 @@ export class CryptoManager {
       throw new Error('Cannot change the local passcode without an unlocked master key');
     }
     if (!newPasscode) throw new Error('New passcode must not be empty');
+    if (newPasscode.length < LOCAL_PASSCODE_MIN_LENGTH) {
+      throw new Error(`Passcode must be at least ${LOCAL_PASSCODE_MIN_LENGTH} characters`);
+    }
 
     const record = this.readLocalPasscodeWrapRecord();
     if (!record) throw new Error('No local passcode is set');

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -52,9 +52,20 @@ export { isEncryptedDataReadable } from './decrypt-probe';
 export {
   encryptWithPassword,
   decryptWithPassword,
+  decryptWithPasswordOrPhrase,
   PASSWORD_ENVELOPE_ALGORITHM
 } from './password-envelope';
 export type { PasswordEnvelopeParts } from './password-envelope';
+
+// Local-mode passcode policy (shared min length, failure throttle, soft quality)
+export {
+  LOCAL_PASSCODE_MIN_LENGTH,
+  LOCAL_PASSCODE_FREE_ATTEMPTS,
+  LOCAL_PASSCODE_MAX_DELAY_MS,
+  localPasscodeRetryDelayMs,
+  isTriviallyGuessablePasscode,
+  LocalPasscodeThrottledError
+} from './local-passcode';
 
 // Backup recovery phrase (user-held secret that encrypts automated backups)
 export {

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -60,9 +60,9 @@ export type { PasswordEnvelopeParts } from './password-envelope';
 // Local-mode passcode policy (shared min length, failure throttle, soft quality)
 export {
   LOCAL_PASSCODE_MIN_LENGTH,
-  LOCAL_PASSCODE_FREE_ATTEMPTS,
-  LOCAL_PASSCODE_MAX_DELAY_MS,
-  localPasscodeRetryDelayMs,
+  UNLOCK_THROTTLE_FREE_ATTEMPTS,
+  UNLOCK_THROTTLE_MAX_DELAY_MS,
+  unlockThrottleDelayMs,
   isTriviallyGuessablePasscode,
   LocalPasscodeThrottledError
 } from './local-passcode';

--- a/packages/crypto/src/local-passcode.ts
+++ b/packages/crypto/src/local-passcode.ts
@@ -1,0 +1,74 @@
+/**
+ * Local-mode passcode policy: shared constants and helpers for the optional
+ * at-rest wrap of the local master key (see cryptoManager "Local-mode
+ * passcode" section). Centralized here so the crypto layer ENFORCES the same
+ * rules the settings UI merely displays (audit 012 N6 - the minimum length
+ * used to live only in the two apps' pages, so any direct caller could set
+ * "1").
+ *
+ * The failure throttle implemented on top of these helpers is friction, not a
+ * hard boundary: the wrap lives in web-readable storage, so an attacker with
+ * scripting access to the origin can brute-force offline regardless. It
+ * defends against the realistic case - someone holding the device typing
+ * guesses into the lock screen - where each attempt already costs one PBKDF2
+ * 600K derivation and now also waits out a growing delay.
+ */
+
+/** Minimum passcode length, enforced by enable/change and shown by the UI. */
+export const LOCAL_PASSCODE_MIN_LENGTH = 6;
+
+/** Consecutive failures allowed before the retry delay kicks in. */
+export const LOCAL_PASSCODE_FREE_ATTEMPTS = 3;
+
+/** Upper bound on the retry delay (15 min), reached after ~10 failures. */
+export const LOCAL_PASSCODE_MAX_DELAY_MS = 15 * 60 * 1000;
+
+/**
+ * Delay before the next unlock attempt after `failedCount` consecutive
+ * failures: none for the first {@link LOCAL_PASSCODE_FREE_ATTEMPTS}, then 10 s
+ * doubling per failure up to {@link LOCAL_PASSCODE_MAX_DELAY_MS}. At the cap,
+ * 100 attempts take over a day - enough to make guessing a weak numeric code
+ * on-device impractical.
+ */
+export function localPasscodeRetryDelayMs(failedCount: number): number {
+  if (failedCount < LOCAL_PASSCODE_FREE_ATTEMPTS) return 0;
+  const doublings = failedCount - LOCAL_PASSCODE_FREE_ATTEMPTS;
+  // Past the cap 2**doublings overflows quickly; clamp the exponent first.
+  if (doublings > 30) return LOCAL_PASSCODE_MAX_DELAY_MS;
+  return Math.min(10_000 * 2 ** doublings, LOCAL_PASSCODE_MAX_DELAY_MS);
+}
+
+/**
+ * Thrown by `unlockWithLocalPasscode` when an attempt is made inside the
+ * failure-throttle window. Carries the remaining wait so lock screens can show
+ * a countdown instead of a misleading "wrong passcode".
+ */
+export class LocalPasscodeThrottledError extends Error {
+  /** Milliseconds until the next attempt is allowed. */
+  public readonly retryAfterMs: number;
+
+  constructor(retryAfterMs: number) {
+    super(`Local passcode unlock throttled - retry in ${Math.ceil(retryAfterMs / 1000)} s`);
+    this.name = 'LocalPasscodeThrottledError';
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
+ * Soft quality check for a new passcode: flags the two patterns that dominate
+ * real-world guess lists - one repeated character ("111111", "aaaaaa") and a
+ * straight run in either direction ("123456", "abcdef", "987654"). Advisory
+ * only: the settings UI shows a warning but does not block, since the passcode
+ * is an optional extra layer over local-only data (audit 012 N6, "soft quality
+ * assessment"). Deliberately heuristic - no wordlists, no dependencies.
+ */
+export function isTriviallyGuessablePasscode(passcode: string): boolean {
+  if (passcode.length < 2) return true;
+  const codes = Array.from(passcode).map((ch) => ch.codePointAt(0) as number);
+  const step = codes[1] - codes[0];
+  if (step !== 0 && step !== 1 && step !== -1) return false;
+  for (let i = 2; i < codes.length; i++) {
+    if (codes[i] - codes[i - 1] !== step) return false;
+  }
+  return true;
+}

--- a/packages/crypto/src/local-passcode.ts
+++ b/packages/crypto/src/local-passcode.ts
@@ -17,25 +17,32 @@
 /** Minimum passcode length, enforced by enable/change and shown by the UI. */
 export const LOCAL_PASSCODE_MIN_LENGTH = 6;
 
-/** Consecutive failures allowed before the retry delay kicks in. */
-export const LOCAL_PASSCODE_FREE_ATTEMPTS = 3;
+// Naming note: the throttle identifiers below deliberately avoid the word
+// "passcode" because their values flow into `localStorage.setItem` (the
+// attempts record) and CodeQL's js/clear-text-storage-of-sensitive-data
+// flags stored values by NAME heuristics (password|passcode|key|...), not
+// data flow - the same FP that renamed PASSCODE_WRAP_VERSION to
+// WRAP_FORMAT_VERSION (see guideline 64, "CodeQL i nazwy identyfikatorów").
 
-/** Upper bound on the retry delay (15 min), reached after ~10 failures. */
-export const LOCAL_PASSCODE_MAX_DELAY_MS = 15 * 60 * 1000;
+/** Consecutive failures allowed before the unlock retry delay kicks in. */
+export const UNLOCK_THROTTLE_FREE_ATTEMPTS = 3;
+
+/** Upper bound on the unlock retry delay (15 min), reached after ~10 failures. */
+export const UNLOCK_THROTTLE_MAX_DELAY_MS = 15 * 60 * 1000;
 
 /**
  * Delay before the next unlock attempt after `failedCount` consecutive
- * failures: none for the first {@link LOCAL_PASSCODE_FREE_ATTEMPTS}, then 10 s
- * doubling per failure up to {@link LOCAL_PASSCODE_MAX_DELAY_MS}. At the cap,
- * 100 attempts take over a day - enough to make guessing a weak numeric code
- * on-device impractical.
+ * failures: none for the first {@link UNLOCK_THROTTLE_FREE_ATTEMPTS}, then
+ * 10 s doubling per failure up to {@link UNLOCK_THROTTLE_MAX_DELAY_MS}. At the
+ * cap, 100 attempts take over a day - enough to make guessing a weak numeric
+ * code on-device impractical.
  */
-export function localPasscodeRetryDelayMs(failedCount: number): number {
-  if (failedCount < LOCAL_PASSCODE_FREE_ATTEMPTS) return 0;
-  const doublings = failedCount - LOCAL_PASSCODE_FREE_ATTEMPTS;
+export function unlockThrottleDelayMs(failedCount: number): number {
+  if (failedCount < UNLOCK_THROTTLE_FREE_ATTEMPTS) return 0;
+  const doublings = failedCount - UNLOCK_THROTTLE_FREE_ATTEMPTS;
   // Past the cap 2**doublings overflows quickly; clamp the exponent first.
-  if (doublings > 30) return LOCAL_PASSCODE_MAX_DELAY_MS;
-  return Math.min(10_000 * 2 ** doublings, LOCAL_PASSCODE_MAX_DELAY_MS);
+  if (doublings > 30) return UNLOCK_THROTTLE_MAX_DELAY_MS;
+  return Math.min(10_000 * 2 ** doublings, UNLOCK_THROTTLE_MAX_DELAY_MS);
 }
 
 /**

--- a/packages/crypto/src/password-envelope.ts
+++ b/packages/crypto/src/password-envelope.ts
@@ -19,6 +19,7 @@ import {
   arrayBufferToBase64,
   base64ToArrayBuffer
 } from './encryption';
+import { isValidRecoveryPhrase, normalizeRecoveryPhrase } from './recovery-phrase';
 
 /** Algorithm marker stored in envelopes; matches existing v3 / portable files. */
 export const PASSWORD_ENVELOPE_ALGORITHM = 'aes-256-gcm-pbkdf2';
@@ -74,4 +75,35 @@ export async function decryptWithPassword(
     'string'
   );
   return plaintext as string;
+}
+
+/**
+ * {@link decryptWithPassword}, tolerant of recovery-phrase re-typing. The KDF
+ * canonically receives the NORMALIZED phrase (see `normalizeRecoveryPhrase`),
+ * but a user restoring a backup types the phrase from paper - with numbering,
+ * capitals or line breaks - and the raw form then fails as a generic "wrong
+ * password", which reads as a corrupt backup (audit 012 N4). When the input
+ * parses as a valid recovery phrase whose normalized form differs, that form
+ * is tried as a second candidate. The raw input stays FIRST so a deliberate
+ * password that merely looks like a phrase keeps working; the extra attempt
+ * costs one more PBKDF2 derivation, only on the failure path.
+ */
+export async function decryptWithPasswordOrPhrase(
+  envelope: PasswordEnvelopeParts,
+  input: string
+): Promise<string> {
+  const candidates = [input];
+  if (isValidRecoveryPhrase(input)) {
+    const normalized = normalizeRecoveryPhrase(input);
+    if (normalized !== input) candidates.push(normalized);
+  }
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    try {
+      return await decryptWithPassword(envelope, candidate);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
 }

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -88,6 +88,8 @@
       "mismatch": "Die Codes stimmen nicht überein.",
       "wrong": "Falscher Code.",
       "wrong_current": "Der aktuelle Code ist falsch.",
+      "throttled": "Zu viele Fehlversuche. Versuche es in {time} erneut.",
+      "weak_warning": "Dieser Code scheint leicht zu erraten. Vermeide wiederholte oder aufeinanderfolgende Zeichen.",
       "save_failed": "Code konnte nicht gespeichert werden. Bitte versuche es erneut.",
       "success_enabled": "Code festgelegt.",
       "success_changed": "Code geändert.",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -88,6 +88,8 @@
       "mismatch": "Passcodes do not match.",
       "wrong": "Wrong passcode.",
       "wrong_current": "Current passcode is incorrect.",
+      "throttled": "Too many failed attempts. Try again in {time}.",
+      "weak_warning": "This passcode looks easy to guess. Avoid repeated or sequential characters.",
       "save_failed": "Could not save the passcode. Please try again.",
       "success_enabled": "Passcode set.",
       "success_changed": "Passcode changed.",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -88,6 +88,8 @@
       "mismatch": "Los códigos no coinciden.",
       "wrong": "Código incorrecto.",
       "wrong_current": "El código actual es incorrecto.",
+      "throttled": "Demasiados intentos fallidos. Inténtalo de nuevo en {time}.",
+      "weak_warning": "Este código parece fácil de adivinar. Evita caracteres repetidos o consecutivos.",
       "save_failed": "No se pudo guardar el código. Inténtalo de nuevo.",
       "success_enabled": "Código establecido.",
       "success_changed": "Código cambiado.",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -88,6 +88,8 @@
       "mismatch": "Les codes ne correspondent pas.",
       "wrong": "Code incorrect.",
       "wrong_current": "Le code actuel est incorrect.",
+      "throttled": "Trop de tentatives échouées. Réessayez dans {time}.",
+      "weak_warning": "Ce code semble facile à deviner. Évitez les caractères répétés ou consécutifs.",
       "save_failed": "Impossible d'enregistrer le code. Veuillez réessayer.",
       "success_enabled": "Code défini.",
       "success_changed": "Code modifié.",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -88,6 +88,8 @@
       "mismatch": "Kody się nie zgadzają.",
       "wrong": "Nieprawidłowy kod.",
       "wrong_current": "Obecny kod jest nieprawidłowy.",
+      "throttled": "Zbyt wiele nieudanych prób. Spróbuj ponownie za {time}.",
+      "weak_warning": "Ten kod wygląda na łatwy do odgadnięcia. Unikaj powtarzających się lub kolejnych znaków.",
       "save_failed": "Nie udało się zapisać kodu. Spróbuj ponownie.",
       "success_enabled": "Kod dostępu ustawiony.",
       "success_changed": "Kod dostępu zmieniony.",

--- a/packages/i18n/src/translations/tasks/de/local_mode.json
+++ b/packages/i18n/src/translations/tasks/de/local_mode.json
@@ -37,6 +37,8 @@
     "mismatch": "Die Codes stimmen nicht überein.",
     "wrong": "Falscher Code.",
     "wrong_current": "Der aktuelle Code ist falsch.",
+    "throttled": "Zu viele Fehlversuche. Versuche es in {time} erneut.",
+    "weak_warning": "Dieser Code scheint leicht zu erraten. Vermeide wiederholte oder aufeinanderfolgende Zeichen.",
     "save_failed": "Code konnte nicht gespeichert werden. Bitte versuche es erneut.",
     "success_enabled": "Code festgelegt.",
     "success_changed": "Code geändert.",

--- a/packages/i18n/src/translations/tasks/en/local_mode.json
+++ b/packages/i18n/src/translations/tasks/en/local_mode.json
@@ -37,6 +37,8 @@
     "mismatch": "Passcodes do not match.",
     "wrong": "Wrong passcode.",
     "wrong_current": "Current passcode is incorrect.",
+    "throttled": "Too many failed attempts. Try again in {time}.",
+    "weak_warning": "This passcode looks easy to guess. Avoid repeated or sequential characters.",
     "save_failed": "Could not save the passcode. Please try again.",
     "success_enabled": "Passcode set.",
     "success_changed": "Passcode changed.",

--- a/packages/i18n/src/translations/tasks/es/local_mode.json
+++ b/packages/i18n/src/translations/tasks/es/local_mode.json
@@ -37,6 +37,8 @@
     "mismatch": "Los códigos no coinciden.",
     "wrong": "Código incorrecto.",
     "wrong_current": "El código actual es incorrecto.",
+    "throttled": "Demasiados intentos fallidos. Inténtalo de nuevo en {time}.",
+    "weak_warning": "Este código parece fácil de adivinar. Evita caracteres repetidos o consecutivos.",
     "save_failed": "No se pudo guardar el código. Inténtalo de nuevo.",
     "success_enabled": "Código establecido.",
     "success_changed": "Código cambiado.",

--- a/packages/i18n/src/translations/tasks/fr/local_mode.json
+++ b/packages/i18n/src/translations/tasks/fr/local_mode.json
@@ -37,6 +37,8 @@
     "mismatch": "Les codes ne correspondent pas.",
     "wrong": "Code incorrect.",
     "wrong_current": "Le code actuel est incorrect.",
+    "throttled": "Trop de tentatives échouées. Réessayez dans {time}.",
+    "weak_warning": "Ce code semble facile à deviner. Évitez les caractères répétés ou consécutifs.",
     "save_failed": "Impossible d'enregistrer le code. Veuillez réessayer.",
     "success_enabled": "Code défini.",
     "success_changed": "Code modifié.",

--- a/packages/i18n/src/translations/tasks/pl/local_mode.json
+++ b/packages/i18n/src/translations/tasks/pl/local_mode.json
@@ -37,6 +37,8 @@
     "mismatch": "Kody się nie zgadzają.",
     "wrong": "Nieprawidłowy kod.",
     "wrong_current": "Obecny kod jest nieprawidłowy.",
+    "throttled": "Zbyt wiele nieudanych prób. Spróbuj ponownie za {time}.",
+    "weak_warning": "Ten kod wygląda na łatwy do odgadnięcia. Unikaj powtarzających się lub kolejnych znaków.",
     "save_failed": "Nie udało się zapisać kodu. Spróbuj ponownie.",
     "success_enabled": "Kod dostępu ustawiony.",
     "success_changed": "Kod dostępu zmieniony.",


### PR DESCRIPTION
## Summary

Closes the five remaining LOW findings from security audit 012 in one client-side/native batch (server-side N1/N2/N8 landed in #405). After this PR nothing from audit 012 stays open except backlog observations.

- **N4 - phrase-tolerant restore.** New `decryptWithPasswordOrPhrase` in `@reborn/crypto`: tries the raw input first, then the normalized recovery-phrase form when the input parses as a valid 12-word phrase. A phrase re-typed from paper (numbering, capitals, line breaks) no longer fails as a misleading "wrong password". Wired into notes `importJsonBackup` (v2/v3) and the task portable-import envelope.
- **N5 - ZIP filename hardening (notes export).** `sanitizeFilename` now neutralizes dot-only names (`..` folder = `../note.md` zip-slip entry on naive extractors), strips trailing dots/spaces and prefixes Windows-reserved device names (`CON`, `PRN`, `COM1`..., also with extensions) so archives extract everywhere.
- **N6 - local passcode brute-force throttle.** Enforced in `cryptoManager.unlockWithLocalPasscode`: 3 free attempts, then a 10 s doubling delay capped at 15 min (counter in localStorage next to the wrap). Both lock screens show a live m:ss countdown and disable submit. `LOCAL_PASSCODE_MIN_LENGTH` is now enforced by `enableLocalPasscode`/`changeLocalPasscode` (was UI-only), and a soft, non-blocking warning flags repeated/sequential passcodes during setup.
- **N7 - purge verification on passcode enable.** `enableLocalPasscode` reads back IndexedDB and the native vault after purging the raw key; if any cleartext copy survives, the wrap is rolled back and the call throws - the UI shows an error instead of claiming protection while the raw extractable key is still readable.
- **N3 - iOS `FolderFs.resolveChild` traversal guard.** Rejects `..`/`.`/absolute segments with a thrown `PathTraversalError` (`call.reject`) in `readFile`/`writeFile`/`deleteFile`. Defense-in-depth (paths come from trusted JS); Android was already immune. Ships with the next native build - no store resubmit needed pre-GA.

New i18n keys `local_mode.passcode.{throttled,weak_warning}` x5 locales x2 namespaces (parity green).

### Decisions to review (auto mode)

1. **N4 at the crypto-helper level, raw input always first** - covers both apps; a deliberate password that merely looks like a phrase is never silently rewritten. Rejected: normalizing in the UI field.
2. **N6 throttle in cryptoManager, counter in localStorage** - one implementation for both apps and every caller. Deliberately friction, not a boundary: same-origin script can clear the counter, and devtools access already allows offline brute-force of the wrap itself (documented in code + guideline 64). Schedule: 3 free -> 10 s x 2^n -> cap 15 min.
3. **N7 rollback semantics** - on purge failure the wrap is removed and the method throws (consistent "no passcode" baseline instead of half-enabled); vault read-back added beyond the audit's IDB-focused recommendation.
4. **N3 throws instead of sanitizing** - a dot segment in this plugin is always a bug or an attack.
5. **N5 slightly beyond the recommendation** - trailing dots/spaces stripped too (same Windows-extraction failure class); reserved names prefixed `_CON` instead of replaced (keeps the name readable).

## Test plan

- CI mirror ran locally: lint 0 errors (notes/task/crypto), svelte-check 0/0 both apps, tests crypto 284 / notes 1194 / task 85 / i18n 27, i18n parity, tsup + vite builds, Swift parse-check.
- Smoke (local-only mode with a passcode set):
  1. Lock screen: 3x wrong code -> countdown alert + disabled button; reload during the window -> countdown resumes; correct code after the window -> unlock (counter cleared).
  2. Passcode setup: "12345" -> min-length validation; "111111" -> amber weak-passcode warning but still saveable; normal code -> saved.
  3. Import a portable/auto-backup file typing the recovery phrase with numbering and capitals -> import succeeds.
  4. Export all notes as ZIP with a folder named `..` or `CON` -> archive extracts cleanly (entries `untitled/`, `_CON/`).
  5. (Next native build) iOS folder sync + auto-backup still read/write normally.