### PR TITLE
fix(notes): show initial-sync banner only when local DB is empty

### DIFF
--- a/apps/reborn-notes/src/lib/components/sync/InitialSyncBanner.svelte
+++ b/apps/reborn-notes/src/lib/components/sync/InitialSyncBanner.svelte
@@ -18,6 +18,8 @@
 -->
 <script lang="ts">
   import { Loader2 } from '@lucide/svelte';
+  import { slide } from 'svelte/transition';
+  import { prefersReducedMotion } from 'svelte/motion';
   import { isInitialSync, syncProgress } from '$lib/stores/sync-status.store';
   import { t } from '$lib/stores/i18n.store';
 
@@ -44,7 +46,14 @@
 </script>
 
 {#if showAfterDelay && $isInitialSync}
+  <!-- slide (not a bare {#if} swap): the measured banner stack feeds
+       --rn-banner-h, which the 100dvh page layouts subtract - an instant
+       mount/unmount snaps the whole UI by the banner height (worst at sync
+       completion, an unpredictable moment). bind:clientHeight is
+       ResizeObserver-based, so the var tracks the animated height per frame
+       and the layout follows the slide instead of jumping. -->
   <div
+    transition:slide={{ duration: prefersReducedMotion.current ? 0 : 200 }}
     class="border-b border-primary/15 bg-primary/5"
     role="status"
     aria-live="polite"

--- a/apps/reborn-notes/src/lib/components/sync/initial-sync-ux.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/components/sync/initial-sync-ux.regression.spec.ts
@@ -44,6 +44,31 @@ describe('initial-sync UX - banner + periodic pending (2026-06-28)', () => {
       expect(src).toMatch(/role="progressbar"/);
       expect(src).toMatch(/\$t\('sync_status\.initial\.building'\)/);
     });
+
+    it('slides in/out (reduced-motion aware) instead of snapping the layout', () => {
+      // The banner stack feeds --rn-banner-h, which the 100dvh layouts subtract;
+      // a bare {#if} mount/unmount snaps the whole UI by the banner height in one
+      // frame. transition:slide animates it, and the ResizeObserver-based
+      // bind:clientHeight makes the layout follow per frame (2026-07-09).
+      expect(src).toMatch(
+        /transition:slide=\{\{\s*duration:\s*prefersReducedMotion\.current\s*\?\s*0\s*:/
+      );
+    });
+  });
+
+  describe('runPullFromServer initial-sync gate', () => {
+    const src = readSource('../../services/notes-sync.service.ts');
+
+    it('raises isInitialSync only when the local notes table is EMPTY, not on every cold boot', () => {
+      // lastSyncedAt is in-memory (null in every fresh JS context), so alone it
+      // misread every native cold start as a first sync - the banner flashed
+      // "building local database" over an already-built DB for the 1-2s the
+      // CapacitorHttp pull needs before the first notes page, then jumped the
+      // layout back (2026-07-09). The gate must also require an empty table.
+      expect(src).toMatch(
+        /get\(lastSyncedAt\)\s*===\s*null\s*&&\s*\(await noteStore\.count\(\)\)\s*===\s*0/
+      );
+    });
   });
 
   describe('+layout.svelte banner mount', () => {

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -190,11 +190,23 @@ async function runPullFromServer(): Promise<boolean> {
     }
   }
 
-  // First-ever pull (nothing synced yet): show the loading placeholder. Cleared
-  // by refreshStoresAfterPull on success (once notes are in memory) or by the
-  // finally below if this pull fails - never left stuck. Placed after the
-  // storage-init early-return above so a failed re-init can't strand it true.
-  if (get(lastSyncedAt) === null) isInitialSync.set(true);
+  // First pull with an EMPTY local notes table (fresh login, or wiped IDB):
+  // the local database is genuinely about to be built, so raise the initial-
+  // sync state (top banner + placeholders). lastSyncedAt === null alone is NOT
+  // enough: that store is in-memory and starts null in every fresh JS context,
+  // so it misread every cold start as a first sync - and on native, where the
+  // two serial CapacitorHttp round-trips before the first notes page exceed
+  // the banner's 300ms anti-flicker, that flashed "building local database"
+  // over an already-built DB and jumped the layout. A populated table proves a
+  // prior sync built the DB - routine boot pulls stay silent. The lastSyncedAt
+  // check still guards the session dimension: a later periodic pull after the
+  // user deleted their last note must not re-raise it. Cleared by pullNotes
+  // after the first page / refreshStoresAfterPull / the finally below on
+  // failure - never left stuck. Placed after the storage-init early-return
+  // above so a failed re-init can't strand it true.
+  if (get(lastSyncedAt) === null && (await noteStore.count()) === 0) {
+    isInitialSync.set(true);
+  }
 
   isSyncing.set(true);
   syncError.set(false);

--- a/packages/ui/src/components/auth/SessionExpiredBanner.svelte
+++ b/packages/ui/src/components/auth/SessionExpiredBanner.svelte
@@ -9,6 +9,8 @@
 -->
 <script lang="ts">
   import { AlertTriangle } from '@lucide/svelte';
+  import { slide } from 'svelte/transition';
+  import { prefersReducedMotion } from 'svelte/motion';
   import { t } from '@reborn/i18n';
   import ReAuthModal from './ReAuthModal.svelte';
   import type { ReAuthResult } from './reauth-types';
@@ -35,7 +37,14 @@
 </script>
 
 {#if visible}
-  <div class="sticky top-0 z-50">
+  <!-- slide: in reborn-notes this banner sits in the measured stack feeding
+       --rn-banner-h (100dvh layouts subtract it), so an instant mount/unmount
+       snaps the whole UI by the banner height. Animating the height lets the
+       ResizeObserver-based measurement follow smoothly. -->
+  <div
+    transition:slide={{ duration: prefersReducedMotion.current ? 0 : 200 }}
+    class="sticky top-0 z-50"
+  >
     <!-- pt: max() extends the banner's red background under the iOS notch /
          Dynamic Island so the text starts below it (env() is 0 elsewhere) -->
     <button


### PR DESCRIPTION
## Summary

User report: on every native (Capacitor) cold start the "Building local database" banner appeared for 1-2s over an already populated UI, pushing the whole layout down and snapping it back when the banner vanished.

Root cause (verified in code): the banner's gate in `runPullFromServer` was `lastSyncedAt === null`, but that store is purely in-memory - it starts `null` in every fresh JS context, so every cold boot was misread as a first-ever sync. Web rarely shows it because the pre-first-page window usually stays under the banner's 300ms anti-flicker; on native the two serial CapacitorHttp round trips before the first notes page always exceed it.

Changes:
- `runPullFromServer` raises `isInitialSync` only when the local notes table is also EMPTY (`noteStore.count() === 0`) - a populated table proves a prior sync already built the DB, so routine boot pulls stay silent. The `lastSyncedAt === null` check stays as the session guard (a periodic pull after deleting the last note cannot re-raise the flag). `lastSyncedAt` is deliberately NOT hydrated from persistence: periodic-notes' pre-pull guard and the first-load placeholder rely on its null-per-session semantics.
- Both stacked banners (`InitialSyncBanner`, shared `SessionExpiredBanner`) now `transition:slide` (200ms, 0 under `prefers-reduced-motion`). The ResizeObserver-based `bind:clientHeight` tracks the animated height per frame, so `--rn-banner-h` and the 100dvh layouts follow the slide smoothly when a banner legitimately appears, instead of jumping.
- Both contracts pinned in `initial-sync-ux.regression.spec.ts`.

Decision notes for review: the empty-table predicate means a genuinely-zero-notes account (rare) and a wiped-IDB rebuild still show the banner - both are cases where the local DB really is being built. Hydrating `lastSyncedAt` was considered and rejected (would silently disable the periodic-notes pre-pull guard).

## Test plan

- `vitest run` (reborn-notes): 86 files / 1263 tests green, incl. 2 new regression pins.
- `svelte-check` reborn-notes + reborn-task: 0 errors / 0 warnings; `tsc --noEmit` packages/ui clean; eslint clean.
- Smoke (native build): cold start with a populated account - no "Budowanie lokalnej bazy danych" banner, no layout jump; fresh login on an account with notes - banner still appears with progress and slides in/out smoothly; session-expiry banner slides instead of snapping.