### PR TITLE
fix(notes): keep Cmd/Ctrl+B for bold and gate Live Preview on focus

### DIFF
--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.test.ts
@@ -3,7 +3,13 @@ import { EditorState } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
 import { Strikethrough, Table, TaskList } from '@lezer/markdown';
 import type { DecorationSet } from '@codemirror/view';
-import { buildDecorations, isAnySelectionInRange, resolveListClickForward } from './decorations';
+import {
+  buildDecorations,
+  isAnySelectionInRange,
+  resolveListClickForward,
+  setEditorFocus,
+  editorFocusField
+} from './decorations';
 import { TableWidget } from './table-widget';
 import { ImageWidget } from './image-widget';
 import { CodeBlockWidget, TaskCheckboxWidget } from './widgets';
@@ -30,6 +36,18 @@ function makeState(doc: string, cursorPos = 0) {
     extensions: [markdown({ extensions: [Strikethrough, Table, TaskList] })],
     selection: { anchor: cursorPos, head: cursorPos }
   });
+}
+
+// Builds a state that carries `editorFocusField`, so `buildDecorations` gates the
+// raw-marker reveal on focus (the real editor path). Direct `makeState` above has
+// no focus field → the `?? true` fallback keeps its legacy cursor-only reveal.
+function makeFocusState(doc: string, cursorPos: number, focused: boolean) {
+  const base = EditorState.create({
+    doc,
+    extensions: [markdown({ extensions: [Strikethrough, Table, TaskList] }), editorFocusField],
+    selection: { anchor: cursorPos, head: cursorPos }
+  });
+  return focused ? base.update({ effects: setEditorFocus.of(true) }).state : base;
 }
 
 function asRanges(set: DecorationSet): DecoRange[] {
@@ -177,6 +195,47 @@ describe('buildDecorations — strong/emphasis/inline code', () => {
     const state = makeState('~~a~~', 3);
     const ranges = asRanges(buildDecorations(state));
     expect(classAt(ranges, 0, 5)).toBe('cm-lp-strike');
+  });
+});
+
+describe('buildDecorations — focus gating (#425)', () => {
+  // `**Bold Text**` is 13 chars: `**`(0..2) `Bold Text`(2..11) `**`(11..13).
+
+  it('does NOT reveal leading ** when the editor is unfocused, even with the caret at 0', () => {
+    // The exact reporter scenario: select a note that begins with markdown, do
+    // not click in. Default caret is at 0 (inside the bold), yet nothing reveals.
+    const state = makeFocusState('**Bold Text**\nmore', 0, false);
+    const ranges = asRanges(buildDecorations(state));
+    // Bold styling still applies — the note renders as a clean preview…
+    expect(classAt(ranges, 0, 13)).toBe('cm-lp-strong');
+    // …but the raw ** markers stay hidden despite the caret sitting on them.
+    expect(hasHiddenRange(ranges, 0, 2)).toBe(true);
+    expect(hasHiddenRange(ranges, 11, 13)).toBe(true);
+  });
+
+  it('reveals the leading ** once the editor is focused with the caret on it', () => {
+    const state = makeFocusState('**Bold Text**\nmore', 0, true);
+    const ranges = asRanges(buildDecorations(state));
+    expect(classAt(ranges, 0, 13)).toBe('cm-lp-strong');
+    // Markers shown (dimmed via cm-lp-mark), not hidden — editing view.
+    expect(hasHiddenRange(ranges, 0, 2)).toBe(false);
+    expect(classAt(ranges, 0, 2)).toBe('cm-lp-mark');
+  });
+
+  it('renders a link widget when unfocused even though the caret is inside it', () => {
+    // Reveal (raw markdown for editing) is suppressed while unfocused, so the
+    // block/inline widget wins regardless of caret position.
+    const doc = '[example](https://example.com) trailing';
+    const state = makeFocusState(doc, 5, false); // caret inside [example]
+    const ranges = asRanges(buildDecorations(state));
+    expect(ranges.filter((r) => r.hasWidget)).toHaveLength(1);
+  });
+
+  it('keeps the link raw (no widget) when focused with the caret inside it', () => {
+    const doc = '[example](https://example.com) trailing';
+    const state = makeFocusState(doc, 5, true);
+    const ranges = asRanges(buildDecorations(state));
+    expect(ranges.filter((r) => r.hasWidget)).toHaveLength(0);
   });
 });
 

--- a/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/decorations.ts
@@ -77,6 +77,51 @@ const DEFAULT_OPTIONS: BuildDecorationsOptions = {
  */
 export const rebuildLivePreview = StateEffect.define<null>();
 
+/**
+ * Editor focus, mirrored into editor state so the (state-only) decoration
+ * builder can gate the raw-markdown reveal on it. `buildDecorations` runs inside
+ * a `StateField` with no `EditorView` access, so it can't read `view.hasFocus`
+ * directly — `editorFocusWatcher` pushes focus/blur into this field instead.
+ *
+ * Why gate on focus at all: Live Preview reveals a node's raw markers only when
+ * the caret sits on it. But a freshly-opened note is UNFOCUSED with the caret at
+ * its default position 0 — so a note that begins with `**bold**` would flash its
+ * raw `**` before the user ever clicks in (reapps #425). Tying the reveal to
+ * focus means an unfocused editor renders fully clean (Obsidian parity); the raw
+ * markers appear only once the user actually focuses the editor.
+ */
+export const setEditorFocus = StateEffect.define<boolean>();
+export const editorFocusField = StateField.define<boolean>({
+  create: () => false,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setEditorFocus)) value = effect.value;
+    }
+    return value;
+  }
+});
+
+/**
+ * Mirrors DOM focus/blur into {@link editorFocusField}. Dispatched from real DOM
+ * events (not the update cycle), so a synchronous dispatch is safe here — unlike
+ * `livePreviewSyncListener`, which must defer. Guarded so it only fires on an
+ * actual change, avoiding redundant transactions.
+ */
+export const editorFocusWatcher = EditorView.domEventHandlers({
+  focus(_event, view) {
+    if (!view.state.field(editorFocusField, false)) {
+      view.dispatch({ effects: setEditorFocus.of(true) });
+    }
+    return false;
+  },
+  blur(_event, view) {
+    if (view.state.field(editorFocusField, false)) {
+      view.dispatch({ effects: setEditorFocus.of(false) });
+    }
+    return false;
+  }
+});
+
 const HIDDEN = Decoration.replace({});
 // Visible markdown markers on the actively-edited line (cursor in range). The
 // CSS rule in `theme.ts` dims them to `--muted-foreground` so the eye lands
@@ -297,6 +342,17 @@ export function buildDecorations(
   const doc = state.doc;
   const loaded = getLoadedImages(state);
 
+  // Reveal a node's raw markdown only when the editor is focused AND the
+  // selection actually sits on it. With the editor unfocused there is no
+  // "active" node, so the whole note renders clean — no markers flash on the
+  // default caret line of a just-opened note (#425). The `?? true` fallback
+  // keeps direct callers (unit tests) that build decorations without the editor
+  // extension on the legacy cursor-only behaviour; the real editor always
+  // installs `editorFocusField`, so the fallback never fires in the app.
+  const focused = state.field(editorFocusField, false) ?? true;
+  const revealInRange = (from: number, to: number): boolean =>
+    focused && isAnySelectionInRange(state, from, to);
+
   // ─── In-note table of contents ───────────────────────────────
   // The managed `<!-- toc -->` block is NOT a single syntax node (comment +
   // paragraph + list + comment), so it is found by text range, not tree node.
@@ -333,7 +389,7 @@ export function buildDecorations(
     // nothing double-decorates the TOC.
     tocSkipFrom = startLine.from;
     tocSkipTo = endLine.to;
-    if (!isAnySelectionInRange(state, startLine.from, endLine.to)) {
+    if (!revealInRange(startLine.from, endLine.to)) {
       // Cursor outside → one boxed widget.
       const innerMd = tocInnerMarkdown(docText) ?? '';
       // Drift is independent of the (preserved) title, so a bare fallback is
@@ -400,7 +456,7 @@ export function buildDecorations(
       if (name === 'FencedCode') {
         const startLine = doc.lineAt(from);
         const endLine = doc.lineAt(to);
-        const cursorInside = isAnySelectionInRange(state, from, to);
+        const cursorInside = revealInRange(from, to);
 
         if (!cursorInside) {
           // Replace the whole block (fences + body) with a rendered widget.
@@ -445,7 +501,7 @@ export function buildDecorations(
       // plain inline replace suffices — no `block: true` needed.
       if (name === 'HorizontalRule') {
         const line = doc.lineAt(from);
-        if (!isAnySelectionInRange(state, line.from, line.to)) {
+        if (!revealInRange(line.from, line.to)) {
           ranges.push(HR_LINE.range(line.from));
           if (line.to > line.from) ranges.push(HIDDEN.range(line.from, line.to));
         } else if (line.to > line.from) {
@@ -459,7 +515,7 @@ export function buildDecorations(
       if (headingMatch) {
         const level = parseInt(headingMatch[1], 10);
         const line = doc.lineAt(from);
-        const cursorInside = isAnySelectionInRange(state, from, to);
+        const cursorInside = revealInRange(from, to);
 
         // Caret on the heading line switches to the `cm-lp-head-active` variant,
         // which reveals the copy-link button (the only way to surface it on
@@ -502,7 +558,7 @@ export function buildDecorations(
       // ─── Strong (**bold** / __bold__) ────────────────────────────
       if (name === 'StrongEmphasis') {
         ranges.push(STRONG_MARK.range(from, to));
-        const cursorInside = isAnySelectionInRange(state, from, to);
+        const cursorInside = revealInRange(from, to);
         forEachChild(nodeRef.node, 'EmphasisMark', (mark) => {
           if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
           else ranges.push(HIDDEN.range(mark.from, mark.to));
@@ -513,7 +569,7 @@ export function buildDecorations(
       // ─── Emphasis (*italic* / _italic_) ──────────────────────────
       if (name === 'Emphasis') {
         ranges.push(EM_MARK.range(from, to));
-        const cursorInside = isAnySelectionInRange(state, from, to);
+        const cursorInside = revealInRange(from, to);
         forEachChild(nodeRef.node, 'EmphasisMark', (mark) => {
           if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
           else ranges.push(HIDDEN.range(mark.from, mark.to));
@@ -524,7 +580,7 @@ export function buildDecorations(
       // ─── Strikethrough (~~text~~) — GFM ──────────────────────────
       if (name === 'Strikethrough') {
         ranges.push(STRIKE_MARK.range(from, to));
-        const cursorInside = isAnySelectionInRange(state, from, to);
+        const cursorInside = revealInRange(from, to);
         forEachChild(nodeRef.node, 'StrikethroughMark', (mark) => {
           if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
           else ranges.push(HIDDEN.range(mark.from, mark.to));
@@ -535,7 +591,7 @@ export function buildDecorations(
       // ─── Inline code (`code`) ────────────────────────────────────
       if (name === 'InlineCode') {
         ranges.push(INLINE_CODE_MARK.range(from, to));
-        const cursorInside = isAnySelectionInRange(state, from, to);
+        const cursorInside = revealInRange(from, to);
         forEachChild(nodeRef.node, 'CodeMark', (mark) => {
           if (cursorInside) ranges.push(VISIBLE_MARK.range(mark.from, mark.to));
           else ranges.push(HIDDEN.range(mark.from, mark.to));
@@ -558,7 +614,7 @@ export function buildDecorations(
         if (parent && parent.type.name === 'Link') {
           return false;
         }
-        if (!isAnySelectionInRange(state, from, to)) {
+        if (!revealInRange(from, to)) {
           const parts = extractImageParts(nodeRef.node, doc);
           if (parts) {
             const effectiveMode = loaded.has(parts.url) ? 'always' : options.imageLoadMode;
@@ -581,7 +637,7 @@ export function buildDecorations(
 
       // ─── Links [text](url) ───────────────────────────────────────
       if (name === 'Link') {
-        if (!isAnySelectionInRange(state, from, to)) {
+        if (!revealInRange(from, to)) {
           const parts = extractLinkParts(nodeRef.node, doc);
           if (parts) {
             ranges.push(
@@ -606,7 +662,7 @@ export function buildDecorations(
           if (m) {
             const markFrom = line.from;
             const markTo = line.from + m[1].length;
-            if (!isAnySelectionInRange(state, line.from, line.to)) {
+            if (!revealInRange(line.from, line.to)) {
               ranges.push(HIDDEN.range(markFrom, markTo));
             } else if (markTo > markFrom) {
               ranges.push(VISIBLE_MARK.range(markFrom, markTo));
@@ -658,7 +714,7 @@ export function buildDecorations(
             ranges.push(HIDDEN.range(itemLine.from, listMark.from));
           }
 
-          const cursorOnLine = isAnySelectionInRange(state, itemLine.from, itemLine.to);
+          const cursorOnLine = revealInRange(itemLine.from, itemLine.to);
 
           if (isTask && taskMarker) {
             const next = doc.sliceString(taskMarker.to, taskMarker.to + 1);
@@ -728,7 +784,11 @@ export function createLivePreviewField(
       return buildDecorations(state, options);
     },
     update(value, tr) {
-      const forced = tr.effects.some((e) => e.is(rebuildLivePreview));
+      // `setEditorFocus` carries no doc/selection change, so it needs its own
+      // rebuild trigger — a focus/blur must re-run the reveal gate (#425).
+      const forced = tr.effects.some(
+        (e) => e.is(rebuildLivePreview) || e.is(setEditorFocus)
+      );
       if (tr.docChanged || tr.selection || forced) {
         return buildDecorations(tr.state, options);
       }

--- a/apps/reborn-notes/src/lib/editor/live-preview/index.ts
+++ b/apps/reborn-notes/src/lib/editor/live-preview/index.ts
@@ -19,6 +19,8 @@ import { Strikethrough, Table, TaskList } from '@lezer/markdown';
 import type { ImageLoadMode } from '@reborn/storage';
 import {
   createLivePreviewField,
+  editorFocusField,
+  editorFocusWatcher,
   livePreviewSyncListener,
   livePreviewAtomicRanges,
   livePreviewListClickForward,
@@ -95,6 +97,10 @@ export function createLivePreviewExtension(options: LivePreviewOptions = {}): Ex
     tableLabels: options.tableLabels ?? DEFAULT_TABLE_LABELS
   });
   return [
+    // Focus field first: buildDecorations (inside `field`) reads its computed
+    // value each rebuild, so it must resolve earlier in the config order.
+    editorFocusField,
+    editorFocusWatcher,
     field,
     loadedImagesField,
     livePreviewSyncListener,
@@ -120,6 +126,8 @@ export function getMarkdownExtension(): Extension {
 export {
   buildDecorations,
   isAnySelectionInRange,
+  setEditorFocus,
+  editorFocusField,
   createLivePreviewField,
   livePreviewField,
   livePreviewSyncListener,

--- a/apps/reborn-notes/src/routes/+page.svelte
+++ b/apps/reborn-notes/src/routes/+page.svelte
@@ -867,6 +867,11 @@
 
   // Load note content when active note changes
   let prevNoteId: string | null = null;
+  // One-shot request to focus the editor for a freshly created blank note (set
+  // when a note opens as `isNewNote`, consumed once its empty editor mounts).
+  // Existing-note opens clear it, so browsing never auto-focuses / pops the
+  // mobile keyboard.
+  let pendingNewNoteFocus = $state(false);
   $effect(() => {
     const id = $activeNoteId;
     historyMode = 'closed';
@@ -883,6 +888,7 @@
     prevNoteId = id;
 
     if (!id) {
+      pendingNewNoteFocus = false;
       if (prev) {
         // leaveNote discards a pristine ephemeral note (#349) or flushes+snapshots
         // a touched one. isUntouchedThisLoad() reads prev's state synchronously
@@ -895,14 +901,33 @@
 
     if (untrack(() => noteDetailService.isNewNote)) {
       viewMode = 'edit';
+      // New blank note: request a one-shot auto-focus so the user can type
+      // straight away (consumed by the effect below once the empty editor mounts).
+      pendingNewNoteFocus = true;
     } else {
       // Existing note: open in the per-device default view mode (#351). Read
       // untracked via get() so changing the preference later doesn't re-run
       // this effect for the already-open note. effectiveViewMode clamps 'split'
       // to 'edit' on mobile, so 'split' is safe to set here.
       viewMode = get(noteOpenMode);
+      pendingNewNoteFocus = false;
     }
     untrack(() => noteDetailService.loadNote(id));
+  });
+
+  // Auto-focus a freshly created blank note so the user can start typing
+  // immediately. Scoped to new notes that open EMPTY (a plain New Note, or an
+  // empty periodic note): existing notes stay unfocused so Live Preview renders
+  // clean and the mobile keyboard doesn't pop just from opening a note (#425).
+  // One-shot; waits for the empty content to land and the CM view to mount.
+  $effect(() => {
+    if (!pendingNewNoteFocus) return;
+    if (effectiveViewMode === 'preview') return;
+    const view = editorView;
+    if (!view) return;
+    if (noteDetailService.content !== '') return;
+    view.focus();
+    pendingNewNoteFocus = false;
   });
 
   // ── New note ─────────────────────────────────────────────────────

--- a/packages/ui/src/components/sidebar/context.svelte.ts
+++ b/packages/ui/src/components/sidebar/context.svelte.ts
@@ -42,6 +42,13 @@ class SidebarState {
 
 	// Event handler to apply to the `<svelte:window>`
 	handleShortcutKeydown = (e: KeyboardEvent) => {
+		// Cmd/Ctrl+B toggles the sidebar only as a global fallback: if a more
+		// specific handler already claimed the chord we must not also toggle.
+		// The notes editor binds Cmd/Ctrl+B to bold — CodeMirror preventDefaults
+		// the key (its table-cell editor does too) but lets it bubble to this
+		// window listener, so without this guard the sidebar would steal the
+		// bold shortcut (reapps #424).
+		if (e.defaultPrevented) return;
 		if (e.key === SIDEBAR_KEYBOARD_SHORTCUT && (e.metaKey || e.ctrlKey)) {
 			e.preventDefault();
 			this.toggle();


### PR DESCRIPTION
## Summary

Two note-editor bugs reported by @computrav, plus a companion new-note UX tweak. Closes #424, closes #425.

- **#424** - `Cmd/Ctrl+B` toggled the sidebar instead of bolding in the note editor. The shadcn-svelte sidebar (`@reborn/ui`) listens on `<svelte:window>` and claimed the chord even while the editor was focused; CodeMirror preventDefaults the key but lets it bubble. `handleShortcutKeydown` now bails on `e.defaultPrevented`, so the global sidebar toggle yields to any closer handler that already consumed the chord (editor bold, table-cell bold). No change to `Cmd/Ctrl+B` outside an editor; benefits reborn-task too.
- **#425** - Live Preview showed raw markdown before the editor was focused. Reveal was driven purely by the selection, and a freshly-opened note is unfocused with the caret at position 0, so a note starting with `**bold**` flashed its raw `**`. Focus is now mirrored into editor state (`editorFocusField` + `setEditorFocus` + `editorFocusWatcher`) and every raw/rendered decision routes through `revealInRange = focused && isAnySelectionInRange`. An unfocused editor renders fully clean (Obsidian parity); the active line reveals only once focused.
- **Auto-focus a new blank note** (companion to #425) - with reveal gated on focus, opening a note leaves the editor unfocused, so a brand-new *empty* note is now auto-focused once (via a one-shot flag consumed when the empty editor mounts) so you can type straight away. Existing notes stay unfocused (clean render, no mobile keyboard on open). An untouched blank note is ephemeral (#349), so the focus never dirties it or bumps `updated_at`.

Rejected alternative (discussed): an Obsidian-style throwaway empty line at the top of *existing* notes. It would fight the `content <-> editor` sync effect, risk false `updated_at` bumps + sync churn, and leak a phantom into the encryption pipeline. "Type immediately in an existing note" is parked as a desktop-only P2.

**Version note:** shipped as `fix` (patch); the primary intent is the two bug fixes and the auto-focus is a companion to the #425 fix. Re-title to `feat(notes)` before merge if you'd rather cut a minor for the new-note focus.

## Test plan

Smoke in **reborn-notes**, editor mode = Live Preview:

- **#424:** In the editor, select text and press `Cmd/Ctrl+B` -> text bolds, sidebar does **not** toggle. Repeat inside a table cell. With focus outside any editor, `Cmd/Ctrl+B` still toggles the sidebar.
- **#425:** Open a note that begins with `**Bold Text**` by selecting it from the sidebar **without clicking into the editor** -> the first line shows rendered **Bold Text**, no `**`. Click onto the first line -> `**` reveals for editing. Click outside the editor (blur) -> renders clean again.
- **Auto-focus:** Click **New Note** -> editor is focused, you can type immediately (mobile: keyboard opens). Open an **existing** note -> editor is **not** focused (mobile: no keyboard), content renders clean.

Automated: `decorations.test.ts` +4 focus-gating cases; full notes suite (1257 tests) green; `svelte-check` / eslint / ui `tsc` clean.