### PR TITLE
fix(auth): per-user row caps for folders/tags and data endpoint rate limiting

### DIFF
--- a/apps/reborn-notes/src/hooks.server.ts
+++ b/apps/reborn-notes/src/hooks.server.ts
@@ -1,7 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
-import { authLimiter, refreshLimiter, registerLimiter, powLimiter } from '$lib/server/rate-limit';
+import {
+  authLimiter,
+  refreshLimiter,
+  registerLimiter,
+  powLimiter,
+  dataLimiter
+} from '$lib/server/rate-limit';
 import { getClientIp } from '$lib/server/client-ip';
 import { verifyToken } from '@reborn/auth/server';
 import {
@@ -116,6 +122,38 @@ const authHandle: Handle = async ({ event, resolve }) => {
     // Don't fail the request, just continue without auth
   }
 
+  return resolve(event);
+};
+
+// ── Per-user data endpoint rate limiting ──────────────────────────
+
+/**
+ * Abuse backstop for every /api/ data route. Auth routes keep their own,
+ * stricter per-IP limiters above; health and app-config are public, cheap and
+ * polled by monitors, so they stay out. Runs AFTER authHandle so it can key by
+ * the stable userId - an IP key would punish users behind one NAT while doing
+ * nothing against an attacker rotating IPs. Unauthenticated hits (e.g. public
+ * share views) fall back to the IP key; the dedicated per-route limiters
+ * (sharePublicLimiter et al.) stay the tighter bound there.
+ */
+const DATA_RATE_EXEMPT = new Set([`${BASE}/api/health`, `${BASE}/api/app-config`]);
+
+const dataRateLimitHandle: Handle = async ({ event, resolve }) => {
+  const { pathname } = event.url;
+  if (
+    pathname.startsWith(`${BASE}/api/`) &&
+    !pathname.startsWith(`${BASE}/api/auth/`) &&
+    !DATA_RATE_EXEMPT.has(pathname)
+  ) {
+    const key = event.locals.userId ?? `ip:${getClientIp(event)}`;
+    if (!dataLimiter.check(key)) {
+      const retryAfter = dataLimiter.retryAfter(key);
+      return json(
+        { success: false, error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } }
+      );
+    }
+  }
   return resolve(event);
 };
 
@@ -283,4 +321,4 @@ const localeHandle: Handle = async ({ event, resolve }) => {
   });
 };
 
-export const handle = sequence(requestSizeHandle, rateLimitHandle, authHandle, idempotencyHandle, shareCleanupHandle, localeHandle, securityHandle);
+export const handle = sequence(requestSizeHandle, rateLimitHandle, authHandle, dataRateLimitHandle, idempotencyHandle, shareCleanupHandle, localeHandle, securityHandle);

--- a/apps/reborn-notes/src/lib/server/rate-limit.ts
+++ b/apps/reborn-notes/src/lib/server/rate-limit.ts
@@ -176,3 +176,15 @@ export const sharePublicLimiter = createRateLimiter({ maxRequests: 100, windowMs
  * versa).
  */
 export const sharePasswordLimiter = createRateLimiter({ maxRequests: 10, windowMs: 15 * 60_000 });
+
+/**
+ * Authenticated data endpoints (notes/folders/tags/saved-searches/settings/…):
+ * 10 000 requests per 15 minutes per userId (IP-keyed fallback for
+ * unauthenticated hits). An abuse backstop, NOT a throttle: a cold first sync
+ * or a huge vault import legitimately fires thousands of POSTs (bounded to ~10
+ * in flight by settleInBatches) and must pass with headroom - what this bounds
+ * is a runaway script/loop. 429 is transient for the sync client (not in
+ * PERMANENT_PUSH_STATUSES), so even a capped burst keeps its rows 'pending'
+ * and self-heals on the next window.
+ */
+export const dataLimiter = createRateLimiter({ maxRequests: 10_000, windowMs: 15 * 60_000 });

--- a/apps/reborn-notes/src/routes/api/folders/+server.ts
+++ b/apps/reborn-notes/src/routes/api/folders/+server.ts
@@ -7,6 +7,11 @@ import { getUserFromToken } from '$lib/server/auth';
 
 const logger = createLogger('Notes-API-Folders');
 
+// Row cap per user (audit 012 N2 unification - saved searches got theirs in
+// PR #405; folders/tags shared the same pre-existing gap). Generous vs any
+// real tree (the UI renders hundreds of folders fine, thousands are abuse).
+const MAX_FOLDERS_PER_USER = 500;
+
 /** GET /api/folders — fetch all folders for the authenticated user. */
 export const GET: RequestHandler = async ({ request, url }) => {
   try {
@@ -72,6 +77,22 @@ export const POST: RequestHandler = async ({ request }) => {
     const existingFolder = await prisma.folder.findUnique({ where: { id }, select: { user_id: true } });
     if (existingFolder && existingFolder.user_id !== userId) {
       return json({ success: false, error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Row cap applies to creates only - updates of existing rows stay allowed
+    // (this POST is an upsert; a re-push of row #501 must not brick its edits).
+    // 422 (not 5xx) so the client's push failure stays quiet: the row keeps
+    // sync_status='pending' and retries once per periodic sync (cheap single
+    // POST). Classifying 422 as a permanent rejection for folders/tags/saved
+    // searches is a known gap (TODO P3) - the cap protects the server either way.
+    if (!existingFolder) {
+      const count = await prisma.folder.count({ where: { user_id: userId } });
+      if (count >= MAX_FOLDERS_PER_USER) {
+        return json(
+          { success: false, error: 'FOLDER_LIMIT_EXCEEDED', limit: MAX_FOLDERS_PER_USER },
+          { status: 422 }
+        );
+      }
     }
 
     const folder = await prisma.folder.upsert({

--- a/apps/reborn-notes/src/routes/api/folders/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/folders/server.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  folder: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    count: vi.fn(),
+    upsert: vi.fn()
+  }
+};
+
+vi.mock('@reborn/database', () => ({ prisma: mockPrisma }));
+
+const mockGetUserFromToken = vi.fn();
+vi.mock('$lib/server/auth', () => ({
+  getUserFromToken: (...args: unknown[]) => mockGetUserFromToken(...args)
+}));
+
+vi.mock('@reborn/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+}));
+
+const mockValidateBody = vi.fn();
+vi.mock('@reborn/types', () => ({
+  validateBody: (...args: unknown[]) => mockValidateBody(...args),
+  schemas: { CreateFolderRequestSchema: {} }
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const FOLDER_ID = 'a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d';
+const FOLDER_BODY = { id: FOLDER_ID, name_encrypted: 'iv:ciphertext', order_index: 0 };
+
+async function callPost() {
+  const { POST } = await import('./+server');
+  const event = {
+    request: new Request('http://localhost/api/folders', {
+      method: 'POST',
+      headers: { authorization: 'Bearer mock-token', 'content-type': 'application/json' },
+      body: JSON.stringify(FOLDER_BODY)
+    })
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response = await (POST as any)(event);
+  const data = await response.json();
+  return { status: response.status, data };
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserFromToken.mockResolvedValue(USER_ID);
+  mockValidateBody.mockReturnValue({ success: true, data: FOLDER_BODY });
+  mockPrisma.folder.upsert.mockResolvedValue({
+    id: FOLDER_ID,
+    created_at: new Date(),
+    updated_at: new Date(),
+    sync_version: 1
+  });
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('POST /api/folders (per-user row cap)', () => {
+  it('creates a folder while under the cap', async () => {
+    mockPrisma.folder.findUnique.mockResolvedValue(null);
+    mockPrisma.folder.count.mockResolvedValue(499);
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockPrisma.folder.count).toHaveBeenCalledWith({ where: { user_id: USER_ID } });
+    expect(mockPrisma.folder.upsert).toHaveBeenCalled();
+  });
+
+  it('rejects a create at the cap with 422 FOLDER_LIMIT_EXCEEDED', async () => {
+    mockPrisma.folder.findUnique.mockResolvedValue(null);
+    mockPrisma.folder.count.mockResolvedValue(500);
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(422);
+    expect(data).toEqual({ success: false, error: 'FOLDER_LIMIT_EXCEEDED', limit: 500 });
+    expect(mockPrisma.folder.upsert).not.toHaveBeenCalled();
+  });
+
+  // The POST is an upsert: a re-push of an existing row must never be blocked
+  // by the cap, or an over-cap account could not sync edits to what it has.
+  it('lets an update of an existing own row through without counting', async () => {
+    mockPrisma.folder.findUnique.mockResolvedValue({ user_id: USER_ID });
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockPrisma.folder.count).not.toHaveBeenCalled();
+    expect(mockPrisma.folder.upsert).toHaveBeenCalled();
+  });
+
+  it('still returns 403 for a row owned by another user (cap not consulted)', async () => {
+    mockPrisma.folder.findUnique.mockResolvedValue({ user_id: 'someone-else' });
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(mockPrisma.folder.count).not.toHaveBeenCalled();
+    expect(mockPrisma.folder.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/reborn-notes/src/routes/api/saved-searches/+server.ts
+++ b/apps/reborn-notes/src/routes/api/saved-searches/+server.ts
@@ -83,8 +83,12 @@ export const POST: RequestHandler = async ({ request }) => {
     }
 
     // Row cap applies to creates only - updates of existing rows stay allowed.
-    // 422 (not 5xx) so the offline push marks the item sync_error instead of
-    // retrying forever.
+    // 422 (not 5xx) keeps the rejection out of the transient 5xx alarm path.
+    // NOTE: the client does NOT yet classify 422 as permanent for saved
+    // searches (pushSavedSearchPayload throws a plain Error, and 422 is not in
+    // PERMANENT_PUSH_STATUSES) - the row stays 'pending' and retries once per
+    // periodic sync. Cheap and bounded, but a known gap (TODO P3); an earlier
+    // version of this comment over-promised sync_error semantics.
     if (!existingSearch) {
       const count = await prisma.savedSearch.count({ where: { user_id: userId } });
       if (count >= MAX_SAVED_SEARCHES_PER_USER) {

--- a/apps/reborn-notes/src/routes/api/tags/+server.ts
+++ b/apps/reborn-notes/src/routes/api/tags/+server.ts
@@ -7,6 +7,11 @@ import { getUserFromToken } from '$lib/server/auth';
 
 const logger = createLogger('Notes-API-Tags');
 
+// Row cap per user (audit 012 N2 unification - saved searches got theirs in
+// PR #405; folders/tags shared the same pre-existing gap). A real tag cloud
+// is tens of rows; hundreds are fine, thousands are abuse.
+const MAX_TAGS_PER_USER = 500;
+
 /** GET /api/tags — fetch all tags for the authenticated user. */
 export const GET: RequestHandler = async ({ request, url }) => {
   try {
@@ -62,6 +67,26 @@ export const POST: RequestHandler = async ({ request }) => {
     const existingTag = await prisma.tag.findUnique({ where: { id }, select: { user_id: true } });
     if (existingTag && existingTag.user_id !== userId) {
       return json({ success: false, error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Row cap applies to creates only - updates of existing rows stay allowed
+    // (this POST is an upsert; a re-push of row #501 must not brick its edits).
+    // 422 (not 5xx) so the client's push failure stays quiet: the row keeps
+    // sync_status='pending' and retries once per periodic sync (cheap single
+    // POST); permanent 422 classification for these entities is a known gap
+    // (TODO P3). The P2002 same-name fallback below stays reachable: it resolves to an
+    // EXISTING row, which is exactly the case the cap must not block - but the
+    // cap check runs first, so an over-cap import degrades to 422 even when
+    // the name would have deduped. Acceptable: at 500 tags the account is far
+    // outside real use, and the dedup path still works below the cap.
+    if (!existingTag) {
+      const count = await prisma.tag.count({ where: { user_id: userId } });
+      if (count >= MAX_TAGS_PER_USER) {
+        return json(
+          { success: false, error: 'TAG_LIMIT_EXCEEDED', limit: MAX_TAGS_PER_USER },
+          { status: 422 }
+        );
+      }
     }
 
     let tag;

--- a/apps/reborn-notes/src/routes/api/tags/server.spec.ts
+++ b/apps/reborn-notes/src/routes/api/tags/server.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  tag: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    count: vi.fn(),
+    upsert: vi.fn()
+  }
+};
+
+vi.mock('@reborn/database', () => ({ prisma: mockPrisma }));
+
+const mockGetUserFromToken = vi.fn();
+vi.mock('$lib/server/auth', () => ({
+  getUserFromToken: (...args: unknown[]) => mockGetUserFromToken(...args)
+}));
+
+vi.mock('@reborn/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+}));
+
+const mockValidateBody = vi.fn();
+vi.mock('@reborn/types', () => ({
+  validateBody: (...args: unknown[]) => mockValidateBody(...args),
+  schemas: { CreateTagRequestSchema: {} }
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const TAG_ID = 'b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e';
+const TAG_BODY = { id: TAG_ID, name_encrypted: 'iv:ciphertext' };
+
+async function callPost() {
+  const { POST } = await import('./+server');
+  const event = {
+    request: new Request('http://localhost/api/tags', {
+      method: 'POST',
+      headers: { authorization: 'Bearer mock-token', 'content-type': 'application/json' },
+      body: JSON.stringify(TAG_BODY)
+    })
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response = await (POST as any)(event);
+  const data = await response.json();
+  return { status: response.status, data };
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserFromToken.mockResolvedValue(USER_ID);
+  mockValidateBody.mockReturnValue({ success: true, data: TAG_BODY });
+  mockPrisma.tag.upsert.mockResolvedValue({
+    id: TAG_ID,
+    created_at: new Date(),
+    updated_at: new Date(),
+    sync_version: 1
+  });
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('POST /api/tags (per-user row cap)', () => {
+  it('creates a tag while under the cap', async () => {
+    mockPrisma.tag.findUnique.mockResolvedValue(null);
+    mockPrisma.tag.count.mockResolvedValue(499);
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockPrisma.tag.count).toHaveBeenCalledWith({ where: { user_id: USER_ID } });
+    expect(mockPrisma.tag.upsert).toHaveBeenCalled();
+  });
+
+  it('rejects a create at the cap with 422 TAG_LIMIT_EXCEEDED', async () => {
+    mockPrisma.tag.findUnique.mockResolvedValue(null);
+    mockPrisma.tag.count.mockResolvedValue(500);
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(422);
+    expect(data).toEqual({ success: false, error: 'TAG_LIMIT_EXCEEDED', limit: 500 });
+    expect(mockPrisma.tag.upsert).not.toHaveBeenCalled();
+  });
+
+  // The POST is an upsert: a re-push of an existing row must never be blocked
+  // by the cap, or an over-cap account could not sync edits to what it has.
+  it('lets an update of an existing own row through without counting', async () => {
+    mockPrisma.tag.findUnique.mockResolvedValue({ user_id: USER_ID });
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockPrisma.tag.count).not.toHaveBeenCalled();
+    expect(mockPrisma.tag.upsert).toHaveBeenCalled();
+  });
+
+  it('still returns 403 for a row owned by another user (cap not consulted)', async () => {
+    mockPrisma.tag.findUnique.mockResolvedValue({ user_id: 'someone-else' });
+
+    const { status, data } = await callPost();
+
+    expect(status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(mockPrisma.tag.count).not.toHaveBeenCalled();
+    expect(mockPrisma.tag.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/reborn-task/src/hooks.server.ts
+++ b/apps/reborn-task/src/hooks.server.ts
@@ -3,7 +3,13 @@ import type { Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { createLogger } from '@reborn/utils';
 import { verifyToken } from '@reborn/auth/server';
-import { authLimiter, refreshLimiter, registerLimiter, powLimiter } from '$lib/server/rate-limit';
+import {
+	authLimiter,
+	refreshLimiter,
+	registerLimiter,
+	powLimiter,
+	dataLimiter
+} from '$lib/server/rate-limit';
 import { getClientIp } from '$lib/server/client-ip';
 import {
 	findIdempotencyKey,
@@ -196,6 +202,37 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 	});
 };
 
+// Per-user data endpoint rate limiting
+//
+// Abuse backstop for every /api/ data route. Auth routes keep their own,
+// stricter per-IP limiters above; health is public, cheap and polled by
+// monitors, so it stays out. Runs AFTER authHandle so it can key by the
+// stable userId - an IP key would punish users behind one NAT while doing
+// nothing against an attacker rotating IPs. Unauthenticated hits (e.g.
+// public share views) fall back to the IP key; the dedicated per-route
+// limiters (sharePublicLimiter, notificationLimiter) stay the tighter
+// bound where they apply.
+const DATA_RATE_EXEMPT = new Set([`${BASE}/api/health`]);
+
+const dataRateLimitHandle: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+	if (
+		pathname.startsWith(`${BASE}/api/`) &&
+		!pathname.startsWith(`${BASE}/api/auth/`) &&
+		!DATA_RATE_EXEMPT.has(pathname)
+	) {
+		const key = event.locals.userId ?? `ip:${getClientIp(event)}`;
+		if (!dataLimiter.check(key)) {
+			const retryAfter = dataLimiter.retryAfter(key);
+			return json(
+				{ success: false, error: 'Too many requests. Please try again later.' },
+				{ status: 429, headers: { 'Retry-After': String(retryAfter) } }
+			);
+		}
+	}
+	return resolve(event);
+};
+
 // Security headers middleware
 const securityHandle: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
@@ -281,6 +318,7 @@ export const handle = sequence(
 	requestSizeHandle,
 	rateLimitHandle,
 	authHandle,
+	dataRateLimitHandle,
 	idempotencyHandle,
 	shareCleanupHandle,
 	localeHandle,

--- a/apps/reborn-task/src/lib/server/rate-limit.ts
+++ b/apps/reborn-task/src/lib/server/rate-limit.ts
@@ -179,3 +179,15 @@ export const sharePasswordLimiter = createRateLimiter({ maxRequests: 10, windowM
  * still bounds DB abuse.
  */
 export const notificationLimiter = createRateLimiter({ maxRequests: 60, windowMs: 60_000 });
+
+/**
+ * Authenticated data endpoints (tasks/tasklists/subtasks/settings/…): 10 000
+ * requests per 15 minutes per userId (IP-keyed fallback for unauthenticated
+ * hits). An abuse backstop, NOT a throttle: a cold first sync or a large import
+ * legitimately fires thousands of queued operations (bounded concurrency) and
+ * must pass with headroom - what this bounds is a runaway script/loop. 429 is
+ * transient for the operation queue (not in PERMANENT_PUSH_STATUSES), so even
+ * a capped burst keeps its ops queued and self-heals on the next window.
+ * Tighter per-route limiters (notificationLimiter above) still win where set.
+ */
+export const dataLimiter = createRateLimiter({ maxRequests: 10_000, windowMs: 15 * 60_000 });


### PR DESCRIPTION
## Summary

Server-side pair from the pre-store hardening list (fresh store installs = unknown users = abuse surface). Two commits:

**1. Row caps for folders/tags (notes)** - closes the audit 012 N2 unification: saved searches got their cap in #405, folders/tags shared the same gap. `POST /api/folders` / `POST /api/tags` reject a **create** at **500 rows/user** with 422 `FOLDER_LIMIT_EXCEEDED` / `TAG_LIMIT_EXCEEDED`. Both POSTs are upserts - the cap counts only when the row id doesn't exist, so re-pushes of existing rows keep syncing and the tags P2002 same-name dedup stays reachable. New endpoint specs pin all four paths.

**2. Per-user rate limiter on data endpoints (both apps)** - data routes had no limiter at all (only `/api/auth/*`, per IP). New `dataRateLimitHandle` sits **after `authHandle`** and keys on `event.locals.userId` (fallback `ip:<addr>` for unauthenticated hits, where per-route limiters like `sharePublicLimiter` remain tighter). **10 000 req / 15 min / user**, 429 + `Retry-After`. Exempt: `/api/auth/*` (own limiters), `/api/health`, `/api/app-config`.

## Decisions to review (auto mode)

- **Cap value 500/500** (folders/tags) - per the TODO note; real trees/clouds are 1-2 orders of magnitude smaller.
- **Limiter threshold 10k/15min** - deliberately generous so a cold first sync / huge vault import (thousands of POSTs at ~10 concurrent via `settleInBatches`) never throttles; a runaway loop still gets cut. 429 stays transient client-side, so a capped burst self-heals next window.
- **Scope-outs, tracked in TODO P3**: (a) client-side permanent classification of 422 for folders/tags/saved searches - needs `markSyncError` infrastructure these entities don't have; today an over-cap row retries one cheap POST per periodic sync (bounded, and the saved-searches comment that over-promised sync_error semantics is now honest); (b) row caps for task-side tasklists (different creation pattern, no upsert - separate small change if desired).

Zero Knowledge untouched (no schema/visibility changes; counting ciphertext rows only).

## Test plan

- [x] notes: vitest 1253/1253 (8 new cap specs), svelte-check 0/0, eslint clean, build green
- [x] task: vitest 85/85, svelte-check 0/0, eslint clean, build green
- [x] Smoke: create a folder + tag in re/notes and a task in re/task (normal flow unaffected); optionally hammer an endpoint in a loop past 10k to see 429 + Retry-After