### PR TITLE
fix(crypto): stop logging raw base64 input on decode failure

### DIFF
--- a/packages/crypto/src/encryption.ts
+++ b/packages/crypto/src/encryption.ts
@@ -255,8 +255,10 @@ export function base64ToArrayBuffer(base64: string): Uint8Array {
     }
     return bytes;
   } catch (error) {
+    // Deliberately not logging the input itself: it is ciphertext (or a
+    // corrupted stand-in for one), and "never log ciphertext" is cheaper to
+    // enforce than to reason about per call-site (audit 013 O53).
     logger.error('Failed to convert base64 to ArrayBuffer:', error);
-    logger.error('Input base64 string:', base64);
     throw new Error(
       `Failed to decode base64 string: ${error instanceof Error ? error.message : String(error)}`,
       { cause: error }


### PR DESCRIPTION
## Summary

Audit 013 **O53**: `base64ToArrayBuffer` in `@reborn/crypto` logged the raw input string on conversion failure. The value is ciphertext (already server-visible) and the logger has no network transport, so this was hygiene, not a leak - but the strict "never log ciphertext" reading of the ZK rules says it goes. The error object/message alone still identify the failure; a comment pins the rationale so the line does not come back.

## Test plan

- Crypto suite: 284 tests passed; eslint clean; tsup dts build green.
- No behavior change beyond the removed log line (error thrown as before, `cause` preserved).