### PR TITLE
fix(notes): folder tree multi-touch latch and stale move feedback

### DIFF
--- a/apps/reborn-notes/src/lib/components/sidebar/FolderActionMenu.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderActionMenu.svelte
@@ -122,7 +122,14 @@
 
   async function handleMoveTo(folderId: string | null) {
     if (!folder) return;
-    await foldersStore.move(folder.id, folderId);
+    try {
+      await foldersStore.move(folder.id, folderId);
+    } catch {
+      // Folder or its target deleted remotely mid-pick - tell the user and
+      // refresh so the stale row disappears (audit 013 O56).
+      toastStore.error($t('folders.move_failed_missing'));
+      foldersStore.refresh();
+    }
   }
 
   function handleImportHere() {

--- a/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
+++ b/apps/reborn-notes/src/lib/components/sidebar/FolderTree.svelte
@@ -20,6 +20,20 @@
   export const dropTarget = writable<{ id: string; zone: DropZone } | null>(null);
   // Row lifted by an active touch drag - dimmed while its clone follows the finger.
   export const touchDraggingId = writable<string | null>(null);
+  // One touch gesture at a time across ALL tree instances. Rows live in
+  // recursive component instances, so the per-instance guards (pressTimer /
+  // touchDragging) cannot see a press started at another depth - a second
+  // concurrent long-press would overwrite the shared dragBlockedIds /
+  // touchDraggingId stores and corrupt the first gesture's cycle guard.
+  let touchGestureActive = false;
+  function claimTouchGesture(): boolean {
+    if (touchGestureActive) return false;
+    touchGestureActive = true;
+    return true;
+  }
+  function releaseTouchGesture() {
+    touchGestureActive = false;
+  }
 </script>
 
 <script lang="ts">
@@ -325,10 +339,18 @@
   async function handleMoveTo(folderId: string | null) {
     const folder = $movingFolder;
     if (!folder) return;
-    await foldersStore.move(folder.id, folderId);
-    // Reveal the new location, mirroring the drag&drop path.
-    if (folderId) expandedIds.add(folderId);
-    movingFolder.set(null);
+    try {
+      await foldersStore.move(folder.id, folderId);
+      // Reveal the new location, mirroring the drag&drop path.
+      if (folderId) expandedIds.add(folderId);
+    } catch {
+      // Folder or its target deleted remotely mid-pick - tell the user and
+      // refresh so the stale row disappears (audit 013 O56).
+      toastStore.error($t('folders.move_failed_missing'));
+      foldersStore.refresh();
+    } finally {
+      movingFolder.set(null);
+    }
   }
 
   // ── Import .md files / folder tree to folder ────────────────────
@@ -635,6 +657,12 @@
       } else {
         await insertRelativeToRow(draggedId, eff.id, eff.zone, $dragBlockedIds);
       }
+    } catch {
+      // Dragged row or drop target deleted remotely mid-gesture - surface it
+      // instead of an unhandled rejection, refresh to drop the stale row
+      // (audit 013 O56).
+      toastStore.error($t('folders.move_failed_missing'));
+      foldersStore.refresh();
     } finally {
       dropTarget.set(null);
       dragBlockedIds.set(null);
@@ -694,6 +722,9 @@
     // Chevron / kebab / rename input own their taps - no drag from controls.
     if ((e.target as HTMLElement).closest('button, input')) return;
     if (pressTimer || touchDragging) return; // second finger while active
+    // Cross-instance latch: a press at another tree depth is a separate
+    // component instance - the guards above can't see it (audit 013 N3).
+    if (!claimTouchGesture()) return;
     pressFolder = folder;
     pressPointerId = e.pointerId;
     pressStart = { x: e.clientX, y: e.clientY };
@@ -867,12 +898,18 @@
     // A release without movement still produces a click on the row - swallow
     // it so dropping doesn't also open the folder.
     suppressNextClick();
-    if (target.zone === 'into') {
-      if (blocked?.has(target.id)) return;
-      await foldersStore.move(dragged.id, target.id);
-      expandedIds.add(target.id);
-    } else {
-      await insertRelativeToRow(dragged.id, target.id, target.zone, blocked);
+    try {
+      if (target.zone === 'into') {
+        if (blocked?.has(target.id)) return;
+        await foldersStore.move(dragged.id, target.id);
+        expandedIds.add(target.id);
+      } else {
+        await insertRelativeToRow(dragged.id, target.id, target.zone, blocked);
+      }
+    } catch {
+      // Same stale-target handling as the desktop onDrop (audit 013 O56).
+      toastStore.error($t('folders.move_failed_missing'));
+      foldersStore.refresh();
     }
   }
 
@@ -894,6 +931,11 @@
   }
 
   function cancelPress() {
+    // Release the cross-instance latch only when this instance owns a gesture
+    // (pressFolder set) - the unmount cleanup below calls cancelPress on every
+    // instance, and an unconditional release would free a latch held by the
+    // still-running gesture of another instance.
+    if (pressFolder) releaseTouchGesture();
     if (pressTimer) {
       clearTimeout(pressTimer);
       pressTimer = null;

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -1067,7 +1067,14 @@
     if (!draggedId) return;
     // Already at the top level - skip the pointless order bump + sync push.
     if ($foldersStore.some((f) => f.id === draggedId)) return;
-    await foldersStore.move(draggedId, null);
+    try {
+      await foldersStore.move(draggedId, null);
+    } catch {
+      // Dragged folder deleted remotely mid-gesture - surface it instead of
+      // an unhandled rejection and refresh the tree (audit 013 O56).
+      toastStore.error($t('folders.move_failed_missing'));
+      foldersStore.refresh();
+    }
   }
 
   async function handleSectionClick(section: Section) {

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -342,6 +342,7 @@
     "sort_custom": "Eigene Reihenfolge",
     "move_up": "Nach oben",
     "move_down": "Nach unten",
+    "move_failed_missing": "Verschieben nicht möglich: Dieser Ordner existiert nicht mehr. Er wurde möglicherweise auf einem anderen Gerät gelöscht.",
     "no_folders": "Noch keine Ordner",
     "no_folders_short": "Noch keine Ordner.",
     "folder_name": "Ordnername",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -342,6 +342,7 @@
     "sort_custom": "Custom order",
     "move_up": "Move up",
     "move_down": "Move down",
+    "move_failed_missing": "Couldn't move: this folder no longer exists. It may have been deleted on another device.",
     "no_folders": "No folders yet",
     "no_folders_short": "No folders yet.",
     "folder_name": "Folder name",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -342,6 +342,7 @@
     "sort_custom": "Orden personalizado",
     "move_up": "Subir",
     "move_down": "Bajar",
+    "move_failed_missing": "No se puede mover: esta carpeta ya no existe. Puede que se haya eliminado en otro dispositivo.",
     "no_folders": "Aún no hay carpetas",
     "no_folders_short": "Aún no hay carpetas.",
     "folder_name": "Nombre de la carpeta",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -342,6 +342,7 @@
     "sort_custom": "Ordre personnalisé",
     "move_up": "Monter",
     "move_down": "Descendre",
+    "move_failed_missing": "Déplacement impossible : ce dossier n'existe plus. Il a peut-être été supprimé sur un autre appareil.",
     "no_folders": "Aucun dossier pour le moment",
     "no_folders_short": "Aucun dossier pour le moment.",
     "folder_name": "Nom du dossier",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -342,6 +342,7 @@
     "sort_custom": "Własna kolejność",
     "move_up": "Przesuń w górę",
     "move_down": "Przesuń w dół",
+    "move_failed_missing": "Nie można przenieść: ten folder już nie istnieje. Mógł zostać usunięty na innym urządzeniu.",
     "no_folders": "Brak folderów",
     "no_folders_short": "Brak folderów.",
     "folder_name": "Nazwa folderu",


### PR DESCRIPTION
## Summary

Two folder-tree gesture robustness fixes from audit 013:

- **N3 - multi-touch gesture latch.** The "second finger" guard in `onRowPointerDown` was per-component-instance, but each tree depth is a separate recursive `FolderTree` instance while `dragBlockedIds`/`touchDraggingId` are module-level - two concurrent long-presses at different depths overwrote each other's cycle-guard set (unhandled rejections + ghost/indicator glitches; real cycle corruption was already blocked by the storage-layer `moveFolder` check). A module-level latch (`claimTouchGesture`/`releaseTouchGesture`) now admits one touch gesture across all instances. Release is gated on `pressFolder` so the unconditional unmount cleanup of sibling instances cannot free a latch owned by the still-running gesture.
- **O56 - stale move-target feedback.** `handleMoveTo` (tree picker and `FolderActionMenu`), the desktop `onDrop`, the touch drop in `onPointerUp`, and the root drop zone in `+page.svelte` awaited `foldersStore.move` with no catch - a folder deleted on another device mid-gesture became an unhandled `'Folder not found'` rejection with zero user feedback. Each handler now shows a localized error toast (new `folders.move_failed_missing` key, all 5 locales) and refreshes the tree so the stale row disappears.

## Test plan

- `node scripts/check-i18n-parity.mjs` PASSED; each locale file +1 line; JSON parse verified.
- svelte-check 0 errors, eslint clean, notes vitest suite 1229 passed, single-file svelte compile gate OK on all three components.
- Smoke (mobile viewport): long-press drag a folder works as before; while one finger drags, a second long-press on another row is ignored. Move a folder via "Move to…" onto a folder deleted in a second session - error toast appears and the tree refreshes instead of a silent console rejection.