### PR TITLE
feat(notes): pull on in-app navigation for fresher cross-device data

### DIFF
--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -85,6 +85,13 @@ describe('notes-sync - regression (offline data loss)', () => {
     // The tab-return (visibilitychange) handler delegates to the SAME activitySync
     // so both triggers share one 30s cooldown and coalesce.
     expect(src).toMatch(/onForegroundSync\s*=\s*\(\)\s*=>\s*\{[\s\S]*?activitySync\(\)/);
+    // Switching notes / IconNav sections is STATE within the '/' route, not a
+    // route navigation, so a capture-phase pointerdown drives the same
+    // activitySync (can't miss a specific view-state variable).
+    expect(src).toMatch(/onPointerActivity\s*=\s*\(\)\s*=>\s*activitySync\(\)/);
+    expect(src).toMatch(
+      /addEventListener\(\s*['"]pointerdown['"]\s*,\s*onPointerActivity\s*,\s*\{\s*capture:\s*true/
+    );
   });
 
   it('delete/restore push ops are serialized per-entity (BUG-5 part A/B/C)', () => {

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -67,6 +67,26 @@ describe('notes-sync - regression (offline data loss)', () => {
     expect(firstPushCall).toBeLessThan(firstPullCall);
   });
 
+  it('layout pulls on in-app navigation and tab-return via a shared-cooldown activitySync (freshness)', () => {
+    const src = readSource('../../routes/+layout.svelte');
+    // In-app navigation triggers a pull, skipping the initial load (from===null).
+    expect(src).toMatch(/afterNavigate\s*\(/);
+    expect(src).toMatch(/nav\.from === null/);
+    // The pull runs through activitySync, which is cooldown-gated and push-first.
+    const activity = src.slice(
+      src.indexOf('function activitySync'),
+      src.indexOf('function activitySync') + 700
+    );
+    expect(activity).toMatch(/ACTIVITY_SYNC_DEBOUNCE_MS/);
+    const pushIdx = activity.search(/pushPendingItems\s*\(/);
+    const pullIdx = activity.search(/pullFromServer\s*\(/);
+    expect(pushIdx).toBeGreaterThan(-1);
+    expect(pullIdx).toBeGreaterThan(pushIdx);
+    // The tab-return (visibilitychange) handler delegates to the SAME activitySync
+    // so both triggers share one 30s cooldown and coalesce.
+    expect(src).toMatch(/onForegroundSync\s*=\s*\(\)\s*=>\s*\{[\s\S]*?activitySync\(\)/);
+  });
+
   it('delete/restore push ops are serialized per-entity (BUG-5 part A/B/C)', () => {
     const src = readSource('./notes-sync.service.ts');
 

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   import { shareDeepLinkToRoute } from '$lib/utils/deep-link';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
+  import { afterNavigate } from '$app/navigation';
   import { initializeStorage, isDatabaseInitialized } from '@reborn/storage';
   import { cryptoManager } from '@reborn/crypto';
   import { getSettings } from '$lib/utils/app-settings';
@@ -221,6 +222,43 @@
     runSync().catch(() => {});
   });
 
+  // ── Cross-device freshness: "user is active" pull triggers ──────────────
+  // One shared 30s cooldown for both activity triggers below (tab-return
+  // visibility + in-app navigation), so a nav right after a tab-return - or a
+  // burst of navigations - coalesces into a single delta pull instead of
+  // hammering the server. Push-before-pull with the same auth/online guards as
+  // the periodic interval; a pure delta pull (no forced reconcile), cheap on
+  // large accounts (guideline 36 rule 18.e).
+  let lastActivitySyncAt = 0;
+  const ACTIVITY_SYNC_DEBOUNCE_MS = 30_000;
+  function activitySync(): void {
+    if (!browser) return;
+    if (!navigator.onLine) return;
+    if (!($authStore.isAuthenticated && $authStore.hasE2E)) return;
+    const now = Date.now();
+    if (now - lastActivitySyncAt < ACTIVITY_SYNC_DEBOUNCE_MS) return;
+    lastActivitySyncAt = now;
+    pushPendingItems().catch(() => {});
+    pullFromServer()
+      .then(async (synced) => {
+        if (synced) await refreshStoresAfterPull();
+      })
+      .catch(() => {});
+  }
+
+  // Pull on in-app navigation (web + native). SvelteKit client-side navigation
+  // fires no visibilitychange, so without this an actively-used tab/app shows a
+  // peer device's edits only after the 5-min interval - the user navigates
+  // around (opens a folder, switches notes) but never tab-switches. Opening a
+  // new view is a strong "I'm looking now" signal. Cooldown-gated by activitySync
+  // (shared with tab-return). Skip the initial load (`from === null`): the boot
+  // sync in onMount already covers it. Guard-gated inside activitySync, so a nav
+  // on an auth/lock screen is a no-op. See guideline 36.
+  afterNavigate((nav) => {
+    if (nav.from === null) return;
+    activitySync();
+  });
+
   onMount(() => {
     if (!browser) return;
 
@@ -390,35 +428,17 @@
 
     // Tab-return / foreground sync (web + installed PWA). On mobile the user
     // leaves and re-enters the app dozens of times a day; without this they see
-    // stale data (a peer device's edits) until the 5-min interval fires. Mirrors
-    // the interval body exactly: same push-before-pull ordering and auth/online
-    // guards, and stays a pure delta pull (no forced reconcile) so it's cheap on
-    // large accounts - a hard delete from another device still lands on cold
-    // start / manual / reconnect (Variant B trade-off, guideline 36 rule 18.e).
+    // stale data (a peer device's edits) until the 5-min interval fires. Routes
+    // through activitySync (shared 30s cooldown with the in-app navigation sync).
     //
     // Native drives the same refresh through platform.lifecycle.onResume below
     // (visibilitychange is unreliable under capacitor://), so this listener is
-    // dead-code-eliminated from the native bundle to avoid a double sync on
-    // resume. Debounced 30s so rapid tab flips don't spam the server (mirrors
-    // reborn-task's tab-return sync).
+    // dead-code-eliminated from the native bundle to avoid a double sync on resume.
     let offForegroundSync: (() => void) | undefined;
     if (!__REBORN_NATIVE__) {
-      let lastForegroundSyncAt = 0;
-      const FOREGROUND_SYNC_DEBOUNCE_MS = 30_000;
       const onForegroundSync = () => {
         if (document.visibilityState !== 'visible') return;
-        if (!navigator.onLine) return;
-        if (!($authStore.isAuthenticated && $authStore.hasE2E)) return;
-        const now = Date.now();
-        if (now - lastForegroundSyncAt < FOREGROUND_SYNC_DEBOUNCE_MS) return;
-        lastForegroundSyncAt = now;
-        // fire-and-forget, same as the interval above
-        pushPendingItems().catch(() => {});
-        pullFromServer()
-          .then(async (synced) => {
-            if (synced) await refreshStoresAfterPull();
-          })
-          .catch(() => {});
+        activitySync();
       };
       document.addEventListener('visibilitychange', onForegroundSync);
       offForegroundSync = () => document.removeEventListener('visibilitychange', onForegroundSync);

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -444,6 +444,20 @@
       offForegroundSync = () => document.removeEventListener('visibilitychange', onForegroundSync);
     }
 
+    // In-app activity sync (web + native). The notes shell is a single route
+    // ('/'), so switching notes (activeNoteId store) or IconNav sections
+    // (activeSection page state, plus folder/tag/saved-search sub-selections)
+    // changes STATE, not the URL - afterNavigate and visibilitychange never fire
+    // for them, so those views showed a peer's edits only after the 5-min
+    // interval. A capture-phase pointerdown on the document is a robust "user is
+    // actively using the app" signal that can't miss a particular view-state
+    // variable, and it fires under capacitor:// too. Cooldown-gated by
+    // activitySync (shared 30s), so a burst of taps coalesces into a single delta
+    // pull; passive + capture so it never interferes with any handler. See
+    // guideline 36.
+    const onPointerActivity = () => activitySync();
+    document.addEventListener('pointerdown', onPointerActivity, { capture: true, passive: true });
+
     // Native: there is no Service Worker under capacitor://, so returning to the
     // foreground (App 'resume') drives the sync that the SW + online-transition
     // handler cover on web. Push BEFORE pull (same ordering as everywhere else)
@@ -505,6 +519,7 @@
       clearTimeout(timeoutId);
       clearInterval(syncInterval);
       offForegroundSync?.();
+      document.removeEventListener('pointerdown', onPointerActivity, { capture: true });
       if (updateGateTimer) clearTimeout(updateGateTimer);
       unsubscribeNetwork();
       cleanupFolderSync();


### PR DESCRIPTION
## Summary

Follow-up to the multi-device freshness work (#428). Diagnosis of a reported gap: on device A, editing already pushes to the server immediately (fire-and-forget, ~2s editor debounce; pin/star/move/rename push on the action; `beforeNavigate` flushes on nav) - so a peer edit is on the server in seconds. The latency was entirely on device B's **pull** side.

B pulled only on: the 5-min interval, online-recovery, tab-return (`visibilitychange`, #428), and manual sync. In-app view changes never triggered a pull - and crucially the notes shell is a **single route** (`/`): switching notes (the `activeNoteId` store) and IconNav sections (`activeSection` page state, plus folder/tag/saved-search sub-selections) change **state, not the URL**, so `afterNavigate` never fires for them. Only real route changes (Settings) did.

**Fix (two triggers, one shared 30s cooldown via `activitySync`):**
- `afterNavigate` -> pull on real route transitions (Settings, back-button, programmatic `goto`), skipping the initial load (`from === null`).
- **capture-phase, passive `pointerdown`** on the document -> pull on any in-app interaction (switching notes, IconNav sections, folders, tags). This is a robust "user is actively using the app" signal that can't miss a specific view-state variable, and it fires under `capacitor://` too (web + native).

Both route through `activitySync` (push -> pull -> refresh), which shares **one** 30s cooldown, so a burst of taps / a nav right after a tab-return coalesces into a single delta pull. Guard-gated (auth + `hasE2E` + online), so activity on a lock/auth screen is a no-op. Pure delta pull - cheap on large accounts, and the reconcile fixes in #429 make the extra pulls safe.

## Test plan

- `svelte-check` 0/0, eslint clean, `notes-sync.regression.spec.ts` green (49 tests incl. a source-level pin for the `afterNavigate` + `pointerdown` + shared-cooldown wiring).

Smoke (two devices / tabs, same account):
1. On device A edit a note's body. On device B, **without switching browser tabs**, switch between notes and IconNav sections (folders, starred, trash). Within ~a moment (at most one 30s cooldown) B reflects A's edit - no 5-min wait, no manual sync.
2. Enter Settings and return -> also syncs (route nav).
3. Rapidly tap around within 30s -> only one delta pull fires (shared cooldown).
4. On a lock/login screen, tapping does not sync (guards hold).
5. Note: a freshly created **empty** note is deliberately not synced until you type something into it (ephemeral, #349).
