### PR TITLE
fix(notes): batch pull writes for folders/tags/saved searches via saveMany

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -682,6 +682,43 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(code).toMatch(/settleInBatches\(\s*tagRemoves\b/);
   });
 
+  it('pullFolders/pullTags/pullSavedSearches batch upserts via saveMany (rule 16)', () => {
+    // Same O(n²)-refresh trap as pullNotes above, on the smaller tables: a
+    // per-row save() refreshes the whole table on every call inside the
+    // Promise.all fan-out. Each helper must buffer its upserts (reconciliation
+    // rows ride the same buffer) and flush them with a single saveMany().
+    const src = readSource('./notes-sync.service.ts');
+    const stripComments = (s: string) => s.replace(/\/\/.*$/gm, '');
+
+    const folders = stripComments(
+      src.slice(src.indexOf('async function pullFolders'), src.indexOf('async function pullTags'))
+    );
+    expect(folders).toMatch(/folderStore\.saveMany\(/);
+    // The only per-row save left is the post-sweep parent_id cycle repair,
+    // which re-reads the current row and touches at most a few cycle members -
+    // the pull fan-out itself must ride the buffer.
+    expect(folders.match(/folderStore\.save\(/g) ?? []).toHaveLength(1);
+    expect(folders.indexOf('folderStore.save(')).toBeGreaterThan(folders.indexOf('deleteMany'));
+
+    const tags = stripComments(
+      src.slice(
+        src.indexOf('async function pullTags'),
+        src.indexOf('async function pullSavedSearches')
+      )
+    );
+    expect(tags).toMatch(/tagStore\.saveMany\(/);
+    expect(tags).not.toMatch(/tagStore\.save\(/);
+
+    const searches = stripComments(
+      src.slice(
+        src.indexOf('async function pullSavedSearches'),
+        src.indexOf('const NOTES_PAGE_SIZE')
+      )
+    );
+    expect(searches).toMatch(/savedSearchStore\.saveMany\(/);
+    expect(searches).not.toMatch(/savedSearchStore\.save\(/);
+  });
+
   it('post-pull reconciler runs in +layout.svelte runSync and onMount paths', () => {
     const layout = readSource('../../routes/+layout.svelte');
     expect(layout).toMatch(/from '\$lib\/services\/shadow-index-reconciler\.service'/);

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -21,14 +21,17 @@ import {
   noteHistoryStore,
   initializeStorage,
   isDatabaseInitialized,
-  clearAllUserData
+  clearAllUserData,
+  // The storage-layer TagEncrypted extends the base @reborn/types one with the
+  // local-only usage fields (usage_count / last_used_at) that the pull carries
+  // over on upsert - the buffered writes must be typed against it.
+  type TagEncrypted
 } from '@reborn/storage';
 import type {
   NoteEncrypted,
   NoteStoredLocal,
   NoteHistoryEntry,
   FolderEncrypted,
-  TagEncrypted,
   SavedSearchEncrypted,
   SyncErrorCode
 } from '@reborn/types';
@@ -299,6 +302,12 @@ async function pullFolders(): Promise<void> {
   if (!res.ok) throw new Error(`GET /api/folders: ${res.status}`);
   const { data } = await res.json();
 
+  // Buffer every write and flush it in ONE saveMany below: a per-row save()
+  // refreshes the whole table each time, and inside Promise.all that stacks
+  // up to the O(n²) burst that OOM-killed the Android WebView in pullNotes
+  // (guideline 36, rule 16). Reconciliation rows ride the same buffer.
+  const foldersToWrite: FolderEncrypted[] = [];
+
   await Promise.all(
     (
       data as Array<{
@@ -331,12 +340,12 @@ async function pullFolders(): Promise<void> {
             localFolder.order_index !== f.order_index)
         ) {
           logger.warn(`Reconciling orphaned folder edit ${f.id} - marking pending`);
-          await folderStore.save({ ...localFolder, sync_status: 'pending' });
+          foldersToWrite.push({ ...localFolder, sync_status: 'pending' });
         }
         return;
       }
 
-      const folder: FolderEncrypted = {
+      foldersToWrite.push({
         id: f.id,
         user_id: userId,
         parent_id: f.parent_id ?? undefined,
@@ -347,10 +356,16 @@ async function pullFolders(): Promise<void> {
         sync_status: 'synced',
         created_at: f.created_at,
         updated_at: f.updated_at
-      };
-      await folderStore.save(folder);
+      });
     })
   );
+
+  if (foldersToWrite.length > 0) {
+    const result = await folderStore.saveMany(foldersToWrite);
+    if (result.failed > 0) {
+      logger.warn(`pullFolders: ${result.failed}/${foldersToWrite.length} folder writes failed`);
+    }
+  }
 
   // Remove local folders that no longer exist on the server (deleted on another device).
   // Only remove 'synced' items - 'pending' items were created/edited locally and not yet
@@ -411,6 +426,9 @@ async function pullTags(): Promise<void> {
   if (!res.ok) throw new Error(`GET /api/tags: ${res.status}`);
   const { data } = await res.json();
 
+  // Buffered writes, one saveMany - see pullFolders() / guideline 36 rule 16.
+  const tagsToWrite: TagEncrypted[] = [];
+
   await Promise.all(
     (
       data as Array<{
@@ -439,12 +457,12 @@ async function pullTags(): Promise<void> {
             (localTag.color_encrypted ?? null) !== (t.color_encrypted ?? null))
         ) {
           logger.warn(`Reconciling orphaned tag edit ${t.id} - marking pending`);
-          await tagStore.save({ ...localTag, sync_status: 'pending' });
+          tagsToWrite.push({ ...localTag, sync_status: 'pending' });
         }
         return;
       }
 
-      await tagStore.save({
+      tagsToWrite.push({
         id: t.id,
         user_id: userId,
         name_encrypted: t.name_encrypted,
@@ -457,6 +475,13 @@ async function pullTags(): Promise<void> {
       });
     })
   );
+
+  if (tagsToWrite.length > 0) {
+    const result = await tagStore.saveMany(tagsToWrite);
+    if (result.failed > 0) {
+      logger.warn(`pullTags: ${result.failed}/${tagsToWrite.length} tag writes failed`);
+    }
+  }
 
   // Remove local tags that no longer exist on the server (hard-deleted on another device).
   // Synced-mid-pull tags are excluded via the pre-pull snapshot - see pullFolders().
@@ -487,6 +512,9 @@ async function pullSavedSearches(): Promise<void> {
   const res = await authFetch(`${API_BASE}/saved-searches`);
   if (!res.ok) throw new Error(`GET /api/saved-searches: ${res.status}`);
   const { data } = await res.json();
+
+  // Buffered writes, one saveMany - see pullFolders() / guideline 36 rule 16.
+  const searchesToWrite: SavedSearchEncrypted[] = [];
 
   await Promise.all(
     (
@@ -525,12 +553,12 @@ async function pullSavedSearches(): Promise<void> {
             local.position !== s.position)
         ) {
           logger.warn(`Reconciling orphaned saved-search edit ${s.id} - marking pending`);
-          await savedSearchStore.save({ ...local, sync_status: 'pending' });
+          searchesToWrite.push({ ...local, sync_status: 'pending' });
         }
         return;
       }
 
-      const record: SavedSearchEncrypted = {
+      searchesToWrite.push({
         id: s.id,
         user_id: userId,
         name_encrypted: s.name_encrypted,
@@ -542,10 +570,18 @@ async function pullSavedSearches(): Promise<void> {
         sync_status: 'synced',
         created_at: s.created_at,
         updated_at: s.updated_at
-      };
-      await savedSearchStore.save(record);
+      });
     })
   );
+
+  if (searchesToWrite.length > 0) {
+    const result = await savedSearchStore.saveMany(searchesToWrite);
+    if (result.failed > 0) {
+      logger.warn(
+        `pullSavedSearches: ${result.failed}/${searchesToWrite.length} saved-search writes failed`
+      );
+    }
+  }
 
   // Remove local saved searches that no longer exist on the server (hard-deleted on another
   // device). Synced-mid-pull rows are excluded via the pre-pull snapshot - see pullFolders().


### PR DESCRIPTION
## Summary

Closes the guideline 36 **rule 16** P3 follow-up ahead of the store release: `pullFolders`/`pullTags`/`pullSavedSearches` still wrote per entity inside their `Promise.all` fan-out - the same O(n²)-refresh pattern (`save()` runs a full-table `refreshItems()` on every call) that OOM-killed the in-process Android System WebView in `pullNotes` on a large account's first sync. These tables are smaller and never crashed, but a fresh store-install syncing an account with hundreds of folders walks straight into the identical burst.

- Each helper now mirrors the `pullNotes` pattern: upserts **and reconciliation rows** are buffered and flushed with a single `saveMany()` (one transaction, one refresh; per-item encryption-guard validation preserved, failed rows counted and logged instead of failing the pull).
- Flush happens **before** the orphan-delete sweep - sweep/`getAll` ordering and the pre-pull synced-ids snapshot semantics (PR #412) are unchanged.
- The post-sweep `parent_id` cycle repair in `pullFolders` stays on per-row `save()` on purpose: runs after the flush, re-reads the current row, touches at most a few cycle members.
- `tagsToWrite` is typed against the storage-layer `TagEncrypted` (extends the base type with local-only `usage_count`/`last_used_at` carried over on upsert) - same import pattern as `tag.service.ts`.
- New regression test pins `saveMany` in all three helpers (allowing exactly the one post-sweep repair `save` in `pullFolders`).

No wire/API changes, no Zero Knowledge impact (same ciphertext rows, written in one transaction instead of many).

## Test plan

- [x] vitest 1242/1242 (including the new pin + both sync regression specs)
- [x] svelte-check 5709 files, 0 errors; eslint clean; `vite build` green
- [x] Smoke (web or native): log into an account with folders/tags/saved searches on a fresh profile → first sync populates all three panels correctly; rename a folder offline on another device, sync both → reconciliation still converges (pending re-push)