### PR TITLE
chore(android): add splash-screen plugin to generated Capacitor lists

### DIFF
--- a/apps/reborn-notes/android/app/capacitor.build.gradle
+++ b/apps/reborn-notes/android/app/capacitor.build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation project(':capacitor-filesystem')
     implementation project(':capacitor-network')
     implementation project(':capacitor-share')
+    implementation project(':capacitor-splash-screen')
 
 }
 

--- a/apps/reborn-notes/android/capacitor.settings.gradle
+++ b/apps/reborn-notes/android/capacitor.settings.gradle
@@ -22,3 +22,6 @@ project(':capacitor-network').projectDir = new File('../../../node_modules/.pnpm
 
 include ':capacitor-share'
 project(':capacitor-share').projectDir = new File('../../../node_modules/.pnpm/@capacitor+share@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/share/android')
+
+include ':capacitor-splash-screen'
+project(':capacitor-splash-screen').projectDir = new File('../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/splash-screen/android')


### PR DESCRIPTION
## Summary
- Commits the `npx cap sync android` output for @capacitor/splash-screen (added in #437): plugin entries in `capacitor.build.gradle` and `capacitor.settings.gradle`.
- Without these generated lists the native Android build does not include the splash-hold plugin.
- Post-merge step from the #437 checklist.

## Test plan
- No runtime code change on web. Native: next emulator build should load the SplashScreen plugin (cold start from the launcher icon shows the system splash held until the shell is ready).