### PR TITLE
chore(android): bump notes versionCode to 3 for internal testing

### DIFF
--- a/apps/reborn-notes/android/app/build.gradle
+++ b/apps/reborn-notes/android/app/build.gradle
@@ -33,7 +33,7 @@ android {
         // Store versioning (Faza 5, plan D5): versionName = public semver of the
         // native shell (independent of the monorepo's nx-release version);
         // versionCode = monotonic int, bumped on every store submission.
-        versionCode 2
+        versionCode 3
         versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {


### PR DESCRIPTION
## Summary

Play rejects re-uploading `app-release.aab` because its `versionCode 2` is already live on the internal-testing track (uploaded in #432). Every Play upload needs a unique, monotonic `versionCode`, so this bumps `apps/reborn-notes/android/app/build.gradle` `versionCode` 2 -> 3. `versionName` stays `1.0.0` (same public release; only the build number changes).

This build carries the native cold-start splash follow-up (#434).

## Test plan

- Rebuild the AAB (`build-native*` -> `cap sync android` -> Android Studio bundle / `./gradlew bundleRelease`) and confirm it reports `versionCode 3`.
- Upload to the Play internal-testing track - the "version code already in use" error is gone.