### PR TITLE
fix(notes): mark folder reorder/move rows pending atomically

### DIFF
--- a/apps/reborn-notes/src/lib/services/folder.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder.service.ts
@@ -322,27 +322,28 @@ export async function deleteFolder(
 }
 
 // `options.skipSync` defers the push to the caller (see renameFolder above).
+// The storage layer marks the row `pending` atomically with the move itself,
+// so there is no window where a sync pull could revert the fresh parent_id.
 export async function moveFolderToParent(
   id: string,
   newParentId: string | null,
   options?: { skipSync?: boolean }
 ): Promise<void> {
   await folderOperations.moveFolder(id, newParentId);
-  const current = await folderStore.get(id);
-  if (current) await folderStore.save({ ...current, sync_status: 'pending' });
   if (!options?.skipSync) pushFolderUpdate(id, { parent_id: newParentId });
 }
 
+// The storage layer writes order_index + `pending` in one batch (no window
+// for a pull to revert a not-yet-pending row) and skips ids deleted or
+// reparented remotely mid-gesture - push only what was actually written,
+// so the server never gets a 404 PATCH or an index for a foreign group.
 export async function reorderSiblings(
   parentId: string | null,
   orderedIds: string[]
 ): Promise<void> {
-  await folderOperations.reorderFolders(parentId, orderedIds);
-  for (const folderId of orderedIds) {
-    const current = await folderStore.get(folderId);
-    if (current) await folderStore.save({ ...current, sync_status: 'pending' });
-  }
+  const reordered = await folderOperations.reorderFolders(parentId, orderedIds);
+  const written = new Set(reordered);
   orderedIds.forEach((folderId, index) => {
-    pushFolderUpdate(folderId, { order_index: index });
+    if (written.has(folderId)) pushFolderUpdate(folderId, { order_index: index });
   });
 }

--- a/packages/storage/src/__tests__/folder-reorder.spec.ts
+++ b/packages/storage/src/__tests__/folder-reorder.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// core/store imports validateEncryptedPayload at module level; stub the
+// browser-only crypto package so the module graph loads in the test env.
+vi.mock('@reborn/crypto', () => ({
+  validateEncryptedPayload: vi.fn()
+}));
+
+import { folderStore, folderOperations } from '../stores/folder.store';
+import type { FolderEncrypted } from '@reborn/types';
+import type { BatchResult } from '../core/types';
+
+const EMPTY_BATCH: BatchResult = { success: 0, failed: 0, errors: [] };
+
+function makeFolder(overrides: Partial<FolderEncrypted> & { id: string }): FolderEncrypted {
+  return {
+    user_id: 'user-1',
+    name_encrypted: 'aXZfYmFzZTY0XzE2:Y2lwaGVydGV4dA==',
+    order_index: 0,
+    is_archived: false,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    sync_status: 'synced',
+    sync_version: 3,
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Regression tests for audit 013 N1: a pull racing a folder reorder could
+// revert it, because order_index was written first and sync_status:'pending'
+// only afterwards row-by-row (the pull guard skips only already-pending rows).
+describe('folderOperations.reorderFolders', () => {
+  it('writes order_index and sync_status pending in a single batch', async () => {
+    const a = makeFolder({ id: 'a', order_index: 0 });
+    const b = makeFolder({ id: 'b', order_index: 1 });
+    vi.spyOn(folderStore, 'getMany').mockResolvedValue([a, b]);
+    const saveMany = vi
+      .spyOn(folderStore, 'saveMany')
+      .mockResolvedValue({ ...EMPTY_BATCH, success: 2 });
+    const save = vi.spyOn(folderStore, 'save').mockResolvedValue();
+
+    const written = await folderOperations.reorderFolders(null, ['b', 'a']);
+
+    expect(saveMany).toHaveBeenCalledTimes(1);
+    expect(save).not.toHaveBeenCalled();
+    const rows = saveMany.mock.calls[0]![0] as FolderEncrypted[];
+    expect(rows.map((r) => [r.id, r.order_index, r.sync_status])).toEqual([
+      ['b', 0, 'pending'],
+      ['a', 1, 'pending']
+    ]);
+    expect(written).toEqual(['b', 'a']);
+  });
+
+  it('skips ids deleted remotely mid-gesture and keeps position-derived indexes', async () => {
+    const a = makeFolder({ id: 'a' });
+    const c = makeFolder({ id: 'c' });
+    // 'b' no longer exists locally - getMany silently drops it.
+    vi.spyOn(folderStore, 'getMany').mockResolvedValue([a, c]);
+    const saveMany = vi
+      .spyOn(folderStore, 'saveMany')
+      .mockResolvedValue({ ...EMPTY_BATCH, success: 2 });
+
+    const written = await folderOperations.reorderFolders(null, ['c', 'b', 'a']);
+
+    const rows = saveMany.mock.calls[0]![0] as FolderEncrypted[];
+    // Indexes match the position in the requested order (what the caller
+    // pushes to the server), not a compacted 0..n-1 sequence.
+    expect(rows.map((r) => [r.id, r.order_index])).toEqual([
+      ['c', 0],
+      ['a', 2]
+    ]);
+    expect(written).toEqual(['c', 'a']);
+  });
+
+  it('skips rows reparented away from the sibling group mid-gesture', async () => {
+    const a = makeFolder({ id: 'a', parent_id: 'group' });
+    const b = makeFolder({ id: 'b', parent_id: 'elsewhere' });
+    vi.spyOn(folderStore, 'getMany').mockResolvedValue([a, b]);
+    const saveMany = vi
+      .spyOn(folderStore, 'saveMany')
+      .mockResolvedValue({ ...EMPTY_BATCH, success: 1 });
+
+    const written = await folderOperations.reorderFolders('group', ['b', 'a']);
+
+    const rows = saveMany.mock.calls[0]![0] as FolderEncrypted[];
+    expect(rows.map((r) => r.id)).toEqual(['a']);
+    expect(rows[0]!.order_index).toBe(1);
+    expect(written).toEqual(['a']);
+  });
+
+  it('treats undefined parent_id as the root group', async () => {
+    const root = makeFolder({ id: 'root-child' }); // parent_id undefined
+    vi.spyOn(folderStore, 'getMany').mockResolvedValue([root]);
+    const saveMany = vi
+      .spyOn(folderStore, 'saveMany')
+      .mockResolvedValue({ ...EMPTY_BATCH, success: 1 });
+
+    const written = await folderOperations.reorderFolders(null, ['root-child']);
+
+    expect((saveMany.mock.calls[0]![0] as FolderEncrypted[]).map((r) => r.id)).toEqual([
+      'root-child'
+    ]);
+    expect(written).toEqual(['root-child']);
+  });
+});
+
+describe('folderOperations.moveFolder', () => {
+  it('marks the row pending in the same write as the move', async () => {
+    const folder = makeFolder({ id: 'a', parent_id: 'old-parent', order_index: 5 });
+    vi.spyOn(folderStore, 'get').mockResolvedValue(folder);
+    // New parent group is the root: getRootFolders() -> getAll()
+    vi.spyOn(folderStore, 'getAll').mockResolvedValue([]);
+    const save = vi.spyOn(folderStore, 'save').mockResolvedValue();
+
+    await folderOperations.moveFolder('a', null);
+
+    expect(save).toHaveBeenCalledTimes(1);
+    const row = save.mock.calls[0]![0] as FolderEncrypted;
+    expect(row.parent_id).toBeUndefined();
+    expect(row.order_index).toBe(0);
+    expect(row.sync_status).toBe('pending');
+  });
+});

--- a/packages/storage/src/stores/folder.store.ts
+++ b/packages/storage/src/stores/folder.store.ts
@@ -125,12 +125,14 @@ export const folderOperations = {
   },
 
   /**
-   * Move folder to new parent
+   * Move folder to new parent. Marks the row `sync_status: 'pending'` in the
+   * same write - a sync pull landing between the move and a separate pending
+   * mark could revert it with the older server row.
    */
   moveFolder: async (folderId: string, newParentId: string | null): Promise<void> => {
     const folder = await folderStore.get(folderId);
     if (!folder) throw new Error('Folder not found');
-    
+
     // Check for circular reference
     if (newParentId) {
       const parentPath = await folderQueries.getFolderPath(newParentId);
@@ -138,18 +140,19 @@ export const folderOperations = {
         throw new Error('Cannot move folder to its own descendant');
       }
     }
-    
+
     // Get new siblings for ordering
-    const newSiblings = newParentId 
+    const newSiblings = newParentId
       ? await folderQueries.getChildren(newParentId)
       : await folderQueries.getRootFolders();
-    
+
     const maxOrder = Math.max(...newSiblings.map(s => s.order_index), -1);
-    
+
     await folderStore.save({
       ...folder,
       parent_id: newParentId ?? undefined,
       order_index: maxOrder + 1,
+      sync_status: 'pending',
       updated_at: new Date().toISOString()
     });
   },
@@ -190,16 +193,33 @@ export const folderOperations = {
   },
 
   /**
-   * Reorder folders
+   * Reorder folders within one sibling group.
+   *
+   * The new `order_index` and `sync_status: 'pending'` are written in a single
+   * batch, so a sync pull can never observe a reordered row that is not yet
+   * pending (pull would overwrite it with the older server row). Ids missing
+   * locally or no longer children of `parentId` (deleted / moved remotely
+   * mid-gesture) are skipped; surviving rows keep their position-derived
+   * index so the local state matches what the caller pushes.
+   *
+   * Returns the ids actually written, in `folderIds` order.
    */
-  reorderFolders: async (parentId: string | null, folderIds: string[]): Promise<void> => {
+  reorderFolders: async (parentId: string | null, folderIds: string[]): Promise<string[]> => {
     const folders = await folderStore.getMany(folderIds);
-    const updated = folders.map((folder, index) => ({
-      ...folder,
-      order_index: index,
-      updated_at: new Date().toISOString()
-    }));
+    const byId = new Map(folders.map(folder => [folder.id, folder]));
+    const updated: FolderEncrypted[] = [];
+    folderIds.forEach((folderId, index) => {
+      const folder = byId.get(folderId);
+      if (!folder || (folder.parent_id ?? null) !== parentId) return;
+      updated.push({
+        ...folder,
+        order_index: index,
+        sync_status: 'pending',
+        updated_at: new Date().toISOString()
+      });
+    });
     await folderStore.saveMany(updated);
+    return updated.map(folder => folder.id);
   },
 
   /**


### PR DESCRIPTION
## Summary

Fixes audit 013 **N1** (last same-family race after #412): a sync pull racing a folder reorder could silently revert it.

- `reorderSiblings` wrote the new `order_index` via `saveMany` first and only afterwards marked each row `sync_status:'pending'` in a sequential get+save loop - the unprotected window grows linearly with group size. `moveFolderToParent` had the same two-step shape. The pull guard only skips rows that are *already* pending, so a pull inside the window overwrites the fresh row with the older server row.
- The storage layer (`folderOperations.reorderFolders` / `moveFolder`) now writes `order_index` + `sync_status:'pending'` **in the same batch/write** (single IndexedDB readwrite transaction), and the service loops are gone.
- While here (same audit finding): `reorderFolders` no longer ignores `parentId` - ids deleted remotely mid-gesture or reparented away from the sibling group are skipped, surviving rows keep their position-derived index, and it returns the ids actually written so the service pushes only those (no 404 PATCH noise, no order_index landing in a foreign sibling group).

New regression spec: `packages/storage/src/__tests__/folder-reorder.spec.ts` (5 tests - atomic pending batch, deleted-id skip, reparented-row skip, root-group normalization, atomic pending on move).

## Test plan

- `nx affected -t lint check test typecheck build` green locally (storage 45 tests incl. 5 new).
- Smoke (custom sort mode): drag-reorder a folder group / nudge up-down → order sticks after a manual sync pull; drag a folder into another parent → move sticks. Cross-device: reorder offline on A, edit same folder on B, reconnect A → A's reorder pushes without reverting.