### PR TITLE
fix(notes): don't wipe pending edits when push probe runs locked

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.key-mismatch.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.key-mismatch.regression.spec.ts
@@ -37,6 +37,19 @@ describe('notes-sync - cross-key pending guard (audit 012 S6)', () => {
     expect(firstPushIdx).toBeGreaterThan(probeIdx);
   });
 
+  it('never runs the probe without a loaded master key (audit 013 S1)', () => {
+    // The probe cannot tell "wrong key" from "no key in memory" - decryptText
+    // rejects either way. The offline→online handler calls pushPendingItems()
+    // on every route, including /auth/unlock: a fresh tab opened offline with
+    // unsynced edits would probe all-fail once connectivity returned and the
+    // online branch wiped those edits before they ever reached the server.
+    // The gate must be an early return that precedes the probe.
+    const gateIdx = body.indexOf('if (!cryptoManager.isInitialized()) return;');
+    const probeIdx = body.indexOf('isEncryptedDataReadable');
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(probeIdx);
+  });
+
   it('probes one ciphertext per pending entity kind', () => {
     expect(body).toMatch(/pendingNotes\[0\] \?\? pendingArchivedNotes\[0\]/);
     expect(body).toMatch(/pendingFolders\[0\]\?\.name_encrypted/);

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -988,6 +988,14 @@ let pendingRowsKeyChecked = false;
  */
 export async function pushPendingItems(): Promise<void> {
   if (!isAuthenticated()) return;
+  // Authenticated but locked (master key not in memory - e.g. a fresh tab
+  // parked on /auth/unlock when the offline→online handler fires): the
+  // cross-key probe below cannot tell "wrong key" from "no key loaded",
+  // decryptText rejects either way, so it would misread every pending row as
+  // foreign and the online branch would wipe not-yet-pushed offline edits.
+  // Without the key row ownership cannot be verified - defer the push to the
+  // post-unlock sync, like the import guard does (audit 013 S1).
+  if (!cryptoManager.isInitialized()) return;
 
   const [allFolders, allTags, allSavedSearches, allNotes] = await Promise.all([
     folderStore.getAll() as Promise<FolderEncrypted[]>,


### PR DESCRIPTION
## Summary

Fixes finding **S1 from security audit 013** - a regression introduced by the audit 012 S6 fix (#404).

The cross-key push guard in `pushPendingItems()` probes one pending ciphertext per entity kind and, on an online mismatch, wipes local data so the paired pull can restore the account state. But the probe cannot tell "wrong key" from "no key in memory": `decryptText` rejects either way. The offline->online handler in `sync-status.store.ts` calls `pushPendingItems()` without a `hasE2E` gate and is live on every route, including `/auth/unlock` - so a fresh tab opened offline with unsynced pending edits (master key not yet in sessionStorage) would probe all-fail the moment connectivity returned and wipe those edits before they ever reached the server. Same window on native while App Lock is engaged.

Fix per the audit recommendation: early-return `if (!cryptoManager.isInitialized()) return;` at the top of `pushPendingItems()`. Without the key, row ownership cannot be verified, so the push is deferred to the post-unlock sync - consistent with the guard's own "offline = skip, never wipe" branch and with the twin import guard (audit 012 S3), which already requires `isInitialized()`.

A source-level regression test pins the gate before the probe.

## Test plan

- `nx run-many -t lint check test -p reborn-notes` green locally (1229 tests incl. the new regression test; svelte-check 0 errors).
- Smoke (optional): account with pending offline edits -> open a fresh tab offline (lands on `/auth/unlock`) -> restore connectivity while still locked: notes must survive; after unlock the pending edits push to the server.