### PR TITLE
fix(notes): hold native splash until the shell is ready to paint

### DIFF
--- a/apps/reborn-notes/capacitor.config.ts
+++ b/apps/reborn-notes/capacitor.config.ts
@@ -53,7 +53,20 @@ const config: CapacitorConfig = {
     cleartext: process.env.CAP_DEV_CLEARTEXT === '1'
   },
   plugins: {
-    CapacitorHttp: { enabled: true }
+    CapacitorHttp: { enabled: true },
+    // Hold the system splash past the activity's first frame so a cold start
+    // goes splash -> populated UI, with no intermediate #app-loading spinner
+    // (guideline 61, third cold-start phase). The web layer hides it early at
+    // appReady/initTimeout (src/lib/utils/native-splash.ts) - typically well
+    // under launchShowDuration. launchAutoHide stays TRUE on purpose: the
+    // generous duration is the native dead-man's switch when the JS bundle
+    // never executes (corrupt install / webview crash); launchAutoHide: false
+    // has no native fallback and would strand the splash forever.
+    SplashScreen: {
+      launchShowDuration: 6000,
+      launchAutoHide: true,
+      launchFadeOutDuration: 200
+    }
   }
 };
 

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -46,6 +46,7 @@
     "@capacitor/ios": "8.4.0",
     "@capacitor/network": "8.0.1",
     "@capacitor/share": "8.0.1",
+    "@capacitor/splash-screen": "8.0.1",
     "@codemirror/autocomplete": "6.20.3",
     "@codemirror/commands": "6.10.3",
     "@codemirror/lang-css": "6.3.1",

--- a/apps/reborn-notes/src/lib/utils/native-splash.ts
+++ b/apps/reborn-notes/src/lib/utils/native-splash.ts
@@ -1,0 +1,36 @@
+/**
+ * Native splash-screen handoff (cold-start UX, third phase after PR #433/#434).
+ *
+ * The Capacitor SplashScreen plugin holds the system splash past the
+ * activity's first frame (capacitor.config.ts `plugins.SplashScreen`), so the
+ * intermediate #app-loading spinner screen from app.html never paints on
+ * native: the cold-start sequence becomes splash -> populated UI. This util
+ * drops the splash the moment the shell can actually paint - +layout.svelte
+ * calls it when `appReady` (populated first paint, guideline 61 Fix 7) or the
+ * 2s `initTimeout` safety net flips.
+ *
+ * Dead-man's switch lives in the CONFIG, not here: `launchAutoHide: true`
+ * with a generous `launchShowDuration` means that if the JS bundle never
+ * executes (corrupt install, webview crash), the plugin's own timeout drops
+ * the splash instead of leaving it stuck forever - the documented risk of
+ * `launchAutoHide: false`, which has no native fallback on either platform.
+ *
+ * Fire-and-forget: a failed hide() leaves the auto-hide timeout in charge -
+ * cosmetic, never blocking. Safe to call repeatedly (hide() no-ops once the
+ * splash is gone) and on every boot path: unauth / App-Lock boots flip
+ * appReady fast, so their screens come up straight from the splash, masked by
+ * the config's fade-out. The dynamic import sits INSIDE the positive
+ * `if (__REBORN_NATIVE__)` block (same pattern as `$lib/utils/clipboard.ts`,
+ * verified by build grep) so the web build dead-code-eliminates both the
+ * branch and the plugin - boot-wedge lesson, guideline 61.
+ */
+export async function hideNativeSplash(): Promise<void> {
+  if (__REBORN_NATIVE__) {
+    try {
+      const { SplashScreen } = await import('@capacitor/splash-screen');
+      await SplashScreen.hide();
+    } catch {
+      // Plugin missing or bridge hiccup: launchShowDuration auto-hide covers it.
+    }
+  }
+}

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -39,6 +39,7 @@
   import LocalModeWelcome from '$lib/components/LocalModeWelcome.svelte';
   import UpdateRequiredGate from '$lib/components/layout/UpdateRequiredGate.svelte';
   import { checkNativeUpdateGate } from '$lib/utils/native-app-update';
+  import { hideNativeSplash } from '$lib/utils/native-splash';
   import { initAppLock, shouldLockOnResume } from '$lib/services/app-lock.service';
   import { createLogger } from '@reborn/utils';
   import type { ReleasePlatform } from '@reborn/i18n';
@@ -69,6 +70,18 @@
   // but measuring the wrapper sums them correctly if both ever show. 0 when none.
   let bannerStackHeight = $state(0);
   let hasTriggeredInitialSync = $state(false);
+
+  // Native: drop the held system splash the moment the shell can paint -
+  // appReady (populated first paint) or the 2s initTimeout net, i.e. exactly
+  // the condition that mounts the app shell below. Effects run after the DOM
+  // update, so by the time hide() crosses the bridge the shell (or the
+  // auth-guard redirect target) is already rendering; the config fade-out
+  // masks the handoff. If this never runs (JS dead), the config's
+  // launchShowDuration auto-hide is the fallback. See native-splash.ts.
+  $effect(() => {
+    if (!__REBORN_NATIVE__) return;
+    if (appReady || initTimeout) void hideNativeSplash();
+  });
 
   // Auth guard - blocked until onMount finishes initialization (appReady).
   // Uses untrack on goto() to prevent reactive dependency on navigation result.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       '@capacitor/share':
         specifier: 8.0.1
         version: 8.0.1(@capacitor/core@8.4.0)
+      '@capacitor/splash-screen':
+        specifier: 8.0.1
+        version: 8.0.1(@capacitor/core@8.4.0)
       '@codemirror/autocomplete':
         specifier: 6.20.3
         version: 6.20.3
@@ -1549,6 +1552,11 @@ packages:
 
   '@capacitor/share@8.0.1':
     resolution: {integrity: sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/splash-screen@8.0.1':
+    resolution: {integrity: sha512-c/ew/Z3eA7z8l06WoRAtzVF16VwYYrExmHmfGq1Cg675pVzaC/yuucB8/1xG1vhEfnW4fZ1KhSf/kzR1RiVYgg==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
@@ -7794,6 +7802,10 @@ snapshots:
       '@capacitor/core': 8.4.0
 
   '@capacitor/share@8.0.1(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
+
+  '@capacitor/splash-screen@8.0.1(@capacitor/core@8.4.0)':
     dependencies:
       '@capacitor/core': 8.4.0
 


### PR DESCRIPTION
## Summary

Third cold-start phase (after #433/#434), approved as a separate PR. Today the native cold start shows three surfaces: system splash -> intermediate "Loading re/notes" spinner (#app-loading) -> populated UI. The splash dismisses at the activity's first frame because nothing holds it. This PR adds `@capacitor/splash-screen@8.0.1` (new dependency, approved) and holds the splash until the shell can actually paint, collapsing the sequence to splash -> populated UI.

- `capacitor.config.ts`: `SplashScreen { launchShowDuration: 6000, launchAutoHide: true, launchFadeOutDuration: 200 }`. `launchAutoHide` stays TRUE on purpose - the generous duration is the native dead-man's switch when the JS bundle never executes (corrupt install / webview crash). `launchAutoHide: false` was rejected: it has no native fallback on either platform (verified in plugin 8.0.1 source) and would strand the splash forever.
- `src/lib/utils/native-splash.ts` + a `+layout.svelte` `$effect` call `SplashScreen.hide()` the moment `appReady || initTimeout` flips - i.e. exactly when the shell mounts (populated first paint from #434, or the 2s safety net). Unauth/App-Lock boots flip `appReady` fast, so login/lock screens come straight off the splash, masked by the fade-out.
- Web bundle unaffected: dynamic import inside the positive `__REBORN_NATIVE__` block (clipboard.ts pattern); build grep of `.svelte-kit/output/client` shows zero splash-screen occurrences. Honest expectation: this does not shorten boot time - it replaces the spinner screen with a longer branded splash (one continuous surface instead of two).

## Test plan

- Green in sandbox: svelte-check (0/0), vitest 86 files / 1261 tests, eslint, web `vite build` + dead-code grep.
- Before a native build (Michal, outside sandbox): `pnpm install`, then `CAP_DEV_CLEARTEXT=1 npx cap sync android` for emulator runs / plain `npx cap sync` for release - cap sync adds the plugin to the generated android/iOS plugin lists (commit those diffs to this branch).
- On-device smoke: cold start logged-in with notes (splash -> populated UI, no "Loading re/notes" screen, no frozen feel), logged-out (splash -> login), App-Lock (splash -> biometric screen), resume from background (no stray splash), dark/light (splash bg per #434 stays correct), and the pathological check that the app still appears by ~6s if hide() were never called.