### PR TITLE
fix(notes): surface undecryptable folders, tags and notes

### DIFF
--- a/apps/reborn-notes/src/lib/components/SubfolderList.svelte
+++ b/apps/reborn-notes/src/lib/components/SubfolderList.svelte
@@ -91,7 +91,15 @@
             onkeydown={(e) => e.key === 'Enter' && onselect(folder.id)}
           >
             <Folder class="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span class="min-w-0 flex-1 truncate">{folder.name}</span>
+            {#if folder.decrypt_failed}
+              <!-- Name is the only ciphertext - the folder itself stays browsable. -->
+              <span
+                class="min-w-0 flex-1 truncate italic text-muted-foreground"
+                title={$t('folders.undecryptable_hint')}>{$t('folders.undecryptable')}</span
+              >
+            {:else}
+              <span class="min-w-0 flex-1 truncate">{folder.name}</span>
+            {/if}
             <ChevronRight
               class="h-4 w-4 shrink-0 text-muted-foreground/60 transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground"
             />

--- a/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
+++ b/apps/reborn-notes/src/lib/components/editor/NoteEditorHeader.svelte
@@ -209,7 +209,16 @@
 
   {#if !activeTrash}
     <!-- Save status indicator (before E2EE to avoid layout shift) -->
-    {#if noteDetailService.saveStatus === 'over_limit'}
+    {#if noteDetailService.decryptFailed}
+      <!-- Undecryptable note (defense in depth - such notes normally can't be
+           opened from the list): edits/saves are no-ops, say why. -->
+      <span
+        class="flex h-7 w-7 shrink-0 items-center justify-center text-destructive"
+        title={$t('notes.undecryptable_hint')}
+      >
+        <AlertTriangle class="h-4 w-4" />
+      </span>
+    {:else if noteDetailService.saveStatus === 'over_limit'}
       <span
         class="flex h-7 w-7 shrink-0 items-center justify-center text-destructive"
         title={$t('notes.errors.size_limit_exceeded', {

--- a/apps/reborn-notes/src/lib/components/folders/FolderTreePicker.svelte
+++ b/apps/reborn-notes/src/lib/components/folders/FolderTreePicker.svelte
@@ -288,10 +288,17 @@
               onclick={(e) => selectFolder(folder.id, e)}
               disabled={isCurrent}
               aria-current={isCurrent ? 'true' : undefined}
-              title={folder.name}
+              title={folder.decrypt_failed ? $t('folders.undecryptable_hint') : folder.name}
             >
               <FolderIcon class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span class="min-w-0 flex-1 truncate">{folder.name}</span>
+              {#if folder.decrypt_failed}
+                <!-- Still a valid move target - only its NAME is undecryptable. -->
+                <span class="min-w-0 flex-1 truncate italic text-muted-foreground"
+                  >{$t('folders.undecryptable')}</span
+                >
+              {:else}
+                <span class="min-w-0 flex-1 truncate">{folder.name}</span>
+              {/if}
               {#if isCurrent}
                 <Check class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
               {/if}

--- a/apps/reborn-notes/src/lib/components/notes/MoveToFolderMenu.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/MoveToFolderMenu.svelte
@@ -380,12 +380,27 @@
               onclick={(e) => handleRowClick(folder.id, e)}
               disabled={isCurrent || isExcluded}
               aria-current={isCurrent ? 'true' : undefined}
-              title={isCurrent ? $t('notes.folder_current_location') : folder.name}
+              title={isCurrent
+                ? $t('notes.folder_current_location')
+                : folder.decrypt_failed
+                  ? $t('folders.undecryptable_hint')
+                  : folder.name}
             >
               <FolderIcon class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span class="min-w-0 flex-1 truncate {isExcluded ? 'opacity-50' : ''}">
-                {folder.name}
-              </span>
+              {#if folder.decrypt_failed}
+                <!-- Still a valid move target - only its NAME is undecryptable. -->
+                <span
+                  class="min-w-0 flex-1 truncate italic text-muted-foreground {isExcluded
+                    ? 'opacity-50'
+                    : ''}"
+                >
+                  {$t('folders.undecryptable')}
+                </span>
+              {:else}
+                <span class="min-w-0 flex-1 truncate {isExcluded ? 'opacity-50' : ''}">
+                  {folder.name}
+                </span>
+              {/if}
               {#if isCurrent}
                 <Check class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
               {/if}

--- a/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteActionSheet.svelte
@@ -97,10 +97,33 @@
        action list scrolls. -->
   <SheetContent side="bottom" class="flex max-h-[85dvh] flex-col">
     <SheetHeader class="shrink-0 pr-8 text-left">
-      <SheetTitle class="line-clamp-2 text-left">{note?.title || $t('notes.untitled')}</SheetTitle>
+      <SheetTitle class="line-clamp-2 text-left"
+        >{note?.decrypt_failed
+          ? $t('notes.undecryptable')
+          : note?.title || $t('notes.untitled')}</SheetTitle
+      >
     </SheetHeader>
     <div class="flex-1 space-y-1 overflow-y-auto">
-      {#if isTrash}
+      {#if note?.decrypt_failed && !isTrash}
+        <!-- Undecryptable note: deletion only (see NoteListItem). Trash rows
+             fall through - restore / permanent delete are both row-level ops. -->
+        <p class="px-3 pb-2 text-sm text-muted-foreground">
+          {$t('notes.undecryptable_hint')}
+        </p>
+        <Button
+          variant="ghost"
+          class="w-full justify-start text-destructive hover:text-destructive"
+          onclick={() => note && ondelete(note.id)}
+        >
+          <Trash2 class="mr-2 h-4 w-4" />
+          {$t('notes.delete_note')}
+        </Button>
+      {:else if isTrash}
+        {#if note?.decrypt_failed}
+          <p class="px-3 pb-2 text-sm text-muted-foreground">
+            {$t('notes.undecryptable_hint')}
+          </p>
+        {/if}
         <Button
           variant="ghost"
           class="w-full justify-start"

--- a/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
+++ b/apps/reborn-notes/src/lib/components/notes/NoteListItem.svelte
@@ -63,16 +63,16 @@
   }: {
     note: NoteListItem;
     isTrash?: boolean;
-    /** Folder path to show under the title — used for search results from subfolders. */
+    /** Folder path to show under the title - used for search results from subfolders. */
     breadcrumb?: string;
     movingNoteId: string | null;
     /** Whether the parent NoteList is currently in multi-select mode. */
     selectionMode?: boolean;
     /** Whether this item is currently selected. */
     isSelected?: boolean;
-    /** Long-press / Cmd-click on a non-selection list — enter selection mode with this item. */
+    /** Long-press / Cmd-click on a non-selection list - enter selection mode with this item. */
     onenterselection?: () => void;
-    /** Click while in selection mode — toggle this item. opts.shift = range from last anchor. */
+    /** Click while in selection mode - toggle this item. opts.shift = range from last anchor. */
     ontoggleselect?: (opts?: { shift?: boolean }) => void;
     onmenuopen: (noteId: string) => void;
     onpin: (noteId: string, e?: Event) => void;
@@ -116,7 +116,17 @@
     }
   });
 
-  // Single source of truth for the row's actions — fed to both the desktop kebab
+  // Undecryptable rows (foreign key epoch / corrupted ciphertext) render an
+  // explicit placeholder instead of a blank title and never open the editor -
+  // its debounced save would overwrite the ciphertext with an empty body. The
+  // menu shrinks to deletion (trash rows keep restore + permanent delete: both
+  // operate on the row, not its plaintext). Selection mode still works, so
+  // bulk delete can sweep several ghosts at once.
+  const displayTitle = $derived(
+    note.decrypt_failed ? $t('notes.undecryptable') : note.title || $t('notes.untitled')
+  );
+
+  // Single source of truth for the row's actions - fed to both the desktop kebab
   // (DropdownMenu) and the desktop right-click ContextMenu, so they can't drift.
   const noteActions: RowAction[] = $derived(
     isTrash
@@ -136,7 +146,17 @@
             separatorBefore: true
           }
         ]
-      : [
+      : note.decrypt_failed
+        ? [
+            {
+              key: 'delete',
+              icon: Trash2,
+              label: $t('notes.delete_note'),
+              run: (e) => ondelete(note.id, e),
+              destructive: true
+            }
+          ]
+        : [
           {
             key: 'pin',
             icon: note.is_pinned ? PinOff : Pin,
@@ -193,7 +213,7 @@
 
   function handleItemClick(e: MouseEvent) {
     if (selectionMode) {
-      // Click in selection mode never opens the note — toggle selection instead.
+      // Click in selection mode never opens the note - toggle selection instead.
       // shift-click extends from the last anchor; cmd/ctrl-click also toggles single.
       ontoggleselect?.({ shift: e.shiftKey });
       return;
@@ -204,6 +224,7 @@
       onenterselection?.();
       return;
     }
+    if (note.decrypt_failed) return; // inert - never open the editor on a ghost
     activeNoteId.set(note.id);
   }
 
@@ -211,7 +232,7 @@
     if (e.key !== 'Enter') return;
     if (selectionMode) {
       ontoggleselect?.({ shift: e.shiftKey });
-    } else {
+    } else if (!note.decrypt_failed) {
       activeNoteId.set(note.id);
     }
   }
@@ -238,7 +259,9 @@
             e.dataTransfer!.setData('text/plain', note.id);
           }}
           use:longPress={() => onenterselection?.()}
-          class="note-item-bg group flex cursor-pointer items-start gap-2 rounded-lg p-4 md:p-3 transition-colors
+          class="note-item-bg group flex {note.decrypt_failed && !selectionMode
+            ? 'cursor-default'
+            : 'cursor-pointer'} items-start gap-2 rounded-lg p-4 md:p-3 transition-colors
             {isActive && !selectionMode ? 'list-row-active text-accent-foreground' : ''}
             {selectionMode && isSelected ? 'bg-primary/10' : ''}
             {selectionMode ? 'select-none' : ''}"
@@ -274,8 +297,12 @@
 
           <div class="min-w-0 flex-1">
             <div class="flex items-start gap-1">
-              <p class="min-w-0 flex-1 line-clamp-2 text-base md:text-sm font-normal leading-snug text-foreground">
-                {note.title || $t('notes.untitled')}
+              <p
+                class="min-w-0 flex-1 line-clamp-2 text-base md:text-sm font-normal leading-snug
+                  {note.decrypt_failed ? 'italic text-muted-foreground' : 'text-foreground'}"
+                title={note.decrypt_failed ? $t('notes.undecryptable_hint') : undefined}
+              >
+                {displayTitle}
               </p>
               <!-- Star indicator -->
               {#if note.is_starred}
@@ -319,7 +346,7 @@
             {/if}
           </div>
 
-          <!-- Kebab menu button (hidden in selection mode — bulk actions live in the selection bar) -->
+          <!-- Kebab menu button (hidden in selection mode - bulk actions live in the selection bar) -->
           <div class="shrink-0 mt-1.5 md:-mt-1 {selectionMode ? 'invisible pointer-events-none' : ''}">
             {#if isMobileQuery.value}
               <button

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -195,6 +195,16 @@
     onselect(folder.id);
   }
 
+  // Undecryptable rows (foreign key epoch / corrupted ciphertext) render an
+  // explicit placeholder instead of a blank name. Unlike saved searches
+  // (Delete-only, #410), the name is a folder's ONLY ciphertext: selection,
+  // expansion and the subtree stay fully usable, and a rename re-encrypts the
+  // name under the current key - i.e. repairs the row - so the menu offers
+  // Rename + Delete.
+  function folderDisplayName(folder: FolderWithChildren): string {
+    return folder.decrypt_failed ? $t('folders.undecryptable') : folder.name;
+  }
+
   // ── Context menu (kebab) ────────────────────────────────────────
   const isMobileQuery = useIsMobile();
   let menuOpenId = $state<string | null>(null);
@@ -374,6 +384,24 @@
   // Single source of truth for a folder's actions - fed to both the desktop kebab
   // (DropdownMenu) and the desktop right-click ContextMenu, so they can't drift.
   function folderActions(folder: FolderWithChildren, syncConfigId: string | null): RowAction[] {
+    if (folder.decrypt_failed) {
+      return [
+        {
+          key: 'rename',
+          icon: Pencil,
+          label: $t('folders.rename'),
+          run: (e) => startRename(folder, e)
+        },
+        {
+          key: 'delete',
+          icon: Trash2,
+          label: $t('folders.delete_folder'),
+          run: (e) => handleDelete(folder, e),
+          destructive: true,
+          separatorBefore: true
+        }
+      ];
+    }
     const actions: RowAction[] = [];
     if (syncConfigId) {
       actions.push({
@@ -996,7 +1024,8 @@
               tabindex="0"
               onclick={() => handleRowSelect(folder)}
               onkeydown={(e) => e.key === 'Enter' && handleRowSelect(folder)}
-              aria-label={$t('folders.folder_label', { values: { name: folder.name } })}
+              aria-label={$t('folders.folder_label', { values: { name: folderDisplayName(folder) } })}
+              title={folder.decrypt_failed ? $t('folders.undecryptable_hint') : undefined}
             >
               <!-- Custom sort: insertion line for a between-rows drop. Starts
                    at the row's own indent so the target LEVEL is visible
@@ -1034,6 +1063,10 @@
                   }}
                   onblur={() => commitRename(folder.id)}
                 />
+              {:else if folder.decrypt_failed}
+                <span class="min-w-0 flex-1 truncate italic text-muted-foreground"
+                  >{folderDisplayName(folder)}</span
+                >
               {:else}
                 <span class="min-w-0 flex-1 truncate">{folder.name}</span>
               {/if}
@@ -1164,9 +1197,30 @@
 <Sheet bind:open={folderActionSheetOpen}>
   <SheetContent side="bottom" class="h-auto">
     <SheetHeader>
-      <SheetTitle>{activeMenuFolder?.name ?? ''}</SheetTitle>
+      <SheetTitle>{activeMenuFolder ? folderDisplayName(activeMenuFolder) : ''}</SheetTitle>
     </SheetHeader>
     <div class="mt-4 space-y-1">
+      {#if activeMenuFolder?.decrypt_failed}
+        <p class="px-3 pb-2 text-sm text-muted-foreground">
+          {$t('folders.undecryptable_hint')}
+        </p>
+        <Button
+          variant="ghost"
+          class="w-full justify-start"
+          onclick={() => activeMenuFolder && handleStartRename(activeMenuFolder)}
+        >
+          <Pencil class="mr-2 h-4 w-4" />
+          {$t('folders.rename')}
+        </Button>
+        <Button
+          variant="ghost"
+          class="w-full justify-start text-destructive hover:text-destructive"
+          onclick={() => activeMenuFolder && handleDelete(activeMenuFolder)}
+        >
+          <Trash2 class="mr-2 h-4 w-4" />
+          {$t('folders.delete_folder')}
+        </Button>
+      {:else}
       {#if activeMenuSyncId}
         <Button
           variant="ghost"
@@ -1248,6 +1302,7 @@
         <Trash2 class="mr-2 h-4 w-4" />
         {$t('folders.delete_folder')}
       </Button>
+      {/if}
     </div>
   </SheetContent>
 </Sheet>
@@ -1255,7 +1310,7 @@
 <DeleteFolderDialog
   bind:open={deleteFolderDialogOpen}
   folderId={folderToDelete?.id ?? null}
-  folderName={folderToDelete?.name ?? ''}
+  folderName={folderToDelete ? folderDisplayName(folderToDelete) : ''}
   onConfirm={confirmDeleteFolder}
 />
 

--- a/apps/reborn-notes/src/lib/components/tags/TagActionSheet.svelte
+++ b/apps/reborn-notes/src/lib/components/tags/TagActionSheet.svelte
@@ -19,9 +19,20 @@
 <Sheet bind:open={tagManager.tagActionSheetOpen}>
   <SheetContent side="bottom" class="h-auto">
     <SheetHeader>
-      <SheetTitle>{activeMenuTag?.name ?? ''}</SheetTitle>
+      <SheetTitle
+        >{activeMenuTag?.decrypt_failed
+          ? $t('tags.undecryptable')
+          : (activeMenuTag?.name ?? '')}</SheetTitle
+      >
     </SheetHeader>
     <div class="mt-4 space-y-1">
+      {#if activeMenuTag?.decrypt_failed}
+        <!-- Rename repairs the row (the name is the tag's whole ciphertext);
+             the color picker is pointless on a row whose color degraded. -->
+        <p class="px-3 pb-2 text-sm text-muted-foreground">
+          {$t('tags.undecryptable_hint')}
+        </p>
+      {/if}
       <Button
         variant="ghost"
         class="w-full justify-start"
@@ -32,15 +43,17 @@
         <Pencil class="mr-2 h-4 w-4" />
         {$t('tags.rename')}
       </Button>
-      <Button
-        variant="ghost"
-        class="w-full justify-start"
-        onclick={() =>
-          activeMenuTag && tagManager.startColorPicker(activeMenuTag.id)}
-      >
-        <Palette class="mr-2 h-4 w-4" />
-        {$t('tags.tag_color')}
-      </Button>
+      {#if !activeMenuTag?.decrypt_failed}
+        <Button
+          variant="ghost"
+          class="w-full justify-start"
+          onclick={() =>
+            activeMenuTag && tagManager.startColorPicker(activeMenuTag.id)}
+        >
+          <Palette class="mr-2 h-4 w-4" />
+          {$t('tags.tag_color')}
+        </Button>
+      {/if}
       <Button
         variant="ghost"
         class="w-full justify-start text-destructive hover:text-destructive"

--- a/apps/reborn-notes/src/lib/components/tags/TagListMobile.svelte
+++ b/apps/reborn-notes/src/lib/components/tags/TagListMobile.svelte
@@ -115,7 +115,13 @@
                 style={tag.color ? `background-color: ${tag.color}` : ''}
                 class:bg-muted-foreground={!tag.color}
               ></span>
-              <span class="min-w-0 flex-1 truncate text-left text-sm">{tag.name}</span>
+              {#if tag.decrypt_failed}
+                <span class="min-w-0 flex-1 truncate text-left text-sm italic text-muted-foreground"
+                  >{$t('tags.undecryptable')}</span
+                >
+              {:else}
+                <span class="min-w-0 flex-1 truncate text-left text-sm">{tag.name}</span>
+              {/if}
             </button>
             <button
               type="button"

--- a/apps/reborn-notes/src/lib/components/tags/TagSidebarSection.svelte
+++ b/apps/reborn-notes/src/lib/components/tags/TagSidebarSection.svelte
@@ -42,8 +42,12 @@
       : $tagsStore
   );
 
-  // Single source of truth for a tag's actions — fed to both the kebab
+  // Single source of truth for a tag's actions - fed to both the kebab
   // (DropdownMenu) and the right-click ContextMenu, so they can't drift.
+  // An undecryptable tag (foreign key epoch / corrupted ciphertext) keeps
+  // rename - the name is the tag's whole ciphertext, so renaming re-encrypts
+  // it under the current key and repairs the row - plus delete; the color
+  // picker is pointless on a row whose color degraded to none.
   function tagActions(tag: TagDecrypted): RowAction[] {
     return [
       {
@@ -52,12 +56,16 @@
         label: $t('tags.rename'),
         run: () => tagManager.startRenameTag(tag.id, tag.name)
       },
-      {
-        key: 'color',
-        icon: Palette,
-        label: $t('tags.tag_color'),
-        run: () => tagManager.startColorPicker(tag.id)
-      },
+      ...(tag.decrypt_failed
+        ? []
+        : [
+            {
+              key: 'color',
+              icon: Palette,
+              label: $t('tags.tag_color'),
+              run: () => tagManager.startColorPicker(tag.id)
+            }
+          ]),
       {
         key: 'delete',
         icon: Trash2,
@@ -191,7 +199,14 @@
                       style={tag.color ? `background-color: ${tag.color}` : ''}
                       class:bg-muted-foreground={!tag.color}
                     ></span>
-                    <span class="min-w-0 flex-1 truncate text-left text-sm">{tag.name}</span>
+                    {#if tag.decrypt_failed}
+                      <span
+                        class="min-w-0 flex-1 truncate text-left text-sm italic text-muted-foreground"
+                        title={$t('tags.undecryptable_hint')}>{$t('tags.undecryptable')}</span
+                      >
+                    {:else}
+                      <span class="min-w-0 flex-1 truncate text-left text-sm">{tag.name}</span>
+                    {/if}
                   </button>
                   <DropdownMenu>
                     <DropdownMenuTrigger>

--- a/apps/reborn-notes/src/lib/services/folder.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder.service.ts
@@ -29,6 +29,7 @@ import {
 import { noteIndex } from '$lib/services/note-index.svelte';
 import { getSetting } from '$lib/utils/app-settings';
 import { sortFoldersByCustomOrder, sortFoldersByName } from '$lib/utils/folder-helpers';
+import { createUndecryptableRowCache, decodeTextField } from './undecryptable-rows';
 
 // ── User identity ─────────────────────────────────────────────────
 
@@ -46,23 +47,39 @@ async function encodeName(name: string): Promise<string> {
   return cryptoManager.encryptText(name);
 }
 
-async function decodeName(stored: string): Promise<string> {
-  if (!stored) return '';
-  if (!cryptoManager.isInitialized()) {
-    throw new Error('[E2E] decodeName called without master key loaded');
-  }
-  try {
-    return await cryptoManager.decryptText(stored);
-  } catch {
-    return ''; // deszyfrowanie nie powiodło się (uszkodzone dane)
-  }
-}
+// Session cache of rows that already failed to decrypt - see
+// undecryptable-rows.ts for the shared pattern (guideline 63, #15).
+const undecryptableRows = createUndecryptableRowCache();
 
-async function toDecrypted(enc: FolderEncrypted): Promise<Omit<FolderWithChildren, 'children'>> {
+// The name is the folder's ONLY ciphertext: structure (parent_id), ordering and
+// contents stay fully usable on an undecryptable row, and a rename re-encrypts
+// the name under the current key (= repairs the row). The UI therefore keeps
+// selection/expansion active and offers rename + delete.
+function toUndecryptable(enc: FolderEncrypted): Omit<FolderWithChildren, 'children'> {
   return {
     id: enc.id,
     parent_id: enc.parent_id,
-    name: await decodeName(enc.name_encrypted),
+    name: '',
+    order_index: enc.order_index,
+    is_archived: enc.is_archived,
+    created_at: enc.created_at,
+    updated_at: enc.updated_at,
+    decrypt_failed: true
+  };
+}
+
+async function toDecrypted(enc: FolderEncrypted): Promise<Omit<FolderWithChildren, 'children'>> {
+  if (undecryptableRows.has(enc.id, enc.updated_at)) return toUndecryptable(enc);
+  const name = await decodeTextField(enc.name_encrypted, 'folder name');
+  if (name === null) {
+    undecryptableRows.mark(enc.id, enc.updated_at);
+    return toUndecryptable(enc);
+  }
+  undecryptableRows.clear(enc.id);
+  return {
+    id: enc.id,
+    parent_id: enc.parent_id,
+    name,
     order_index: enc.order_index,
     is_archived: enc.is_archived,
     created_at: enc.created_at,

--- a/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-detail.service.svelte.ts
@@ -19,12 +19,21 @@ interface NoteEditState {
 }
 
 class NoteDetailService {
-  // ── Reactive state (Svelte 5 runes — used in .svelte files) ──
+  // ── Reactive state (Svelte 5 runes - used in .svelte files) ──
   title = $state('');
   content = $state('');
   folderId = $state<string | null | undefined>(undefined);
   saveStatus = $state<SaveStatus>('idle');
   isNewNote = $state(false);
+  /**
+   * The loaded note's ciphertext failed to decrypt (see undecryptable-rows.ts).
+   * The editor buffer is left empty and every write path below is a no-op:
+   * saving would overwrite the (possibly foreign-keyed) ciphertext with an
+   * empty body. Normally unreachable - list rows of such notes don't open -
+   * but programmatic setters of activeNoteId (nav history, deep links) funnel
+   * through loadNote, so the guard lives here.
+   */
+  decryptFailed = $state(false);
 
   /** Current note size in bytes (title + content). */
   contentSize = $derived(new Blob([this.title, this.content]).size);
@@ -41,7 +50,7 @@ class NoteDetailService {
   private contentDebounceTimer?: ReturnType<typeof setTimeout>;
   private readonly DEBOUNCE_MS = 2000;
 
-  // Checkpoint timer — saves version snapshot every 30 minutes of editing
+  // Checkpoint timer - saves version snapshot every 30 minutes of editing
   private checkpointTimer?: ReturnType<typeof setInterval>;
   private readonly CHECKPOINT_MS = 30 * 60 * 1000; // 30 min
   private editedSinceLastSnapshot = false;
@@ -89,6 +98,7 @@ class NoteDetailService {
     this.baselineCaptured = false;
     const note = await notesStore.loadNote(id);
     if (note) {
+      this.decryptFailed = note.decrypt_failed === true;
       this.title = note.title;
       this.content = note.content;
       this.folderId = note.folder_id ?? null;
@@ -108,6 +118,9 @@ class NoteDetailService {
 
     const note = await notesStore.loadNote(id);
     if (!note) return;
+    // A pull can rewrite the open note into an undecryptable state (foreign
+    // key epoch). Keep the in-memory plaintext - it is the best copy there is.
+    if (note.decrypt_failed) return;
 
     if (this.title !== note.title) this.title = note.title;
     if (this.content !== note.content) this.content = note.content;
@@ -119,6 +132,7 @@ class NoteDetailService {
    * Set title with debounce. Captures value synchronously.
    */
   setTitleDebounced(title: string): void {
+    if (this.decryptFailed) return;
     this.captureBaselineSnapshot();
     this.title = title;
     this.pendingTitle = title;
@@ -138,6 +152,7 @@ class NoteDetailService {
    * Set content with debounce. Captures value synchronously.
    */
   setContentDebounced(content: string): void {
+    if (this.decryptFailed) return;
     this.captureBaselineSnapshot();
     this.content = content;
     this.pendingContent = content;
@@ -192,12 +207,13 @@ class NoteDetailService {
 
   /**
    * Flush all pending changes immediately.
-   * Uses internal noteId — never reads reactive store.
+   * Uses internal noteId - never reads reactive store.
    * Returns true on success, false on failure.
    */
   async flushPendingSave(noteId?: string): Promise<boolean> {
     this.clearTimers();
 
+    if (this.decryptFailed) return true; // nothing legitimate to write
     if (!this.hasPendingChanges() && this.saveStatus !== 'dirty') return true;
 
     // Block save if note exceeds size limit
@@ -294,6 +310,7 @@ class NoteDetailService {
     this.folderId = undefined;
     this.saveStatus = 'idle';
     this.isNewNote = false;
+    this.decryptFailed = false;
     this.pendingTitle = null;
     this.pendingContent = null;
     this.editedSinceLastSnapshot = false;
@@ -381,7 +398,7 @@ class NoteDetailService {
 
   private async save(): Promise<void> {
     const id = this.noteId;
-    if (!id) return;
+    if (!id || this.decryptFailed) return;
 
     // Block save if note exceeds size limit
     if (this.isOverLimit) {

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -1,5 +1,5 @@
 /**
- * NoteIndex — in-memory cache of decrypted note metadata for list views.
+ * NoteIndex - in-memory cache of decrypted note metadata for list views.
  *
  * Security: RAM-only, NEVER persisted to IndexedDB/localStorage/sessionStorage.
  * Cleared on lock/logout. Rebuilt after sync.
@@ -7,9 +7,9 @@
  *
  * Consumers: NoteList, NotePicker, autocomplete [[, search sidebar.
  *
- * Replaces the old NoteTitleIndex — now stores all metadata needed for list rendering:
+ * Replaces the old NoteTitleIndex - now stores all metadata needed for list rendering:
  * title, folderId, isPinned, isStarred, isArchived, createdAt, updatedAt, tagIds.
- * Full content is NEVER stored here — loaded on demand by note-detail.service.
+ * Full content is NEVER stored here - loaded on demand by note-detail.service.
  */
 import { noteStore, noteTagStore, noteTagQueries } from '@reborn/storage';
 import { cryptoManager } from '@reborn/crypto';
@@ -28,9 +28,12 @@ export interface NoteIndexEntry {
   createdAt: string;
   updatedAt: string;
   tagIds: string[];
+  /** Row's ciphertext failed to decrypt (see undecryptable-rows.ts) - the list
+   *  renders an explicit placeholder and the row cannot be opened. */
+  decryptFailed?: boolean;
 }
 
-/** Lightweight note type for list views — NoteDecrypted minus content. */
+/** Lightweight note type for list views - NoteDecrypted minus content. */
 export type NoteListItem = Omit<NoteDecrypted, 'content' | 'deleted_at'>;
 
 export type SortBy = 'updated_at' | 'created_at' | 'title';
@@ -59,7 +62,7 @@ export interface FilterResult {
 
 /**
  * AST-driven filter options. Mirrors the pre-filter slice of FilterOptions
- * (folder/tag/starred/archived) — body content is NOT handled here. Operators
+ * (folder/tag/starred/archived) - body content is NOT handled here. Operators
  * that need decrypted content (`has:link`, freetext-in-body) are evaluated by
  * the content-search path in `notes.store.ts`, which streams one body at a
  * time through the bare `evaluate()` + `toSearchEntity()` helpers.
@@ -78,17 +81,17 @@ export interface FilterByAstOptions {
 const BATCH_SIZE = 100;
 
 class NoteIndex {
-  /** Internal map — NOT reactive on purpose; we bump _version to signal changes. */
+  /** Internal map - NOT reactive on purpose; we bump _version to signal changes. */
   private _map = new Map<string, NoteIndexEntry>();
 
-  /** Svelte 5 reactive version counter — consumers that read derived data re-render. */
+  /** Svelte 5 reactive version counter - consumers that read derived data re-render. */
   private _version = $state(0);
 
   private _building = $state(false);
 
   // ── Bulk operations ────────────────────────────────────────────
 
-  /** Build the cache from scratch (after unlock). Non-blocking — processes in batches. */
+  /** Build the cache from scratch (after unlock). Non-blocking - processes in batches. */
   async build(): Promise<void> {
     if (!cryptoManager.isInitialized()) return;
     // The link graph shadows the same note set; invalidate it so it rebuilds
@@ -122,7 +125,8 @@ class NoteIndex {
             isArchived: e.isArchived,
             createdAt: e.createdAt,
             updatedAt: e.updatedAt,
-            tagIds: tagMap.get(e.id) ?? []
+            tagIds: tagMap.get(e.id) ?? [],
+            ...(e.decryptFailed ? { decryptFailed: true } : {})
           });
         }
         // Yield to event loop between batches
@@ -143,9 +147,10 @@ class NoteIndex {
    * each page lands in the index without an O(n) rebuild per page (which would
    * re-deserialize the whole notes table every page = the O(n²) trap PR #353
    * removed). Tags are read from the (already-applied) note-tag relations, so
-   * call this AFTER the page's tag deltas are written. Same crypto guard as
-   * build(): a row that fails to decrypt is skipped; a later full rebuild
-   * (refreshStoresAfterPull) reconciles it.
+   * call this AFTER the page's tag deltas are written. An undecryptable row
+   * lands flagged (decryptFailed) like in build(); the catch below only guards
+   * transient errors (e.g. crypto not ready), where skipping is right - a
+   * later full rebuild (refreshStoresAfterPull) reconciles it.
    */
   async upsertFromStore(ids: string[]): Promise<void> {
     if (!cryptoManager.isInitialized() || ids.length === 0) return;
@@ -163,7 +168,8 @@ class NoteIndex {
           isArchived: e.isArchived,
           createdAt: e.createdAt,
           updatedAt: e.updatedAt,
-          tagIds
+          tagIds,
+          ...(e.decryptFailed ? { decryptFailed: true } : {})
         });
         changed = true;
       } catch {
@@ -213,7 +219,7 @@ class NoteIndex {
     this._version++;
   }
 
-  /** Partial update — merges with existing entry. */
+  /** Partial update - merges with existing entry. */
   patch(id: string, partial: Partial<NoteIndexEntry>): void {
     const existing = this._map.get(id);
     if (!existing) return;
@@ -229,11 +235,13 @@ class NoteIndex {
 
   // ── Read API (backward-compatible with NoteTitleIndex) ─────────
 
-  /** All non-archived titles sorted by updatedAt desc. Reactive via _version. */
+  /** All non-archived titles sorted by updatedAt desc. Reactive via _version.
+   *  Excludes undecryptable rows - they feed [[link]] autocomplete and pickers,
+   *  where a blank garbage target must not be offered. */
   getAll(): { id: string; title: string }[] {
     void this._version;
     return Array.from(this._map.entries())
-      .filter(([, e]) => !e.isArchived)
+      .filter(([, e]) => !e.isArchived && !e.decryptFailed)
       .sort((a, b) => b[1].updatedAt.localeCompare(a[1].updatedAt))
       .map(([id, e]) => ({ id, title: e.title }));
   }
@@ -265,7 +273,8 @@ class NoteIndex {
       is_archived: e.isArchived,
       created_at: e.createdAt,
       updated_at: e.updatedAt,
-      tags: e.tagIds
+      tags: e.tagIds,
+      ...(e.decryptFailed ? { decrypt_failed: true } : {})
     };
   }
 
@@ -288,7 +297,7 @@ class NoteIndex {
 
   /**
    * Snapshot of all non-archived entries for dedup / lookup callers (e.g.
-   * the markdown import pipeline). Returns a new array each call — safe
+   * the markdown import pipeline). Returns a new array each call - safe
    * to mutate. Excludes archived notes; importer should not collide with
    * trashed titles.
    */
@@ -312,7 +321,7 @@ class NoteIndex {
   /**
    * Unified filtering + sorting + pagination over the in-memory index.
    *
-   * All operations are synchronous on the Map — no IndexedDB hit, no decryption.
+   * All operations are synchronous on the Map - no IndexedDB hit, no decryption.
    * Typical cost: <1ms for 10K entries.
    */
   getFiltered(options: FilterOptions = {}): FilterResult {
@@ -336,7 +345,7 @@ class NoteIndex {
     // archived filter
     entries = entries.filter(([, e]) => e.isArchived === archived);
 
-    // folder filter — folderIds (set) takes precedence over folderId (single)
+    // folder filter - folderIds (set) takes precedence over folderId (single)
     if (folderIds !== undefined) {
       const set = new Set(folderIds);
       entries = entries.filter(([, e]) => e.folderId !== undefined && set.has(e.folderId));
@@ -367,7 +376,7 @@ class NoteIndex {
 
     // 2. Sort (pinned always first, then by sort key)
     entries.sort((a, b) => {
-      // Pinned first (skip in archived/trash mode — no pin concept)
+      // Pinned first (skip in archived/trash mode - no pin concept)
       if (!archived) {
         if (a[1].isPinned && !b[1].isPinned) return -1;
         if (!a[1].isPinned && b[1].isPinned) return 1;
@@ -397,7 +406,8 @@ class NoteIndex {
       is_archived: e.isArchived,
       created_at: e.createdAt,
       updated_at: e.updatedAt,
-      tags: e.tagIds
+      tags: e.tagIds,
+      ...(e.decryptFailed ? { decrypt_failed: true } : {})
     }));
 
     return {
@@ -413,7 +423,7 @@ class NoteIndex {
    * Pre-filter (folder/tag/starred/archived) narrows the candidate set, then
    * each remaining entry is mapped to a SearchEntity (with `body = undefined`)
    * and evaluated against the AST. Operators that require content
-   * (`has:link`, freetext-in-body) are NOT served here — the caller must take
+   * (`has:link`, freetext-in-body) are NOT served here - the caller must take
    * the body-aware path in `notes.store.ts → triggerContentSearch`.
    *
    * Operator → entity mapping for notes:
@@ -422,7 +432,7 @@ class NoteIndex {
    *   - `is:completed`/`is:overdue`/`due:`     → always false (notes have no completion/due semantics)
    *   - `list:`       → always false (notes have no lists)
    *
-   * The active/trash split is handled by the `archived` pre-filter above —
+   * The active/trash split is handled by the `archived` pre-filter above -
    * there is no public `is:trashed` operator.
    */
   getFilteredByAst(
@@ -494,7 +504,8 @@ class NoteIndex {
       is_archived: e.isArchived,
       created_at: e.createdAt,
       updated_at: e.updatedAt,
-      tags: e.tagIds
+      tags: e.tagIds,
+      ...(e.decryptFailed ? { decrypt_failed: true } : {})
     }));
 
     return { items, total, hasMore: start + pageSize < total };

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -2,7 +2,7 @@
  * Note service for Reborn Notes.
  *
  * Wraps @reborn/storage note operations with E2E encryption via CryptoManager.
- * Notes are always encrypted with the user's master key — E2E must be unlocked before use.
+ * Notes are always encrypted with the user's master key - E2E must be unlocked before use.
  */
 import {
   noteStore,
@@ -31,6 +31,7 @@ import {
   pushNoteVersion,
   pullNoteVersionsForNote
 } from './notes-sync.service';
+import { createUndecryptableRowCache, decodeTextField } from './undecryptable-rows';
 
 const logger = createLogger('Note-Service');
 
@@ -52,24 +53,45 @@ async function encodeText(text: string): Promise<string> {
   return cryptoManager.encryptText(text);
 }
 
-async function decodeText(stored: string): Promise<string> {
-  if (!stored) return '';
-  if (!cryptoManager.isInitialized()) {
-    throw new Error('[E2E] decodeText called without master key loaded');
-  }
-  try {
-    return await cryptoManager.decryptText(stored);
-  } catch {
-    return ''; // deszyfrowanie nie powiodło się (uszkodzone dane)
-  }
-}
+// Session cache of rows that already failed to decrypt - see
+// undecryptable-rows.ts for the shared pattern (guideline 63, #15). Shared by
+// BOTH decode paths (full toDecrypted and the title-only NoteIndex path), so a
+// row marked by either one is served from the cache by the other.
+const undecryptableRows = createUndecryptableRowCache();
 
-async function toDecrypted(enc: NoteStoredLocal): Promise<NoteDecrypted> {
+// A note's ciphertext IS its value - unlike folders/tags there is no
+// rename-repair, so the UI renders the placeholder inert (opening the editor
+// and saving would overwrite the ciphertext with an empty body) and only
+// offers deletion.
+function toUndecryptable(enc: NoteStoredLocal): NoteDecrypted {
   return {
     id: enc.id,
     folder_id: enc.folder_id,
-    title: await decodeText(enc.title_encrypted),
-    content: await decodeText(enc.content_encrypted),
+    title: '',
+    content: '',
+    is_pinned: enc.is_pinned,
+    is_starred: enc.is_starred,
+    is_archived: enc.is_archived,
+    created_at: enc.created_at,
+    updated_at: enc.updated_at,
+    decrypt_failed: true
+  };
+}
+
+async function toDecrypted(enc: NoteStoredLocal): Promise<NoteDecrypted> {
+  if (undecryptableRows.has(enc.id, enc.updated_at)) return toUndecryptable(enc);
+  const title = await decodeTextField(enc.title_encrypted, 'note title');
+  const content = await decodeTextField(enc.content_encrypted, 'note content');
+  if (title === null || content === null) {
+    undecryptableRows.mark(enc.id, enc.updated_at);
+    return toUndecryptable(enc);
+  }
+  undecryptableRows.clear(enc.id);
+  return {
+    id: enc.id,
+    folder_id: enc.folder_id,
+    title,
+    content,
     // Shadow indexes (available directly on NoteStoredLocal)
     is_pinned: enc.is_pinned,
     is_starred: enc.is_starred,
@@ -79,7 +101,7 @@ async function toDecrypted(enc: NoteStoredLocal): Promise<NoteDecrypted> {
   };
 }
 
-/** Decrypt only the title (skip content_encrypted) — used by NoteIndex cache. */
+/** Decrypt only the title (skip content_encrypted) - used by NoteIndex cache. */
 export async function decryptTitleOnly(enc: NoteStoredLocal): Promise<{
   id: string;
   title: string;
@@ -89,17 +111,31 @@ export async function decryptTitleOnly(enc: NoteStoredLocal): Promise<{
   isArchived: boolean;
   createdAt: string;
   updatedAt: string;
+  decryptFailed: boolean;
 }> {
+  // Cache-hit also covers content-only corruption found by toDecrypted: the
+  // index entry then flags the row even though its title alone would decode.
+  // The reverse gap (content corrupt, title fine, index built first) closes
+  // the moment the full decode runs. Deliberately no clear() on success -
+  // a title-only decode cannot prove the content is healthy.
+  let title: string | null = '';
+  let decryptFailed = true;
+  if (!undecryptableRows.has(enc.id, enc.updated_at)) {
+    title = await decodeTextField(enc.title_encrypted, 'note title');
+    if (title === null) undecryptableRows.mark(enc.id, enc.updated_at);
+    else decryptFailed = false;
+  }
   return {
     id: enc.id,
-    title: await decodeText(enc.title_encrypted),
+    title: title ?? '',
     folderId: enc.folder_id,
     // Shadow indexes (available directly on NoteStoredLocal)
     isPinned: enc.is_pinned ?? false,
     isStarred: enc.is_starred ?? false,
     isArchived: enc.is_archived ?? false,
     createdAt: enc.created_at,
-    updatedAt: enc.updated_at
+    updatedAt: enc.updated_at,
+    decryptFailed
   };
 }
 
@@ -129,7 +165,7 @@ export function filterNotes(notes: NoteDecrypted[], query: string): NoteDecrypte
   );
 }
 
-/** Filter notes by title only (default search — fast, no content scan). */
+/** Filter notes by title only (default search - fast, no content scan). */
 export function filterNotesByTitle(notes: NoteDecrypted[], query: string): NoteDecrypted[] {
   if (!query.trim()) return notes;
   const q = query.toLowerCase();
@@ -300,11 +336,11 @@ export async function createNote(
 }
 
 /**
- * Update note title and/or content. Does NOT create version history — use saveVersionSnapshot().
+ * Update note title and/or content. Does NOT create version history - use saveVersionSnapshot().
  *
  * `options.updatedAt` lets importers preserve the source file's modified
  * timestamp (e.g. Obsidian frontmatter) when overwriting an existing note.
- * `options.skipSync` defers the network push to the caller — used by batch
+ * `options.skipSync` defers the network push to the caller - used by batch
  * importers that bulk-push at the end to avoid per-file race conditions.
  */
 export async function updateNote(
@@ -381,7 +417,7 @@ export async function deleteNote(id: string): Promise<void> {
     updatedAt: new Date().toISOString()
   });
 
-  // Note never reached the server — skip DELETE and mark as synced locally.
+  // Note never reached the server - skip DELETE and mark as synced locally.
   if (!existing || existing.sync_status === 'pending') {
     const archived = await noteStore.get(id);
     if (archived) await noteStore.save({ ...archived, sync_status: 'synced' });
@@ -680,7 +716,7 @@ function serializeVersionWrite<T>(noteId: string, run: () => Promise<T>): Promis
 }
 
 /**
- * Save a version snapshot for a note (copies ciphertext from IndexedDB — zero re-encryption).
+ * Save a version snapshot for a note (copies ciphertext from IndexedDB - zero re-encryption).
  * Skips if note content is identical to the latest version. Prunes to MAX_NOTE_VERSIONS.
  */
 export async function saveVersionSnapshot(noteId: string): Promise<void> {
@@ -688,7 +724,7 @@ export async function saveVersionSnapshot(noteId: string): Promise<void> {
     const existing = await noteStore.get(noteId);
     if (!existing) return;
 
-    // Compare with latest version — skip if identical (avoid duplicate snapshots)
+    // Compare with latest version - skip if identical (avoid duplicate snapshots)
     const latest = await noteHistoryQueries.getForNote(noteId);
     if (latest.length > 0) {
       const top = latest[0];
@@ -726,14 +762,14 @@ export async function saveVersionSnapshot(noteId: string): Promise<void> {
  * an editing session. Unlike `saveVersionSnapshot`, it reconciles with the
  * server FIRST.
  *
- * Why: version history is lazy (no longer pulled during sync — guideline 36), so
+ * Why: version history is lazy (no longer pulled during sync - guideline 36), so
  * on a cold start the LOCAL history store is empty even for a note that already
  * has versions on the server. Writing a baseline against an empty local history
- * would duplicate the pre-edit state — which is already a server version from a
- * previous session — and that twin surfaces the moment the panel pulls server
+ * would duplicate the pre-edit state - which is already a server version from a
+ * previous session - and that twin surfaces the moment the panel pulls server
  * history. So we pull the note's server versions first, then skip if any version
  * already holds this exact pre-edit ciphertext. A never-versioned note still
- * gets its baseline (nothing on the server to dedup against — this is the case
+ * gets its baseline (nothing on the server to dedup against - this is the case
  * the original bug lost); an already-versioned note writes nothing (its pre-edit
  * state is already recoverable from the server).
  *
@@ -742,12 +778,12 @@ export async function saveVersionSnapshot(noteId: string): Promise<void> {
  * re-encryption) to the same versions endpoint as every other snapshot.
  */
 export async function saveBaselineSnapshot(noteId: string): Promise<void> {
-  // Capture the pristine entry before anything awaits — the debounced save runs
+  // Capture the pristine entry before anything awaits - the debounced save runs
   // later, so IndexedDB still holds the pre-edit state at this point.
   const entry = await noteStore.get(noteId);
   if (!entry) return;
 
-  // A never-promoted ephemeral note (#349) has no server row yet — the debounced
+  // A never-promoted ephemeral note (#349) has no server row yet - the debounced
   // first-edit save creates it later (pushNoteMutation → POST /api/notes). Both
   // the server-history pull (syncNoteVersionsFromServer) and the version push
   // target /api/notes/{id}/versions, which 404s until the parent note exists, so
@@ -790,7 +826,7 @@ export async function saveBaselineSnapshot(noteId: string): Promise<void> {
   });
 }
 
-/** Get version history for a note — raw encrypted entries (newest first). */
+/** Get version history for a note - raw encrypted entries (newest first). */
 export async function getNoteHistory(noteId: string): Promise<NoteHistoryEntry[]> {
   return noteHistoryQueries.getForNote(noteId);
 }
@@ -829,14 +865,16 @@ export async function getNoteHistoryDecrypted(noteId: string): Promise<NoteHisto
     entries.map(async (e) => ({
       id: e.id,
       note_id: e.note_id,
-      title: await decodeText(e.title_encrypted),
-      content: await decodeText(e.content_encrypted),
+      // Version rows have no decrypt_failed surface (panel rows are ephemeral
+      // UI) - an undecryptable snapshot degrades to empty fields as before.
+      title: (await decodeTextField(e.title_encrypted, 'note version title')) ?? '',
+      content: (await decodeTextField(e.content_encrypted, 'note version content')) ?? '',
       created_at: e.created_at
     }))
   );
 }
 
-/** Restore a specific version — overwrites current note content. */
+/** Restore a specific version - overwrites current note content. */
 export async function restoreNoteVersion(
   noteId: string,
   entry: NoteHistoryDecrypted

--- a/apps/reborn-notes/src/lib/services/note.service.undecryptable.spec.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.undecryptable.spec.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NoteStoredLocal } from '@reborn/types';
+
+// Undecryptable-row wiring for notes (guideline 63, #15). Notes are the one
+// entity with TWO decode paths - the full codec (toDecrypted, editor/trash)
+// and the title-only NoteIndex path - sharing a single session cache, so this
+// spec focuses on their interplay on top of the per-row flagging basics.
+
+const rows = new Map<string, NoteStoredLocal>();
+const decryptTextSpy = vi.fn(async (stored: string) => {
+  if (stored.startsWith('bad:')) throw new Error('OperationError');
+  return stored.replace(/^enc:/, '');
+});
+
+vi.mock('@reborn/crypto', () => ({
+  cryptoManager: {
+    isInitialized: () => true,
+    encryptText: async (value: string) => `enc:${value}`,
+    decryptText: (stored: string) => decryptTextSpy(stored),
+    encryptObject: async (value: unknown) => `encobj:${JSON.stringify(value)}`,
+    decryptObject: async (stored: string) => JSON.parse(stored.replace(/^encobj:/, ''))
+  }
+}));
+
+vi.mock('@reborn/storage', () => ({
+  noteStore: {
+    get: async (id: string) => rows.get(id) ?? null,
+    getAll: async () => [...rows.values()],
+    getMany: async (ids: string[]) => ids.map((id) => rows.get(id)).filter(Boolean),
+    save: async (row: NoteStoredLocal) => {
+      rows.set(row.id, row);
+    },
+    delete: async (id: string) => {
+      rows.delete(id);
+    },
+    deleteMany: async (ids: string[]) => {
+      ids.forEach((id) => rows.delete(id));
+    }
+  },
+  noteQueries: {
+    getActive: async () => [...rows.values()].filter((n) => !n.is_archived),
+    getArchived: async () => [...rows.values()].filter((n) => n.is_archived),
+    byFolder: async () => [],
+    byFolders: async () => []
+  },
+  noteOperations: {},
+  noteTagStore: { getAll: async () => [] },
+  noteTagQueries: { getTagsForNote: async () => [], getNotesForTag: async () => [] },
+  noteHistoryQueries: { getForNote: async () => [] },
+  noteHistoryOperations: {
+    saveVersion: async () => 'v-1',
+    pruneVersions: async () => {},
+    deleteAllForNote: async () => {}
+  }
+}));
+
+vi.mock('$lib/stores/auth.store', async () => {
+  const { writable } = await import('svelte/store');
+  return { authStore: writable({ userId: 'user-1', isAuthenticated: true }) };
+});
+
+vi.mock('$lib/stores/connectivity.store', () => ({ checkOnline: () => false }));
+
+vi.mock('$lib/services/note-index.svelte', () => ({
+  noteIndex: { update: vi.fn(), patch: vi.fn(), remove: vi.fn(), get: () => undefined }
+}));
+vi.mock('$lib/services/note-link-graph.svelte', () => ({
+  noteLinkGraph: { onNoteSaved: vi.fn(), onNoteRemoved: vi.fn(), clear: vi.fn() }
+}));
+vi.mock('$lib/services/note-nav-history.svelte', () => ({
+  noteNavHistory: { remove: vi.fn(), clear: vi.fn() }
+}));
+
+vi.mock('./notes-sync.service', () => ({
+  pushNote: vi.fn(),
+  pushNoteUpdate: vi.fn(),
+  pushNoteMutation: vi.fn(),
+  pushNoteDelete: vi.fn(),
+  pushNoteRestore: vi.fn(),
+  pushNoteVersion: vi.fn(),
+  pullNoteVersionsForNote: vi.fn()
+}));
+
+const { getNote, getAllNotes, decryptTitleOnly } = await import('./note.service');
+
+function seed(partial: Partial<NoteStoredLocal> & { id: string }): NoteStoredLocal {
+  const row: NoteStoredLocal = {
+    user_id: 'user-1',
+    title_encrypted: 'enc:Seeded title',
+    content_encrypted: 'enc:Seeded content',
+    is_archived: false,
+    sync_version: 1,
+    sync_status: 'synced',
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    ...partial
+  };
+  rows.set(row.id, row);
+  return row;
+}
+
+beforeEach(() => {
+  rows.clear();
+  decryptTextSpy.mockClear();
+  // NOTE: the service keeps a module-scoped session cache of undecryptable
+  // rows (keyed by id + updated_at) which survives between tests - seed
+  // corrupt rows under ids unique to their test.
+});
+
+describe('undecryptable note rows (foreign key epoch / corruption)', () => {
+  it('flags the row and degrades both fields when the title does not decrypt', async () => {
+    seed({ id: 'ghost-1', title_encrypted: 'bad:title' });
+
+    const ghost = await getNote('ghost-1');
+
+    expect(ghost!.decrypt_failed).toBe(true);
+    expect(ghost!.title).toBe('');
+    expect(ghost!.content).toBe('');
+  });
+
+  it('flags the row when only the content is corrupt', async () => {
+    seed({ id: 'ghost-2', content_encrypted: 'bad:content' });
+
+    const ghost = await getNote('ghost-2');
+
+    expect(ghost!.decrypt_failed).toBe(true);
+    expect(ghost!.title).toBe('');
+  });
+
+  it('leaves healthy rows unflagged next to a corrupt one', async () => {
+    seed({ id: 'ghost-3', title_encrypted: 'bad:title' });
+    seed({ id: 'fine-3' });
+
+    const byId = new Map((await getAllNotes()).map((n) => [n.id, n]));
+
+    expect(byId.get('ghost-3')!.decrypt_failed).toBe(true);
+    expect(byId.get('fine-3')!.decrypt_failed).toBeUndefined();
+    expect(byId.get('fine-3')!.title).toBe('Seeded title');
+  });
+
+  it('does not re-decrypt a known-bad row until its updated_at changes', async () => {
+    seed({ id: 'ghost-4', title_encrypted: 'bad:title' });
+
+    await getNote('ghost-4');
+
+    decryptTextSpy.mockClear();
+    const stillGhost = await getNote('ghost-4');
+    expect(stillGhost!.decrypt_failed).toBe(true);
+    expect(decryptTextSpy).not.toHaveBeenCalled();
+
+    // Rewritten row (e.g. repaired from a device holding the right key):
+    // retried, decodes normally, sticky entry dropped.
+    seed({ id: 'ghost-4', updated_at: '2026-06-02T00:00:00.000Z' });
+    const repaired = await getNote('ghost-4');
+    expect(repaired!.decrypt_failed).toBeUndefined();
+    expect(repaired!.title).toBe('Seeded title');
+  });
+
+  describe('title-only path (NoteIndex) sharing the session cache', () => {
+    it('flags a title-corrupt row and skips decryption on later calls', async () => {
+      const enc = seed({ id: 'ghost-5', title_encrypted: 'bad:title' });
+
+      const first = await decryptTitleOnly(enc);
+      expect(first.decryptFailed).toBe(true);
+      expect(first.title).toBe('');
+
+      decryptTextSpy.mockClear();
+      // Cache hit - both the title-only path AND the full codec skip decoding.
+      const second = await decryptTitleOnly(enc);
+      expect(second.decryptFailed).toBe(true);
+      const full = await getNote('ghost-5');
+      expect(full!.decrypt_failed).toBe(true);
+      expect(decryptTextSpy).not.toHaveBeenCalled();
+    });
+
+    it('inherits a content-corruption mark made by the full codec', async () => {
+      const enc = seed({ id: 'ghost-6', content_encrypted: 'bad:content' });
+
+      // Title decodes, so the title-only path alone cannot see the corruption...
+      const before = await decryptTitleOnly(enc);
+      expect(before.decryptFailed).toBe(false);
+
+      // ...but once the full codec marks the row, the index path serves the
+      // flag from the shared cache without another decrypt attempt.
+      await getNote('ghost-6');
+      decryptTextSpy.mockClear();
+      const after = await decryptTitleOnly(enc);
+      expect(after.decryptFailed).toBe(true);
+      expect(after.title).toBe('');
+      expect(decryptTextSpy).not.toHaveBeenCalled();
+    });
+
+    it('a healthy title-only decode does not clear a full-codec mark (same row version)', async () => {
+      const enc = seed({ id: 'ghost-7', content_encrypted: 'bad:content' });
+      await getNote('ghost-7'); // marks
+
+      // Title-only ran BEFORE the mark in some other tab/path - simulate by
+      // calling it now on the same updated_at: it must serve the flag, not
+      // "repair" the cache entry with its partial success.
+      const view = await decryptTitleOnly(enc);
+      expect(view.decryptFailed).toBe(true);
+
+      const full = await getNote('ghost-7');
+      expect(full!.decrypt_failed).toBe(true);
+    });
+  });
+});

--- a/apps/reborn-notes/src/lib/services/saved-search.service.ts
+++ b/apps/reborn-notes/src/lib/services/saved-search.service.ts
@@ -26,6 +26,7 @@ import {
   pushSavedSearchUpdate,
   pushSavedSearchDelete
 } from './notes-sync.service';
+import { createUndecryptableRowCache, decodeTextField } from './undecryptable-rows';
 
 // ── User identity ─────────────────────────────────────────────────
 
@@ -41,19 +42,6 @@ async function encode(value: string, what: 'name' | 'query'): Promise<string> {
     throw new Error(`[E2E] encode saved-search ${what} called without master key loaded`);
   }
   return cryptoManager.encryptText(value);
-}
-
-/** `null` = ciphertext present but undecryptable (wrong key epoch / corruption). */
-async function decode(stored: string): Promise<string | null> {
-  if (!stored) return '';
-  if (!cryptoManager.isInitialized()) {
-    throw new Error('[E2E] decode saved-search called without master key loaded');
-  }
-  try {
-    return await cryptoManager.decryptText(stored);
-  } catch {
-    return null;
-  }
 }
 
 async function decodeMetadata(
@@ -79,12 +67,9 @@ const METADATA_DEFAULTS: Required<SavedSearchSensitiveMetadata> = {
   pinned_to_root: false
 };
 
-// Rows that already failed to decrypt this session, keyed by id with the
-// updated_at they failed at. Refreshes run after every sync pull and re-decode
-// every row - without this cache a permanently undecryptable row would repeat
-// the same crypto errors in the console on each cycle. A changed updated_at
-// (row rewritten, possibly from a device holding the right key) retries.
-const undecryptableRows = new Map<string, string>();
+// Session cache of rows that already failed to decrypt - see
+// undecryptable-rows.ts for the shared pattern (guideline 63, #15).
+const undecryptableRows = createUndecryptableRowCache();
 
 function toUndecryptable(enc: SavedSearchEncrypted): SavedSearchDecrypted {
   return {
@@ -102,15 +87,15 @@ function toUndecryptable(enc: SavedSearchEncrypted): SavedSearchDecrypted {
 }
 
 async function toDecrypted(enc: SavedSearchEncrypted): Promise<SavedSearchDecrypted> {
-  if (undecryptableRows.get(enc.id) === enc.updated_at) return toUndecryptable(enc);
+  if (undecryptableRows.has(enc.id, enc.updated_at)) return toUndecryptable(enc);
   const meta = await decodeMetadata(enc.metadata_encrypted);
-  const name = await decode(enc.name_encrypted);
-  const query = await decode(enc.query_encrypted);
+  const name = await decodeTextField(enc.name_encrypted, 'saved-search name');
+  const query = await decodeTextField(enc.query_encrypted, 'saved-search query');
   if (meta === null || name === null || query === null) {
-    undecryptableRows.set(enc.id, enc.updated_at);
+    undecryptableRows.mark(enc.id, enc.updated_at);
     return toUndecryptable(enc);
   }
-  undecryptableRows.delete(enc.id);
+  undecryptableRows.clear(enc.id);
   return {
     id: enc.id,
     name,

--- a/apps/reborn-notes/src/lib/services/tag.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/tag.service.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TagEncrypted } from '@reborn/types';
+
+// Undecryptable-row wiring for tags (guideline 63, #15): any failed field
+// (name OR color) flags the whole row, the session cache skips re-decryption,
+// and a rewritten row is retried. Mirrors saved-search.service.spec.ts.
+
+const rows: TagEncrypted[] = [];
+const decryptTextSpy = vi.fn(async (stored: string) => {
+  if (stored.startsWith('bad:')) throw new Error('OperationError');
+  return stored.replace(/^enc:/, '');
+});
+
+vi.mock('@reborn/crypto', () => ({
+  cryptoManager: {
+    isInitialized: () => true,
+    encryptText: async (value: string) => `enc:${value}`,
+    decryptText: (stored: string) => decryptTextSpy(stored)
+  }
+}));
+
+vi.mock('@reborn/storage', () => ({
+  tagStore: {
+    get: async (id: string) => rows.find((r) => r.id === id) ?? null,
+    getAll: async () => [...rows],
+    delete: async (id: string) => {
+      const idx = rows.findIndex((r) => r.id === id);
+      if (idx >= 0) rows.splice(idx, 1);
+    }
+  },
+  tagOperations: {
+    saveTag: async (row: TagEncrypted) => {
+      const idx = rows.findIndex((r) => r.id === row.id);
+      if (idx >= 0) rows[idx] = row;
+      else rows.push(row);
+    }
+  },
+  noteTagQueries: {
+    getTagsForNote: async () => [],
+    getNotesForTag: async () => []
+  },
+  noteTagOperations: {
+    removeAllNotesFromTag: async () => {}
+  },
+  noteStore: {
+    get: async () => null
+  }
+}));
+
+vi.mock('$lib/stores/auth.store', async () => {
+  const { writable } = await import('svelte/store');
+  return { authStore: writable({ userId: 'user-1', isAuthenticated: true }) };
+});
+
+vi.mock('./notes-sync.service', () => ({
+  pushTag: vi.fn(),
+  pushTagUpdate: vi.fn(),
+  pushTagDelete: vi.fn(),
+  pushNoteUpdate: vi.fn(),
+  pushNoteMutation: vi.fn()
+}));
+
+vi.mock('$lib/services/note-index.svelte', () => ({
+  noteIndex: { get: () => undefined, patch: vi.fn() }
+}));
+
+const { getAllTags, renameTag } = await import('./tag.service');
+
+function seed(partial: Partial<TagEncrypted> & { id: string }): TagEncrypted {
+  const row: TagEncrypted = {
+    user_id: 'user-1',
+    name_encrypted: 'enc:Seeded',
+    sync_version: 1,
+    sync_status: 'synced',
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    ...partial
+  };
+  rows.push(row);
+  return row;
+}
+
+beforeEach(() => {
+  rows.length = 0;
+  decryptTextSpy.mockClear();
+  // NOTE: the service keeps a module-scoped session cache of undecryptable
+  // rows (keyed by id + updated_at) which survives between tests - seed
+  // corrupt rows under ids unique to their test.
+});
+
+describe('undecryptable tag rows (foreign key epoch / corruption)', () => {
+  it('flags the row and degrades every field when the name does not decrypt', async () => {
+    seed({ id: 'ghost-1', name_encrypted: 'bad:name', color_encrypted: 'enc:#ef4444' });
+
+    const [ghost] = await getAllTags();
+
+    expect(ghost!.decrypt_failed).toBe(true);
+    expect(ghost!.name).toBe('');
+    expect(ghost!.color).toBeUndefined();
+  });
+
+  it('flags the row when only the color is corrupt', async () => {
+    seed({ id: 'ghost-2', color_encrypted: 'bad:color' });
+
+    const [ghost] = await getAllTags();
+
+    expect(ghost!.decrypt_failed).toBe(true);
+    expect(ghost!.name).toBe('');
+  });
+
+  it('an absent color is legal - no flag', async () => {
+    seed({ id: 'fine-1', name_encrypted: 'enc:Work' });
+
+    const [tag] = await getAllTags();
+
+    expect(tag!.decrypt_failed).toBeUndefined();
+    expect(tag!.name).toBe('Work');
+    expect(tag!.color).toBeUndefined();
+  });
+
+  it('leaves healthy rows unflagged next to a corrupt one', async () => {
+    seed({ id: 'ghost-3', name_encrypted: 'bad:name' });
+    seed({ id: 'fine-3', name_encrypted: 'enc:Fine' });
+
+    const byId = new Map((await getAllTags()).map((t) => [t.id, t]));
+
+    expect(byId.get('ghost-3')!.decrypt_failed).toBe(true);
+    expect(byId.get('fine-3')!.decrypt_failed).toBeUndefined();
+    expect(byId.get('fine-3')!.name).toBe('Fine');
+  });
+
+  it('does not re-decrypt a known-bad row until its updated_at changes', async () => {
+    seed({ id: 'ghost-4', name_encrypted: 'bad:name' });
+
+    await getAllTags();
+
+    decryptTextSpy.mockClear();
+    const [stillGhost] = await getAllTags();
+    expect(stillGhost!.decrypt_failed).toBe(true);
+    expect(decryptTextSpy).not.toHaveBeenCalled();
+
+    // Rewritten row (e.g. repaired from a device holding the right key):
+    // retried, decodes normally, sticky entry dropped.
+    rows.length = 0;
+    seed({ id: 'ghost-4', updated_at: '2026-06-02T00:00:00.000Z' });
+    const [repaired] = await getAllTags();
+    expect(repaired!.decrypt_failed).toBeUndefined();
+    expect(repaired!.name).toBe('Seeded');
+  });
+
+  it('rename re-encrypts under the current key (repair path)', async () => {
+    seed({ id: 'ghost-5', name_encrypted: 'bad:name' });
+    await getAllTags(); // marks the row in the session cache
+
+    await renameTag('ghost-5', 'Recovered');
+
+    const [repaired] = await getAllTags();
+    expect(repaired!.decrypt_failed).toBeUndefined();
+    expect(repaired!.name).toBe('Recovered');
+  });
+});

--- a/apps/reborn-notes/src/lib/services/tag.service.ts
+++ b/apps/reborn-notes/src/lib/services/tag.service.ts
@@ -2,7 +2,7 @@
  * Tag service for Reborn Notes.
  *
  * Wraps @reborn/storage tag/noteTag operations with E2E encryption via CryptoManager.
- * Tag names and colors are always encrypted with the user's master key — E2E must be unlocked before use.
+ * Tag names and colors are always encrypted with the user's master key - E2E must be unlocked before use.
  */
 import {
   tagStore,
@@ -19,6 +19,7 @@ import { pushTag, pushTagUpdate, pushTagDelete, pushNoteUpdate, pushNoteMutation
 import { noteStore } from '@reborn/storage';
 import type { NoteSensitiveMetadata, NoteStoredLocal } from '@reborn/types';
 import { noteIndex } from '$lib/services/note-index.svelte';
+import { createUndecryptableRowCache, decodeTextField } from './undecryptable-rows';
 
 // ── User identity ─────────────────────────────────────────────────
 
@@ -48,18 +49,6 @@ async function encodeName(name: string): Promise<string> {
   return cryptoManager.encryptText(name);
 }
 
-async function decodeName(stored: string): Promise<string> {
-  if (!stored) return '';
-  if (!cryptoManager.isInitialized()) {
-    throw new Error('[E2E] decodeName called without master key loaded');
-  }
-  try {
-    return await cryptoManager.decryptText(stored);
-  } catch {
-    return ''; // deszyfrowanie nie powiodło się (uszkodzone dane)
-  }
-}
-
 async function encodeColor(color: string): Promise<string> {
   if (!cryptoManager.isInitialized()) {
     throw new Error('[E2E] encodeColor called without master key loaded');
@@ -67,23 +56,38 @@ async function encodeColor(color: string): Promise<string> {
   return cryptoManager.encryptText(color);
 }
 
-async function decodeColor(stored: string): Promise<string> {
-  if (!stored) return '';
-  if (!cryptoManager.isInitialized()) {
-    throw new Error('[E2E] decodeColor called without master key loaded');
-  }
-  try {
-    return await cryptoManager.decryptText(stored);
-  } catch {
-    return ''; // deszyfrowanie nie powiodło się (uszkodzone dane)
-  }
+// Session cache of rows that already failed to decrypt - see
+// undecryptable-rows.ts for the shared pattern (guideline 63, #15).
+const undecryptableRows = createUndecryptableRowCache();
+
+// Like folders, a tag's function survives an undecryptable row: note
+// relationships live outside the ciphertext, and a rename (plus re-picking the
+// color) re-encrypts under the current key and repairs the row. The UI keeps
+// selection active and offers rename + delete.
+function toUndecryptable(enc: TagEncrypted): TagDecrypted {
+  return {
+    id: enc.id,
+    name: '',
+    color: undefined,
+    created_at: enc.created_at,
+    updated_at: enc.updated_at,
+    decrypt_failed: true
+  };
 }
 
 async function toDecrypted(enc: TagEncrypted): Promise<TagDecrypted> {
+  if (undecryptableRows.has(enc.id, enc.updated_at)) return toUndecryptable(enc);
+  const name = await decodeTextField(enc.name_encrypted, 'tag name');
+  const color = await decodeTextField(enc.color_encrypted, 'tag color');
+  if (name === null || color === null) {
+    undecryptableRows.mark(enc.id, enc.updated_at);
+    return toUndecryptable(enc);
+  }
+  undecryptableRows.clear(enc.id);
   return {
     id: enc.id,
-    name: await decodeName(enc.name_encrypted),
-    color: enc.color_encrypted ? await decodeColor(enc.color_encrypted) : undefined,
+    name,
+    color: color || undefined,
     created_at: enc.created_at,
     updated_at: enc.updated_at
   };
@@ -101,7 +105,7 @@ export async function getAllTags(): Promise<TagDecrypted[]> {
 /**
  * Create a new tag. Returns the new tag ID.
  *
- * `options.skipSync` defers the network push to the caller — used by batch
+ * `options.skipSync` defers the network push to the caller - used by batch
  * importers that bulk-push everything via `pushPendingItems()` at the end so
  * folders/tags land before any note that references them.
  */
@@ -235,7 +239,7 @@ export async function setTagsForNote(noteId: string, tagIds: string[], options?:
     try {
       await tagOperations.incrementUsage(tagId);
     } catch {
-      // tag may have been deleted concurrently — ignore
+      // tag may have been deleted concurrently - ignore
     }
   }
   for (const tagId of toRemove) {
@@ -246,7 +250,7 @@ export async function setTagsForNote(noteId: string, tagIds: string[], options?:
       // ignore
     }
   }
-  // Update metadata_encrypted with new tag IDs (E2E — tags stay encrypted)
+  // Update metadata_encrypted with new tag IDs (E2E - tags stay encrypted)
   const existing = await noteStore.get(noteId);
   if (existing) {
     let meta: NoteSensitiveMetadata = {

--- a/apps/reborn-notes/src/lib/services/undecryptable-rows.spec.ts
+++ b/apps/reborn-notes/src/lib/services/undecryptable-rows.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Shared codec + session cache behind the decrypt_failed pattern (guideline 63,
+// #15). The per-entity wiring is covered by the service specs (saved-search,
+// tag, note); this locks the engine itself.
+
+let cryptoReady = true;
+const decryptTextSpy = vi.fn(async (stored: string) => {
+  if (stored.startsWith('bad:')) throw new Error('OperationError');
+  return stored.replace(/^enc:/, '');
+});
+
+vi.mock('@reborn/crypto', () => ({
+  cryptoManager: {
+    isInitialized: () => cryptoReady,
+    decryptText: (stored: string) => decryptTextSpy(stored)
+  }
+}));
+
+const { decodeTextField, createUndecryptableRowCache } = await import('./undecryptable-rows');
+
+beforeEach(() => {
+  cryptoReady = true;
+  decryptTextSpy.mockClear();
+});
+
+describe('decodeTextField', () => {
+  it('returns "" for a legally absent field without touching crypto', async () => {
+    expect(await decodeTextField('', 'x')).toBe('');
+    expect(await decodeTextField(undefined, 'x')).toBe('');
+    expect(decryptTextSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the plaintext for healthy ciphertext', async () => {
+    expect(await decodeTextField('enc:Hello', 'x')).toBe('Hello');
+  });
+
+  it('returns null (not "") for present-but-undecryptable ciphertext', async () => {
+    expect(await decodeTextField('bad:garbage', 'x')).toBeNull();
+  });
+
+  it('throws when the master key is not loaded - a programming error, not corruption', async () => {
+    cryptoReady = false;
+    await expect(decodeTextField('enc:Hello', 'folder name')).rejects.toThrow(
+      '[E2E] decode folder name called without master key loaded'
+    );
+  });
+});
+
+describe('createUndecryptableRowCache', () => {
+  it('matches only the exact updated_at the row failed at', () => {
+    const cache = createUndecryptableRowCache();
+    cache.mark('id-1', '2026-06-01');
+    expect(cache.has('id-1', '2026-06-01')).toBe(true);
+    // Rewritten row (new updated_at) must be retried.
+    expect(cache.has('id-1', '2026-06-02')).toBe(false);
+    expect(cache.has('id-2', '2026-06-01')).toBe(false);
+  });
+
+  it('clear() forgets the row', () => {
+    const cache = createUndecryptableRowCache();
+    cache.mark('id-1', '2026-06-01');
+    cache.clear('id-1');
+    expect(cache.has('id-1', '2026-06-01')).toBe(false);
+  });
+
+  it('instances are independent (one per entity service)', () => {
+    const a = createUndecryptableRowCache();
+    const b = createUndecryptableRowCache();
+    a.mark('id-1', '2026-06-01');
+    expect(b.has('id-1', '2026-06-01')).toBe(false);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/undecryptable-rows.ts
+++ b/apps/reborn-notes/src/lib/services/undecryptable-rows.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared codec + session cache for rows whose ciphertext does not decrypt with
+ * the current master key (foreign key epoch / corrupted data).
+ *
+ * The pattern (guideline 63, #15 - introduced for saved searches, generalized
+ * to folders / tags / notes):
+ *   1. The codec distinguishes present-but-undecryptable ciphertext (`null`)
+ *      from legal absence (`''`), so callers can tell corruption apart from a
+ *      simply empty field.
+ *   2. Any failed field marks the WHOLE row `decrypt_failed` with degraded
+ *      fields; the UI renders an explicit placeholder instead of a blank row.
+ *   3. A session-scoped cache (id -> updated_at it failed at) skips
+ *      re-decryption on later refreshes - refreshes run after every sync pull
+ *      and re-decode every row, so without the cache a permanently
+ *      undecryptable row would repeat the same crypto-layer console errors on
+ *      each cycle. The errors surface once per session instead.
+ *   4. A rewritten row (new updated_at, e.g. repaired from a device holding
+ *      the right key) misses the cache, is retried, and unflagged when it
+ *      decodes again.
+ */
+import { cryptoManager } from '@reborn/crypto';
+
+/**
+ * Decrypt a text field. `''` = legally absent; `null` = present but
+ * undecryptable (wrong key epoch / corruption). `what` names the field in the
+ * not-unlocked error message (a programming error, not a data error).
+ */
+export async function decodeTextField(
+  stored: string | undefined,
+  what: string
+): Promise<string | null> {
+  if (!stored) return '';
+  if (!cryptoManager.isInitialized()) {
+    throw new Error(`[E2E] decode ${what} called without master key loaded`);
+  }
+  try {
+    return await cryptoManager.decryptText(stored);
+  } catch {
+    return null;
+  }
+}
+
+export interface UndecryptableRowCache {
+  /** True when `id` already failed at exactly this `updated_at` - skip re-decrypting. */
+  has(id: string, updatedAt: string): boolean;
+  /** Remember that `id` failed to decrypt at `updatedAt`. */
+  mark(id: string, updatedAt: string): void;
+  /**
+   * Forget `id` - call when the row decoded fully. Callers that decode only a
+   * subset of the row's fields (e.g. the note title-only path) must NOT clear:
+   * they cannot prove the fields they skipped are healthy. Not clearing is
+   * safe - `has()` matches on the exact updated_at, so a rewritten row is
+   * retried regardless of a stale entry.
+   */
+  clear(id: string): void;
+}
+
+/**
+ * One cache per entity service, module-scoped there so it survives store
+ * refreshes for the whole session (cleared only by a page reload).
+ */
+export function createUndecryptableRowCache(): UndecryptableRowCache {
+  const failedAt = new Map<string, string>();
+  return {
+    has: (id, updatedAt) => failedAt.get(id) === updatedAt,
+    mark: (id, updatedAt) => {
+      failedAt.set(id, updatedAt);
+    },
+    clear: (id) => {
+      failedAt.delete(id);
+    }
+  };
+}

--- a/apps/reborn-notes/src/lib/utils/folder-helpers.ts
+++ b/apps/reborn-notes/src/lib/utils/folder-helpers.ts
@@ -25,13 +25,14 @@ export function sortFoldersByCustomOrder<
   );
 }
 
-/** Flatten a nested folder tree into a flat array of {id, name}. */
+/** Flatten a nested folder tree into a flat array of {id, name}. Carries the
+ *  decrypt_failed flag so name consumers can render the placeholder. */
 export function flattenFolderTree(
   nodes: FolderWithChildren[],
-  result: { id: string; name: string }[] = []
-): { id: string; name: string }[] {
+  result: { id: string; name: string; decrypt_failed?: boolean }[] = []
+): { id: string; name: string; decrypt_failed?: boolean }[] {
   for (const f of nodes) {
-    result.push({ id: f.id, name: f.name });
+    result.push({ id: f.id, name: f.name, ...(f.decrypt_failed ? { decrypt_failed: true } : {}) });
     flattenFolderTree(f.children ?? [], result);
   }
   return result;

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -700,6 +700,7 @@
     if (activeSection === 'all') return $t('nav.all_notes');
     if (activeSection === 'tags') {
       const tag = $tagsStore.find((t) => t.id === activeTagId);
+      if (tag?.decrypt_failed) return $t('tags.undecryptable');
       return tag ? tag.name : $t('nav.tags');
     }
     if (isPeriodicSection(activeSection)) {
@@ -714,18 +715,18 @@
     }
     if (activeFolderId === undefined) return $t('nav.all_notes');
     if (activeFolderId === null) return $t('nav.no_folder');
-    return (
-      flattenFolderTree($foldersStore).find((f) => f.id === activeFolderId)?.name ??
-      $t('nav.folders')
-    );
+    const folder = flattenFolderTree($foldersStore).find((f) => f.id === activeFolderId);
+    if (folder?.decrypt_failed) return $t('folders.undecryptable');
+    return folder?.name ?? $t('nav.folders');
   });
 
   let activeNoteFolderName = $derived.by(() => {
     if (!$activeNoteId || noteDetailService.folderId == null) return null;
-    return (
-      flattenFolderTree($foldersStore).find((f) => f.id === noteDetailService.folderId)?.name ??
-      null
+    const folder = flattenFolderTree($foldersStore).find(
+      (f) => f.id === noteDetailService.folderId
     );
+    if (folder?.decrypt_failed) return $t('folders.undecryptable');
+    return folder?.name ?? null;
   });
 
   // ── Sync store filters to nav state ─────────────────────────────

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -141,6 +141,8 @@
     "support": "Unterstütze uns"
   },
   "notes": {
+    "undecryptable": "Entschlüsselung nicht möglich",
+    "undecryptable_hint": "Diese Notiz konnte mit Ihrem Schlüssel nicht entschlüsselt werden. Sie kann nur gelöscht werden.",
     "title": "Notizen",
     "new_note": "Neue Notiz",
     "edit_note": "Notiz bearbeiten",
@@ -324,6 +326,8 @@
     }
   },
   "folders": {
+    "undecryptable": "Entschlüsselung nicht möglich",
+    "undecryptable_hint": "Der Name dieses Ordners konnte mit Ihrem Schlüssel nicht entschlüsselt werden. Der Inhalt ist davon nicht betroffen - benennen Sie den Ordner um, um ihn zu reparieren, oder löschen Sie ihn.",
     "title": "Ordner",
     "new_folder": "Neuer Ordner",
     "edit_folder": "Ordner bearbeiten",
@@ -399,6 +403,8 @@
     }
   },
   "tags": {
+    "undecryptable": "Entschlüsselung nicht möglich",
+    "undecryptable_hint": "Der Name dieses Tags konnte mit Ihrem Schlüssel nicht entschlüsselt werden. Benennen Sie das Tag um, um es zu reparieren, oder löschen Sie es.",
     "title": "Tags",
     "new_tag": "Neues Tag",
     "edit_tag": "Tag bearbeiten",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -141,6 +141,8 @@
     "support": "Support us"
   },
   "notes": {
+    "undecryptable": "Cannot decrypt",
+    "undecryptable_hint": "This note could not be decrypted with your encryption key. It can only be deleted.",
     "title": "Notes",
     "new_note": "New Note",
     "edit_note": "Edit Note",
@@ -324,6 +326,8 @@
     }
   },
   "folders": {
+    "undecryptable": "Cannot decrypt",
+    "undecryptable_hint": "This folder's name could not be decrypted with your encryption key. Its contents are unaffected - rename the folder to fix it, or delete it.",
     "title": "Folders",
     "new_folder": "New Folder",
     "edit_folder": "Edit Folder",
@@ -399,6 +403,8 @@
     }
   },
   "tags": {
+    "undecryptable": "Cannot decrypt",
+    "undecryptable_hint": "This tag's name could not be decrypted with your encryption key. Rename the tag to fix it, or delete it.",
     "title": "Tags",
     "new_tag": "New Tag",
     "edit_tag": "Edit Tag",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -141,6 +141,8 @@
     "support": "Apóyanos"
   },
   "notes": {
+    "undecryptable": "No se puede descifrar",
+    "undecryptable_hint": "No se pudo descifrar esta nota con su clave de cifrado. Solo puede eliminarla.",
     "title": "Notas",
     "new_note": "Nueva nota",
     "edit_note": "Editar nota",
@@ -324,6 +326,8 @@
     }
   },
   "folders": {
+    "undecryptable": "No se puede descifrar",
+    "undecryptable_hint": "No se pudo descifrar el nombre de esta carpeta con su clave de cifrado. Su contenido no se ve afectado - cámbiele el nombre para repararla o elimínela.",
     "title": "Carpetas",
     "new_folder": "Nueva carpeta",
     "edit_folder": "Editar carpeta",
@@ -399,6 +403,8 @@
     }
   },
   "tags": {
+    "undecryptable": "No se puede descifrar",
+    "undecryptable_hint": "No se pudo descifrar el nombre de esta etiqueta con su clave de cifrado. Cámbiele el nombre para repararla o elimínela.",
     "title": "Etiquetas",
     "new_tag": "Nueva etiqueta",
     "edit_tag": "Editar etiqueta",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -141,6 +141,8 @@
     "support": "Soutenez-nous"
   },
   "notes": {
+    "undecryptable": "Déchiffrement impossible",
+    "undecryptable_hint": "Impossible de déchiffrer cette note avec votre clé de chiffrement. Elle peut uniquement être supprimée.",
     "title": "Notes",
     "new_note": "Nouvelle note",
     "edit_note": "Modifier la note",
@@ -324,6 +326,8 @@
     }
   },
   "folders": {
+    "undecryptable": "Déchiffrement impossible",
+    "undecryptable_hint": "Impossible de déchiffrer le nom de ce dossier avec votre clé de chiffrement. Son contenu n'est pas affecté - renommez le dossier pour le réparer, ou supprimez-le.",
     "title": "Dossiers",
     "new_folder": "Nouveau dossier",
     "edit_folder": "Modifier le dossier",
@@ -399,6 +403,8 @@
     }
   },
   "tags": {
+    "undecryptable": "Déchiffrement impossible",
+    "undecryptable_hint": "Impossible de déchiffrer le nom de ce tag avec votre clé de chiffrement. Renommez-le pour le réparer, ou supprimez-le.",
     "title": "Tags",
     "new_tag": "Nouveau tag",
     "edit_tag": "Modifier le tag",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -141,6 +141,8 @@
     "support": "Wesprzyj nas"
   },
   "notes": {
+    "undecryptable": "Nie można odszyfrować",
+    "undecryptable_hint": "Tej notatki nie udało się odszyfrować Twoim kluczem szyfrowania. Można ją tylko usunąć.",
     "title": "Notatki",
     "new_note": "Nowa notatka",
     "edit_note": "Edytuj notatkę",
@@ -324,6 +326,8 @@
     }
   },
   "folders": {
+    "undecryptable": "Nie można odszyfrować",
+    "undecryptable_hint": "Nazwy tego folderu nie udało się odszyfrować Twoim kluczem szyfrowania. Zawartość folderu jest nienaruszona - zmień jego nazwę, aby go naprawić, albo go usuń.",
     "title": "Foldery",
     "new_folder": "Nowy folder",
     "edit_folder": "Edytuj folder",
@@ -399,6 +403,8 @@
     }
   },
   "tags": {
+    "undecryptable": "Nie można odszyfrować",
+    "undecryptable_hint": "Nazwy tego tagu nie udało się odszyfrować Twoim kluczem szyfrowania. Zmień jego nazwę, aby go naprawić, albo go usuń.",
     "title": "Tagi",
     "new_tag": "Nowy tag",
     "edit_tag": "Edytuj tag",

--- a/packages/types/src/entities/folder.ts
+++ b/packages/types/src/entities/folder.ts
@@ -11,6 +11,14 @@ export interface FolderDecrypted {
   created_at: string;
   updated_at: string;
   deleted_at?: string;
+  /**
+   * True when the folder's ciphertext could not be decrypted with the current
+   * master key (foreign key epoch / corrupted data). Such a row keeps an empty
+   * name; the UI renders an explicit placeholder and offers rename (repair) or
+   * deletion. The folder's structure and contents stay fully usable - only the
+   * name is ciphertext.
+   */
+  decrypt_failed?: boolean;
 }
 
 export interface FolderEncrypted extends SyncableEncryptedEntity {
@@ -30,8 +38,8 @@ export interface FolderWithChildren extends FolderDecrypted {
 /** Maximum plaintext folder name size in bytes. */
 export const MAX_FOLDER_NAME_BYTES = 500; // ~250 Unicode chars
 
-/** Maximum encrypted folder name — server Zod. */
+/** Maximum encrypted folder name - server Zod. */
 export const MAX_ENCRYPTED_FOLDER_NAME_BYTES = 750;
 
-/** Maximum encrypted folder metadata bundle — server Zod. Contains color, icon. */
+/** Maximum encrypted folder metadata bundle - server Zod. Contains color, icon. */
 export const MAX_ENCRYPTED_FOLDER_METADATA_BYTES = 2_000;

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -29,7 +29,7 @@ export interface PeriodicNoteMetadata {
 export interface NoteSensitiveMetadata {
   is_starred?: boolean;
   is_pinned?: boolean;
-  tags?: string[]; // tag IDs — filtering moved client-side
+  tags?: string[]; // tag IDs - filtering moved client-side
   /** Set when this note was created by the Periodic Notes feature. */
   periodic?: PeriodicNoteMetadata;
 }
@@ -48,9 +48,17 @@ export interface NoteDecrypted {
   created_at: string;
   updated_at: string;
   deleted_at?: string;
+  /**
+   * True when any of the note's ciphertexts (title, content) could not be
+   * decrypted with the current master key (foreign key epoch / corrupted data).
+   * Such a row keeps empty title/content; the UI renders an explicit
+   * placeholder, never opens the editor for it (a save would overwrite the
+   * ciphertext), and only offers deletion.
+   */
+  decrypt_failed?: boolean;
 }
 
-// ─── Encrypted type (server/sync — no plaintext sensitive data) ──────
+// ─── Encrypted type (server/sync - no plaintext sensitive data) ──────
 
 /** Wire format sent to/from server. is_starred/is_pinned inside metadata_encrypted. */
 export interface NoteEncrypted extends SyncableEncryptedEntity {
@@ -58,10 +66,10 @@ export interface NoteEncrypted extends SyncableEncryptedEntity {
   title_encrypted: string;
   content_encrypted: string;
   metadata_encrypted?: string; // Contains NoteSensitiveMetadata
-  is_archived?: boolean; // Operational (like deleted_at) — stays plain
+  is_archived?: boolean; // Operational (like deleted_at) - stays plain
 }
 
-// ─── Local storage type (IndexedDB — shadow indexes for queries) ─────
+// ─── Local storage type (IndexedDB - shadow indexes for queries) ─────
 
 // `SyncErrorCode` moved to `../base` (both apps produce it now); re-exported
 // there. NoteStoredLocal still pairs it with `sync_status: 'sync_error'`.
@@ -92,17 +100,17 @@ export interface NoteStoredLocal extends NoteEncrypted {
 /** Maximum number of version snapshots kept per note (client and server). */
 export const MAX_NOTE_VERSIONS = 10;
 
-/** Maximum plaintext size of a single note (title + content) in bytes — enforced client-side. */
+/** Maximum plaintext size of a single note (title + content) in bytes - enforced client-side. */
 export const MAX_NOTE_CONTENT_BYTES = 500_000; // 500 KB
 
-/** Maximum encrypted payload size per note field — enforced server-side via Zod. */
+/** Maximum encrypted payload size per note field - enforced server-side via Zod. */
 export const MAX_ENCRYPTED_CONTENT_BYTES = 750_000; // ~500 KB plaintext + encryption overhead
 
-/** Maximum encrypted note title size — server Zod. */
+/** Maximum encrypted note title size - server Zod. */
 export const MAX_ENCRYPTED_NOTE_TITLE_BYTES = 1_500; // ~1 KB plaintext + encryption overhead
 
-/** Maximum encrypted metadata bundle size — server Zod. Contains is_starred, is_pinned, tag IDs. */
-export const MAX_ENCRYPTED_NOTE_METADATA_BYTES = 10_000; // ~7 KB plaintext — enough for ~200 tag UUIDs
+/** Maximum encrypted metadata bundle size - server Zod. Contains is_starred, is_pinned, tag IDs. */
+export const MAX_ENCRYPTED_NOTE_METADATA_BYTES = 10_000; // ~7 KB plaintext - enough for ~200 tag UUIDs
 
 /** Default per-user storage quota in bytes (configurable via USER_STORAGE_LIMIT_BYTES env). */
 export const DEFAULT_USER_STORAGE_LIMIT_BYTES = 104_857_600; // 100 MB
@@ -117,7 +125,7 @@ export interface NoteHistoryEntry {
   created_at: string;
 }
 
-/** Decrypted version snapshot — used only in UI (on-demand decryption). */
+/** Decrypted version snapshot - used only in UI (on-demand decryption). */
 export interface NoteHistoryDecrypted {
   id: string;
   note_id: string;

--- a/packages/types/src/entities/tag.ts
+++ b/packages/types/src/entities/tag.ts
@@ -6,6 +6,13 @@ export interface TagDecrypted {
   color?: string;
   created_at: string;
   updated_at: string;
+  /**
+   * True when any of the tag's ciphertexts (name, color) could not be decrypted
+   * with the current master key (foreign key epoch / corrupted data). Such a row
+   * keeps an empty name and no color; the UI renders an explicit placeholder and
+   * offers rename (repair) or deletion.
+   */
+  decrypt_failed?: boolean;
 }
 
 export interface TagEncrypted extends SyncableEncryptedEntity {
@@ -24,8 +31,8 @@ export interface NoteTag {
 /** Maximum plaintext tag name size in bytes. */
 export const MAX_TAG_NAME_BYTES = 200; // ~100 Unicode chars
 
-/** Maximum encrypted tag name — server Zod. */
+/** Maximum encrypted tag name - server Zod. */
 export const MAX_ENCRYPTED_TAG_NAME_BYTES = 350;
 
-/** Maximum encrypted tag color — server Zod. Color is ~7 chars (#RRGGBB), encrypted ~100-150 bytes. */
+/** Maximum encrypted tag color - server Zod. Color is ~7 chars (#RRGGBB), encrypted ~100-150 bytes. */
 export const MAX_ENCRYPTED_TAG_COLOR_BYTES = 200;


### PR DESCRIPTION
## Summary

Generalizes the decrypt-failed pattern from #410 (saved searches, guideline 63 #15) to folders, tags and notes. An undecryptable row (foreign key epoch / corrupted ciphertext) now renders an explicit italic *"Cannot decrypt"* placeholder instead of a blank row, and the session cache stops the post-sync refresh from repeating the same crypto errors in the console on every cycle.

- **Shared helper** `undecryptable-rows.ts` (codec: `''` = legal absence vs `null` = undecryptable; session cache id → `updated_at`); the saved-search service is refactored onto it (its 22-test spec passes unchanged, locking the pattern).
- `decrypt_failed?: boolean` added to `FolderDecrypted` / `TagDecrypted` / `NoteDecrypted` (additive).

**Decisions to review (auto mode)** - per-entity menus deliberately diverge from #410's Delete-only:

1. **Folders / tags: Rename (repair) + Delete, row stays interactive.** The name is their only ciphertext - a ghost folder's subtree, notes and a ghost tag's relations are fully healthy, and renaming re-encrypts under the current key, which repairs the row (flag drops). Delete-only would be needlessly destructive for a folder full of healthy notes. Placeholder also shown in the list header, SubfolderList, FolderTreePicker and MoveToFolderMenu (a ghost is a valid move target - only its name is unreadable).
2. **Notes: inert row + Delete only** (trash: Restore + permanent delete - row-level ops). Opening the editor would let the debounced autosave overwrite the ciphertext with an empty body, so the row never opens; defense-in-depth guards in `note-detail.service` also no-op all edit/save paths and keep the in-memory plaintext if a pull rewrites the open note into a ghost. Both decode paths (full codec + title-only NoteIndex) share one cache; ghosts are excluded from `[[` autocomplete.
3. **Known cosmetic gap:** picker breadcrumbs still render blank for ghost path segments.

Console behavior is unchanged by design: a ghost logs its crypto errors **once per session** (first decode attempt - kept as a diagnostic trace); full silence comes from deleting or repairing the ghost via the UI.

6 new i18n keys × 5 locales (register matched per file: DE Sie / FR vous / ES usted; PL informal). New specs: `undecryptable-rows.spec.ts`, `tag.service.spec.ts`, `note.service.undecryptable.spec.ts` (dual-path cache interplay). Local gates: notes suite 82 files / 1227 tests, i18n + types suites, svelte-check 0 errors, eslint, i18n parity, full `vite build` - all green.

## Test plan

1. **Ghost saved search from the last session (localprod):** Search section → italic "Nie można odszyfrować" row → Delete → hard refresh (Ctrl+Shift+R) → console shows **no** decrypt errors (the 6 errors you saw were this ghost's once-per-session log, working as designed in #410 - deletion is what silences them).
2. Simulate a ghost folder/tag/note (or reuse a foreign-key-epoch account): row shows the italic placeholder with a tooltip; folder/tag menu = Rename + Delete (rename with a new name clears the flag), note row does not open the editor and offers Delete only.
3. Ghost folder: expand/collapse and opening it still lists its healthy notes; it appears with the placeholder in Move-to pickers and drill-down subfolder list.
4. Trash with a ghost note: placeholder row, Restore and Delete permanently both work.
5. Regression smoke: rename/color/delete on healthy tags, folder drag/reorder, note open/edit/autosave - unchanged.