### PR TITLE
fix(notes): stop pull orphan-delete racing mid-pull pushes

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -265,12 +265,10 @@ describe('notes-sync - regression (offline data loss)', () => {
     // Sanity: folders and tags push in SEPARATE sweeps (if they shared one,
     // layering wouldn't matter). Between the folders POST and the tags POST
     // there must be a fresh `await settleInBatches(pendingTags, …)`.
-    const foldersPostIdx = fn.indexOf("'/api/folders'") >= 0
-      ? fn.indexOf("'/api/folders'")
-      : fn.indexOf('/api/folders');
-    const tagsPostIdx = fn.indexOf("'/api/tags'") >= 0
-      ? fn.indexOf("'/api/tags'")
-      : fn.indexOf('/api/tags');
+    const foldersPostIdx =
+      fn.indexOf("'/api/folders'") >= 0 ? fn.indexOf("'/api/folders'") : fn.indexOf('/api/folders');
+    const tagsPostIdx =
+      fn.indexOf("'/api/tags'") >= 0 ? fn.indexOf("'/api/tags'") : fn.indexOf('/api/tags');
     expect(foldersPostIdx).toBeGreaterThan(-1);
     expect(tagsPostIdx).toBeGreaterThan(-1);
     const between = fn.slice(foldersPostIdx, tagsPostIdx);
@@ -371,9 +369,7 @@ describe('notes-sync - regression (offline data loss)', () => {
     // and keeps the batched write: saveMany is one transaction per note, avoiding
     // the per-row churn that OOM'd the Android WebView on the notes path (PR #353).
     const syncSrc = readSource('./notes-sync.service.ts');
-    expect(syncSrc).toMatch(
-      /export async function pullNoteVersionsForNote\(noteId: string\)/
-    );
+    expect(syncSrc).toMatch(/export async function pullNoteVersionsForNote\(noteId: string\)/);
     const helper = syncSrc.slice(
       syncSrc.indexOf('export async function pullNoteVersionsForNote'),
       syncSrc.indexOf('async function pushPendingVersions')
@@ -470,12 +466,8 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(importFolderStart).toBeGreaterThan(helpersStart);
     const helpers = src.slice(helpersStart, importFolderStart);
 
-    expect(helpers).toMatch(
-      /FolderService\.createFolder\([^)]*\{\s*skipSync:\s*true\s*\}\s*\)/
-    );
-    expect(helpers).toMatch(
-      /TagService\.createTag\([^)]*\{\s*skipSync:\s*true\s*\}\s*\)/
-    );
+    expect(helpers).toMatch(/FolderService\.createFolder\([^)]*\{\s*skipSync:\s*true\s*\}\s*\)/);
+    expect(helpers).toMatch(/TagService\.createTag\([^)]*\{\s*skipSync:\s*true\s*\}\s*\)/);
 
     // No direct pushNote/pushFolder/pushTag calls inside importFolder -
     // pushPendingItems() is the single push path so order is enforced.
@@ -496,13 +488,13 @@ describe('notes-sync - regression (offline data loss)', () => {
     // weight we don't use. See guideline 44.
     const src = readSource('./export-import.service.ts');
 
-    const folderLoopStart = src.indexOf("for (const folder of backupData.folders");
+    const folderLoopStart = src.indexOf('for (const folder of backupData.folders');
     const folderSafeParseIdx = src.indexOf('FolderEncryptedSchema.safeParse', folderLoopStart);
     expect(folderSafeParseIdx).toBeGreaterThan(folderLoopStart);
     const folderPreValidate = src.slice(folderLoopStart, folderSafeParseIdx);
     expect(folderPreValidate).toMatch(/normalized\.user_id\s*=\s*userId/);
 
-    const tagLoopStart = src.indexOf("for (const tag of backupData.tags");
+    const tagLoopStart = src.indexOf('for (const tag of backupData.tags');
     const tagSafeParseIdx = src.indexOf('TagEncryptedSchema.safeParse', tagLoopStart);
     expect(tagSafeParseIdx).toBeGreaterThan(tagLoopStart);
     const tagPreValidate = src.slice(tagLoopStart, tagSafeParseIdx);
@@ -557,7 +549,9 @@ describe('notes-sync - regression (offline data loss)', () => {
     // included. Ensure we never silently re-use the v1 flag.
     const cleanupSrc = readSource('./idb-cleanup.service.ts');
     expect(cleanupSrc).toMatch(/idb-null-fk-cleanup-v2/);
-    expect(cleanupSrc).not.toMatch(/^const\s+FLAG_KEY\s*=\s*'reborn-notes:idb-null-fk-cleanup-v1'/m);
+    expect(cleanupSrc).not.toMatch(
+      /^const\s+FLAG_KEY\s*=\s*'reborn-notes:idb-null-fk-cleanup-v1'/m
+    );
   });
 
   it('v1 export sanitizer stamps current userId into records with invalid user_id', () => {
@@ -597,9 +591,7 @@ describe('notes-sync - regression (offline data loss)', () => {
       }
     }
     for (const argList of eachCall(fullExport, 'normalizeExportUuids')) {
-      expect(argList, `normalizeExportUuids call must thread userId: ${argList}`).toMatch(
-        /userId/
-      );
+      expect(argList, `normalizeExportUuids call must thread userId: ${argList}`).toMatch(/userId/);
     }
   });
 
@@ -778,6 +770,48 @@ describe('notes-sync - paginated delta sync (stage 2b)', () => {
     // The old "diff against the response body" orphan path must be gone - in
     // delta mode the body is only the changed notes, so it is NOT authoritative.
     expect(code).not.toMatch(/serverNoteIds/);
+  });
+
+  it('orphan-delete only sweeps items that were synced BEFORE the pull started', () => {
+    // A note created and POSTed while the reconcile pull is paging (live folder
+    // sync imports a brand-new file mid-pull) turns 'synced' AFTER the server
+    // built all_ids, so it is absent from that set. Sweeping it hard-deleted a
+    // note the server has: it resurrected on a later delta while folder sync
+    // re-imported its file in the gap - the duplicate-note incident of
+    // 2026-07-03. Every pull helper must intersect its sweep with a snapshot
+    // of synced ids taken before its first request.
+    const code = pullNotesSrc().replace(/\/\/.*$/gm, '');
+    // Snapshot is gated to sweep-capable runs and taken before the paging loop.
+    expect(code).toMatch(/if\s*\(reconcile \|\| !since\)/);
+    expect(code.indexOf('prePullSyncedIds')).toBeGreaterThan(-1);
+    expect(code.indexOf('prePullSyncedIds')).toBeLessThan(code.indexOf('do {'));
+    // The sweep requires membership in the snapshot, with an empty-set fail-safe.
+    expect(code).toMatch(/preSynced\.has\(n\.id\)/);
+    expect(code).toMatch(/prePullSyncedIds \?\? new Set/);
+
+    // Same pattern in the three single-request pull helpers.
+    const src = readSource('./notes-sync.service.ts').replace(/\/\/.*$/gm, '');
+    const helpers = [
+      ['async function pullFolders', 'async function pullTags', /prePullSyncedIds\.has\(f\.id\)/],
+      [
+        'async function pullTags',
+        'async function pullSavedSearches',
+        /prePullSyncedIds\.has\(t\.id\)/
+      ],
+      [
+        'async function pullSavedSearches',
+        'const NOTES_PAGE_SIZE',
+        /prePullSyncedIds\.has\(s\.id\)/
+      ]
+    ] as const;
+    for (const [start, end, sweepRe] of helpers) {
+      const fn = src.slice(src.indexOf(start), src.indexOf(end));
+      // Snapshot precedes the fetch...
+      expect(fn.indexOf('prePullSyncedIds')).toBeGreaterThan(-1);
+      expect(fn.indexOf('prePullSyncedIds')).toBeLessThan(fn.indexOf('authFetch'));
+      // ...and gates the sweep.
+      expect(fn).toMatch(sweepRe);
+    }
   });
 
   it('reads the delta watermark behind a count() guard and advances it after the pull', () => {

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -136,9 +136,8 @@ export async function refreshStoresAfterPull(): Promise<void> {
   // pre-filter, zero decryption) and only decrypts on an actual collision.
   void (async () => {
     try {
-      const { detectAndNotifyPeriodicDuplicates } = await import(
-        '$lib/services/periodic-dedup.service'
-      );
+      const { detectAndNotifyPeriodicDuplicates } =
+        await import('$lib/services/periodic-dedup.service');
       await detectAndNotifyPeriodicDuplicates();
     } catch (e) {
       logger.warn('Periodic duplicate scan failed', e);
@@ -280,6 +279,21 @@ async function pullFolders(): Promise<void> {
   // `idb-cleanup.service.ts`.
   const userId = get(authStore).userId;
   if (!userId) return;
+  // Snapshot the already-synced ids BEFORE the request leaves. The orphan-
+  // delete below may only remove items from this set: an item that turned
+  // 'synced' while the pull was in flight (e.g. created and POSTed by a live
+  // folder-sync import racing this pull) is absent from the server's response
+  // only because that response was built before its POST landed - deleting it
+  // locally would hard-drop a record the server actually has. It then
+  // resurrects on a later pull, and in the gap live folder sync re-imports its
+  // file as a duplicate note. An item synced before this snapshot is genuinely
+  // authoritative: the server already knew it when answering, so its absence
+  // means a real remote delete.
+  const prePullSyncedIds = new Set(
+    ((await folderStore.getAll()) as FolderEncrypted[])
+      .filter((f) => f.sync_status === 'synced')
+      .map((f) => f.id)
+  );
   const res = await authFetch(`${API_BASE}/folders`);
   if (!res.ok) throw new Error(`GET /api/folders: ${res.status}`);
   const { data } = await res.json();
@@ -338,11 +352,15 @@ async function pullFolders(): Promise<void> {
   );
 
   // Remove local folders that no longer exist on the server (deleted on another device).
-  // Only remove 'synced' items - 'pending' items were created/edited locally and not yet pushed.
+  // Only remove 'synced' items - 'pending' items were created/edited locally and not yet
+  // pushed, and items that became synced mid-pull (pre-pull snapshot miss) were acked by
+  // the server AFTER this response was built, so they are not orphans.
   const serverFolderIds = new Set((data as Array<{ id: string }>).map((f) => f.id));
   const allLocalFolders = (await folderStore.getAll()) as FolderEncrypted[];
   const orphanIds = allLocalFolders
-    .filter((f) => f.sync_status === 'synced' && !serverFolderIds.has(f.id))
+    .filter(
+      (f) => f.sync_status === 'synced' && !serverFolderIds.has(f.id) && prePullSyncedIds.has(f.id)
+    )
     .map((f) => f.id);
   if (orphanIds.length > 0) {
     await folderStore.deleteMany(orphanIds);
@@ -354,6 +372,13 @@ async function pullTags(): Promise<void> {
   // See pullFolders() for rationale on the userId guard.
   const userId = get(authStore).userId;
   if (!userId) return;
+  // Pre-request snapshot of synced ids - see pullFolders() for the rationale
+  // (a tag pushed mid-pull must survive the orphan-delete sweep).
+  const prePullSyncedIds = new Set(
+    ((await tagStore.getAll()) as TagEncrypted[])
+      .filter((t) => t.sync_status === 'synced')
+      .map((t) => t.id)
+  );
   const res = await authFetch(`${API_BASE}/tags`);
   if (!res.ok) throw new Error(`GET /api/tags: ${res.status}`);
   const { data } = await res.json();
@@ -406,10 +431,13 @@ async function pullTags(): Promise<void> {
   );
 
   // Remove local tags that no longer exist on the server (hard-deleted on another device).
+  // Synced-mid-pull tags are excluded via the pre-pull snapshot - see pullFolders().
   const serverTagIds = new Set((data as Array<{ id: string }>).map((t) => t.id));
   const allLocalTags = (await tagStore.getAll()) as TagEncrypted[];
   const orphanTagIds = allLocalTags
-    .filter((t) => t.sync_status === 'synced' && !serverTagIds.has(t.id))
+    .filter(
+      (t) => t.sync_status === 'synced' && !serverTagIds.has(t.id) && prePullSyncedIds.has(t.id)
+    )
     .map((t) => t.id);
   if (orphanTagIds.length > 0) {
     await tagStore.deleteMany(orphanTagIds);
@@ -421,6 +449,13 @@ async function pullSavedSearches(): Promise<void> {
   // See pullFolders() for rationale on the userId guard.
   const userId = get(authStore).userId;
   if (!userId) return;
+  // Pre-request snapshot of synced ids - see pullFolders() for the rationale
+  // (a saved search pushed mid-pull must survive the orphan-delete sweep).
+  const prePullSyncedIds = new Set(
+    ((await savedSearchStore.getAll()) as SavedSearchEncrypted[])
+      .filter((s) => s.sync_status === 'synced')
+      .map((s) => s.id)
+  );
   const res = await authFetch(`${API_BASE}/saved-searches`);
   if (!res.ok) throw new Error(`GET /api/saved-searches: ${res.status}`);
   const { data } = await res.json();
@@ -484,11 +519,12 @@ async function pullSavedSearches(): Promise<void> {
     })
   );
 
-  // Remove local saved searches that no longer exist on the server (hard-deleted on another device).
+  // Remove local saved searches that no longer exist on the server (hard-deleted on another
+  // device). Synced-mid-pull rows are excluded via the pre-pull snapshot - see pullFolders().
   const serverIds = new Set((data as Array<{ id: string }>).map((s) => s.id));
   const allLocal = (await savedSearchStore.getAll()) as SavedSearchEncrypted[];
   const orphanIds = allLocal
-    .filter((s) => s.sync_status === 'synced' && !serverIds.has(s.id))
+    .filter((s) => s.sync_status === 'synced' && !serverIds.has(s.id) && prePullSyncedIds.has(s.id))
     .map((s) => s.id);
   if (orphanIds.length > 0) {
     await savedSearchStore.deleteMany(orphanIds);
@@ -587,6 +623,26 @@ async function pullNotes(): Promise<string[]> {
   const hasLocalNotes = (await noteStore.count()) > 0;
   const since = hasLocalNotes ? readWatermark(userId) : null;
 
+  // Pre-pull snapshot of already-synced ids - see pullFolders() for the full
+  // rationale. The orphan-delete below may only remove notes that were synced
+  // BEFORE the first request left: a note POSTed and acked while this pull is
+  // paging (e.g. a live folder-sync import racing the pull) is missing from
+  // all_ids only because that set was captured server-side ahead of its POST.
+  // Sweeping it hard-deletes a note the server has; it resurrects on a later
+  // delta while folder sync re-imports its file in the gap - a duplicate note.
+  // Taken only when the sweep can actually fire (reconcile, or a no-watermark
+  // bulk against an old server, where the empty-store snapshot is free):
+  // noteStore.getAll() deserializes every content blob, which the 5-min delta
+  // pulls deliberately avoid.
+  let prePullSyncedIds: Set<string> | null = null;
+  if (reconcile || !since) {
+    prePullSyncedIds = new Set(
+      ((await noteStore.getAll()) as NoteStoredLocal[])
+        .filter((n) => n.sync_status === 'synced')
+        .map((n) => n.id)
+    );
+  }
+
   // Dynamic imports (same rationale as refreshStoresAfterPull): avoids a
   // sync-service <-> note-index/notes-store import cycle. Cached by the bundler.
   const { noteIndex } = await import('$lib/services/note-index.svelte');
@@ -661,12 +717,17 @@ async function pullNotes(): Promise<string[]> {
 
   // Orphan-delete ONLY from the authoritative all_ids (never from page contents:
   // a delta page holds just the changed notes). Skipped entirely when allIds is
-  // null (old server, or a non-reconcile periodic pull).
+  // null (old server, or a non-reconcile periodic pull). Intersected with the
+  // pre-pull snapshot so a note that became synced mid-pull is never swept.
   if (allIds) {
     const serverIds = allIds;
+    // allIds implies the snapshot was taken (reconcile or !since). If that
+    // invariant ever breaks, an empty set means "delete nothing" rather than
+    // re-opening the mid-pull race.
+    const preSynced = prePullSyncedIds ?? new Set<string>();
     const allLocalNotes = (await noteStore.getAll()) as NoteStoredLocal[];
     const orphanNoteIds = allLocalNotes
-      .filter((n) => n.sync_status === 'synced' && !serverIds.has(n.id))
+      .filter((n) => n.sync_status === 'synced' && !serverIds.has(n.id) && preSynced.has(n.id))
       .map((n) => n.id);
     if (orphanNoteIds.length > 0) {
       await noteStore.deleteMany(orphanNoteIds);
@@ -752,10 +813,7 @@ async function writeNotesPage(
         //      response was dropped before we could mirror the new version locally.
         // We only adjust is_archived here - content fields stay as they are so
         // local edits aren't clobbered.
-        if (
-          localNote.sync_status === 'synced' &&
-          !!localNote.is_archived !== serverArchived
-        ) {
+        if (localNote.sync_status === 'synced' && !!localNote.is_archived !== serverArchived) {
           logger.info(
             `Reconciling archive state for note ${n.id}: local=${localNote.is_archived} server=${serverArchived}`
           );

--- a/apps/reborn-notes/src/lib/services/saved-searches-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/saved-searches-sync.regression.spec.ts
@@ -41,8 +41,11 @@ describe('saved searches - pull sync', () => {
     expect(fn).toMatch(/metadata_encrypted \?\? null/);
     expect(fn).toMatch(/folder_id \?\? null/);
     expect(fn).toMatch(/position !== s\.position/);
-    // Rows hard-deleted on another device disappear locally - but only synced ones.
+    // Rows hard-deleted on another device disappear locally - but only rows that
+    // were ALREADY synced before the pull started (a row pushed mid-pull is not
+    // an orphan: the server response was built before its POST landed).
     expect(fn).toMatch(/sync_status === 'synced' && !serverIds\.has/);
+    expect(fn).toMatch(/prePullSyncedIds\.has\(s\.id\)/);
     expect(fn).toMatch(/deleteMany\(orphanIds\)/);
   });
 });


### PR DESCRIPTION
## Summary

Root-cause fix for the duplicated folder-sync notes reported on prod v0.42.1 (`70-keyboard-shortcuts`, `71-auto-backup-zk` appearing twice, the older copy frozen at the file's creation-era mtime).

The chain: a note created and POSTed while a reconcile pull was paging turned `synced` after the server had already built its authoritative id set (`all_ids`), so the end-of-pull orphan sweep hard-deleted it locally despite the server having it. On the next folder-sync run the path manifest id no longer resolved and the title index no longer held the note, so the file was force-re-imported as a duplicate; a later delta pull then resurrected the original. The race has existed since the notes orphan-delete shipped; the paginated reconcile pull (#356) widened the window to the whole multi-page run.

Fix: all four pull sweeps (`pullNotes`, `pullFolders`, `pullTags`, `pullSavedSearches`) snapshot the locally-synced ids before their first request and only delete ids that are synced AND absent from the server set AND present in that snapshot. Entities synced mid-pull survive; entities deleted on another device are still swept (they were synced before the pull, so they sit in the snapshot). In `pullNotes` the snapshot is gated on `reconcile || !since` so idle 5-min delta pulls keep avoiding the expensive `noteStore.getAll()`, with an empty-set fail-safe (no snapshot = delete nothing).

No schema, API or semantics changes - the sweep still converges remote hard-deletes; it just stops eating records born mid-pull.

## Test plan

- `vitest` reborn-notes: 82 files / 1228 tests green, including a new regression test pinning snapshot-before-fetch + snapshot-gated sweep in all four helpers, and an extended saved-searches assertion.
- svelte-check 0 errors / 0 warnings, eslint + prettier clean.
- Smoke (after deploy): create a new `.md` file in a synced folder, then reload the app (or toggle offline/online) so the reconcile pull and the folder-sync import overlap; the imported note should persist through the pull and later edits of the file should keep updating the same note instead of minting a second copy. Existing cleanup: the two old frozen copies can be deleted manually (they are not referenced by the sync manifest).