### PR TITLE
chore(android): bump notes versionCode to 2 for internal testing

### DIFF
--- a/apps/reborn-notes/android/app/build.gradle
+++ b/apps/reborn-notes/android/app/build.gradle
@@ -33,7 +33,7 @@ android {
         // Store versioning (Faza 5, plan D5): versionName = public semver of the
         // native shell (independent of the monorepo's nx-release version);
         // versionCode = monotonic int, bumped on every store submission.
-        versionCode 1
+        versionCode 2
         versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {


### PR DESCRIPTION
## Summary

Build 1 (`versionName 1.0.0`, `versionCode 1`) is already on the Google Play
internal testing track (published 2026-07-04, built from `main @ 74f47ea`).
Play rejects re-using a `versionCode`, so the next AAB upload must be
`versionCode 2`.

- `versionCode 1 -> 2` in `apps/reborn-notes/android/app/build.gradle`
- `versionName` stays `1.0.0`: the public store version bumps per store release,
  not per internal build (runbook guideline 62 s1). The "build N" suffix in the
  About screen distinguishes internal iterations.

No other source changes - the new AAB otherwise bundles current `main`, so it
picks up all recent app changes.

## Test plan

After merge, from updated `main`:

1. `pnpm nx build-native-prod reborn-notes` (prod API bundle)
2. `cd apps/reborn-notes && nvm use && npx cap sync android` (no `CAP_DEV_CLEARTEXT`)
3. `cd android && ./gradlew bundleRelease`
4. Confirm the AAB reports `versionCode 2` / `versionName 1.0.0` and is signed with
   the upload cert: `keytool -printcert -jarfile app/build/outputs/bundle/release/app-release.aab`
   -> `Owner: CN=Fundacja Reborn`.