### PR TITLE
fix(notes): repair folder parent_id cycles at pull

### DIFF
--- a/apps/reborn-notes/src/lib/services/folder-cycle-repair.spec.ts
+++ b/apps/reborn-notes/src/lib/services/folder-cycle-repair.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { findFolderCycles, pickCycleRepairTarget, planCycleRepairs } from './folder-cycle-repair';
+
+// Regression tests for audit 013 N2: the server accepts concurrent
+// cross-device moves that close a parent_id cycle; pull detects the cycle in
+// the local mirror and reparents exactly one member per cycle to the root.
+
+function f(id: string, parent_id?: string, updated_at = '2026-07-01T00:00:00.000Z') {
+  return { id, parent_id, updated_at };
+}
+
+function sorted(cycles: string[][]): string[][] {
+  return cycles.map((c) => [...c].sort()).sort((a, b) => a[0]!.localeCompare(b[0]!));
+}
+
+describe('findFolderCycles', () => {
+  it('empty input → no cycles', () => {
+    expect(findFolderCycles([])).toEqual([]);
+  });
+
+  it('a healthy tree has no cycles', () => {
+    const rows = [f('root'), f('a', 'root'), f('b', 'root'), f('c', 'a')];
+    expect(findFolderCycles(rows)).toEqual([]);
+  });
+
+  it('detects the two-device A↔B cycle', () => {
+    const rows = [f('a', 'b'), f('b', 'a')];
+    expect(sorted(findFolderCycles(rows))).toEqual([['a', 'b']]);
+  });
+
+  it('detects a direct self-parent as a one-member cycle', () => {
+    expect(findFolderCycles([f('a', 'a')])).toEqual([['a']]);
+  });
+
+  it('detects a deep cycle (a→b→c→a)', () => {
+    const rows = [f('a', 'b'), f('b', 'c'), f('c', 'a')];
+    expect(sorted(findFolderCycles(rows))).toEqual([['a', 'b', 'c']]);
+  });
+
+  it('folders hanging off a cycle are NOT members (reparenting one member frees them)', () => {
+    // sub and leaf dangle from the a↔b loop - only the loop is the cycle.
+    const rows = [f('a', 'b'), f('b', 'a'), f('sub', 'a'), f('leaf', 'sub')];
+    expect(sorted(findFolderCycles(rows))).toEqual([['a', 'b']]);
+  });
+
+  it('reports each independent cycle exactly once', () => {
+    const rows = [f('a', 'b'), f('b', 'a'), f('x', 'y'), f('y', 'x'), f('root'), f('kid', 'root')];
+    expect(sorted(findFolderCycles(rows))).toEqual([
+      ['a', 'b'],
+      ['x', 'y']
+    ]);
+  });
+
+  it('a dangling parent_id terminates the walk without reporting a cycle', () => {
+    const rows = [f('orphan', 'gone'), f('root')];
+    expect(findFolderCycles(rows)).toEqual([]);
+  });
+});
+
+describe('pickCycleRepairTarget', () => {
+  it('picks the most recently updated member (the move that closed the cycle)', () => {
+    const rows = [
+      f('a', 'b', '2026-07-01T00:00:00.000Z'),
+      f('b', 'a', '2026-07-01T00:00:05.000Z')
+    ];
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    expect(pickCycleRepairTarget(['a', 'b'], byId)).toBe('b');
+  });
+
+  it('breaks timestamp ties by the greater id (deterministic across devices)', () => {
+    const rows = [f('a', 'b'), f('b', 'a')];
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    expect(pickCycleRepairTarget(['a', 'b'], byId)).toBe('b');
+    expect(pickCycleRepairTarget(['b', 'a'], byId)).toBe('b');
+  });
+});
+
+describe('planCycleRepairs', () => {
+  it('returns one repair target per cycle and nothing for healthy trees', () => {
+    const rows = [
+      f('root'),
+      f('kid', 'root'),
+      f('a', 'b', '2026-07-01T00:00:00.000Z'),
+      f('b', 'a', '2026-07-01T00:00:05.000Z'),
+      f('x', 'y', '2026-07-02T00:00:00.000Z'),
+      f('y', 'x', '2026-07-01T00:00:00.000Z')
+    ];
+    expect(planCycleRepairs(rows).sort()).toEqual(['b', 'x']);
+    expect(planCycleRepairs([f('root'), f('kid', 'root')])).toEqual([]);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/folder-cycle-repair.ts
+++ b/apps/reborn-notes/src/lib/services/folder-cycle-repair.ts
@@ -1,0 +1,81 @@
+import type { FolderEncrypted } from '@reborn/types';
+
+/**
+ * Detection and repair planning for folder `parent_id` cycles (audit 013 N2).
+ *
+ * The server does not validate the folder graph beyond direct self-parenting,
+ * so two devices moving concurrently (A under B on one, B under A on the
+ * other) both pass their local pre-move cycle checks and both writes land -
+ * the server ends up with a cycle. Tree materialization walks from the roots,
+ * so every member of a cycle (and its whole subtree) silently disappears from
+ * the folder views on all devices.
+ *
+ * Pull is the choke point where each device converges on server state, so
+ * `pullFolders()` runs this detection over the local mirror and reparents ONE
+ * member per cycle to the root. Picking the most recently updated member
+ * undoes the move that closed the cycle while preserving the other device's
+ * earlier move, and because the timestamps come from the server, every device
+ * picks the SAME member - concurrent repairs converge instead of cutting
+ * different edges.
+ */
+
+type FolderRow = Pick<FolderEncrypted, 'id' | 'parent_id' | 'updated_at'>;
+
+/**
+ * Find all `parent_id` cycles. Returns each cycle as the list of member ids
+ * (only the loop itself - folders that merely hang off a cycle are not
+ * members; reparenting one member makes the whole subtree reachable again).
+ * A parent id pointing at a row absent from `rows` terminates the walk (a
+ * dangling FK is not a cycle).
+ */
+export function findFolderCycles(rows: FolderRow[]): string[][] {
+  const parentById = new Map(rows.map((r) => [r.id, r.parent_id]));
+  // Ids whose walk already terminated (reached a root, a dangling parent, or
+  // a previously classified chain) - each node is walked at most once.
+  const resolved = new Set<string>();
+  const cycles: string[][] = [];
+
+  for (const row of rows) {
+    if (resolved.has(row.id)) continue;
+    const path: string[] = [];
+    const pathIndex = new Map<string, number>();
+    let cursor: string | undefined = row.id;
+    while (cursor !== undefined && parentById.has(cursor) && !resolved.has(cursor)) {
+      const seenAt = pathIndex.get(cursor);
+      if (seenAt !== undefined) {
+        // Walked back into the current path - the loop portion is the cycle.
+        cycles.push(path.slice(seenAt));
+        break;
+      }
+      pathIndex.set(cursor, path.length);
+      path.push(cursor);
+      cursor = parentById.get(cursor) ?? undefined;
+    }
+    for (const id of path) resolved.add(id);
+  }
+
+  return cycles;
+}
+
+/**
+ * Pick the cycle member to reparent to the root: newest `updated_at` (= the
+ * move that closed the cycle), ties broken by the greater id so the choice
+ * stays deterministic across devices.
+ */
+export function pickCycleRepairTarget(cycle: string[], byId: Map<string, FolderRow>): string {
+  return cycle.reduce((best, id) => {
+    const bestTime = Date.parse(byId.get(best)?.updated_at ?? '') || 0;
+    const time = Date.parse(byId.get(id)?.updated_at ?? '') || 0;
+    if (time > bestTime) return id;
+    if (time === bestTime && id > best) return id;
+    return best;
+  });
+}
+
+/** Ids to reparent to the root - one per detected cycle. */
+export function planCycleRepairs(rows: FolderRow[]): string[] {
+  const cycles = findFolderCycles(rows);
+  if (cycles.length === 0) return [];
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  return cycles.map((cycle) => pickCycleRepairTarget(cycle, byId));
+}

--- a/apps/reborn-notes/src/lib/services/folder-push-order.ts
+++ b/apps/reborn-notes/src/lib/services/folder-push-order.ts
@@ -17,10 +17,11 @@ import type { FolderEncrypted } from '@reborn/types';
  * Within a layer, siblings are independent and push in parallel; awaiting
  * between layers guarantees children see their parents server-side.
  *
- * Cycles cannot exist in valid folder data (server enforces a tree), but if
- * one does sneak in via corruption, leftover folders get appended as a final
- * layer so the server can reject them rather than the client silently
- * dropping them on the floor.
+ * Cycles CAN transiently exist here: the server accepts concurrent
+ * cross-device moves that close a parent_id loop, and pullFolders() only
+ * repairs them on the next pull (see folder-cycle-repair.ts). Leftover
+ * folders from such a cycle get appended as a final layer so the server can
+ * take them rather than the client silently dropping them on the floor.
  */
 export function buildFolderLayers(folders: FolderEncrypted[]): FolderEncrypted[][] {
   if (folders.length === 0) return [];

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -243,6 +243,29 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(pullNotes).toMatch(/sync_status.*===.*'synced'/);
   });
 
+  it('pullFolders repairs parent_id cycles after the orphan sweep (audit 013 N2)', () => {
+    // The server accepts concurrent cross-device moves that close a parent_id
+    // cycle; cycle members are unreachable from the roots and silently vanish
+    // from every folder view. Pull must detect cycles over the post-sweep
+    // local mirror, reparent one member per cycle to the root with
+    // sync_status:'pending' in the SAME save, and push the repair.
+    const src = readSource('./notes-sync.service.ts');
+    const pullFolders = src.slice(
+      src.indexOf('async function pullFolders'),
+      src.indexOf('async function pullTags')
+    );
+    const orphanSweepIdx = pullFolders.search(/folderStore\.deleteMany/);
+    const repairIdx = pullFolders.search(/planCycleRepairs/);
+    expect(orphanSweepIdx).toBeGreaterThan(-1);
+    expect(repairIdx).toBeGreaterThan(orphanSweepIdx);
+    // The repair write clears the parent and marks pending atomically…
+    expect(pullFolders).toMatch(
+      /parent_id:\s*undefined,\s*\n\s*sync_status:\s*'pending'/
+    );
+    // …and the repaired parent lands on the server like a user move.
+    expect(pullFolders).toMatch(/pushFolderUpdate\(folderId,\s*\{\s*parent_id:\s*null\s*\}\)/);
+  });
+
   it('pushPendingItems pushes folders BFS-by-layer (parent before child)', () => {
     // Server's POST /api/folders FK-checks parent_id and 404s if the parent
     // isn't on the server yet. A flat fan-out would 404-spam mid-batch on

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -52,6 +52,7 @@ import { validateEncryptedPayload } from '@reborn/crypto';
 import { refreshQuota } from '$lib/stores/storage-quota.store';
 import { connectivityStore } from '$lib/stores/connectivity.store';
 import { buildFolderLayers } from './folder-push-order';
+import { planCycleRepairs } from './folder-cycle-repair';
 import { settleInBatches } from './sync-batch';
 import { notifyNoteSyncError, notifyBatchSyncErrors } from './sync-error-notify';
 import { ensureOk, HttpPushError } from './push-error';
@@ -357,14 +358,41 @@ async function pullFolders(): Promise<void> {
   // the server AFTER this response was built, so they are not orphans.
   const serverFolderIds = new Set((data as Array<{ id: string }>).map((f) => f.id));
   const allLocalFolders = (await folderStore.getAll()) as FolderEncrypted[];
-  const orphanIds = allLocalFolders
-    .filter(
-      (f) => f.sync_status === 'synced' && !serverFolderIds.has(f.id) && prePullSyncedIds.has(f.id)
-    )
-    .map((f) => f.id);
-  if (orphanIds.length > 0) {
-    await folderStore.deleteMany(orphanIds);
-    logger.debug(`Removed ${orphanIds.length} locally-synced folders no longer on server`);
+  const orphanIds = new Set(
+    allLocalFolders
+      .filter(
+        (f) =>
+          f.sync_status === 'synced' && !serverFolderIds.has(f.id) && prePullSyncedIds.has(f.id)
+      )
+      .map((f) => f.id)
+  );
+  if (orphanIds.size > 0) {
+    await folderStore.deleteMany([...orphanIds]);
+    logger.debug(`Removed ${orphanIds.size} locally-synced folders no longer on server`);
+  }
+
+  // Repair parent_id cycles (audit 013 N2). Two devices moving A under B and
+  // B under A concurrently both pass their local pre-move cycle checks, and
+  // the server accepts both writes - the pulled mirror now contains a cycle
+  // whose members (plus their subtrees) are unreachable from the roots and
+  // silently vanish from every folder view. Reparent one member per cycle to
+  // the root; see folder-cycle-repair.ts for why the pick is deterministic
+  // across devices. The repair row is marked pending atomically with the
+  // write (same rationale as reorderFolders) and pushed like a user move.
+  const survivors = allLocalFolders.filter((f) => !orphanIds.has(f.id));
+  for (const folderId of planCycleRepairs(survivors)) {
+    // Re-read: the row may have changed since the getAll() above (user move
+    // racing this pull) - repair the current row, not the stale snapshot.
+    const row = (await folderStore.get(folderId)) as FolderEncrypted | null;
+    if (!row) continue;
+    logger.warn(`Folder ${folderId} is part of a parent_id cycle - reparenting to root`);
+    await folderStore.save({
+      ...row,
+      parent_id: undefined,
+      sync_status: 'pending',
+      updated_at: new Date().toISOString()
+    });
+    pushFolderUpdate(folderId, { parent_id: null });
   }
 }
 

--- a/packages/storage/src/__tests__/folder-path-cycle.spec.ts
+++ b/packages/storage/src/__tests__/folder-path-cycle.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// core/store imports validateEncryptedPayload at module level; stub the
+// browser-only crypto package so the module graph loads in the test env.
+vi.mock('@reborn/crypto', () => ({
+  validateEncryptedPayload: vi.fn()
+}));
+
+import { folderStore, folderQueries } from '../stores/folder.store';
+import type { FolderEncrypted } from '@reborn/types';
+
+function makeFolder(overrides: Partial<FolderEncrypted> & { id: string }): FolderEncrypted {
+  return {
+    user_id: 'user-1',
+    name_encrypted: 'aXZfYmFzZTY0XzE2:Y2lwaGVydGV4dA==',
+    order_index: 0,
+    is_archived: false,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    sync_status: 'synced',
+    sync_version: 3,
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Regression tests for audit 013 N2 hardening: sync can briefly land a
+// parent_id cycle (concurrent cross-device moves; repaired at pull). The
+// breadcrumb walk must terminate on it instead of hanging the tab.
+describe('folderQueries.getFolderPath', () => {
+  it('walks a healthy chain root-first', async () => {
+    const rows = new Map([
+      ['root', makeFolder({ id: 'root' })],
+      ['mid', makeFolder({ id: 'mid', parent_id: 'root' })],
+      ['leaf', makeFolder({ id: 'leaf', parent_id: 'mid' })]
+    ]);
+    vi.spyOn(folderStore, 'get').mockImplementation(async (id: string) => rows.get(id) ?? null);
+
+    const path = await folderQueries.getFolderPath('leaf');
+
+    expect(path.map((p) => p.id)).toEqual(['root', 'mid', 'leaf']);
+  });
+
+  it('terminates on a parent_id cycle instead of looping forever', async () => {
+    const rows = new Map([
+      ['a', makeFolder({ id: 'a', parent_id: 'b' })],
+      ['b', makeFolder({ id: 'b', parent_id: 'a' })]
+    ]);
+    const get = vi
+      .spyOn(folderStore, 'get')
+      .mockImplementation(async (id: string) => rows.get(id) ?? null);
+
+    const path = await folderQueries.getFolderPath('a');
+
+    // Each member is visited exactly once; the second visit of 'a' is refused.
+    expect(path.map((p) => p.id)).toEqual(['b', 'a']);
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('terminates on a direct self-parent row', async () => {
+    const rows = new Map([['a', makeFolder({ id: 'a', parent_id: 'a' })]]);
+    vi.spyOn(folderStore, 'get').mockImplementation(async (id: string) => rows.get(id) ?? null);
+
+    const path = await folderQueries.getFolderPath('a');
+
+    expect(path.map((p) => p.id)).toEqual(['a']);
+  });
+});

--- a/packages/storage/src/stores/folder.store.ts
+++ b/packages/storage/src/stores/folder.store.ts
@@ -76,16 +76,20 @@ export const folderQueries = {
    */
   getFolderPath: async (folderId: string): Promise<FolderEncrypted[]> => {
     const path: FolderEncrypted[] = [];
+    // Sync can briefly land a parent_id cycle (concurrent cross-device moves;
+    // repaired at pull) - the visited set keeps this walk from hanging on it.
+    const visited = new Set<string>();
     let currentId: string | null = folderId;
-    
-    while (currentId) {
+
+    while (currentId && !visited.has(currentId)) {
+      visited.add(currentId);
       const folder = await folderStore.get(currentId);
       if (!folder) break;
-      
+
       path.unshift(folder);
       currentId = folder.parent_id ?? null;
     }
-    
+
     return path;
   },
 


### PR DESCRIPTION
## Summary

Audit 013 **N2**: the server accepts concurrent cross-device folder moves that close a `parent_id` cycle (each device's pre-move cycle check is per-device TOCTOU). Tree materialization walks from the roots, so cycle members and their entire subtrees silently vanished from every folder view.

- New pure module `folder-cycle-repair.ts`: cycle detection over the local mirror (each node walked once, dangling FKs are not cycles) + deterministic repair-target pick.
- `pullFolders()` runs the detection after the orphan sweep and reparents **one member per cycle to the root**: the most recently updated member, i.e. the move that closed the cycle - the other device's earlier move survives. The pick keys on server timestamps, so all devices pick the same member and concurrent repairs converge (no cross-device churn). The repair write sets `parent_id: undefined` + `sync_status: 'pending'` atomically (same rationale as #415) and pushes `PATCH {parent_id: null}`.
- Hardening: `getFolderPath()` in `@reborn/storage` now walks with a visited set - a briefly-present cycle can no longer hang the breadcrumb walk.
- Fixed the stale "server enforces a tree" comment in `folder-push-order.ts`.

**Decision (agreed with product):** client-side repair at pull was chosen over server-side ancestor-walk rejection - no API change, graph semantics stay client-side, and it also self-heals any cycle already present in stored data.

## Test plan

- `folder-cycle-repair.spec.ts`: healthy trees, A↔B cycle, self-parent, deep cycle, subtrees hanging off a cycle (not repaired), independent cycles, dangling parent, deterministic pick (timestamp + id tiebreak).
- `folder-path-cycle.spec.ts` (storage): breadcrumb walk terminates on 2-cycles and self-parent rows.
- Source-level pin in `notes-sync.regression.spec.ts`: repair runs after the orphan sweep, atomic pending write, repair push shape.
- Local gate green: vitest (storage 48, notes 1241), svelte-check 0 errors, eslint, tsup storage build (dts).
- Smoke (optional, needs two sessions): on device A move folder X into Y while device B moves Y into X offline, reconnect B, sync both - after the next pull both devices show the same tree with the later-moved folder back at root, nothing disappears.