### PR TITLE
fix(notes): release persisted SAF grant when auto-backup state is wiped

### DIFF
--- a/apps/reborn-notes/android/app/src/main/java/eu/reapps/notes/FolderFsPlugin.java
+++ b/apps/reborn-notes/android/app/src/main/java/eu/reapps/notes/FolderFsPlugin.java
@@ -366,6 +366,39 @@ public class FolderFsPlugin extends Plugin {
         }
     }
 
+    // MARK: - releaseDirectory
+
+    /**
+     * Relinquish the persisted SAF grant for a bookmarked tree - the mirror of the
+     * take in handlePickResult, called when the app forgets the bookmark (the
+     * auto-backup wipe on logout / local reset). Without this the OS keeps the
+     * grant alive even though the Uri is gone from our storage and can never be
+     * used again. `write` must echo the mode the folder was picked with, so the
+     * released modes match the persisted ones. Releasing a grant the OS no longer
+     * holds is a silent no-op, which keeps the wipe path idempotent.
+     */
+    @PluginMethod
+    public void releaseDirectory(PluginCall call) {
+        String bookmark = call.getString("bookmark");
+        if (bookmark == null) {
+            call.reject("Missing or invalid bookmark");
+            return;
+        }
+        boolean write = Boolean.TRUE.equals(call.getBoolean("write", false));
+        int grantFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        if (write) {
+            grantFlags |= Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+        }
+        try {
+            getContext()
+                .getContentResolver()
+                .releasePersistableUriPermission(Uri.parse(bookmark), grantFlags);
+            call.resolve(new JSObject());
+        } catch (Exception e) {
+            call.reject("Failed to release folder access: " + e.getMessage(), "RELEASE_FAILED");
+        }
+    }
+
     // MARK: - helpers
 
     /** Walk frame: a directory's documentId plus its accumulated <leaf>/<sub> path. */

--- a/apps/reborn-notes/ios/App/App/FolderFsPlugin.swift
+++ b/apps/reborn-notes/ios/App/App/FolderFsPlugin.swift
@@ -36,7 +36,8 @@ public class FolderFsPlugin: CAPPlugin, CAPBridgedPlugin, UIDocumentPickerDelega
         CAPPluginMethod(name: "readFile", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isSameDirectory", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "writeFile", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "deleteFile", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "deleteFile", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "releaseDirectory", returnType: CAPPluginReturnPromise)
     ]
 
     /// Upper bound on waiting for an iCloud placeholder to download before a read.
@@ -452,5 +453,17 @@ public class FolderFsPlugin: CAPPlugin, CAPBridgedPlugin, UIDocumentPickerDelega
         }
         if let coordError = coordError { throw coordError }
         if let removeError = removeError { throw removeError }
+    }
+
+    // MARK: - releaseDirectory
+
+    /// No-op on iOS, kept so the JS contract is uniform across platforms. A plain
+    /// security-scoped bookmark holds no OS-level persisted grant to relinquish
+    /// (access is bracketed per call via start/stopAccessingSecurityScopedResource,
+    /// see the header comment) - deleting the bookmark string IS the release.
+    /// Android's SAF, by contrast, persists the grant in the OS until it is
+    /// explicitly released; see FolderFsPlugin.java.
+    @objc func releaseDirectory(_ call: CAPPluginCall) {
+        call.resolve()
     }
 }

--- a/apps/reborn-notes/src/lib/services/auto-backup/index.spec.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/index.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Locks the wipe-path ordering in `clearAutoBackupState`: the folder bookmark
+ * must be captured BEFORE `clearAutoBackupPrefs()` removes the config entry
+ * (the SAF tree Uri is unrecoverable afterwards, so a late read would leak the
+ * persisted WRITE grant in the OS forever), and the release must echo the
+ * `write: true` mode the folder was picked with.
+ *
+ * Source-level assertions (same pattern as `notes-sync.regression.spec.ts`):
+ * `__REBORN_NATIVE__` is a compile-time define (false under vitest), so the
+ * native branch cannot be exercised at runtime here.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const src = readFileSync(resolve(__dirname, './index.ts'), 'utf-8');
+const fn = src.slice(src.indexOf('export async function clearAutoBackupState'));
+
+describe('clearAutoBackupState wipe path (source-level)', () => {
+  it('captures the folder bookmark before the prefs wipe removes it', () => {
+    const bookmarkRead = fn.indexOf('loadAutoBackupConfig().folderBookmark');
+    const prefsWipe = fn.indexOf('clearAutoBackupPrefs()');
+    expect(bookmarkRead).toBeGreaterThan(-1);
+    expect(prefsWipe).toBeGreaterThan(-1);
+    expect(bookmarkRead).toBeLessThan(prefsWipe);
+  });
+
+  it('releases the persisted SAF grant with the WRITE mode it was taken with', () => {
+    expect(fn).toMatch(/releaseDirectory\(\{ bookmark: folderBookmark, write: true \}\)/);
+  });
+
+  it('runs the release before the vault wipe, in its own try/catch', () => {
+    const releaseIdx = fn.indexOf('releaseDirectory');
+    const vaultIdx = fn.indexOf('clearRecoveryPhrase');
+    expect(releaseIdx).toBeGreaterThan(-1);
+    expect(vaultIdx).toBeGreaterThan(-1);
+    expect(releaseIdx).toBeLessThan(vaultIdx);
+    // A failed release must not block the recovery-phrase wipe that follows.
+    expect(fn.slice(releaseIdx, vaultIdx)).toContain('catch');
+  });
+});

--- a/apps/reborn-notes/src/lib/services/auto-backup/index.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/index.ts
@@ -66,17 +66,37 @@ export async function runNotesAutoBackupIfDue(
 
 /**
  * Wipe the CURRENT user's auto-backup footprint on this device: config +
- * runtime state (localStorage) and the recovery phrase (OS vault). Called on
- * logout and on the local-only wipe, BEFORE the session keys are removed -
- * the entries are keyed by the session's user id, so this is the last moment
- * they are addressable. Best-effort by design: a failed wipe is logged but
- * must never block the logout flow (per-user keying already prevents another
- * account from reading what might remain).
+ * runtime state (localStorage), the OS-level folder grant (Android SAF) and
+ * the recovery phrase (OS vault). Called on logout and on the local-only
+ * wipe, BEFORE the session keys are removed - the entries are keyed by the
+ * session's user id, so this is the last moment they are addressable.
+ * Best-effort by design: a failed wipe is logged but must never block the
+ * logout flow (per-user keying already prevents another account from reading
+ * what might remain).
  */
 export async function clearAutoBackupState(): Promise<void> {
   try {
+    // Capture the bookmark BEFORE the prefs wipe: releasing the persisted SAF
+    // grant needs the tree Uri, and once the config entry is gone the Uri is
+    // unrecoverable - the orphaned grant would dangle in the OS until uninstall.
+    const folderBookmark = __REBORN_NATIVE__
+      ? loadAutoBackupConfig().folderBookmark
+      : undefined;
     clearAutoBackupPrefs();
     if (!__REBORN_NATIVE__) return;
+    if (folderBookmark) {
+      try {
+        // Lazy import keeps the FolderFs bridge out of the web bundle. The
+        // backup folder was picked with { write: true }, so release the same
+        // READ|WRITE modes. iOS resolves this as a no-op (a plain bookmark
+        // holds no OS-level grant).
+        const { getFolderFs } = await import('$lib/utils/native-folder-fs');
+        await getFolderFs().releaseDirectory({ bookmark: folderBookmark, write: true });
+      } catch (err) {
+        // Own catch: a failed release must not block the vault wipe below.
+        logger.error('Failed to release auto-backup folder grant:', err);
+      }
+    }
     // Lazy import keeps the native secure-storage bridge out of the web bundle.
     const { clearRecoveryPhrase } = await import('./recovery-phrase-vault');
     await clearRecoveryPhrase();

--- a/apps/reborn-notes/src/lib/utils/native-folder-fs.ts
+++ b/apps/reborn-notes/src/lib/utils/native-folder-fs.ts
@@ -93,6 +93,16 @@ export interface FolderFsPlugin {
    * picked with `{ write: true }`.
    */
   deleteFile(options: { bookmark: string; path: string }): Promise<{ staleBookmark?: string }>;
+  /**
+   * Relinquish the OS-level persisted grant behind a bookmark that the app is
+   * about to forget - the mirror of {@link pickDirectory}. `write` must echo the
+   * mode the folder was picked with so the released modes match the persisted
+   * ones. Android releases the SAF grant (which otherwise dangles in the OS until
+   * uninstall); iOS resolves as a no-op - a plain security-scoped bookmark holds
+   * no OS-level grant, deleting the bookmark string is the release. Releasing an
+   * unknown grant is a no-op, so the call is safe to repeat.
+   */
+  releaseDirectory(options: { bookmark: string; write?: boolean }): Promise<void>;
 }
 
 let plugin: FolderFsPlugin | null = null;


### PR DESCRIPTION
## Summary

Closes the audit 012 **W1 follow-up** (audit 013 **O58**): `clearAutoBackupState()` (logout / local wipe) removed the folder bookmark from localStorage but left the persisted **SAF WRITE grant** alive in Android's UriGrantsManager - orphaned forever, since the tree Uri becomes unrecoverable once the config entry is gone.

- **`FolderFsPlugin.java`**: new `releaseDirectory` plugin method - the mirror of the `takePersistableUriPermission` in `handlePickResult`, releasing the same READ(|WRITE) modes the folder was picked with. Releasing a grant the OS no longer holds is a silent no-op (idempotent wipe).
- **`FolderFsPlugin.swift`**: `releaseDirectory` resolves as a no-op - a plain iOS security-scoped bookmark holds no OS-level persisted grant (access is bracketed per call); deleting the bookmark string is the release. Kept so the JS contract is uniform.
- **`clearAutoBackupState()`**: captures the bookmark **before** `clearAutoBackupPrefs()` removes it, then releases the grant in its own try/catch (a failed release never blocks the recovery-phrase vault wipe or the logout flow).
- **New source-level spec** pins the capture-before-wipe ordering and the `write: true` mode echo (same pattern as `notes-sync.regression.spec.ts` - the `__REBORN_NATIVE__` guard is compile-time false under vitest).

Zero Knowledge untouched (device-local OS permission hygiene only). Web bundle unchanged: `releaseDirectory` is absent from `build/client`; the `FolderFs` "native-only" throw-stub chunk predates this change (verified against a main build).

Requires a native rebuild to take effect - lands ahead of the first Play Store AAB upload.

## Test plan

- [x] vitest: new `auto-backup/index.spec.ts` (3) + `folder-source/native.spec.ts` (7) green
- [x] svelte-check 5710 files, 0 errors; eslint clean; `swiftc -parse` clean
- [x] `vite build` green; DCE verified (no `releaseDirectory`/`registerPlugin` in web bundle)
- [x] Smoke (Android emulator/device, after native rebuild): pick a backup folder in Settings → Backup, then log out → `adb shell dumpsys activity permissions` (or re-open Settings → Backup) shows the persisted grant gone; picking a folder again still works