### PR TITLE
feat(notes): sync notes on tab return / app foreground (web)

### DIFF
--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -388,6 +388,42 @@
       5 * 60 * 1000
     );
 
+    // Tab-return / foreground sync (web + installed PWA). On mobile the user
+    // leaves and re-enters the app dozens of times a day; without this they see
+    // stale data (a peer device's edits) until the 5-min interval fires. Mirrors
+    // the interval body exactly: same push-before-pull ordering and auth/online
+    // guards, and stays a pure delta pull (no forced reconcile) so it's cheap on
+    // large accounts - a hard delete from another device still lands on cold
+    // start / manual / reconnect (Variant B trade-off, guideline 36 rule 18.e).
+    //
+    // Native drives the same refresh through platform.lifecycle.onResume below
+    // (visibilitychange is unreliable under capacitor://), so this listener is
+    // dead-code-eliminated from the native bundle to avoid a double sync on
+    // resume. Debounced 30s so rapid tab flips don't spam the server (mirrors
+    // reborn-task's tab-return sync).
+    let offForegroundSync: (() => void) | undefined;
+    if (!__REBORN_NATIVE__) {
+      let lastForegroundSyncAt = 0;
+      const FOREGROUND_SYNC_DEBOUNCE_MS = 30_000;
+      const onForegroundSync = () => {
+        if (document.visibilityState !== 'visible') return;
+        if (!navigator.onLine) return;
+        if (!($authStore.isAuthenticated && $authStore.hasE2E)) return;
+        const now = Date.now();
+        if (now - lastForegroundSyncAt < FOREGROUND_SYNC_DEBOUNCE_MS) return;
+        lastForegroundSyncAt = now;
+        // fire-and-forget, same as the interval above
+        pushPendingItems().catch(() => {});
+        pullFromServer()
+          .then(async (synced) => {
+            if (synced) await refreshStoresAfterPull();
+          })
+          .catch(() => {});
+      };
+      document.addEventListener('visibilitychange', onForegroundSync);
+      offForegroundSync = () => document.removeEventListener('visibilitychange', onForegroundSync);
+    }
+
     // Native: there is no Service Worker under capacitor://, so returning to the
     // foreground (App 'resume') drives the sync that the SW + online-transition
     // handler cover on web. Push BEFORE pull (same ordering as everywhere else)
@@ -448,6 +484,7 @@
     return () => {
       clearTimeout(timeoutId);
       clearInterval(syncInterval);
+      offForegroundSync?.();
       if (updateGateTimer) clearTimeout(updateGateTimer);
       unsubscribeNetwork();
       cleanupFolderSync();


### PR DESCRIPTION
## Summary

Notes had no web tab-return sync. Only the 5-minute interval and the native-only `platform.lifecycle.onResume` handler drove foreground pulls, so on an installed PWA (or any browser tab) returning to the app showed stale data - a peer device's edits - until the interval fired. On mobile users re-enter the app dozens of times a day, so the gap is felt.

This mirrors reborn-task's `visibilitychange` -> sync pattern in the notes root layout (`apps/reborn-notes/src/routes/+layout.svelte`):

- On `visibilitychange` -> `visible` + `navigator.onLine` + `isAuthenticated && hasE2E`, run the exact interval body: `pushPendingItems()` -> `pullFromServer()` -> `refreshStoresAfterPull()`.
- Debounced 30s so rapid tab flips don't spam the server (mirrors reborn-task).
- Gated to the web bundle (`!__REBORN_NATIVE__`): native already covers foreground via `onResume`, and `visibilitychange` is unreliable under `capacitor://`, so an ungated listener would double-sync on native resume.
- Stays a **pure delta pull** (no forced reconcile), consistent with the native resume handler, so it's cheap on large accounts (guideline 36 rule 18.e). A hard delete from another device still lands on cold start / manual / reconnect.

Closes the "Tab-return sync: Brak (TODO)" row for reborn-notes in the sync-architecture comparison (guideline 36).

## Test plan

Quality gate (green): `svelte-check` 0 errors / 0 warnings, eslint clean on the changed file.

Smoke (web / installed PWA, two devices or two tabs, same account):
1. Open a note list on tab A. On tab B (or a second device) edit/create/delete a note.
2. Switch away from tab A and back (or background/foreground the PWA). Within a moment the list reflects tab B's change without waiting ~5 min or hitting manual sync.
3. Rapidly flip away/back several times within 30s -> only one sync fires (debounce).
4. While offline or on the login/unlock screen, returning to the tab does NOT sync (guards hold).
5. Confirm no double behaviour regression on the native build (listener is compiled out; `onResume` still drives native foreground sync).