### PR TITLE
fix(notes): surface undecryptable saved searches

### DIFF
--- a/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/SavedSearchRow.svelte
@@ -94,6 +94,14 @@
   let menuOpen = $state(false);
   const rowMenuActive = $derived(menuOpen || actionSheetOpen);
 
+  // Undecryptable rows (foreign key epoch / corrupted ciphertext) render an
+  // explicit placeholder instead of a blank name and only offer deletion -
+  // every other action would either operate on garbage or re-encrypt it under
+  // the current key as if it were real data.
+  const displayName = $derived(
+    search.decrypt_failed ? $t('saved_searches.undecryptable') : search.name
+  );
+
   function handleMenuButton(e: Event) {
     e.stopPropagation();
     actionSheetOpen = true;
@@ -126,36 +134,48 @@
   // Single source of truth for the desktop actions - feeds both the kebab
   // (DropdownMenu) and the right-click ContextMenu, so they can't drift (mirrors
   // FolderTree.folderActions). The mobile Sheet lists the same actions by hand.
-  const rowActions = $derived<RowAction[]>([
-    { key: 'rename', icon: Pencil, label: $t('saved_searches.rename'), run: startRename },
-    {
-      key: 'edit-query',
-      icon: SearchCode,
-      label: $t('saved_searches.edit_query'),
-      run: startEditQuery
-    },
-    ...(context === 'panel'
+  const rowActions = $derived<RowAction[]>(
+    search.decrypt_failed
       ? [
           {
-            key: 'move',
-            icon: FolderInput,
-            label: $t('saved_searches.move_to_folder'),
-            run: requestMove
+            key: 'delete',
+            icon: Trash2,
+            label: $t('saved_searches.delete'),
+            run: requestDelete,
+            destructive: true
           }
         ]
-      : []),
-    ...(search.folder_id || search.pinned_to_root
-      ? [{ key: 'unpark', icon: FolderX, label: $t('saved_searches.unpark'), run: unpark }]
-      : []),
-    {
-      key: 'delete',
-      icon: Trash2,
-      label: $t('saved_searches.delete'),
-      run: requestDelete,
-      destructive: true,
-      separatorBefore: true
-    }
-  ]);
+      : [
+          { key: 'rename', icon: Pencil, label: $t('saved_searches.rename'), run: startRename },
+          {
+            key: 'edit-query',
+            icon: SearchCode,
+            label: $t('saved_searches.edit_query'),
+            run: startEditQuery
+          },
+          ...(context === 'panel'
+            ? [
+                {
+                  key: 'move',
+                  icon: FolderInput,
+                  label: $t('saved_searches.move_to_folder'),
+                  run: requestMove
+                }
+              ]
+            : []),
+          ...(search.folder_id || search.pinned_to_root
+            ? [{ key: 'unpark', icon: FolderX, label: $t('saved_searches.unpark'), run: unpark }]
+            : []),
+          {
+            key: 'delete',
+            icon: Trash2,
+            label: $t('saved_searches.delete'),
+            run: requestDelete,
+            destructive: true,
+            separatorBefore: true
+          }
+        ]
+  );
 </script>
 
 <li role={context === 'tree' ? 'treeitem' : 'listitem'} aria-selected={context === 'tree' ? false : undefined}>
@@ -166,7 +186,9 @@
       {#snippet child({ props: triggerProps })}
         <div
           {...triggerProps}
-          class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm cursor-pointer transition-colors
+          class="group relative flex items-center gap-1.5 rounded-md px-2 py-2.5 text-sm {search.decrypt_failed
+            ? 'cursor-default'
+            : 'cursor-pointer'} transition-colors
             {active
             ? 'list-row-active text-accent-foreground font-medium'
             : rowMenuActive
@@ -176,10 +198,11 @@
           style="padding-left: {depth * 0.75 + 0.5}rem"
           role="button"
           tabindex="0"
-          onclick={() => !editing && onselect(search)}
-          onkeydown={(e) => e.key === 'Enter' && !editing && onselect(search)}
-          aria-label={$t('saved_searches.item_label', { values: { name: search.name } })}
-          title={search.query}
+          onclick={() => !editing && !search.decrypt_failed && onselect(search)}
+          onkeydown={(e) =>
+            e.key === 'Enter' && !editing && !search.decrypt_failed && onselect(search)}
+          aria-label={$t('saved_searches.item_label', { values: { name: displayName } })}
+          title={search.decrypt_failed ? $t('saved_searches.undecryptable_hint') : search.query}
         >
           <SearchCheck class="h-4 w-4 shrink-0 text-muted-foreground" />
 
@@ -195,6 +218,8 @@
               }}
               onblur={commitRename}
             />
+          {:else if search.decrypt_failed}
+            <span class="min-w-0 flex-1 truncate italic text-muted-foreground">{displayName}</span>
           {:else}
             <span class="min-w-0 flex-1 truncate">{search.name}</span>
             {#if context === 'panel'}
@@ -275,28 +300,34 @@
   <Sheet bind:open={actionSheetOpen}>
     <SheetContent side="bottom" class="h-auto">
       <SheetHeader>
-        <SheetTitle>{search.name}</SheetTitle>
+        <SheetTitle>{displayName}</SheetTitle>
       </SheetHeader>
       <div class="mt-4 space-y-1">
-        <Button variant="ghost" class="w-full justify-start" onclick={() => startRename()}>
-          <Pencil class="mr-2 h-4 w-4" />
-          {$t('saved_searches.rename')}
-        </Button>
-        <Button variant="ghost" class="w-full justify-start" onclick={() => startEditQuery()}>
-          <SearchCode class="mr-2 h-4 w-4" />
-          {$t('saved_searches.edit_query')}
-        </Button>
-        {#if context === 'panel'}
-          <Button variant="ghost" class="w-full justify-start" onclick={() => requestMove()}>
-            <FolderInput class="mr-2 h-4 w-4" />
-            {$t('saved_searches.move_to_folder')}
+        {#if search.decrypt_failed}
+          <p class="px-3 pb-2 text-sm text-muted-foreground">
+            {$t('saved_searches.undecryptable_hint')}
+          </p>
+        {:else}
+          <Button variant="ghost" class="w-full justify-start" onclick={() => startRename()}>
+            <Pencil class="mr-2 h-4 w-4" />
+            {$t('saved_searches.rename')}
           </Button>
-        {/if}
-        {#if search.folder_id || search.pinned_to_root}
-          <Button variant="ghost" class="w-full justify-start" onclick={() => unpark()}>
-            <FolderX class="mr-2 h-4 w-4" />
-            {$t('saved_searches.unpark')}
+          <Button variant="ghost" class="w-full justify-start" onclick={() => startEditQuery()}>
+            <SearchCode class="mr-2 h-4 w-4" />
+            {$t('saved_searches.edit_query')}
           </Button>
+          {#if context === 'panel'}
+            <Button variant="ghost" class="w-full justify-start" onclick={() => requestMove()}>
+              <FolderInput class="mr-2 h-4 w-4" />
+              {$t('saved_searches.move_to_folder')}
+            </Button>
+          {/if}
+          {#if search.folder_id || search.pinned_to_root}
+            <Button variant="ghost" class="w-full justify-start" onclick={() => unpark()}>
+              <FolderX class="mr-2 h-4 w-4" />
+              {$t('saved_searches.unpark')}
+            </Button>
+          {/if}
         {/if}
         <Button
           variant="ghost"
@@ -315,7 +346,7 @@
 
 <ConfirmDialog
   bind:open={deleteDialogOpen}
-  title={$t('saved_searches.delete_confirm_title', { values: { name: search.name } })}
+  title={$t('saved_searches.delete_confirm_title', { values: { name: displayName } })}
   description={$t('saved_searches.delete_confirm_desc')}
   confirmText={$t('saved_searches.delete')}
   cancelText={$t('saved_searches.dialog.cancel')}

--- a/apps/reborn-notes/src/lib/services/saved-search.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/saved-search.service.spec.ts
@@ -7,14 +7,25 @@ const deleteSpy = vi.fn();
 const pushSpy = vi.fn();
 const pushUpdateSpy = vi.fn();
 const pushDeleteSpy = vi.fn();
+// Spies (not plain functions) so the undecryptable-row tests can assert that
+// known-bad rows are NOT re-decrypted on later refreshes. `bad:` ciphertexts
+// simulate a foreign-key-epoch row; `encobj:not-json` does the same for the
+// metadata bundle (JSON.parse throws).
+const decryptTextSpy = vi.fn(async (stored: string) => {
+  if (stored.startsWith('bad:')) throw new Error('OperationError');
+  return stored.replace(/^enc:/, '');
+});
+const decryptObjectSpy = vi.fn(async (stored: string) =>
+  JSON.parse(stored.replace(/^encobj:/, ''))
+);
 
 vi.mock('@reborn/crypto', () => ({
   cryptoManager: {
     isInitialized: () => true,
     encryptText: async (value: string) => `enc:${value}`,
-    decryptText: async (stored: string) => stored.replace(/^enc:/, ''),
+    decryptText: (stored: string) => decryptTextSpy(stored),
     encryptObject: async (value: unknown) => `encobj:${JSON.stringify(value)}`,
-    decryptObject: async (stored: string) => JSON.parse(stored.replace(/^encobj:/, ''))
+    decryptObject: (stored: string) => decryptObjectSpy(stored)
   }
 }));
 
@@ -84,6 +95,11 @@ beforeEach(() => {
   pushSpy.mockReset();
   pushUpdateSpy.mockReset();
   pushDeleteSpy.mockReset();
+  decryptTextSpy.mockClear();
+  decryptObjectSpy.mockClear();
+  // NOTE: the service keeps a module-scoped session cache of undecryptable
+  // rows (keyed by id + updated_at) which survives between tests - seed
+  // corrupt rows under ids unique to their test.
 });
 
 describe('createSavedSearch', () => {
@@ -344,5 +360,72 @@ describe('deleteSavedSearch', () => {
     expect(rows).toHaveLength(0);
     expect(deleteSpy).toHaveBeenCalledWith('s-1');
     expect(pushDeleteSpy).toHaveBeenCalledWith('s-1');
+  });
+});
+
+describe('undecryptable rows (foreign key epoch / corruption)', () => {
+  it('flags the whole row and degrades every field when the name does not decrypt', async () => {
+    seed({ id: 'ghost-1', name_encrypted: 'bad:name' });
+
+    const [ghost] = await getAllSavedSearches();
+
+    expect(ghost!.decrypt_failed).toBe(true);
+    expect(ghost!.name).toBe('');
+    expect(ghost!.query).toBe('');
+    expect(ghost!.search_in_content).toBe(false);
+    expect(ghost!.pinned_to_root).toBe(false);
+  });
+
+  it('flags the row when only the metadata bundle is corrupt', async () => {
+    seed({ id: 'ghost-2', metadata_encrypted: 'encobj:not-json' });
+
+    const [ghost] = await getAllSavedSearches();
+
+    expect(ghost!.decrypt_failed).toBe(true);
+  });
+
+  it('leaves healthy rows unflagged next to a corrupt one', async () => {
+    seed({ id: 'ghost-3', position: 0, name_encrypted: 'bad:name' });
+    seed({ id: 'fine-3', position: 1, name_encrypted: 'enc:Fine' });
+
+    const all = await getAllSavedSearches();
+    const byId = new Map(all.map((s) => [s.id, s]));
+
+    expect(byId.get('ghost-3')!.decrypt_failed).toBe(true);
+    expect(byId.get('fine-3')!.decrypt_failed).toBeUndefined();
+    expect(byId.get('fine-3')!.name).toBe('Fine');
+  });
+
+  it('does not re-decrypt a known-bad row until its updated_at changes', async () => {
+    seed({ id: 'ghost-4', name_encrypted: 'bad:name' });
+
+    // First refresh attempts and fails; the row is remembered for the session.
+    await getAllSavedSearches();
+
+    decryptTextSpy.mockClear();
+    decryptObjectSpy.mockClear();
+    const [stillGhost] = await getAllSavedSearches();
+    expect(stillGhost!.decrypt_failed).toBe(true);
+    expect(decryptTextSpy).not.toHaveBeenCalled();
+    expect(decryptObjectSpy).not.toHaveBeenCalled();
+
+    // Row rewritten (new updated_at, e.g. repaired from a device holding the
+    // right key): retried, decodes normally, sticky entry dropped.
+    rows.length = 0;
+    seed({ id: 'ghost-4', updated_at: '2026-06-02T00:00:00.000Z' });
+    const [repaired] = await getAllSavedSearches();
+    expect(repaired!.decrypt_failed).toBeUndefined();
+    expect(repaired!.name).toBe('Seeded');
+  });
+
+  it('updateSavedSearchQuery on a corrupt-metadata row writes a fresh bundle (repair)', async () => {
+    seed({ id: 'ghost-5', metadata_encrypted: 'encobj:not-json' });
+
+    await updateSavedSearchQuery('ghost-5', 'tag:new', true);
+
+    const updated = rows.find((r) => r.id === 'ghost-5')!;
+    expect(updated.metadata_encrypted).toBe(
+      'encobj:{"search_in_content":true,"pinned_to_root":false}'
+    );
   });
 });

--- a/apps/reborn-notes/src/lib/services/saved-search.service.ts
+++ b/apps/reborn-notes/src/lib/services/saved-search.service.ts
@@ -43,7 +43,8 @@ async function encode(value: string, what: 'name' | 'query'): Promise<string> {
   return cryptoManager.encryptText(value);
 }
 
-async function decode(stored: string): Promise<string> {
+/** `null` = ciphertext present but undecryptable (wrong key epoch / corruption). */
+async function decode(stored: string): Promise<string | null> {
   if (!stored) return '';
   if (!cryptoManager.isInitialized()) {
     throw new Error('[E2E] decode saved-search called without master key loaded');
@@ -51,16 +52,16 @@ async function decode(stored: string): Promise<string> {
   try {
     return await cryptoManager.decryptText(stored);
   } catch {
-    return ''; // deszyfrowanie nie powiodło się (uszkodzone dane)
+    return null;
   }
 }
 
 async function decodeMetadata(
   stored?: string
-): Promise<Required<SavedSearchSensitiveMetadata>> {
-  // Missing or undecryptable metadata degrades to the conservative defaults
-  // (title-only search, not root-pinned) instead of erroring - same posture as
-  // the name/query codec.
+): Promise<Required<SavedSearchSensitiveMetadata> | null> {
+  // A missing bundle is a legal legacy state and degrades to the conservative
+  // defaults (title-only search, not root-pinned); a present-but-undecryptable
+  // bundle returns null so callers can tell corruption apart from absence.
   if (!stored) return { search_in_content: false, pinned_to_root: false };
   if (!cryptoManager.isInitialized()) {
     throw new Error('[E2E] decode saved-search metadata called without master key loaded');
@@ -69,16 +70,51 @@ async function decodeMetadata(
     const meta = await cryptoManager.decryptObject<SavedSearchSensitiveMetadata>(stored);
     return { search_in_content: !!meta.search_in_content, pinned_to_root: !!meta.pinned_to_root };
   } catch {
-    return { search_in_content: false, pinned_to_root: false };
+    return null;
   }
 }
 
-async function toDecrypted(enc: SavedSearchEncrypted): Promise<SavedSearchDecrypted> {
-  const meta = await decodeMetadata(enc.metadata_encrypted);
+const METADATA_DEFAULTS: Required<SavedSearchSensitiveMetadata> = {
+  search_in_content: false,
+  pinned_to_root: false
+};
+
+// Rows that already failed to decrypt this session, keyed by id with the
+// updated_at they failed at. Refreshes run after every sync pull and re-decode
+// every row - without this cache a permanently undecryptable row would repeat
+// the same crypto errors in the console on each cycle. A changed updated_at
+// (row rewritten, possibly from a device holding the right key) retries.
+const undecryptableRows = new Map<string, string>();
+
+function toUndecryptable(enc: SavedSearchEncrypted): SavedSearchDecrypted {
   return {
     id: enc.id,
-    name: await decode(enc.name_encrypted),
-    query: await decode(enc.query_encrypted),
+    name: '',
+    query: '',
+    search_in_content: false,
+    pinned_to_root: false,
+    folder_id: enc.folder_id,
+    position: enc.position,
+    created_at: enc.created_at,
+    updated_at: enc.updated_at,
+    decrypt_failed: true
+  };
+}
+
+async function toDecrypted(enc: SavedSearchEncrypted): Promise<SavedSearchDecrypted> {
+  if (undecryptableRows.get(enc.id) === enc.updated_at) return toUndecryptable(enc);
+  const meta = await decodeMetadata(enc.metadata_encrypted);
+  const name = await decode(enc.name_encrypted);
+  const query = await decode(enc.query_encrypted);
+  if (meta === null || name === null || query === null) {
+    undecryptableRows.set(enc.id, enc.updated_at);
+    return toUndecryptable(enc);
+  }
+  undecryptableRows.delete(enc.id);
+  return {
+    id: enc.id,
+    name,
+    query,
     search_in_content: meta.search_in_content,
     // Folder-pin wins over root-pin: a search with a live folder_id is shown in
     // the folder tree, never duplicated at the top level (mutual exclusivity is
@@ -183,7 +219,9 @@ export async function updateSavedSearchQuery(
   if (!trimmedQuery) throw new Error('Saved search query must not be empty');
   const query_encrypted = await encode(trimmedQuery, 'query');
 
-  const meta = await decodeMetadata(existing.metadata_encrypted);
+  // An undecryptable bundle falls back to the defaults; re-encoding then writes
+  // a fresh bundle under the current key (effectively repairs the row).
+  const meta = (await decodeMetadata(existing.metadata_encrypted)) ?? METADATA_DEFAULTS;
   const contentChanged = meta.search_in_content !== searchInContent;
   if (contentChanged && !cryptoManager.isInitialized()) {
     throw new Error('[E2E] encode saved-search metadata called without master key loaded');
@@ -228,7 +266,8 @@ async function setSavedSearchPin(
   const nextFolderId = 'folderId' in target ? target.folderId : null;
   const nextRoot = 'root' in target;
 
-  const meta = await decodeMetadata(existing.metadata_encrypted);
+  // Undecryptable bundle → defaults (see updateSavedSearchQuery).
+  const meta = (await decodeMetadata(existing.metadata_encrypted)) ?? METADATA_DEFAULTS;
   const rootChanged = meta.pinned_to_root !== nextRoot;
   if (rootChanged && !cryptoManager.isInitialized()) {
     throw new Error('[E2E] encode saved-search metadata called without master key loaded');

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -549,7 +549,9 @@
     "unpark": "Lösen",
     "delete": "Löschen",
     "delete_confirm_title": "„{name}“ löschen?",
-    "delete_confirm_desc": "Nur die gespeicherte Ansicht wird entfernt - Ihre Notizen bleiben unberührt."
+    "delete_confirm_desc": "Nur die gespeicherte Ansicht wird entfernt - Ihre Notizen bleiben unberührt.",
+    "undecryptable": "Entschlüsselung nicht möglich",
+    "undecryptable_hint": "Diese gespeicherte Suche konnte mit Ihrem Schlüssel nicht entschlüsselt werden. Sie kann nur gelöscht werden."
   },
   "sort": {
     "title": "Sortieren nach",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -549,7 +549,9 @@
     "unpark": "Unpin",
     "delete": "Delete",
     "delete_confirm_title": "Delete \"{name}\"?",
-    "delete_confirm_desc": "Only the saved view is removed - your notes are not affected."
+    "delete_confirm_desc": "Only the saved view is removed - your notes are not affected.",
+    "undecryptable": "Cannot decrypt",
+    "undecryptable_hint": "This saved search could not be decrypted with your encryption key. It can only be deleted."
   },
   "sort": {
     "title": "Sort by",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -549,7 +549,9 @@
     "unpark": "Desfijar",
     "delete": "Eliminar",
     "delete_confirm_title": "¿Eliminar \"{name}\"?",
-    "delete_confirm_desc": "Solo se elimina la vista guardada: sus notas no se ven afectadas."
+    "delete_confirm_desc": "Solo se elimina la vista guardada: sus notas no se ven afectadas.",
+    "undecryptable": "No se puede descifrar",
+    "undecryptable_hint": "No se pudo descifrar esta búsqueda guardada con su clave de cifrado. Solo puede eliminarla."
   },
   "sort": {
     "title": "Ordenar por",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -549,7 +549,9 @@
     "unpark": "Détacher",
     "delete": "Supprimer",
     "delete_confirm_title": "Supprimer « {name} » ?",
-    "delete_confirm_desc": "Seule la vue enregistrée est supprimée - vos notes ne sont pas affectées."
+    "delete_confirm_desc": "Seule la vue enregistrée est supprimée - vos notes ne sont pas affectées.",
+    "undecryptable": "Déchiffrement impossible",
+    "undecryptable_hint": "Impossible de déchiffrer cette recherche enregistrée avec votre clé de chiffrement. Elle peut uniquement être supprimée."
   },
   "sort": {
     "title": "Trier par",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -549,7 +549,9 @@
     "unpark": "Odepnij",
     "delete": "Usuń",
     "delete_confirm_title": "Usunąć \"{name}\"?",
-    "delete_confirm_desc": "Usuwany jest tylko zapisany widok - notatki pozostają nietknięte."
+    "delete_confirm_desc": "Usuwany jest tylko zapisany widok - notatki pozostają nietknięte.",
+    "undecryptable": "Nie można odszyfrować",
+    "undecryptable_hint": "Tego zapisanego wyszukiwania nie udało się odszyfrować Twoim kluczem szyfrowania. Można je tylko usunąć."
   },
   "sort": {
     "title": "Sortuj według",

--- a/packages/types/src/entities/saved-search.ts
+++ b/packages/types/src/entities/saved-search.ts
@@ -26,6 +26,13 @@ export interface SavedSearchDecrypted {
   position: number;
   created_at: string;
   updated_at: string;
+  /**
+   * True when any of the row's ciphertexts could not be decrypted with the
+   * current master key (foreign key epoch / corrupted data). Such a row keeps
+   * empty name/query and default metadata; the UI renders an explicit
+   * placeholder and only offers deletion.
+   */
+  decrypt_failed?: boolean;
 }
 
 /**
@@ -57,11 +64,11 @@ export const MAX_SAVED_SEARCH_NAME_CHARS = 100;
 /** Maximum plaintext saved-search query length in characters (client-side). */
 export const MAX_SAVED_SEARCH_QUERY_CHARS = 512;
 
-/** Maximum encrypted saved-search name — server Zod. Mirrors folder names. */
+/** Maximum encrypted saved-search name - server Zod. Mirrors folder names. */
 export const MAX_ENCRYPTED_SAVED_SEARCH_NAME_BYTES = 750;
 
-/** Maximum encrypted saved-search query — server Zod. 512 plaintext chars fit with margin. */
+/** Maximum encrypted saved-search query - server Zod. 512 plaintext chars fit with margin. */
 export const MAX_ENCRYPTED_SAVED_SEARCH_QUERY_BYTES = 2_000;
 
-/** Maximum encrypted saved-search metadata bundle — server Zod. Tiny JSON flag object. */
+/** Maximum encrypted saved-search metadata bundle - server Zod. Tiny JSON flag object. */
 export const MAX_ENCRYPTED_SAVED_SEARCH_METADATA_BYTES = 500;


### PR DESCRIPTION
## Summary

Follow-up to the console decrypt errors reported while testing #409 (root cause is independent of that PR): a saved-search row encrypted under a different master key (foreign key epoch / corruption) silently degraded to an empty name - rendering a blank row - and the post-sync store refresh re-attempted decryption on every sync cycle, repeating the same CryptoManager/Encryption errors in the console.

- The saved-search codec now distinguishes undecryptable ciphertext from a legally absent metadata bundle; any failed field marks the whole row `decrypt_failed` (empty name/query, default metadata).
- A session-scoped cache (id + `updated_at`) skips re-decryption of known-bad rows on later refreshes, so crypto errors surface once per session instead of after every sync; a rewritten row is retried and unflagged when it decodes again.
- `SavedSearchRow` renders such rows as an italic "Cannot decrypt" placeholder with an explanatory tooltip; selection is inert and every action surface (kebab, right-click, mobile sheet) offers only Delete.
- Mutations keep the repair path: editing the query/pin of a row with an undecryptable metadata bundle re-encodes a fresh bundle under the current key.
- `decrypt_failed?: boolean` added to `SavedSearchDecrypted` (@reborn/types, additive); 2 new i18n keys in all 5 locales; 5 new spec cases (22 total in the service spec, full notes suite 1203 green).

Folders/tags/notes share the same silent-blank failure mode; extending the pattern there is noted as a backlog item (FolderTree is untouched here to avoid conflicting with #409).

## Test plan

- Search panel: the ghost saved-search row (empty name until now) should render as italic "Nie można odszyfrować" with a tooltip; clicking it does nothing; kebab/right-click/mobile sheet show only Delete; deleting it removes the row locally and on the server.
- After deletion, the [CryptoManager]/[Encryption] console errors no longer appear on subsequent syncs; before deletion they appear at most once per session (first refresh), not on every sync.
- Healthy saved searches: unchanged behavior (select, rename, edit query, pin/unpin, delete).