### PR TITLE
feat(notes): long-press touch reorder for folders

### DIFF
--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -86,6 +86,7 @@
     "marked": "18.0.5",
     "otpauth": "9.5.1",
     "qrcode": "1.5.4",
+    "svelte-dnd-action": "0.9.69",
     "svelte-i18n": "4.0.1",
     "uuid": "14.0.0"
   }

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -86,7 +86,6 @@
     "marked": "18.0.5",
     "otpauth": "9.5.1",
     "qrcode": "1.5.4",
-    "svelte-dnd-action": "0.9.69",
     "svelte-i18n": "4.0.1",
     "uuid": "14.0.0"
   }

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -12,6 +12,14 @@
   // dataTransfer payloads are unreadable during dragover, so rows consult this
   // store instead to refuse drops that would move a folder into itself.
   export const dragBlockedIds = writable<Set<string> | null>(null);
+  // Row the active drag would drop on, and how (ring = into, insertion line =
+  // before/after). Module-level because the touch drag is owned by the
+  // instance where the press started, while the hovered row can belong to any
+  // other instance in the recursion; the desktop dragover path writes it too.
+  export type DropZone = 'into' | 'before' | 'after';
+  export const dropTarget = writable<{ id: string; zone: DropZone } | null>(null);
+  // Row lifted by an active touch drag - dimmed while its clone follows the finger.
+  export const touchDraggingId = writable<string | null>(null);
 </script>
 
 <script lang="ts">
@@ -51,8 +59,6 @@
     toastStore
   } from '@reborn/ui';
   import { flip } from 'svelte/animate';
-  import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME, TRIGGERS } from 'svelte-dnd-action';
-  import type { DndEvent } from 'svelte-dnd-action';
   import type { RowAction } from '$lib/utils/row-action';
   import { syncedFolderConfigs, runFolderSync } from '$lib/services/folder-sync.service';
   // FolderWithChildren comes from the module script import above (module and
@@ -63,8 +69,12 @@
   import { folderSortMode } from '$lib/stores/app-settings.store';
   import { pendingNewFolderDraft } from '$lib/stores/new-folder-draft.store';
   import { t } from '$lib/stores/i18n.store';
-  import { useIsMobile, useIsTouchDevice } from '$lib/utils/mediaQuery.svelte';
-  import { getDescendantFolderIds } from '$lib/utils/folder-helpers';
+  import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
+  import {
+    findChildrenOfParent,
+    findParentAndSiblings,
+    getDescendantFolderIds
+  } from '$lib/utils/folder-helpers';
   import type {
     DeleteFolderMode,
     DeleteFolderProgressCallback
@@ -448,7 +458,7 @@
     return actions;
   }
 
-  // ── Drag & Drop ─────────────────────────────────────────────────
+  // ── Drag & Drop (desktop, HTML5) ────────────────────────────────
   // In the default alphabetical sort, sibling order is derived from names, so
   // a drop on a row only ever means "move dragged folder/note INTO it". In
   // custom sort the row splits into three vertical bands: the outer quarters
@@ -456,14 +466,8 @@
   // meaning "into". Moving a folder to the TOP level goes through the panel's
   // root drop zone (+page.svelte), a between-rows drop at depth 0, or the
   // "Move to…" picker.
-  type DropZone = 'into' | 'before' | 'after';
-  let dropTarget = $state<{ id: string; zone: DropZone } | null>(null);
 
   function onDragStart(folder: FolderWithChildren, e: DragEvent) {
-    // The touch-reorder zone installs a cancelling `ondragstart` on every
-    // <li> (svelte-dnd-action does this even while drag-disabled) - keep the
-    // native dragstart from bubbling into it or desktop drags die instantly.
-    e.stopPropagation();
     e.dataTransfer!.effectAllowed = 'move';
     e.dataTransfer!.setData('text/plain', folder.id);
     e.dataTransfer!.setData('text/folder-id', folder.id);
@@ -476,37 +480,62 @@
     dragBlockedIds.set(null);
   }
 
-  function dropZoneFromEvent(e: DragEvent): DropZone {
-    // Notes have no sibling order among folders - they always move INTO.
-    if ($folderSortMode !== 'custom' || e.dataTransfer!.types.includes('text/note-id')) {
-      return 'into';
-    }
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const y = e.clientY - rect.top;
+  // Which band of a row the pointer is in - shared by the desktop dragover
+  // and the touch drag. Reorder bands exist only in custom sort.
+  function zoneForPoint(rect: DOMRect, clientY: number): DropZone {
+    if ($folderSortMode !== 'custom') return 'into';
+    const y = clientY - rect.top;
     if (y < rect.height * 0.25) return 'before';
     if (y > rect.height * 0.75) return 'after';
     return 'into';
+  }
+
+  function dropZoneFromEvent(e: DragEvent): DropZone {
+    // Notes have no sibling order among folders - they always move INTO.
+    if (e.dataTransfer!.types.includes('text/note-id')) return 'into';
+    return zoneForPoint((e.currentTarget as HTMLElement).getBoundingClientRect(), e.clientY);
   }
 
   function onDragOver(folder: FolderWithChildren, e: DragEvent) {
     // No preventDefault for the dragged folder's own subtree - the browser
     // keeps the no-drop cursor and never fires drop there.
     if ($dragBlockedIds?.has(folder.id)) {
-      dropTarget = null;
+      dropTarget.set(null);
       return;
     }
     e.preventDefault();
     e.dataTransfer!.dropEffect = 'move';
-    dropTarget = { id: folder.id, zone: dropZoneFromEvent(e) };
+    dropTarget.set({ id: folder.id, zone: dropZoneFromEvent(e) });
   }
 
-  function onDragLeave() {
-    dropTarget = null;
+  function onDragLeave(folder: FolderWithChildren) {
+    // Only clear our own indicator - dragenter on the next row may already
+    // have written to the shared store before this leave fires.
+    dropTarget.update((t) => (t?.id === folder.id ? null : t));
   }
 
-  // Insert the dragged folder before/after `targetId` within this instance's
-  // sibling group. A cross-parent drag reparents first (move() appends at the
-  // group's end), then the whole group's order_index is rewritten.
+  // Place `draggedId` before/after `targetId` inside the sibling group under
+  // `groupParentId`. A cross-parent drag reparents first (move() appends at
+  // the group's end), then the whole group's order_index is rewritten.
+  // Shared by the desktop between-rows drop and the touch drop.
+  async function insertIntoGroup(
+    draggedId: string,
+    targetId: string,
+    zone: 'before' | 'after',
+    groupParentId: string | null,
+    siblingIds: string[]
+  ) {
+    const ids = siblingIds.filter((id) => id !== draggedId);
+    const targetIdx = ids.indexOf(targetId);
+    if (targetIdx === -1) return;
+    ids.splice(zone === 'after' ? targetIdx + 1 : targetIdx, 0, draggedId);
+    if (!siblingIds.includes(draggedId)) {
+      await foldersStore.move(draggedId, groupParentId);
+    }
+    await foldersStore.reorder(groupParentId, ids);
+  }
+
+  // Desktop drop between rows targets THIS instance's sibling group.
   async function reorderAround(
     draggedId: string,
     targetId: string,
@@ -515,20 +544,19 @@
     // Group parent inside the dragged subtree would cycle (belt & braces -
     // rows of that subtree already refuse dragover, so it can't be reached).
     if (parentId && $dragBlockedIds?.has(parentId)) return;
-    const ids = nodes.map((n) => n.id).filter((id) => id !== draggedId);
-    const targetIdx = ids.indexOf(targetId);
-    if (targetIdx === -1) return;
-    ids.splice(zone === 'after' ? targetIdx + 1 : targetIdx, 0, draggedId);
-    if (!nodes.some((n) => n.id === draggedId)) {
-      await foldersStore.move(draggedId, parentId);
-    }
-    await foldersStore.reorder(parentId, ids);
+    await insertIntoGroup(
+      draggedId,
+      targetId,
+      zone,
+      parentId,
+      nodes.map((n) => n.id)
+    );
   }
 
   async function onDrop(target: FolderWithChildren, e: DragEvent) {
     e.preventDefault();
     e.stopPropagation(); // prevent bubbling to the panel's root drop zone
-    const zone: DropZone = dropTarget?.id === target.id ? dropTarget.zone : 'into';
+    const zone: DropZone = $dropTarget?.id === target.id ? $dropTarget.zone : 'into';
 
     try {
       // Handle note drop - move note into this folder
@@ -552,7 +580,7 @@
         await reorderAround(draggedId, target.id, zone);
       }
     } finally {
-      dropTarget = null;
+      dropTarget.set(null);
       dragBlockedIds.set(null);
     }
   }
@@ -572,63 +600,295 @@
     await foldersStore.reorder(parentId, ids);
   }
 
-  // ── Touch reorder (long-press drag, custom sort only) ───────────
-  // HTML5 DnD doesn't exist on touch, so each sibling group is also a
-  // svelte-dnd-action zone (nested zones, one per group): hold a row for
-  // 300 ms (moving earlier scrolls instead), then drag within the group.
-  // Cross-parent moves stay in the "Move to…" picker. The zone only unlocks
-  // on coarse-pointer mobile viewports - mouse keeps the native HTML5 path,
-  // and wide touch viewports (tablets) keep the long-press ContextMenu.
-  const isTouchQuery = useIsTouchDevice();
+  // ── Touch drag (long-press) ──────────────────────────────────────
+  // HTML5 DnD doesn't exist on touch, so rows implement their own pointer
+  // gesture with the same semantics as the desktop drag: hold a row for
+  // 300 ms (moving earlier scrolls instead), a clone of the row follows the
+  // finger, hovered rows show the desktop indicators (ring = into, insertion
+  // line = reorder in custom sort), and dwelling over a collapsed folder
+  // spring-loads it open so the drop can land inside it. Mouse pointers keep
+  // the native HTML5 path; the gesture is limited to mobile viewports, where
+  // the long-press ContextMenu is disabled (tablets keep their ContextMenu).
+  // The instance where the press starts owns the whole gesture (window
+  // listeners); cross-instance state flows through the module stores, and the
+  // drop resolves the target's sibling group from the full store tree.
   const LONG_PRESS_MS = 300;
-  const touchReorderEnabled = $derived(
-    $folderSortMode === 'custom' && isMobileQuery.value && isTouchQuery.value
-  );
+  const PRE_ARM_SLOP_PX = 8;
+  const SPRING_LOAD_MS = 600;
+  const EDGE_SCROLL_ZONE_PX = 56;
+  const EDGE_SCROLL_MAX_PX_PER_FRAME = 12;
 
-  // Local order the dnd zone shuffles while a drag is in flight; mirrors
-  // `nodes` whenever no drag is active.
-  // svelte-ignore state_referenced_locally (initial copy - the effect below re-syncs)
-  let dragItems = $state<FolderWithChildren[]>([...nodes]);
-  let dndActive = $state(false);
+  let pressTimer: ReturnType<typeof setTimeout> | null = null;
+  let pressFolder: FolderWithChildren | null = null;
+  let pressPointerId = -1;
+  let pressStart = { x: 0, y: 0 };
+  let pointerX = 0;
+  let pointerY = 0;
+  let touchDragging = false;
+  let dragRowEl: HTMLElement | null = null;
+  let cloneEl: HTMLElement | null = null;
+  let springTimer: ReturnType<typeof setTimeout> | null = null;
+  let springTargetId: string | null = null;
+  let scrollContainer: HTMLElement | null = null;
+  let scrollRaf = 0;
 
-  $effect(() => {
-    const current = nodes;
-    if (!dndActive) dragItems = [...current];
-  });
-
-  function isDragShadow(folder: FolderWithChildren): boolean {
-    return SHADOW_ITEM_MARKER_PROPERTY_NAME in folder;
+  function onRowPointerDown(folder: FolderWithChildren, e: PointerEvent) {
+    if (e.pointerType === 'mouse' || !isMobileQuery.value) return;
+    if (editingId === folder.id) return;
+    // Chevron / kebab / rename input own their taps - no drag from controls.
+    if ((e.target as HTMLElement).closest('button, input')) return;
+    if (pressTimer || touchDragging) return; // second finger while active
+    pressFolder = folder;
+    pressPointerId = e.pointerId;
+    pressStart = { x: e.clientX, y: e.clientY };
+    pointerX = e.clientX;
+    pointerY = e.clientY;
+    dragRowEl = e.currentTarget as HTMLElement;
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerCancel);
+    pressTimer = setTimeout(startTouchDrag, LONG_PRESS_MS);
   }
 
-  // The floating clone mirrors the whole <li> (row plus expanded subtree) -
-  // strip nested lists so only the row follows the finger.
-  function stripSubtreeFromDragClone(el?: HTMLElement) {
-    el?.querySelectorAll('ul').forEach((u) => u.remove());
-  }
-
-  function handleDndConsider(e: CustomEvent<DndEvent<FolderWithChildren>>) {
-    dndActive = true;
-    dragItems = e.detail.items;
-    if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED && 'vibrate' in navigator) {
-      navigator.vibrate(50);
+  function startTouchDrag() {
+    pressTimer = null;
+    const folder = pressFolder;
+    const rowEl = dragRowEl;
+    if (!folder || !rowEl || !rowEl.isConnected) {
+      cancelPress();
+      return;
     }
+    touchDragging = true;
+    // Same cycle guard as the desktop drag: the dragged subtree can't be a target.
+    dragBlockedIds.set(new Set(getDescendantFolderIds([folder], folder.id)));
+    touchDraggingId.set(folder.id);
+    if ('vibrate' in navigator) navigator.vibrate(50);
+    // pointermove alone can't stop native scrolling - block touchmove for the
+    // rest of the gesture (the pre-arm phase deliberately leaves it free).
+    window.addEventListener('touchmove', blockScroll, { passive: false });
+    // Holding still past the OS threshold must not pop selection/context UI.
+    window.addEventListener('contextmenu', blockEvent, true);
+    makeClone(rowEl);
+    scrollContainer = findScrollParent(rowEl);
+    scrollRaf = requestAnimationFrame(edgeScrollLoop);
+    updateTouchDropTarget();
   }
 
-  async function handleDndFinalize(e: CustomEvent<DndEvent<FolderWithChildren>>) {
-    dragItems = e.detail.items;
-    try {
-      const ids = e.detail.items.map((f) => f.id);
-      const before = nodes.map((n) => n.id);
-      // A drop back in place (or outside the zone) finalizes with the
-      // original order - skip the write so an untouched lazy-seeded group
-      // isn't materialized (see guideline: lazy seeding of order_index).
-      if (ids.length === before.length && ids.some((id, i) => id !== before[i])) {
-        await foldersStore.reorder(parentId, ids);
+  function blockScroll(e: TouchEvent) {
+    e.preventDefault();
+  }
+
+  function blockEvent(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  function makeClone(rowEl: HTMLElement) {
+    const rect = rowEl.getBoundingClientRect();
+    const clone = rowEl.cloneNode(true) as HTMLElement;
+    clone.classList.add('bg-background');
+    clone.style.pointerEvents = 'none';
+    clone.style.position = 'fixed';
+    clone.style.left = `${rect.left}px`;
+    clone.style.top = `${rect.top}px`;
+    clone.style.width = `${rect.width}px`;
+    clone.style.margin = '0';
+    clone.style.zIndex = '9999';
+    clone.style.opacity = '0.92';
+    clone.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.18)';
+    clone.style.willChange = 'transform';
+    document.body.appendChild(clone);
+    cloneEl = clone;
+    positionClone();
+  }
+
+  function positionClone() {
+    if (!cloneEl) return;
+    cloneEl.style.transform = `translate3d(${pointerX - pressStart.x}px, ${pointerY - pressStart.y}px, 0)`;
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (e.pointerId !== pressPointerId) return;
+    pointerX = e.clientX;
+    pointerY = e.clientY;
+    if (!touchDragging) {
+      // Finger moved before the hold elapsed - it's a scroll, not a drag.
+      if (
+        Math.abs(pointerX - pressStart.x) >= PRE_ARM_SLOP_PX ||
+        Math.abs(pointerY - pressStart.y) >= PRE_ARM_SLOP_PX
+      ) {
+        cancelPress();
       }
-    } finally {
-      dndActive = false;
+      return;
+    }
+    positionClone();
+    updateTouchDropTarget();
+  }
+
+  function updateTouchDropTarget() {
+    // The clone has pointer-events: none, so it never shadows the hit test.
+    const el = document.elementFromPoint(pointerX, pointerY);
+    const rowEl = el?.closest<HTMLElement>('[data-folder-id]') ?? null;
+    const targetId = rowEl?.getAttribute('data-folder-id');
+    if (!rowEl || !targetId || targetId === pressFolder?.id || $dragBlockedIds?.has(targetId)) {
+      dropTarget.set(null);
+      setSpringTarget(null);
+      return;
+    }
+    const zone = zoneForPoint(rowEl.getBoundingClientRect(), pointerY);
+    dropTarget.set({ id: targetId, zone });
+    setSpringTarget(zone === 'into' ? targetId : null);
+  }
+
+  // Dwelling over a collapsed folder opens it mid-drag, so the drop can land
+  // between its (now visible) children or on them. Freshly revealed rows are
+  // immediately valid targets - the hit test reads the live DOM.
+  function setSpringTarget(id: string | null) {
+    if (id === springTargetId) return;
+    if (springTimer) {
+      clearTimeout(springTimer);
+      springTimer = null;
+    }
+    springTargetId = id;
+    if (!id || expandedIds.has(id)) return;
+    const hasContent =
+      findChildrenOfParent($foldersStore, id).length > 0 ||
+      (savedSearchesByFolder?.get(id)?.length ?? 0) > 0;
+    if (!hasContent) return;
+    springTimer = setTimeout(() => {
+      springTimer = null;
+      if (touchDragging && springTargetId === id) expandedIds.add(id);
+    }, SPRING_LOAD_MS);
+  }
+
+  function findScrollParent(el: HTMLElement): HTMLElement | null {
+    let cur: HTMLElement | null = el.parentElement;
+    while (cur) {
+      const style = getComputedStyle(cur);
+      if (/(auto|scroll)/.test(style.overflowY) && cur.scrollHeight > cur.clientHeight) {
+        return cur;
+      }
+      cur = cur.parentElement;
+    }
+    return null;
+  }
+
+  // Keeps scrolling while the finger dwells in the container's edge zones
+  // (pointermove stops firing for a stationary finger, hence the rAF loop).
+  function edgeScrollLoop() {
+    if (!touchDragging) return;
+    if (scrollContainer) {
+      const rect = scrollContainer.getBoundingClientRect();
+      let delta = 0;
+      if (pointerY < rect.top + EDGE_SCROLL_ZONE_PX) {
+        const intensity = (rect.top + EDGE_SCROLL_ZONE_PX - pointerY) / EDGE_SCROLL_ZONE_PX;
+        delta = -Math.ceil(intensity * EDGE_SCROLL_MAX_PX_PER_FRAME);
+      } else if (pointerY > rect.bottom - EDGE_SCROLL_ZONE_PX) {
+        const intensity = (pointerY - (rect.bottom - EDGE_SCROLL_ZONE_PX)) / EDGE_SCROLL_ZONE_PX;
+        delta = Math.ceil(intensity * EDGE_SCROLL_MAX_PX_PER_FRAME);
+      }
+      if (delta !== 0) {
+        const before = scrollContainer.scrollTop;
+        scrollContainer.scrollTop = before + delta;
+        if (scrollContainer.scrollTop !== before) updateTouchDropTarget();
+      }
+    }
+    scrollRaf = requestAnimationFrame(edgeScrollLoop);
+  }
+
+  async function onPointerUp(e: PointerEvent) {
+    if (e.pointerId !== pressPointerId) return;
+    if (!touchDragging) {
+      cancelPress(); // plain tap - the native click still selects the row
+      return;
+    }
+    const dragged = pressFolder;
+    const target = $dropTarget;
+    const blocked = $dragBlockedIds;
+    teardownTouchDrag();
+    if (!dragged || !target || target.id === dragged.id) return;
+    // A release without movement still produces a click on the row - swallow
+    // it so dropping doesn't also open the folder.
+    suppressNextClick();
+    if (target.zone === 'into') {
+      if (blocked?.has(target.id)) return;
+      await foldersStore.move(dragged.id, target.id);
+      expandedIds.add(target.id);
+    } else {
+      const located = findParentAndSiblings($foldersStore, target.id);
+      if (!located) return;
+      // Target group hanging inside the dragged subtree would cycle.
+      if (located.parentId && blocked?.has(located.parentId)) return;
+      await insertIntoGroup(
+        dragged.id,
+        target.id,
+        target.zone,
+        located.parentId,
+        located.siblings.map((f) => f.id)
+      );
     }
   }
+
+  function onPointerCancel(e: PointerEvent) {
+    if (e.pointerId !== pressPointerId) return;
+    if (touchDragging) teardownTouchDrag();
+    else cancelPress();
+  }
+
+  function suppressNextClick() {
+    const squelch = (ev: MouseEvent) => {
+      ev.stopPropagation();
+      ev.preventDefault();
+    };
+    window.addEventListener('click', squelch, { capture: true, once: true });
+    // If no click follows (finger moved during the drag), don't let the
+    // squelch linger and eat the next genuine tap.
+    setTimeout(() => window.removeEventListener('click', squelch, { capture: true }), 400);
+  }
+
+  function cancelPress() {
+    if (pressTimer) {
+      clearTimeout(pressTimer);
+      pressTimer = null;
+    }
+    pressFolder = null;
+    pressPointerId = -1;
+    dragRowEl = null;
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerCancel);
+  }
+
+  function teardownTouchDrag() {
+    touchDragging = false;
+    if (springTimer) {
+      clearTimeout(springTimer);
+      springTimer = null;
+    }
+    springTargetId = null;
+    if (scrollRaf) {
+      cancelAnimationFrame(scrollRaf);
+      scrollRaf = 0;
+    }
+    scrollContainer = null;
+    cloneEl?.remove();
+    cloneEl = null;
+    dropTarget.set(null);
+    dragBlockedIds.set(null);
+    touchDraggingId.set(null);
+    window.removeEventListener('touchmove', blockScroll);
+    window.removeEventListener('contextmenu', blockEvent, true);
+    cancelPress();
+  }
+
+  // The gesture owner may unmount mid-drag (remote sync can drop this
+  // subtree) - its window listeners and clone must not outlive it.
+  $effect(() => {
+    return () => {
+      if (touchDragging) teardownTouchDrag();
+      else cancelPress();
+    };
+  });
 </script>
 
 <!-- Close menus when clicking outside -->
@@ -638,80 +898,49 @@
   }}
 />
 
-<!-- Draft row and root-pinned smart folders live OUTSIDE the folder list:
-     the list is a svelte-dnd-action zone, and the zone's children must map
-     1:1 onto its `items` (the folders). -->
-{#if showDraft || (depth === 0 && rootPinnedSearches && rootPinnedSearches.length > 0)}
-  <ul class="select-none" role="tree">
-    {#if showDraft}
-      <li role="treeitem" aria-selected="false">
-        <div
-          class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm bg-accent/30"
-          style="padding-left: {depth * 0.75 + 0.5}rem"
-        >
-          <Folder class="h-4 w-4 shrink-0 text-muted-foreground" />
-          <input
-            bind:this={draftInputEl}
-            bind:value={draftName}
-            class="min-w-0 flex-1 rounded-md border bg-background px-2 py-0.5 text-sm caret-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            onkeydown={(e) => {
-              if (e.key === 'Enter') commitDraft();
-              if (e.key === 'Escape') cancelDraft();
-            }}
-            onblur={commitDraft}
-            aria-label={$t('folders.new_folder')}
-          />
-        </div>
-      </li>
-    {/if}
-    <!-- Top-level smart folders (root-pinned saved searches) render above the
-         folder list. Root instance only; not a drop target (a leaf, not a real
-         folder) and not part of the reorder zone. -->
-    {#if depth === 0 && rootPinnedSearches && rootPinnedSearches.length > 0}
-      {#each rootPinnedSearches as search (search.id)}
-        <SavedSearchRow
-          {search}
-          context="tree"
-          depth={0}
-          active={search.id === activeSavedSearchId}
-          onselect={(s) => onsavedsearchselect?.(s)}
+<ul class="select-none" role="tree">
+  {#if showDraft}
+    <li role="treeitem" aria-selected="false">
+      <div
+        class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm bg-accent/30"
+        style="padding-left: {depth * 0.75 + 0.5}rem"
+      >
+        <Folder class="h-4 w-4 shrink-0 text-muted-foreground" />
+        <input
+          bind:this={draftInputEl}
+          bind:value={draftName}
+          class="min-w-0 flex-1 rounded-md border bg-background px-2 py-0.5 text-sm caret-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          onkeydown={(e) => {
+            if (e.key === 'Enter') commitDraft();
+            if (e.key === 'Escape') cancelDraft();
+          }}
+          onblur={commitDraft}
+          aria-label={$t('folders.new_folder')}
         />
-      {/each}
-    {/if}
-  </ul>
-{/if}
-
-<!-- autoAriaDisabled keeps the tree/treeitem roles (the zone would rewrite
-     them to list/listitem); the -1 tab indexes keep the pre-zone tab order
-     (rows already carry tabindex 0). Keyboard reorder = menu move up/down. -->
-<ul
-  class="select-none"
-  role="tree"
-  use:dndzone={{
-    items: dragItems,
-    dragDisabled: !touchReorderEnabled,
-    delayTouchStart: LONG_PRESS_MS,
-    flipDurationMs: 200,
-    morphDisabled: true,
-    dropFromOthersDisabled: true,
-    dropTargetStyle: {},
-    zoneTabIndex: -1,
-    zoneItemTabIndex: -1,
-    autoAriaDisabled: true,
-    transformDraggedElement: stripSubtreeFromDragClone
-  }}
-  onconsider={handleDndConsider}
-  onfinalize={handleDndFinalize}
->
-  {#each dragItems as folder (folder.id)}
+      </div>
+    </li>
+  {/if}
+  <!-- Top-level smart folders (root-pinned saved searches) render above the folder
+       list. Root instance only; not a drop target (a leaf, not a real folder). -->
+  {#if depth === 0 && rootPinnedSearches && rootPinnedSearches.length > 0}
+    {#each rootPinnedSearches as search (search.id)}
+      <SavedSearchRow
+        {search}
+        context="tree"
+        depth={0}
+        active={search.id === activeSavedSearchId}
+        onselect={(s) => onsavedsearchselect?.(s)}
+      />
+    {/each}
+  {/if}
+  {#each nodes as folder (folder.id)}
     {@const isExpanded = expandedIds.has(folder.id)}
     {@const isActive = activeFolderId === folder.id}
     {@const parkedSearches = savedSearchesByFolder?.get(folder.id) ?? []}
     {@const hasChildren = (folder.children?.length ?? 0) > 0 || parkedSearches.length > 0}
-    {@const dropZone = dropTarget?.id === folder.id ? dropTarget.zone : null}
+    {@const dropZone = $dropTarget?.id === folder.id ? $dropTarget.zone : null}
     {@const syncConfigId = $syncedFolderConfigs.get(folder.id) ?? null}
     {@const rowActions = folderActions(folder, syncConfigId)}
-    {@const isShadow = isDragShadow(folder)}
 
     <li
       role="treeitem"
@@ -727,12 +956,13 @@
             <div
               {...triggerProps}
               data-folder-id={folder.id}
-              draggable={!touchReorderEnabled}
+              draggable="true"
               ondragstart={(e) => onDragStart(folder, e)}
               ondragend={onDragEnd}
               ondragover={(e) => onDragOver(folder, e)}
-              ondragleave={onDragLeave}
+              ondragleave={() => onDragLeave(folder)}
               ondrop={(e) => onDrop(folder, e)}
+              onpointerdown={(e) => onRowPointerDown(folder, e)}
               class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm
                 cursor-pointer transition-colors
                 {isActive
@@ -740,7 +970,8 @@
                 : menuOpenId === folder.id
                   ? 'bg-accent/50 text-foreground'
                   : 'text-foreground hover:bg-accent/50'}
-                {dropZone === 'into' ? 'ring-1 ring-primary bg-accent/30' : ''}"
+                {dropZone === 'into' ? 'ring-1 ring-primary bg-accent/30' : ''}
+                {$touchDraggingId === folder.id ? 'opacity-50' : ''}"
               style="padding-left: {depth * 0.75 + 0.5}rem"
               role="button"
               tabindex="0"
@@ -786,13 +1017,8 @@
 
               <!-- Chevron (right side, only when has children) -->
               {#if hasChildren && editingId !== folder.id}
-                <!-- touchstart must not reach the dnd zone's item listener: its
-                     tap path re-dispatches a synthetic click (a second toggle
-                     would collapse right back) and a press-and-hold on an
-                     action control must not arm a row drag. -->
                 <button
                   type="button"
-                  ontouchstart={(e) => e.stopPropagation()}
                   onclick={(e) => {
                     e.stopPropagation();
                     if (isExpanded) expandedIds.delete(folder.id);
@@ -811,10 +1037,8 @@
               <!-- Kebab menu button (visible on hover) -->
               {#if editingId !== folder.id}
                 {#if isMobileQuery.value}
-                  <!-- touchstart guard: same reason as the chevron above -->
                   <button
                     type="button"
-                    ontouchstart={(e) => e.stopPropagation()}
                     onclick={(e) => toggleMenu(folder.id, e)}
                     class="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
                     aria-label={$t('folders.folder_actions')}
@@ -879,9 +1103,8 @@
       <!-- Saved searches parked in this folder render ABOVE its subfolders -
            same "searches before folders" rule as root-pin and the folder
            drill-down view, and keeps a parked search visible without scrolling
-           past a deep subtree. Hidden for the drag placeholder (isShadow) so
-           only the row marks the drop position while touch-dragging. -->
-      {#if isExpanded && hasChildren && !isShadow}
+           past a deep subtree. -->
+      {#if isExpanded && hasChildren}
         {#if parkedSearches.length > 0}
           <ul class="select-none" role="group">
             {#each parkedSearches as search (search.id)}

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -496,6 +496,26 @@
     return zoneForPoint((e.currentTarget as HTMLElement).getBoundingClientRect(), e.clientY);
   }
 
+  // The bottom band of an EXPANDED folder's row visually points at the slot
+  // before its first child, so make the semantics match the picture
+  // (Finder-style): retarget to that child. Without this the same 1-2 px gap
+  // hides two different levels ("after the whole subtree" vs "first inside"),
+  // and "after the subtree" reads as a no-op when the dragged row already sits
+  // there. Inserting after the subtree instead = drop before the next row
+  // below it (the line indent shows the level).
+  function normalizeRowZone(targetId: string, zone: DropZone): { id: string; zone: DropZone } {
+    if (zone === 'after' && expandedIds.has(targetId)) {
+      const firstChild = findChildrenOfParent($foldersStore, targetId)[0];
+      // A blocked first child means it's the dragged row itself - keep the
+      // raw meaning then, it's the only way to drag a first child out to
+      // "right after its parent".
+      if (firstChild && !$dragBlockedIds?.has(firstChild.id)) {
+        return { id: firstChild.id, zone: 'before' };
+      }
+    }
+    return { id: targetId, zone };
+  }
+
   function onDragOver(folder: FolderWithChildren, e: DragEvent) {
     // No preventDefault for the dragged folder's own subtree - the browser
     // keeps the no-drop cursor and never fires drop there.
@@ -505,7 +525,7 @@
     }
     e.preventDefault();
     e.dataTransfer!.dropEffect = 'move';
-    dropTarget.set({ id: folder.id, zone: dropZoneFromEvent(e) });
+    dropTarget.set(normalizeRowZone(folder.id, dropZoneFromEvent(e)));
   }
 
   function onDragLeave(folder: FolderWithChildren) {
@@ -535,28 +555,35 @@
     await foldersStore.reorder(groupParentId, ids);
   }
 
-  // Desktop drop between rows targets THIS instance's sibling group.
-  async function reorderAround(
+  // Place `draggedId` before/after the row `targetRowId`, wherever that row's
+  // sibling group lives in the tree (normalizeRowZone may have retargeted the
+  // indicator outside this instance's group, and the touch gesture can drop
+  // on any row). Shared by the desktop drop and the touch drop.
+  async function insertRelativeToRow(
     draggedId: string,
-    targetId: string,
-    zone: 'before' | 'after'
+    targetRowId: string,
+    zone: 'before' | 'after',
+    blocked: Set<string> | null
   ) {
-    // Group parent inside the dragged subtree would cycle (belt & braces -
-    // rows of that subtree already refuse dragover, so it can't be reached).
-    if (parentId && $dragBlockedIds?.has(parentId)) return;
+    const located = findParentAndSiblings($foldersStore, targetRowId);
+    if (!located) return;
+    // Target group hanging inside the dragged subtree would cycle.
+    if (located.parentId && blocked?.has(located.parentId)) return;
     await insertIntoGroup(
       draggedId,
-      targetId,
+      targetRowId,
       zone,
-      parentId,
-      nodes.map((n) => n.id)
+      located.parentId,
+      located.siblings.map((f) => f.id)
     );
   }
 
   async function onDrop(target: FolderWithChildren, e: DragEvent) {
     e.preventDefault();
     e.stopPropagation(); // prevent bubbling to the panel's root drop zone
-    const zone: DropZone = $dropTarget?.id === target.id ? $dropTarget.zone : 'into';
+    // The indicator is authoritative: normalizeRowZone may have retargeted it
+    // to the first child while the drop event still fires on the hovered row.
+    const indicated = $dropTarget;
 
     try {
       // Handle note drop - move note into this folder
@@ -568,16 +595,17 @@
 
       const draggedId =
         e.dataTransfer!.getData('text/folder-id') || e.dataTransfer!.getData('text/plain');
-      if (!draggedId || draggedId === target.id) return;
+      const eff = indicated ?? { id: target.id, zone: 'into' as DropZone };
+      if (!draggedId || draggedId === eff.id) return;
       // Cycle guard (dragover already refuses these; keep drop safe too).
-      if ($dragBlockedIds?.has(target.id)) return;
+      if ($dragBlockedIds?.has(eff.id)) return;
 
-      if (zone === 'into') {
+      if (eff.zone === 'into') {
         // Move dragged folder into target
-        await foldersStore.move(draggedId, target.id);
-        expandedIds.add(target.id);
+        await foldersStore.move(draggedId, eff.id);
+        expandedIds.add(eff.id);
       } else {
-        await reorderAround(draggedId, target.id, zone);
+        await insertRelativeToRow(draggedId, eff.id, eff.zone, $dragBlockedIds);
       }
     } finally {
       dropTarget.set(null);
@@ -736,7 +764,8 @@
       return;
     }
     const zone = zoneForPoint(rowEl.getBoundingClientRect(), pointerY);
-    dropTarget.set({ id: targetId, zone });
+    const normalized = normalizeRowZone(targetId, zone);
+    dropTarget.set(normalized);
     setSpringTarget(zone === 'into' ? targetId : null);
   }
 
@@ -815,17 +844,7 @@
       await foldersStore.move(dragged.id, target.id);
       expandedIds.add(target.id);
     } else {
-      const located = findParentAndSiblings($foldersStore, target.id);
-      if (!located) return;
-      // Target group hanging inside the dragged subtree would cycle.
-      if (located.parentId && blocked?.has(located.parentId)) return;
-      await insertIntoGroup(
-        dragged.id,
-        target.id,
-        target.zone,
-        located.parentId,
-        located.siblings.map((f) => f.id)
-      );
+      await insertRelativeToRow(dragged.id, target.id, target.zone, blocked);
     }
   }
 
@@ -979,11 +998,15 @@
               onkeydown={(e) => e.key === 'Enter' && handleRowSelect(folder)}
               aria-label={$t('folders.folder_label', { values: { name: folder.name } })}
             >
-              <!-- Custom sort: insertion line for a between-rows drop -->
+              <!-- Custom sort: insertion line for a between-rows drop. Starts
+                   at the row's own indent so the target LEVEL is visible
+                   (a gap between a nested row and a shallower one offers two
+                   valid levels - the indent says which one this drop takes). -->
               {#if dropZone === 'before' || dropZone === 'after'}
                 <div
-                  class="pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-primary
+                  class="pointer-events-none absolute right-1 z-10 h-0.5 rounded-full bg-primary
                     {dropZone === 'before' ? 'top-0' : 'bottom-0'}"
+                  style="left: {depth * 0.75 + 0.5}rem"
                 ></div>
               {/if}
               <!-- Folder icon (synced top-level folders get a distinct sync glyph) -->

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -50,6 +50,9 @@
     SheetTitle,
     toastStore
   } from '@reborn/ui';
+  import { flip } from 'svelte/animate';
+  import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME, TRIGGERS } from 'svelte-dnd-action';
+  import type { DndEvent } from 'svelte-dnd-action';
   import type { RowAction } from '$lib/utils/row-action';
   import { syncedFolderConfigs, runFolderSync } from '$lib/services/folder-sync.service';
   // FolderWithChildren comes from the module script import above (module and
@@ -60,7 +63,7 @@
   import { folderSortMode } from '$lib/stores/app-settings.store';
   import { pendingNewFolderDraft } from '$lib/stores/new-folder-draft.store';
   import { t } from '$lib/stores/i18n.store';
-  import { useIsMobile } from '$lib/utils/mediaQuery.svelte';
+  import { useIsMobile, useIsTouchDevice } from '$lib/utils/mediaQuery.svelte';
   import { getDescendantFolderIds } from '$lib/utils/folder-helpers';
   import type {
     DeleteFolderMode,
@@ -457,6 +460,10 @@
   let dropTarget = $state<{ id: string; zone: DropZone } | null>(null);
 
   function onDragStart(folder: FolderWithChildren, e: DragEvent) {
+    // The touch-reorder zone installs a cancelling `ondragstart` on every
+    // <li> (svelte-dnd-action does this even while drag-disabled) - keep the
+    // native dragstart from bubbling into it or desktop drags die instantly.
+    e.stopPropagation();
     e.dataTransfer!.effectAllowed = 'move';
     e.dataTransfer!.setData('text/plain', folder.id);
     e.dataTransfer!.setData('text/folder-id', folder.id);
@@ -564,6 +571,64 @@
     [ids[i], ids[j]] = [ids[j]!, ids[i]!];
     await foldersStore.reorder(parentId, ids);
   }
+
+  // ── Touch reorder (long-press drag, custom sort only) ───────────
+  // HTML5 DnD doesn't exist on touch, so each sibling group is also a
+  // svelte-dnd-action zone (nested zones, one per group): hold a row for
+  // 300 ms (moving earlier scrolls instead), then drag within the group.
+  // Cross-parent moves stay in the "Move to…" picker. The zone only unlocks
+  // on coarse-pointer mobile viewports - mouse keeps the native HTML5 path,
+  // and wide touch viewports (tablets) keep the long-press ContextMenu.
+  const isTouchQuery = useIsTouchDevice();
+  const LONG_PRESS_MS = 300;
+  const touchReorderEnabled = $derived(
+    $folderSortMode === 'custom' && isMobileQuery.value && isTouchQuery.value
+  );
+
+  // Local order the dnd zone shuffles while a drag is in flight; mirrors
+  // `nodes` whenever no drag is active.
+  // svelte-ignore state_referenced_locally (initial copy - the effect below re-syncs)
+  let dragItems = $state<FolderWithChildren[]>([...nodes]);
+  let dndActive = $state(false);
+
+  $effect(() => {
+    const current = nodes;
+    if (!dndActive) dragItems = [...current];
+  });
+
+  function isDragShadow(folder: FolderWithChildren): boolean {
+    return SHADOW_ITEM_MARKER_PROPERTY_NAME in folder;
+  }
+
+  // The floating clone mirrors the whole <li> (row plus expanded subtree) -
+  // strip nested lists so only the row follows the finger.
+  function stripSubtreeFromDragClone(el?: HTMLElement) {
+    el?.querySelectorAll('ul').forEach((u) => u.remove());
+  }
+
+  function handleDndConsider(e: CustomEvent<DndEvent<FolderWithChildren>>) {
+    dndActive = true;
+    dragItems = e.detail.items;
+    if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED && 'vibrate' in navigator) {
+      navigator.vibrate(50);
+    }
+  }
+
+  async function handleDndFinalize(e: CustomEvent<DndEvent<FolderWithChildren>>) {
+    dragItems = e.detail.items;
+    try {
+      const ids = e.detail.items.map((f) => f.id);
+      const before = nodes.map((n) => n.id);
+      // A drop back in place (or outside the zone) finalizes with the
+      // original order - skip the write so an untouched lazy-seeded group
+      // isn't materialized (see guideline: lazy seeding of order_index).
+      if (ids.length === before.length && ids.some((id, i) => id !== before[i])) {
+        await foldersStore.reorder(parentId, ids);
+      }
+    } finally {
+      dndActive = false;
+    }
+  }
 </script>
 
 <!-- Close menus when clicking outside -->
@@ -573,42 +638,72 @@
   }}
 />
 
-<ul class="select-none" role="tree">
-  {#if showDraft}
-    <li role="treeitem" aria-selected="false">
-      <div
-        class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm bg-accent/30"
-        style="padding-left: {depth * 0.75 + 0.5}rem"
-      >
-        <Folder class="h-4 w-4 shrink-0 text-muted-foreground" />
-        <input
-          bind:this={draftInputEl}
-          bind:value={draftName}
-          class="min-w-0 flex-1 rounded-md border bg-background px-2 py-0.5 text-sm caret-primary focus:outline-none focus:ring-1 focus:ring-primary"
-          onkeydown={(e) => {
-            if (e.key === 'Enter') commitDraft();
-            if (e.key === 'Escape') cancelDraft();
-          }}
-          onblur={commitDraft}
-          aria-label={$t('folders.new_folder')}
+<!-- Draft row and root-pinned smart folders live OUTSIDE the folder list:
+     the list is a svelte-dnd-action zone, and the zone's children must map
+     1:1 onto its `items` (the folders). -->
+{#if showDraft || (depth === 0 && rootPinnedSearches && rootPinnedSearches.length > 0)}
+  <ul class="select-none" role="tree">
+    {#if showDraft}
+      <li role="treeitem" aria-selected="false">
+        <div
+          class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm bg-accent/30"
+          style="padding-left: {depth * 0.75 + 0.5}rem"
+        >
+          <Folder class="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            bind:this={draftInputEl}
+            bind:value={draftName}
+            class="min-w-0 flex-1 rounded-md border bg-background px-2 py-0.5 text-sm caret-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            onkeydown={(e) => {
+              if (e.key === 'Enter') commitDraft();
+              if (e.key === 'Escape') cancelDraft();
+            }}
+            onblur={commitDraft}
+            aria-label={$t('folders.new_folder')}
+          />
+        </div>
+      </li>
+    {/if}
+    <!-- Top-level smart folders (root-pinned saved searches) render above the
+         folder list. Root instance only; not a drop target (a leaf, not a real
+         folder) and not part of the reorder zone. -->
+    {#if depth === 0 && rootPinnedSearches && rootPinnedSearches.length > 0}
+      {#each rootPinnedSearches as search (search.id)}
+        <SavedSearchRow
+          {search}
+          context="tree"
+          depth={0}
+          active={search.id === activeSavedSearchId}
+          onselect={(s) => onsavedsearchselect?.(s)}
         />
-      </div>
-    </li>
-  {/if}
-  <!-- Top-level smart folders (root-pinned saved searches) render above the folder
-       list. Root instance only; not a drop target (a leaf, not a real folder). -->
-  {#if depth === 0 && rootPinnedSearches && rootPinnedSearches.length > 0}
-    {#each rootPinnedSearches as search (search.id)}
-      <SavedSearchRow
-        {search}
-        context="tree"
-        depth={0}
-        active={search.id === activeSavedSearchId}
-        onselect={(s) => onsavedsearchselect?.(s)}
-      />
-    {/each}
-  {/if}
-  {#each nodes as folder (folder.id)}
+      {/each}
+    {/if}
+  </ul>
+{/if}
+
+<!-- autoAriaDisabled keeps the tree/treeitem roles (the zone would rewrite
+     them to list/listitem); the -1 tab indexes keep the pre-zone tab order
+     (rows already carry tabindex 0). Keyboard reorder = menu move up/down. -->
+<ul
+  class="select-none"
+  role="tree"
+  use:dndzone={{
+    items: dragItems,
+    dragDisabled: !touchReorderEnabled,
+    delayTouchStart: LONG_PRESS_MS,
+    flipDurationMs: 200,
+    morphDisabled: true,
+    dropFromOthersDisabled: true,
+    dropTargetStyle: {},
+    zoneTabIndex: -1,
+    zoneItemTabIndex: -1,
+    autoAriaDisabled: true,
+    transformDraggedElement: stripSubtreeFromDragClone
+  }}
+  onconsider={handleDndConsider}
+  onfinalize={handleDndFinalize}
+>
+  {#each dragItems as folder (folder.id)}
     {@const isExpanded = expandedIds.has(folder.id)}
     {@const isActive = activeFolderId === folder.id}
     {@const parkedSearches = savedSearchesByFolder?.get(folder.id) ?? []}
@@ -616,11 +711,13 @@
     {@const dropZone = dropTarget?.id === folder.id ? dropTarget.zone : null}
     {@const syncConfigId = $syncedFolderConfigs.get(folder.id) ?? null}
     {@const rowActions = folderActions(folder, syncConfigId)}
+    {@const isShadow = isDragShadow(folder)}
 
     <li
       role="treeitem"
       aria-expanded={hasChildren ? isExpanded : undefined}
       aria-selected={activeFolderId === folder.id}
+      animate:flip={{ duration: 200 }}
     >
       <!-- Desktop right-click opens the same folder actions as the kebab (#348).
            Disabled on mobile and while renaming inline. -->
@@ -630,7 +727,7 @@
             <div
               {...triggerProps}
               data-folder-id={folder.id}
-              draggable="true"
+              draggable={!touchReorderEnabled}
               ondragstart={(e) => onDragStart(folder, e)}
               ondragend={onDragEnd}
               ondragover={(e) => onDragOver(folder, e)}
@@ -689,8 +786,13 @@
 
               <!-- Chevron (right side, only when has children) -->
               {#if hasChildren && editingId !== folder.id}
+                <!-- touchstart must not reach the dnd zone's item listener: its
+                     tap path re-dispatches a synthetic click (a second toggle
+                     would collapse right back) and a press-and-hold on an
+                     action control must not arm a row drag. -->
                 <button
                   type="button"
+                  ontouchstart={(e) => e.stopPropagation()}
                   onclick={(e) => {
                     e.stopPropagation();
                     if (isExpanded) expandedIds.delete(folder.id);
@@ -709,8 +811,10 @@
               <!-- Kebab menu button (visible on hover) -->
               {#if editingId !== folder.id}
                 {#if isMobileQuery.value}
+                  <!-- touchstart guard: same reason as the chevron above -->
                   <button
                     type="button"
+                    ontouchstart={(e) => e.stopPropagation()}
                     onclick={(e) => toggleMenu(folder.id, e)}
                     class="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
                     aria-label={$t('folders.folder_actions')}
@@ -775,8 +879,9 @@
       <!-- Saved searches parked in this folder render ABOVE its subfolders -
            same "searches before folders" rule as root-pin and the folder
            drill-down view, and keeps a parked search visible without scrolling
-           past a deep subtree. -->
-      {#if isExpanded && hasChildren}
+           past a deep subtree. Hidden for the drag placeholder (isShadow) so
+           only the row marks the drop position while touch-dragging. -->
+      {#if isExpanded && hasChildren && !isShadow}
         {#if parkedSearches.length > 0}
           <ul class="select-none" role="group">
             {#each parkedSearches as search (search.id)}

--- a/apps/reborn-notes/src/lib/utils/folder-helpers.test.ts
+++ b/apps/reborn-notes/src/lib/utils/folder-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   findChildrenOfParent,
+  findParentAndSiblings,
   buildBreadcrumb,
   buildPathString,
   getAncestorIds,
@@ -131,6 +132,31 @@ describe('getDescendantFolderIds', () => {
     expect(ids).toContain('devsub');
     expect(ids).toContain('guide');
     expect(ids).toHaveLength(4);
+  });
+});
+
+describe('findParentAndSiblings', () => {
+  it('returns null parent and the root group for a root-level folder', () => {
+    const result = findParentAndSiblings(tree, 'dev');
+    expect(result?.parentId).toBeNull();
+    expect(result?.siblings.map((f) => f.id)).toEqual(['r1on1', 'dev', 'people']);
+  });
+
+  it('returns the parent id and full sibling group for a nested folder', () => {
+    const result = findParentAndSiblings(tree, 'devsub');
+    expect(result?.parentId).toBe('reapps');
+    expect(result?.siblings.map((f) => f.id)).toEqual(['arch', 'devsub']);
+  });
+
+  it('works for a deeply nested only child', () => {
+    const result = findParentAndSiblings(tree, 'guide');
+    expect(result?.parentId).toBe('devsub');
+    expect(result?.siblings.map((f) => f.id)).toEqual(['guide']);
+  });
+
+  it('returns null for an unknown folder or empty tree', () => {
+    expect(findParentAndSiblings(tree, 'nope')).toBeNull();
+    expect(findParentAndSiblings([], 'dev')).toBeNull();
   });
 });
 

--- a/apps/reborn-notes/src/lib/utils/folder-helpers.ts
+++ b/apps/reborn-notes/src/lib/utils/folder-helpers.ts
@@ -130,6 +130,31 @@ export function getDescendantFolderIds(
   return ids;
 }
 
+/**
+ * Locate the sibling group containing `folderId`: its parent id (null for the
+ * root level) and the group's members in tree order. Used by drop handlers
+ * that target a row anywhere in the tree (touch drag). Returns null when the
+ * folder isn't in the tree.
+ */
+export function findParentAndSiblings(
+  tree: FolderWithChildren[],
+  folderId: string
+): { parentId: string | null; siblings: FolderWithChildren[] } | null {
+  const stack: { parentId: string | null; group: FolderWithChildren[] }[] = [
+    { parentId: null, group: tree }
+  ];
+  while (stack.length > 0) {
+    const { parentId, group } = stack.pop()!;
+    if (group.some((f) => f.id === folderId)) return { parentId, siblings: group };
+    for (const f of group) {
+      if (f.children && f.children.length > 0) {
+        stack.push({ parentId: f.id, group: f.children });
+      }
+    }
+  }
+  return null;
+}
+
 /** Return IDs of all ancestors (parent → root) so the tree can be expanded to show `folderId`. */
 export function getAncestorIds(folderId: string, tree: FolderWithChildren[]): string[] {
   const parentMap = new Map<string, string>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,6 @@ importers:
       qrcode:
         specifier: 1.5.4
         version: 1.5.4
-      svelte-dnd-action:
-        specifier: 0.9.69
-        version: 0.9.69(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       svelte-i18n:
         specifier: 4.0.1
         version: 4.0.1(svelte@5.56.3(@typescript-eslint/types@8.59.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,8 @@ overrides:
   ws: 8.21.0
   qs: 6.15.2
   undici@<7.28.0: 7.28.0
+  '@babel/core@<7.29.7': 7.29.7
+  uuid@<11.1.1: 11.1.1
 
 importers:
 
@@ -313,6 +315,9 @@ importers:
       qrcode:
         specifier: 1.5.4
         version: 1.5.4
+      svelte-dnd-action:
+        specifier: 0.9.69
+        version: 0.9.69(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       svelte-i18n:
         specifier: 4.0.1
         version: 4.0.1(svelte@5.56.3(@typescript-eslint/types@8.59.3))
@@ -947,8 +952,12 @@ packages:
     resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.7':
@@ -963,22 +972,26 @@ packages:
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-create-class-features-plugin@7.29.3':
     resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/helper-create-regexp-features-plugin@7.28.5':
     resolution: {integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/helper-define-polyfill-provider@0.6.8':
     resolution: {integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': 7.29.7
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
@@ -996,7 +1009,7 @@ packages:
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
@@ -1010,13 +1023,13 @@ packages:
     resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/helper-replace-supers@7.28.6':
     resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
@@ -1034,12 +1047,16 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-wrap-function@7.28.6':
     resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.7':
@@ -1051,420 +1068,420 @@ packages:
     resolution: {integrity: sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1':
     resolution: {integrity: sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3':
     resolution: {integrity: sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1':
     resolution: {integrity: sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.13.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6':
     resolution: {integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-proposal-decorators@7.29.0':
     resolution: {integrity: sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-syntax-decorators@7.28.6':
     resolution: {integrity: sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-syntax-import-assertions@7.28.6':
     resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.28.6':
     resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.28.6':
     resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.28.6':
     resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-arrow-functions@7.27.1':
     resolution: {integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-async-generator-functions@7.29.0':
     resolution: {integrity: sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-async-to-generator@7.28.6':
     resolution: {integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1':
     resolution: {integrity: sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-block-scoping@7.28.6':
     resolution: {integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-class-properties@7.28.6':
     resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-class-static-block@7.28.6':
     resolution: {integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.12.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-classes@7.28.6':
     resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-computed-properties@7.28.6':
     resolution: {integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-destructuring@7.28.5':
     resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-dotall-regex@7.28.6':
     resolution: {integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-duplicate-keys@7.27.1':
     resolution: {integrity: sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0':
     resolution: {integrity: sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-dynamic-import@7.27.1':
     resolution: {integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-explicit-resource-management@7.28.6':
     resolution: {integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-exponentiation-operator@7.28.6':
     resolution: {integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-export-namespace-from@7.27.1':
     resolution: {integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-for-of@7.27.1':
     resolution: {integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-function-name@7.27.1':
     resolution: {integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-json-strings@7.28.6':
     resolution: {integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-literals@7.27.1':
     resolution: {integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.6':
     resolution: {integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-member-expression-literals@7.27.1':
     resolution: {integrity: sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-modules-amd@7.27.1':
     resolution: {integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-modules-commonjs@7.28.6':
     resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-modules-systemjs@7.29.7':
     resolution: {integrity: sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-modules-umd@7.27.1':
     resolution: {integrity: sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.0':
     resolution: {integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-new-target@7.27.1':
     resolution: {integrity: sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
     resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-numeric-separator@7.28.6':
     resolution: {integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-object-rest-spread@7.28.6':
     resolution: {integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-object-super@7.27.1':
     resolution: {integrity: sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-optional-catch-binding@7.28.6':
     resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-optional-chaining@7.28.6':
     resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-parameters@7.27.7':
     resolution: {integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-private-methods@7.28.6':
     resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-private-property-in-object@7.28.6':
     resolution: {integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-property-literals@7.27.1':
     resolution: {integrity: sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-regenerator@7.29.0':
     resolution: {integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-regexp-modifiers@7.28.6':
     resolution: {integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-reserved-words@7.27.1':
     resolution: {integrity: sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-runtime@7.29.0':
     resolution: {integrity: sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-shorthand-properties@7.27.1':
     resolution: {integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-spread@7.28.6':
     resolution: {integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-sticky-regex@7.27.1':
     resolution: {integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-template-literals@7.27.1':
     resolution: {integrity: sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-typeof-symbol@7.27.1':
     resolution: {integrity: sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-typescript@7.28.6':
     resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-unicode-escapes@7.27.1':
     resolution: {integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-unicode-property-regex@7.28.6':
     resolution: {integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-unicode-regex@7.27.1':
     resolution: {integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/plugin-transform-unicode-sets-regex@7.28.6':
     resolution: {integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.7
 
   '@babel/preset-env@7.29.5':
     resolution: {integrity: sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/preset-modules@0.1.6-no-external-plugins':
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
+      '@babel/core': 7.29.7
 
   '@babel/preset-typescript@7.28.5':
     resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -3996,7 +4013,7 @@ packages:
   babel-plugin-const-enum@1.2.0:
     resolution: {integrity: sha512-o1m/6iyyFnp9MRsK1dHF3bneqyf3AlM2q3A/YbgQr2pCat6B6XJVDv2TXqzfY2RYUi4mak6WAksSBPlyYGx9dg==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': 7.29.7
 
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -4005,27 +4022,27 @@ packages:
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': 7.29.7
 
   babel-plugin-polyfill-corejs3@0.13.0:
     resolution: {integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': 7.29.7
 
   babel-plugin-polyfill-corejs3@0.14.2:
     resolution: {integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': 7.29.7
 
   babel-plugin-polyfill-regenerator@0.6.8:
     resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': 7.29.7
 
   babel-plugin-transform-typescript-metadata@0.3.2:
     resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
     peerDependencies:
-      '@babel/core': ^7
+      '@babel/core': 7.29.7
       '@babel/traverse': ^7
     peerDependenciesMeta:
       '@babel/traverse':
@@ -6621,13 +6638,12 @@ packages:
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   valibot@1.2.0:
@@ -6994,13 +7010,15 @@ snapshots:
 
   '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.29.0':
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
@@ -7034,29 +7052,37 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3(supports-color@7.2.0)
@@ -7081,9 +7107,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -7096,18 +7122,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.29.7
@@ -7127,6 +7153,8 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
       '@babel/template': 7.29.7
@@ -7135,7 +7163,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helpers@7.29.2':
+  '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
@@ -7144,541 +7172,541 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/preset-env@7.29.5(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.7
       esutils: 2.0.3
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -8524,19 +8552,19 @@ snapshots:
 
   '@nx/js@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.41(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.41(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.41(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-env': 7.29.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.5(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
       '@babel/runtime': 7.29.2
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.41(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.41(@swc/helpers@0.5.23)))
       '@nx/workspace': 22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.41(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.41(@swc/helpers@0.5.23))
       '@zkochan/js-yaml': 0.0.7
-      babel-plugin-const-enum: 1.2.0(@babel/core@7.29.0)
+      babel-plugin-const-enum: 1.2.0(@babel/core@7.29.7)
       babel-plugin-macros: 3.1.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.29.0)(@babel/traverse@7.29.7)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.29.7)(@babel/traverse@7.29.7)
       chalk: 4.1.2
       columnify: 1.6.0
       detect-port: 2.1.0
@@ -9218,7 +9246,7 @@ snapshots:
       dequal: 2.0.3
       polished: 4.3.1
       storybook: 10.4.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      uuid: 9.0.1
+      uuid: 11.1.1
 
   '@storybook/addon-backgrounds@8.6.14(storybook@10.4.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
@@ -10152,11 +10180,11 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-plugin-const-enum@1.2.0(@babel/core@7.29.0):
+  babel-plugin-const-enum@1.2.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -10167,41 +10195,41 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.12
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.29.0)(@babel/traverse@7.29.7):
+  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.29.7)(@babel/traverse@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
     optionalDependencies:
       '@babel/traverse': 7.29.7
@@ -13028,9 +13056,9 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
 
-  uuid@14.0.0: {}
+  uuid@11.1.1: {}
 
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   valibot@1.2.0(typescript@6.0.3):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,8 @@ overrides:
   ws: '8.21.0' # GHSA-58qx-3vcg-4xpx ws uninitialized memory disclosure
   qs: '6.15.2' # GHSA-q8mj-m7cp-5q26 qs.stringify DoS
   undici@<7.28.0: '7.28.0' # GHSA-vmh5-mc38-953g (high) + GHSA-pr7r-676h-xcf6 (moderate) undici, via vitest>jsdom (test-only)
+  '@babel/core@<7.29.7': '7.29.7' # GHSA-4x5r-pxfx-6jf8 (low) arbitrary file read via sourceMappingURL comment, via @nx/js toolchain (Dependabot #106)
+  uuid@<11.1.1: '11.1.1' # GHSA-w5hq-g745-h8pq (moderate) missing buffer bounds check in v3/v5/v6, via @storybook/addon-actions; direct deps already on uuid 14
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true


### PR DESCRIPTION
## Summary

Two independent changes bundled to avoid a pnpm-lock merge cascade:

**1. Long-press touch reorder for folders (custom sort)** - the natural upgrade over the mobile move up/down menu items from #408 (P3 follow-up of #401). Hold a folder row for 300 ms (moving earlier scrolls instead), feel a short haptic tick, then drag the row within its sibling group. Implemented with `svelte-dnd-action` nested zones, one per sibling group - the same library and pattern as subtask reorder in reborn-task, but using the library's built-in `delayTouchStart` (single gesture, scroll-cancel) instead of a hand-rolled arm timer. Works in the desktop sidebar tree and the mobile folder view; cross-parent moves stay in the "Move to…" picker.

Decisions to review:
- **Gating**: the zone unlocks only when sort mode is `custom` AND viewport is mobile AND the pointer is coarse (`useIsTouchDevice`). Mouse keeps the native HTML5 drag with into/before/after bands; wide touch viewports (tablets) keep the long-press right-click ContextMenu and menu move up/down.
- **A11y**: `autoAriaDisabled` + `-1` zone/item tab indexes, because the zone would otherwise rewrite `role="tree"/"treeitem"` to `list/listitem` and add tab stops. Keyboard reorder path remains the menu's move up/down.
- **Desktop-drag protection**: svelte-dnd-action installs a cancelling `ondragstart` on every `<li>` even while drag-disabled; `onDragStart` now calls `stopPropagation()` so desktop HTML5 drags keep working.
- **Markup**: draft row + root-pinned smart folders moved out of the zone `<ul>` (zone children must map 1:1 onto its `items`); chevron and mobile kebab stop `touchstart` propagation (the zone's tap path re-dispatches a synthetic click - a second toggle would collapse the chevron right back).
- **Lazy seeding preserved**: a drop back in place skips the reorder write, so untouched groups aren't materialized.

**2. `chore(deps)`: transitive CVE pins** (`pnpm-workspace.yaml` overrides, same convention as the existing dev-only pins):
- `@babel/core` -> 7.29.7 (GHSA-4x5r-pxfx-6jf8, low - closes Dependabot alert #106; via @nx/js, dev-only). The v7 line skipped from 7.29.0 straight to 7.29.6/7.29.7, so the advisory's ">=7.29.1" resolves to 7.29.7.
- `uuid@<11.1.1` -> 11.1.1 (GHSA-w5hq-g745-h8pq, moderate; via @storybook/addon-actions, dev-only). Range-scoped so direct `uuid@14` deps stay untouched.

`pnpm audit` is clean after the pins. Note: the stale comment in `ci.yml` still says the pins live in `package.json` - they live in `pnpm-workspace.yaml` (pnpm 10+ ignores the `pnpm` block in package.json); can be fixed next time the workflow file is touched (token lacks workflow scope).

Local gates: eslint 0 errors, svelte-check 0/0 (5704 files), vitest 1198/1198, `vite build` OK, `pnpm audit` clean.

## Test plan

Smoke on a phone (or DevTools device emulation with touch), Notes app:
1. Folders panel -> sort menu -> "Custom order".
2. Long-press a folder row (~300 ms): short vibration, row lifts (only the row follows the finger, not its subtree); drag between siblings and drop - order persists after reload and syncs to a second device.
3. Start moving immediately after touching: the list scrolls, no drag starts.
4. Quick tap on a row still opens the folder; tapping the chevron expands/collapses exactly once; kebab opens the action sheet.
5. Long-press drag of an expanded folder: subtree collapses into the placeholder during the drag, drops with the folder.
6. Alphabetical mode: long-press does nothing (no reorder).
7. Desktop regression: HTML5 drag still works - drop into a folder (ring), before/after bands in custom mode, drop on the root "Folders" panel zone; right-click ContextMenu on rows unchanged.
8. Trees with pinned smart folders at root and a new-folder draft row: rows render as before, reorder unaffected.

Deps: `pnpm install`, then `pnpm audit` (expect no findings). Storybook in packages/ui should still start (uuid 9 -> 11 under addon-actions).