### PR TITLE
fix(notes): close multi-device reconciliation data-loss paths

### DIFF
--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -417,16 +417,35 @@ export async function deleteNote(id: string): Promise<void> {
     updatedAt: new Date().toISOString()
   });
 
-  // Note never reached the server - skip DELETE and mark as synced locally.
-  if (!existing || existing.sync_status === 'pending') {
+  // Note never reached the server - skip the DELETE and mark synced locally.
+  // Gate on sync_version === 0 (the authoritative "on the server yet?" signal
+  // used across the sync layer), NOT sync_status: a note that IS on the server
+  // but currently 'pending' (an unpushed edit) must still be soft-DELETE'd,
+  // otherwise the server keeps it active and the next pull's archive reconcile
+  // (rule 11.e) un-archives it straight back out of trash. See guideline 36.
+  if (!existing || (existing.sync_version ?? 0) === 0) {
     const archived = await noteStore.get(id);
     if (archived) await noteStore.save({ ...archived, sync_status: 'synced' });
     return;
   }
 
-  // Mark pending so pushPendingItems can retry if pushNoteDelete fails.
+  // Mark pending so pushPendingItems can retry if the push fails.
   const archived = await noteStore.get(id);
   if (archived) await noteStore.save({ ...archived, sync_status: 'pending' });
+
+  // If the note carried an unpushed edit (it was 'pending' before this delete),
+  // PATCH the latest content BEFORE the soft-delete: DELETE sends no ciphertext,
+  // so without this the trashed server copy keeps its pre-edit content and the
+  // next pull adopts that, silently dropping the edit. serializePerEntity keeps
+  // the DELETE ordered after the PATCH (rule 11.a / 11.g pattern). See guideline 36.
+  if (existing.sync_status === 'pending') {
+    pushNoteUpdate(id, {
+      title_encrypted: existing.title_encrypted,
+      content_encrypted: existing.content_encrypted,
+      folder_id: existing.folder_id ?? null,
+      metadata_encrypted: existing.metadata_encrypted ?? undefined
+    });
+  }
   pushNoteDelete(id);
 }
 
@@ -675,9 +694,15 @@ export async function emptyTrash(): Promise<number> {
     noteNavHistory.remove(n.id);
   }
 
-  // Push permanent deletes to server (fire-and-forget, skip never-synced notes)
+  // Push permanent deletes to server (fire-and-forget). Gate on sync_version > 0
+  // (the authoritative "reached the server" signal, same as pushPendingItems'
+  // archived retry), NOT sync_status: a trashed note whose soft-delete is still
+  // 'pending' IS on the server, and skipping its permanent DELETE would leave the
+  // server row while the local row was just hard-deleted above - the next pull
+  // then re-adopts it and the note resurrects in trash. A never-synced note
+  // (sync_version === 0) has nothing to delete remotely. See guideline 36.
   for (const n of archived) {
-    if (n.sync_status !== 'pending') {
+    if ((n.sync_version ?? 0) > 0) {
       pushNoteDelete(n.id, true);
     }
   }

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -180,26 +180,35 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(restoreHandler).toMatch(/sync_version:\s*updated\.sync_version/);
   });
 
-  it('pushNoteDelete and pushNoteRestore mirror server sync_version locally (BUG-6)', () => {
+  it('pushNoteDelete/pushNoteRestore do NOT mirror the server sync_version onto local (audit 2026-07-08 finding A)', () => {
+    // Mirroring the bumped server sync_version onto a local row whose content was
+    // NOT refreshed breaks rule-10's "equal version + differing ciphertext =>
+    // local holds the newer unpushed edit" invariant: a note archived/restored on
+    // one device would then re-push its stale content over a peer's newer content
+    // edit (silent data loss). The callbacks must leave sync_version at its
+    // pre-delete value so the next pull adopts the server content via the
+    // strict-greater gate. The SERVER still bumps its own version (asserted in the
+    // BUG-6 endpoint test above) so other devices pick up the archive state.
     const src = readSource('./notes-sync.service.ts');
 
     const deleteBody = src.slice(
       src.indexOf('export function pushNoteDelete'),
       src.indexOf('export function pushNoteRestore')
     );
-    // Must parse the response body and extract sync_version.
-    expect(deleteBody).toMatch(/await res\.json\(\)/);
-    expect(deleteBody).toMatch(/data\?\.sync_version/);
-    // And apply it in noteStore.save under serverSyncVersion.
-    expect(deleteBody).toMatch(/sync_version:\s*serverSyncVersion/);
-
     const restoreBody = src.slice(
       src.indexOf('export function pushNoteRestore'),
       src.indexOf('export function pushFolder')
     );
-    expect(restoreBody).toMatch(/await res\.json\(\)/);
-    expect(restoreBody).toMatch(/data\?\.sync_version/);
-    expect(restoreBody).toMatch(/sync_version:\s*serverSyncVersion/);
+    // No server-version mirror in either callback.
+    expect(deleteBody).not.toMatch(/serverSyncVersion/);
+    expect(deleteBody).not.toMatch(/sync_version:\s*data/);
+    expect(restoreBody).not.toMatch(/serverSyncVersion/);
+    expect(restoreBody).not.toMatch(/sync_version:\s*data/);
+    // Intent-check (rule 11.b) stays: branch on current.is_archived, chain opposite op.
+    expect(deleteBody).toMatch(/current\.is_archived/);
+    expect(deleteBody).toMatch(/pushNoteRestore\s*\(\s*id\s*\)/);
+    expect(restoreBody).toMatch(/current\.is_archived/);
+    expect(restoreBody).toMatch(/pushNoteDelete\s*\(\s*id\s*\)/);
   });
 
   it('pullNotes reconciles is_archived when server differs, even at equal sync_version (BUG-6)', () => {
@@ -213,6 +222,65 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(pullNotes).toMatch(/serverArchived\s*=\s*!!n\.deleted_at\s*\|\|\s*!!n\.is_archived/);
     expect(pullNotes).toMatch(/!!localNote\.is_archived\s*!==\s*serverArchived/);
     expect(pullNotes).toMatch(/is_archived:\s*serverArchived/);
+  });
+
+  // ── Multi-device reconciliation audit (2026-07-08) ──────────────────────
+
+  it('deleteNote gates "never on server" on sync_version===0, not sync_status (finding B)', () => {
+    const src = readSource('./note.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function deleteNote'),
+      src.indexOf('export async function moveNoteToFolder')
+    );
+    // Skip-DELETE branch keys off sync_version (the on-server signal), NOT
+    // sync_status: a pending note that IS on the server must still be soft-
+    // deleted, else the next pull's archive reconcile un-archives it out of trash.
+    expect(fn).toMatch(/!existing\s*\|\|\s*\(existing\.sync_version\s*\?\?\s*0\)\s*===\s*0/);
+    // A pending-on-server note PATCHes its unpushed content BEFORE the DELETE
+    // (DELETE carries no ciphertext, so otherwise the unsynced edit is lost).
+    expect(fn).toMatch(
+      /if\s*\(existing\.sync_status\s*===\s*'pending'\)\s*\{[\s\S]*?pushNoteUpdate\s*\(\s*id\s*,/
+    );
+    expect(fn).toMatch(/pushNoteDelete\s*\(\s*id\s*\)/);
+  });
+
+  it('emptyTrash gates the permanent DELETE on sync_version>0, not sync_status (finding C)', () => {
+    const src = readSource('./note.service.ts');
+    const fn = src.slice(
+      src.indexOf('export async function emptyTrash'),
+      src.indexOf('export async function cleanTrash')
+    );
+    expect(fn).toMatch(/\(n\.sync_version\s*\?\?\s*0\)\s*>\s*0/);
+    expect(fn).toMatch(/pushNoteDelete\s*\(\s*n\.id\s*,\s*true\s*\)/);
+    // Must NOT skip on sync_status pending - that hard-deleted the row locally
+    // but left it on the server, resurrecting the note on the next pull.
+    expect(fn).not.toMatch(/n\.sync_status\s*!==\s*'pending'/);
+  });
+
+  it('pullNotes holds the delta watermark at the earliest unpersisted row (finding G)', () => {
+    const src = readSource('./notes-sync.service.ts');
+    const pullNotes = src.slice(
+      src.indexOf('async function pullNotes'),
+      src.indexOf('async function writeNotesPage')
+    );
+    // writeNotesPage reports the earliest row it failed to persist; pullNotes
+    // caps the watermark there so the next ?since delta re-fetches it instead of
+    // skipping it forever.
+    expect(pullNotes).toMatch(/earliestUnaccounted/);
+    expect(pullNotes).toMatch(
+      /const\s+nextWatermark\s*=\s*earliestUnaccounted\s*\?\?\s*maxUpdatedAt/
+    );
+    expect(pullNotes).toMatch(/writeWatermark\(userId,\s*nextWatermark\)/);
+
+    const writePage = src.slice(
+      src.indexOf('async function writeNotesPage'),
+      src.indexOf('// ── Push helpers')
+    );
+    // Shadow-index throw path records the row as unaccounted; saveMany failures
+    // (no row ids) conservatively hold at the earliest fresh upsert.
+    expect(writePage).toMatch(/unaccountedUpdatedAts\.push\(n\.updated_at\)/);
+    expect(writePage).toMatch(/freshUpsertUpdatedAts/);
+    expect(writePage).toMatch(/minUnaccounted/);
   });
 
   it('pull helpers remove ghost items (synced locally but deleted on server)', () => {
@@ -650,10 +718,13 @@ describe('notes-sync - regression (offline data loss)', () => {
     // call expression (not a comment mention) and look for try/catch/return.
     const callMatch = /await\s+extractShadowIndexes\s*\(/.exec(pullNotes);
     expect(callMatch).not.toBeNull();
-    const window = pullNotes.slice(callMatch!.index, callMatch!.index + 600);
+    const window = pullNotes.slice(callMatch!.index, callMatch!.index + 900);
     expect(window).toMatch(/catch\s*\(/);
     // Skip path returns `null` from the map callback (pullNotes collects the
     // ids it actually wrote; skipped notes contribute null and are filtered).
+    // The catch also records the row as unaccounted so the watermark is held
+    // back (fix G) - the return-null skip still follows it.
+    expect(window).toMatch(/unaccountedUpdatedAts\.push/);
     expect(window).toMatch(/return null;/);
   });
 

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -722,6 +722,11 @@ async function pullNotes(): Promise<string[]> {
   // from a partial delta page (that would wipe every unchanged note).
   let allIds: Set<string> | null = null;
   let maxUpdatedAt = since ?? '';
+  // Earliest server row we failed to persist across all pages (shadow-index
+  // throw / batched-write failure). The watermark is capped here so the next
+  // pull re-fetches from it instead of skipping it forever. Null when every
+  // row was accounted for (the common path - watermark then advances normally).
+  let earliestUnaccounted: string | null = null;
 
   try {
     do {
@@ -755,9 +760,16 @@ async function pullNotes(): Promise<string[]> {
         syncProgress.set({ done: 0, total });
       }
 
-      const { changed: pageChanged, maxUpdatedAt: pageMax } = await writeNotesPage(data, userId);
+      const {
+        changed: pageChanged,
+        maxUpdatedAt: pageMax,
+        minUnaccounted: pageUnaccounted
+      } = await writeNotesPage(data, userId);
       changed.push(...pageChanged);
       if (pageMax > maxUpdatedAt) maxUpdatedAt = pageMax;
+      if (pageUnaccounted && (earliestUnaccounted === null || pageUnaccounted < earliestUnaccounted)) {
+        earliestUnaccounted = pageUnaccounted;
+      }
       done += data.length;
       syncProgress.set({ done, total: Math.max(total, done) });
 
@@ -800,8 +812,14 @@ async function pullNotes(): Promise<string[]> {
   }
 
   // Advance the delta watermark (server-authoritative, monotonic). Next pull
-  // fetches only rows updated at/after this instant.
-  if (maxUpdatedAt && maxUpdatedAt !== since) writeWatermark(userId, maxUpdatedAt);
+  // fetches only rows updated at/after this instant. Cap at the earliest row we
+  // failed to persist so it is re-fetched next time (`since` is gte-inclusive on
+  // the first page, so a watermark equal to that row's updated_at re-includes
+  // it); otherwise advance to the highest updated_at we saw. `earliestUnaccounted`
+  // is always <= maxUpdatedAt (it is one of the page rows), so this only ever
+  // holds the watermark back, never pushes it forward past unseen rows.
+  const nextWatermark = earliestUnaccounted ?? maxUpdatedAt;
+  if (nextWatermark && nextWatermark !== since) writeWatermark(userId, nextWatermark);
   reconciledThisSession = true;
 
   return changed;
@@ -816,7 +834,7 @@ async function pullNotes(): Promise<string[]> {
 async function writeNotesPage(
   data: ServerNote[],
   userId: string
-): Promise<{ changed: string[]; maxUpdatedAt: string }> {
+): Promise<{ changed: string[]; maxUpdatedAt: string; minUnaccounted: string | null }> {
   // Highest server updated_at in this page (ISO strings sort chronologically).
   // Computed over ALL rows, including ones the sync_version guard skips below -
   // we still saw them at that timestamp, so the next ?since must cover them.
@@ -834,6 +852,16 @@ async function writeNotesPage(
   const notesToWrite: NoteStoredLocal[] = [];
   const tagAdds: Array<{ noteId: string; tagId: string }> = [];
   const tagRemoves: Array<{ noteId: string; tagId: string }> = [];
+  // Server rows we did NOT persist this page (shadow-index derivation threw, or
+  // the batched write dropped them). The delta watermark MUST NOT be advanced
+  // past their updated_at, or the next `?since` pull skips them forever - which
+  // would silently break the "will retry on next successful sync" promise below.
+  // pullNotes caps the watermark at the earliest of these. See guideline 36.
+  const unaccountedUpdatedAts: string[] = [];
+  // updated_at of the fresh server upserts queued for saveMany, used to bound the
+  // watermark conservatively if the batched write reports failures (BatchResult
+  // does not say WHICH rows failed).
+  const freshUpsertUpdatedAts: string[] = [];
 
   const changedResults = await Promise.all(
     (
@@ -919,6 +947,11 @@ async function writeNotesPage(
           `Skipping save of note ${n.id} - shadow indexes could not be derived. Will retry on next successful sync.`,
           err
         );
+        // Not persisted: hold the watermark at/below this row so the next pull
+        // re-fetches it (the retry promise above only holds if we do). Without
+        // this, a crypto-not-ready race during a pull would strand the note stale
+        // forever - the `?since` gate would never re-include it. See guideline 36.
+        unaccountedUpdatedAts.push(n.updated_at);
         return null;
       }
 
@@ -938,6 +971,7 @@ async function writeNotesPage(
         updated_at: n.updated_at
       };
       notesToWrite.push(note);
+      freshUpsertUpdatedAts.push(n.updated_at);
 
       // Rebuild local note-tag associations from metadata_encrypted. Collect the
       // deltas here (read-only) and apply them in a bounded sweep below, off the
@@ -969,6 +1003,13 @@ async function writeNotesPage(
         `pullNotes: ${result.failed}/${notesToWrite.length} note writes failed in batch`,
         { errors: result.errors.slice(0, 3) }
       );
+      // BatchResult carries no row ids, so we cannot tell WHICH upsert failed.
+      // Conservatively hold the watermark at the earliest fresh upsert so the
+      // next pull re-fetches the whole batch (rare - the server ciphertext was
+      // valid when stored; a failure here means local re-encoding/guard).
+      if (freshUpsertUpdatedAts.length > 0) {
+        unaccountedUpdatedAts.push(freshUpsertUpdatedAts.reduce((m, u) => (u < m ? u : m)));
+      }
     }
   }
 
@@ -991,9 +1032,15 @@ async function writeNotesPage(
     );
   }
 
+  const minUnaccounted =
+    unaccountedUpdatedAts.length > 0
+      ? unaccountedUpdatedAts.reduce((m, u) => (u < m ? u : m))
+      : null;
+
   return {
     changed: changedResults.filter((id): id is string => id !== null),
-    maxUpdatedAt
+    maxUpdatedAt,
+    minUnaccounted
   };
 }
 
@@ -1595,37 +1642,30 @@ export function pushNoteDelete(id: string, permanent = false): void {
         await ensureOk(res, `DELETE /api/notes/${id}`);
         if (permanent) return;
 
-        // Server bumps sync_version on soft-delete (since rule 11.e) and returns
-        // the new value. We MUST mirror it locally, otherwise the next pull sees
-        // server=N+1 vs local=N and re-applies the archive state we already have
-        // - harmless but churn. More importantly, future pushes would operate on
-        // stale sync_version and look like conflicts.
-        let serverSyncVersion: number | undefined;
-        try {
-          const body = await res.json();
-          serverSyncVersion = body?.data?.sync_version;
-        } catch {
-          // Old server deploy - no body. Leave sync_version untouched.
-        }
-
+        // Do NOT mirror the server's bumped sync_version onto the local row.
+        // The soft-delete bumps the server version but carries no ciphertext, so
+        // local CONTENT is not refreshed here. If a peer edited this note just
+        // before we archived it, copying the server version onto our stale
+        // content produces "server-version + differing ciphertext", which rule-10
+        // reconcile misreads as an unpushed LOCAL edit and re-pushes over the
+        // peer's newer content - silent data loss (audit 2026-07-08 finding A).
+        // Leaving sync_version at its pre-delete value makes the next pull see
+        // server > local and adopt the server's current content + archive state
+        // via the strict-greater gate, so the peer edit survives. Cost: one
+        // benign re-adopt (the churn the mirror was added to avoid); a later
+        // content push re-syncs the version anyway. The server still bumps its
+        // own version so OTHER devices pick up the archive state (rule 11.e).
+        //
         // Intent-check: if the user restored the note while DELETE was in flight,
         // `current.is_archived` will be false. Marking 'synced' would strand the
         // local restore - chain a pushNoteRestore instead. See guideline 36 rule 11.b.
         const current = await noteStore.get(id);
         if (!current) return;
         if (current.is_archived) {
-          await noteStore.save({
-            ...current,
-            sync_status: 'synced',
-            sync_version: serverSyncVersion ?? current.sync_version
-          });
+          await noteStore.save({ ...current, sync_status: 'synced' });
         } else {
           logger.debug(`Note ${id} restored during delete push - chaining restore`);
-          await noteStore.save({
-            ...current,
-            sync_status: 'pending',
-            sync_version: serverSyncVersion ?? current.sync_version
-          });
+          await noteStore.save({ ...current, sync_status: 'pending' });
           pushNoteRestore(id);
         }
       },
@@ -1652,33 +1692,23 @@ export function pushNoteRestore(id: string): void {
         // reasoning as pushNoteDelete. See guideline 36 rule 14.
         await ensureOk(res, `POST /api/notes/${id}/restore`);
 
-        // Server bumps sync_version on restore (since rule 11.e) and returns it.
-        // Mirror locally; fall back to preserving the current value on old deploys.
-        let serverSyncVersion: number | undefined;
-        try {
-          const body = await res.json();
-          serverSyncVersion = body?.data?.sync_version;
-        } catch {
-          // Old server deploy - no body.
-        }
-
+        // Do NOT mirror the server's bumped sync_version (same reasoning as
+        // pushNoteDelete): restore bumps the server version but returns no
+        // ciphertext, so leaving local sync_version at its pre-restore value lets
+        // the next pull adopt the server's current content via strict-greater,
+        // instead of an equal-version reconcile re-pushing possibly-stale local
+        // content over a peer edit (audit 2026-07-08 finding A). The server still
+        // bumps so other devices pick up the un-archive (rule 11.e).
+        //
         // Intent-check: if the user re-archived the note while /restore was in
         // flight, chain a pushNoteDelete to catch up. See guideline 36 rule 11.b.
         const current = await noteStore.get(id);
         if (!current) return;
         if (!current.is_archived) {
-          await noteStore.save({
-            ...current,
-            sync_status: 'synced',
-            sync_version: serverSyncVersion ?? current.sync_version
-          });
+          await noteStore.save({ ...current, sync_status: 'synced' });
         } else {
           logger.debug(`Note ${id} re-archived during restore push - chaining delete`);
-          await noteStore.save({
-            ...current,
-            sync_status: 'pending',
-            sync_version: serverSyncVersion ?? current.sync_version
-          });
+          await noteStore.save({ ...current, sync_status: 'pending' });
           pushNoteDelete(id);
         }
       },


### PR DESCRIPTION
## Summary

A targeted multi-device sync/reconciliation audit (native mobile makes phone+laptop the norm) surfaced real data-loss paths the reconciliation layer does **not** catch - distinct from the known/deferred whole-field last-writer-wins (that stays a CRDT-track item). This PR fixes the four approved as pre-launch **Tier 1**. All keep the server a dumb ciphertext store - **Zero Knowledge intact**, no schema/plaintext changes.

### A - Archive/restore silently reverting a peer's committed content edit `high`
`pushNoteDelete` / `pushNoteRestore` mirrored the server's bumped `sync_version` onto the local row **without** refreshing content. That produced *server-version + stale ciphertext*, which rule-10 reconcile misreads as an unpushed local edit and re-PATCHes over the peer's newer content. Net: a note **archived or restored** on one device silently reverted a **body edit** made on another - only one device touched content, so this is inverted loss, outside the deferred LWW.
**Fix:** leave `sync_version` at its pre-delete value; the next pull adopts the server's current content + archive state via the strict-greater gate, so the peer edit survives. The server still bumps its own version, so other devices pick up the archive state (rule 11.e). Cost: one benign re-adopt (the churn the mirror was added to avoid).

### B - Deleted note resurrecting out of trash `medium`
`deleteNote` used `sync_status === 'pending'` as the "never reached the server" signal. A note that **is** on the server but currently pending (an unpushed edit) skipped its soft-delete and marked synced, so the server kept it active and the next pull's archive reconcile un-archived it. **Fix:** gate on `sync_version === 0`; a pending-on-server note also PATCHes its unpushed content **before** the DELETE (DELETE carries no ciphertext, so the edit would otherwise be lost).

### C - emptyTrash resurrecting a still-pending trashed note `medium`
Same `sync_status` confusion: a trashed note whose soft-delete was still pending got hard-deleted locally but left on the server. **Fix:** gate the permanent DELETE on `sync_version > 0`.

### G - Delta watermark skipping a row a pull failed to persist `medium`
When shadow-index derivation threw (crypto-not-ready race) or the batched write failed, the row was not persisted but the watermark still advanced past it - so the `?since` gate never re-included it, breaking the "retry on next sync" promise. **Fix:** hold the watermark at the earliest unpersisted row so the next pull re-fetches it. Common path (no failures) is unchanged.

**Deferred (documented, not in this PR):** editor cross-field revert (D), a pull-vs-edit TOCTOU (E), the watermark commit-order inversion (F), and the tombstone-less permanent-delete resurrection (H).

## Test plan

- Full reborn-notes suite green (1260 tests), `svelte-check` 0/0, eslint clean.
- Rewrote the BUG-6 mirror assertion to the new no-mirror invariant; added source-level pins for B/C/G.

Smoke (two devices / tabs, same account):
1. **A:** on device 1 edit a note's body; before device 2 pulls, on device 2 move that note to Trash (or restore one). After both sync, device 1's edit must still be present in the note (not reverted to the pre-edit text).
2. **B:** edit a note offline (leave it pending), then Trash it; go online. The note stays in Trash and does not pop back into the list after sync.
3. **C:** with a note whose delete is still pending, Empty Trash; after sync it does not reappear in Trash.
4. Regression: normal edit / delete / restore / empty-trash across two devices still converge.