### PR TITLE
perf(notes): split note content into a separate IndexedDB store (v14)

### DIFF
--- a/apps/reborn-notes/src/hooks.client.ts
+++ b/apps/reborn-notes/src/hooks.client.ts
@@ -103,10 +103,27 @@ if (!isPublicShareRoute) {
     startPwaInstallPrompt();
   }
 
-  // Initialize storage early — before SvelteKit layout mounts.
+  // Initialize storage early - before SvelteKit layout mounts.
   // This is fire-and-forget: if it fails, +layout.svelte will retry in onMount.
   initializeStorage('notes')
     .then(async () => {
+      // One-time sweep after the DB v14 content split: move content ciphertext
+      // still inline on legacy v13 `notes` rows into `noteContents`. Chunked
+      // and resumable - a failure (e.g. storage quota) only delays the sweep,
+      // never blocks boot; joined reads tolerate unswept rows meanwhile. The
+      // localStorage flag skips the scan on every later boot (same pattern as
+      // idb-cleanup.service). Runs BEFORE the trash sweep below so the heavy
+      // move isn't interleaved with deletes on first boot after the upgrade.
+      const SPLIT_SWEEP_FLAG = 'reborn-notes:content-split-swept-v14';
+      try {
+        if (!localStorage.getItem(SPLIT_SWEEP_FLAG)) {
+          const { noteStore } = await import('@reborn/storage');
+          await noteStore.migrateLegacyContent();
+          localStorage.setItem(SPLIT_SWEEP_FLAG, new Date().toISOString());
+        }
+      } catch {
+        // Flag stays unset - the sweep retries on the next boot.
+      }
       // Auto-purge old trash items (notes trashed more than 30 days ago) and
       // any leftover pristine ephemeral notes - New Note rows the user created
       // but never touched, then reloaded/closed before the in-session discard
@@ -116,10 +133,10 @@ if (!isPublicShareRoute) {
         await cleanTrash(30);
         await cleanEphemeralNotes();
       } catch {
-        // Non-critical — trash cleanup is also attempted in layout onMount
+        // Non-critical - trash cleanup is also attempted in layout onMount
       }
     })
     .catch(() => {
-      // Storage init failed — layout onMount will handle retry
+      // Storage init failed - layout onMount will handle retry
     });
 }

--- a/apps/reborn-notes/src/lib/services/auto-backup/watermark.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/watermark.ts
@@ -29,7 +29,8 @@ function maxUpdatedAt(items: Array<{ updated_at: string }>): number {
  */
 export async function getLastDataChangeAt(): Promise<string | null> {
   const [notes, folders, tags] = await Promise.all([
-    noteStore.getAll(),
+    // updated_at lives on the meta row - skip the content blobs (DB v14 split).
+    noteStore.getAllMeta(),
     folderStore.getAll(),
     tagStore.getAll()
   ]);

--- a/apps/reborn-notes/src/lib/services/export-import.service.ts
+++ b/apps/reborn-notes/src/lib/services/export-import.service.ts
@@ -1399,7 +1399,11 @@ function stripUnknownNoteShadowIndexes(raw: unknown): unknown {
  */
 async function buildTitleLookupFromIndex(): Promise<TitleLookup> {
   if (noteIndex.count === 0) {
-    const stored = await noteStore.getAll();
+    // Existence probe via the metadata projection (no content blobs). NOT
+    // noteStore.count(): count() swallows IndexedDB errors to 0, which would
+    // silently skip the dedup index build on a failed read and duplicate
+    // every imported note; getAllMeta() throws like the old getAll() did.
+    const stored = await noteStore.getAllMeta();
     if (stored.length > 0) {
       try {
         await noteIndex.build();

--- a/apps/reborn-notes/src/lib/services/folder-sync.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/folder-sync.service.spec.ts
@@ -29,7 +29,8 @@ vi.mock('@reborn/storage', () => ({
     }
   },
   noteStore: {
-    getAll: async () => [...noteRows]
+    // liveNoteIds() reads the metadata projection (DB v14 split) - ids only.
+    getAllMeta: async () => [...noteRows]
   }
 }));
 

--- a/apps/reborn-notes/src/lib/services/folder-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/folder-sync.service.ts
@@ -734,7 +734,8 @@ async function syncOneConfig(
  * emptied trash drops an id - exactly when a synced file's note must come back.
  */
 async function liveNoteIds(): Promise<Set<string>> {
-  const all = await noteStore.getAll();
+  // ids only - metadata projection, no content blobs (DB v14 split).
+  const all = await noteStore.getAllMeta();
   return new Set(all.map((n) => n.id));
 }
 

--- a/apps/reborn-notes/src/lib/services/internal-link-rewrite.integration.spec.ts
+++ b/apps/reborn-notes/src/lib/services/internal-link-rewrite.integration.spec.ts
@@ -17,7 +17,12 @@ vi.mock('$lib/stores/auth.store', async () => {
 });
 
 vi.mock('@reborn/storage', () => ({
-  noteStore: { getAll: async () => [...notes.values()].map((n) => ({ id: n.id })) },
+  noteStore: {
+    // Import dedup probes existence via count(); liveNoteIds() reads the
+    // metadata projection (DB v14 split) - ids only.
+    count: async () => notes.size,
+    getAllMeta: async () => [...notes.values()].map((n) => ({ id: n.id }))
+  },
   folderStore: {},
   tagStore: {},
   noteTagStore: {},

--- a/apps/reborn-notes/src/lib/services/note-index.svelte.ts
+++ b/apps/reborn-notes/src/lib/services/note-index.svelte.ts
@@ -99,7 +99,10 @@ class NoteIndex {
     noteLinkGraph.clear();
     this._building = true;
     try {
-      const allEncrypted = await noteStore.getAll();
+      // Metadata-only projection: the index needs titles + shadow fields, so
+      // reading `notes` without joining `noteContents` skips deserializing
+      // every content blob - the dominant cold-start cost (DB v14 split).
+      const allEncrypted = await noteStore.getAllMeta();
       // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local temp variable, not reactive state
       const map = new Map<string, NoteIndexEntry>();
 
@@ -142,8 +145,8 @@ class NoteIndex {
 
   /**
    * Incrementally add/update specific notes by id: point-read just those rows
-   * (noteStore.getMany) and decrypt them, instead of build()'s full
-   * getAll()+decrypt of every note. Backs the paginated pull's per-page reveal -
+   * (noteStore.getManyMeta) and decrypt them, instead of build()'s full
+   * getAllMeta()+decrypt of every note. Backs the paginated pull's per-page reveal -
    * each page lands in the index without an O(n) rebuild per page (which would
    * re-deserialize the whole notes table every page = the O(n²) trap PR #353
    * removed). Tags are read from the (already-applied) note-tag relations, so
@@ -154,7 +157,7 @@ class NoteIndex {
    */
   async upsertFromStore(ids: string[]): Promise<void> {
     if (!cryptoManager.isInitialized() || ids.length === 0) return;
-    const encrypted = await noteStore.getMany(ids);
+    const encrypted = await noteStore.getManyMeta(ids);
     let changed = false;
     for (const enc of encrypted) {
       try {

--- a/apps/reborn-notes/src/lib/services/note.service.ts
+++ b/apps/reborn-notes/src/lib/services/note.service.ts
@@ -13,7 +13,7 @@ import {
   noteHistoryQueries,
   noteHistoryOperations
 } from '@reborn/storage';
-import { MAX_NOTE_VERSIONS, type NoteStoredLocal, type NoteDecrypted, type NoteHistoryEntry, type NoteHistoryDecrypted, type NoteSensitiveMetadata, type PeriodicNoteMetadata } from '@reborn/types';
+import { MAX_NOTE_VERSIONS, type NoteStoredLocal, type NoteMetaLocal, type NoteDecrypted, type NoteHistoryEntry, type NoteHistoryDecrypted, type NoteSensitiveMetadata, type PeriodicNoteMetadata } from '@reborn/types';
 import { cryptoManager } from '@reborn/crypto';
 import { createLogger } from '@reborn/utils';
 import { get } from 'svelte/store';
@@ -101,8 +101,10 @@ async function toDecrypted(enc: NoteStoredLocal): Promise<NoteDecrypted> {
   };
 }
 
-/** Decrypt only the title (skip content_encrypted) - used by NoteIndex cache. */
-export async function decryptTitleOnly(enc: NoteStoredLocal): Promise<{
+/** Decrypt only the title - used by NoteIndex cache. Accepts the metadata-only
+ *  projection (`NoteMetaLocal`), so index builds never read content blobs;
+ *  full `NoteStoredLocal` records are assignable and work too. */
+export async function decryptTitleOnly(enc: NoteMetaLocal): Promise<{
   id: string;
   title: string;
   folderId: string | undefined;
@@ -666,7 +668,9 @@ export async function discardIfEphemeral(id: string): Promise<boolean> {
  * removed.
  */
 export async function cleanEphemeralNotes(): Promise<number> {
-  const all = (await noteStore.getAll()) as NoteStoredLocal[];
+  // Metadata-only sweep: the is_ephemeral flag lives on the meta row, so this
+  // startup pass never deserializes content blobs (DB v14 split).
+  const all = await noteStore.getAllMeta();
   const ephemeral = all.filter((n) => n.is_ephemeral === true);
   if (ephemeral.length === 0) return 0;
   for (const n of ephemeral) {

--- a/apps/reborn-notes/src/lib/services/notes-discard-ephemeral.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-discard-ephemeral.regression.spec.ts
@@ -102,12 +102,20 @@ describe('#349 the sync sweep never pushes an ephemeral note (zero-knowledge)', 
       src.indexOf('export async function pushPendingItems'),
       src.indexOf('/** Retry a function with exponential backoff')
     );
-    // Non-archived pending creates/updates.
-    expect(fn).toMatch(/const\s+pendingNotes\s*=\s*allNotes\.filter/);
+    // Non-archived pending creates/updates (meta projection first, then the
+    // full-row re-filter - DB v14 split).
+    expect(fn).toMatch(/const\s+pendingNoteMetas\s*=\s*allNoteMetas\.filter\(isPendingActive\)/);
+    expect(fn).toMatch(/const\s+pendingNotes\s*=\s*fetchedPending\.filter\(isPendingActive\)/);
     // Archived pending soft-deletes.
-    expect(fn).toMatch(/const\s+pendingArchivedNotes\s*=\s*allNotes\.filter/);
-    // BOTH filters must drop ephemeral rows - the server must never learn the
-    // note existed until the user's first deliberate action promotes it.
+    expect(fn).toMatch(
+      /const\s+pendingArchivedMetas\s*=\s*allNoteMetas\.filter\(isPendingArchived\)/
+    );
+    expect(fn).toMatch(
+      /const\s+pendingArchivedNotes\s*=\s*fetchedPending\.filter\(isPendingArchived\)/
+    );
+    // BOTH shared predicates must drop ephemeral rows - the server must never
+    // learn the note existed until the user's first deliberate action promotes
+    // it. Every bucket above goes through these two predicates.
     const ephemeralGuards = fn.match(/!n\.is_ephemeral/g) ?? [];
     expect(ephemeralGuards.length).toBe(2);
   });

--- a/apps/reborn-notes/src/lib/services/notes-sync.key-mismatch.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.key-mismatch.regression.spec.ts
@@ -51,7 +51,9 @@ describe('notes-sync - cross-key pending guard (audit 012 S6)', () => {
   });
 
   it('probes one ciphertext per pending entity kind', () => {
-    expect(body).toMatch(/pendingNotes\[0\] \?\? pendingArchivedNotes\[0\]/);
+    // Notes probe title_encrypted off the metadata projection (DB v14 split) -
+    // the probe must not require joining content blobs.
+    expect(body).toMatch(/pendingNoteMetas\[0\] \?\? pendingArchivedMetas\[0\]/);
     expect(body).toMatch(/pendingFolders\[0\]\?\.name_encrypted/);
     expect(body).toMatch(/pendingTags\[0\]\?\.name_encrypted/);
     expect(body).toMatch(/pendingSavedSearches\[0\]\?\.name_encrypted/);

--- a/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.regression.spec.ts
@@ -176,11 +176,14 @@ describe('notes-sync - regression (offline data loss)', () => {
       src.indexOf('export async function pushPendingItems'),
       src.indexOf('/** Retry a function with exponential backoff')
     );
-    // Non-archived pending notes still POST /api/notes.
-    expect(fn).toMatch(/const\s+pendingNotes\s*=\s*allNotes\.filter/);
+    // Non-archived pending notes still POST /api/notes (meta projection
+    // filtered first, full rows point-read for the push - DB v14 split).
+    expect(fn).toMatch(/const\s+pendingNotes\s*=\s*fetchedPending\.filter\(isPendingActive\)/);
     expect(fn).toMatch(/!n\.is_archived/);
     // Archived pending notes get their own bucket and go through pushNoteDelete.
-    expect(fn).toMatch(/const\s+pendingArchivedNotes\s*=\s*allNotes\.filter/);
+    expect(fn).toMatch(
+      /const\s+pendingArchivedNotes\s*=\s*fetchedPending\.filter\(isPendingArchived\)/
+    );
     expect(fn).toMatch(/pushNoteDelete\s*\(\s*n\.id\s*\)/);
   });
 
@@ -1033,9 +1036,10 @@ describe('notes-sync - paginated delta sync (stage 2b)', () => {
       src.indexOf('async upsertFromStore'),
       src.indexOf('/** Clear and rebuild')
     );
-    expect(method).toMatch(/noteStore\.getMany\(/);
+    expect(method).toMatch(/noteStore\.getManyMeta\(/);
     expect(method).toMatch(/this\._map\.set\(/);
-    // Must NOT fall back to the full-table getAll() that build() uses.
-    expect(method).not.toMatch(/noteStore\.getAll\(/);
+    // Must NOT fall back to a full-table scan - neither the joined getAll()
+    // nor the metadata projection getAllMeta() that build() uses (DB v14).
+    expect(method).not.toMatch(/noteStore\.getAll\w*\(/);
   });
 });

--- a/apps/reborn-notes/src/lib/services/notes-sync.service.ts
+++ b/apps/reborn-notes/src/lib/services/notes-sync.service.ts
@@ -707,13 +707,13 @@ async function pullNotes(): Promise<string[]> {
   // Sweeping it hard-deletes a note the server has; it resurrects on a later
   // delta while folder sync re-imports its file in the gap - a duplicate note.
   // Taken only when the sweep can actually fire (reconcile, or a no-watermark
-  // bulk against an old server, where the empty-store snapshot is free):
-  // noteStore.getAll() deserializes every content blob, which the 5-min delta
-  // pulls deliberately avoid.
+  // bulk against an old server, where the empty-store snapshot is free). The
+  // snapshot needs only id + sync_status, so it reads the metadata projection
+  // (DB v14 split) - no content blobs are deserialized on the boot reconcile.
   let prePullSyncedIds: Set<string> | null = null;
   if (reconcile || !since) {
     prePullSyncedIds = new Set(
-      ((await noteStore.getAll()) as NoteStoredLocal[])
+      (await noteStore.getAllMeta())
         .filter((n) => n.sync_status === 'synced')
         .map((n) => n.id)
     );
@@ -813,7 +813,8 @@ async function pullNotes(): Promise<string[]> {
     // invariant ever breaks, an empty set means "delete nothing" rather than
     // re-opening the mid-pull race.
     const preSynced = prePullSyncedIds ?? new Set<string>();
-    const allLocalNotes = (await noteStore.getAll()) as NoteStoredLocal[];
+    // id + sync_status only - metadata projection, no content blobs.
+    const allLocalNotes = await noteStore.getAllMeta();
     const orphanNoteIds = allLocalNotes
       .filter((n) => n.sync_status === 'synced' && !serverIds.has(n.id) && preSynced.has(n.id))
       .map((n) => n.id);
@@ -853,14 +854,13 @@ async function writeNotesPage(
   const maxUpdatedAt = data.reduce((m, n) => (n.updated_at > m ? n.updated_at : m), '');
 
   // Collect all writes here and flush them in one batch below, instead of issuing
-  // them per-note inside the map. Each `noteStore.save()` runs refreshItems() - a
-  // full getAll() over the whole notes table (every content_encrypted blob) - so
-  // firing 503 of them concurrently made first-sync memory grow ~O(n²) and
-  // OOM-killed the in-process Android System WebView at ~40 s. (iOS WKWebView
-  // renders out of process with a far higher ceiling, so it absorbed the same
-  // spike in ~10 s.) saveMany() does one transaction + one refresh; the UI is
-  // rebuilt by refreshStoresAfterPull() afterwards regardless, so the per-note
-  // refresh was redundant work on top of being the memory bomb. See guideline 36.
+  // them per-note inside the map: saveMany() commits the page in ONE transaction.
+  // Historical context: per-note save() used to also run refreshItems() - a full
+  // getAll() over the whole notes table (every content_encrypted blob) - so 503
+  // concurrent saves made first-sync memory grow ~O(n²) and OOM-killed the
+  // in-process Android System WebView (PR #353). The DB v14 SplitNoteStore has
+  // no refreshItems at all, but the batched single-transaction write remains
+  // the correct shape (atomicity + one commit per page). See guideline 36.
   const notesToWrite: NoteStoredLocal[] = [];
   const tagAdds: Array<{ noteId: string; tagId: string }> = [];
   const tagRemoves: Array<{ noteId: string; tagId: string }> = [];
@@ -1004,10 +1004,10 @@ async function writeNotesPage(
     })
   );
 
-  // Flush every note upsert / reconciliation in a single transaction (one
-  // refreshItems for the whole pull, not one per note). saveMany runs the same
-  // pre-save encryption guard per record as save(); a record that fails it is
-  // counted and skipped rather than aborting the whole sync.
+  // Flush every note upsert / reconciliation of this page in a single
+  // transaction. saveMany runs the same pre-save encryption guard per record
+  // as save(); a record that fails it is counted and skipped rather than
+  // aborting the whole sync.
   if (notesToWrite.length > 0) {
     const result = await noteStore.saveMany(notesToWrite);
     if (result.failed > 0) {
@@ -1120,11 +1120,17 @@ export async function pushPendingItems(): Promise<void> {
   // post-unlock sync, like the import guard does (audit 013 S1).
   if (!cryptoManager.isInitialized()) return;
 
-  const [allFolders, allTags, allSavedSearches, allNotes] = await Promise.all([
+  // Notes go through the metadata projection first (DB v14 split): this sweep
+  // runs on every periodic/foreground/online sync, and the filters below need
+  // only meta fields (sync_status, is_archived, is_ephemeral), so the common
+  // nothing-pending case never deserializes a single content blob. Full rows
+  // (content joined) are point-read further down, only for rows actually
+  // being pushed.
+  const [allFolders, allTags, allSavedSearches, allNoteMetas] = await Promise.all([
     folderStore.getAll() as Promise<FolderEncrypted[]>,
     tagStore.getAll() as Promise<TagEncrypted[]>,
     savedSearchStore.getAll() as Promise<SavedSearchEncrypted[]>,
-    noteStore.getAll() as Promise<NoteStoredLocal[]>
+    noteStore.getAllMeta()
   ]);
 
   const pendingFolders = allFolders.filter((f) => f.sync_status === 'pending');
@@ -1140,19 +1146,19 @@ export async function pushPendingItems(): Promise<void> {
   // notes" whose push is deferred until the user's first action (#349). The
   // server must never see them, so the retry sweep must skip them too - the
   // first deliberate action clears the flag and POSTs the row.
-  const pendingNotes = allNotes.filter(
-    (n) => n.sync_status === 'pending' && !n.is_archived && !n.is_ephemeral
-  );
-  const pendingArchivedNotes = allNotes.filter(
-    (n) => n.sync_status === 'pending' && n.is_archived && !n.is_ephemeral
-  );
+  const isPendingActive = (n: { sync_status?: string; is_archived?: boolean; is_ephemeral?: boolean }) =>
+    n.sync_status === 'pending' && !n.is_archived && !n.is_ephemeral;
+  const isPendingArchived = (n: { sync_status?: string; is_archived?: boolean; is_ephemeral?: boolean }) =>
+    n.sync_status === 'pending' && n.is_archived && !n.is_ephemeral;
+  const pendingNoteMetas = allNoteMetas.filter(isPendingActive);
+  const pendingArchivedMetas = allNoteMetas.filter(isPendingArchived);
 
   if (
     pendingFolders.length +
       pendingTags.length +
       pendingSavedSearches.length +
-      pendingNotes.length +
-      pendingArchivedNotes.length ===
+      pendingNoteMetas.length +
+      pendingArchivedMetas.length ===
     0
   )
     return;
@@ -1171,7 +1177,7 @@ export async function pushPendingItems(): Promise<void> {
   if (!pendingRowsKeyChecked) {
     const readable = await isEncryptedDataReadable(
       [
-        (pendingNotes[0] ?? pendingArchivedNotes[0])?.title_encrypted,
+        (pendingNoteMetas[0] ?? pendingArchivedMetas[0])?.title_encrypted,
         pendingFolders[0]?.name_encrypted,
         pendingTags[0]?.name_encrypted,
         pendingSavedSearches[0]?.name_encrypted
@@ -1202,6 +1208,18 @@ export async function pushPendingItems(): Promise<void> {
     }
     pendingRowsKeyChecked = true;
   }
+
+  // Point-read the full rows (content joined) only for the notes actually
+  // being pushed - push payloads need content_encrypted. Re-apply the filters
+  // on the fetched rows: a row can flip state (or vanish) between the meta
+  // snapshot and this read, and pushing from the live row keeps the same
+  // semantics the old single full-table snapshot had.
+  const fetchedPending = await noteStore.getMany([
+    ...pendingNoteMetas.map((n) => n.id),
+    ...pendingArchivedMetas.map((n) => n.id)
+  ]);
+  const pendingNotes = fetchedPending.filter(isPendingActive);
+  const pendingArchivedNotes = fetchedPending.filter(isPendingArchived);
 
   logger.info(
     `Pushing pending items: ${pendingFolders.length} folders, ${pendingTags.length} tags, ${pendingSavedSearches.length} saved searches, ${pendingNotes.length} notes, ${pendingArchivedNotes.length} archived notes`

--- a/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.spec.ts
+++ b/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.spec.ts
@@ -26,7 +26,11 @@ vi.mock('@reborn/crypto', () => ({
 
 vi.mock('@reborn/storage', () => ({
   noteStore: {
-    getAll: async () => noteRows,
+    // The reconciler scans the metadata projection (DB v14 split); these rows
+    // carry no content_encrypted, matching the real getAllMeta() shape.
+    getAllMeta: async () => noteRows,
+    // Drift writes re-read the full record before save().
+    get: async (id: string) => noteRows.find((r) => r.id === id) ?? null,
     save: async (row: NoteRow) => {
       saveSpy(row);
       const idx = noteRows.findIndex((r) => r.id === row.id);

--- a/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.ts
+++ b/apps/reborn-notes/src/lib/services/shadow-index-reconciler.service.ts
@@ -20,7 +20,6 @@
  * potentially clobber a row whose ciphertext is fine but the key is wrong.
  */
 import { noteStore, noteTagOperations, noteTagQueries } from '@reborn/storage';
-import type { NoteStoredLocal } from '@reborn/types';
 import { cryptoManager } from '@reborn/crypto';
 import { createLogger } from '@reborn/utils';
 import { extractShadowIndexes } from './shadow-index-extractor';
@@ -39,7 +38,11 @@ export async function verifyAndRebuildLocalShadowIndexes(): Promise<ReconcileRes
     return { scanned: 0, reconciledNotes: 0, decryptFailed: 0 };
   }
 
-  const allNotes = (await noteStore.getAll()) as NoteStoredLocal[];
+  // The scan needs only meta fields (metadata_encrypted, shadow booleans, id),
+  // so it reads the metadata projection - this runs after every unlockE2E()
+  // and must not deserialize content blobs (DB v14 split). The (rare) drift
+  // write below re-reads the full record.
+  const allNotes = await noteStore.getAllMeta();
   let reconciledNotes = 0;
   let decryptFailed = 0;
 
@@ -73,7 +76,30 @@ export async function verifyAndRebuildLocalShadowIndexes(): Promise<ReconcileRes
     if (!pinnedDrift && !starredDrift && !tagDrift) continue;
 
     if (pinnedDrift || starredDrift) {
-      await noteStore.save({ ...note, is_pinned, is_starred });
+      // Re-read the full record at write time: save() requires the complete
+      // row (content joined), and re-reading means a row hard-deleted mid-scan
+      // is skipped instead of resurrected from the stale snapshot. Re-derive
+      // the shadow values from the LIVE row's metadata bundle too - the scan
+      // snapshot may be minutes old on a large vault, and writing snapshot-era
+      // booleans over a pin/star the user toggled mid-scan would revert it.
+      const full = await noteStore.get(note.id);
+      if (full?.metadata_encrypted) {
+        try {
+          const fresh = await extractShadowIndexes(full.metadata_encrypted, cryptoManager);
+          const liveDrift =
+            !!full.is_pinned !== fresh.is_pinned || !!full.is_starred !== fresh.is_starred;
+          if (liveDrift) {
+            await noteStore.save({
+              ...full,
+              is_pinned: fresh.is_pinned,
+              is_starred: fresh.is_starred
+            });
+          }
+        } catch {
+          // Live row no longer decrypts - leave it untouched (same rule as
+          // the scan-time catch above).
+        }
+      }
     }
     if (tagDrift) {
       await Promise.all([

--- a/apps/reborn-notes/src/lib/stores/sync-status.store.ts
+++ b/apps/reborn-notes/src/lib/stores/sync-status.store.ts
@@ -120,10 +120,12 @@ function sameErrorCodes(
 
 export async function refreshPendingCount(): Promise<number> {
   try {
-    const stores = [noteStore, folderStore, tagStore] as Array<{
-      getAll(): Promise<Array<{ id: string; sync_status?: string; sync_error_code?: SyncErrorCode }>>;
-    }>;
-    const allItems = await Promise.all(stores.map((s) => s.getAll()));
+    // Notes read the metadata projection (id + sync_status live on the meta
+    // row) - this runs after EVERY push/pull, so it must not deserialize
+    // content blobs (DB v14 split). Folders/tags have no such split.
+    const allItems: Array<
+      Array<{ id: string; sync_status?: string; sync_error_code?: SyncErrorCode }>
+    > = await Promise.all([noteStore.getAllMeta(), folderStore.getAll(), tagStore.getAll()]);
     let pending = 0;
     const errors = new Map<string, SyncErrorCode>();
     for (const items of allItems) {

--- a/packages/storage/src/__tests__/note-store-split.spec.ts
+++ b/packages/storage/src/__tests__/note-store-split.spec.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NoteStoredLocal } from '@reborn/types';
+
+/**
+ * Unit tests for the DB v14 note content split (`SplitNoteStore` in
+ * stores/note.store.ts): joined full reads (including the legacy-inline
+ * precedence), metadata-only reads, atomic dual-store writes, cascading
+ * deletes/clear, the partial-save guard, and the chunked
+ * `migrateLegacyContent()` sweep that moves pre-v14 inline content into
+ * `noteContents` after the (structure-only) upgrade.
+ *
+ * IndexedDB is stubbed with a minimal in-memory implementation of the exact
+ * `idb` surface the store uses (fake-indexeddb is not a workspace dependency).
+ * The stub clones values on the way in and out, mirroring the structured
+ * clone IndexedDB performs.
+ */
+
+// ── In-memory IDB stub ─────────────────────────────────────────────
+
+const clone = <T>(v: T): T => (v === undefined ? v : JSON.parse(JSON.stringify(v)));
+
+class StubObjectStore {
+  data = new Map<string, Record<string, unknown>>();
+  constructor(private indexKeyPaths: Record<string, string> = {}) {}
+
+  async get(id: string) {
+    return clone(this.data.get(id));
+  }
+  async getAll() {
+    return Array.from(this.data.values()).map(clone);
+  }
+  async put(value: Record<string, unknown>) {
+    this.data.set(value.id as string, clone(value));
+    return value.id;
+  }
+  async delete(id: string) {
+    this.data.delete(id);
+  }
+  async clear() {
+    this.data.clear();
+  }
+  async count() {
+    return this.data.size;
+  }
+
+  index(name: string) {
+    const keyPath = this.indexKeyPaths[name];
+    if (!keyPath) throw new Error(`Stub index not defined: ${name}`);
+    const matching = (value: unknown) =>
+      Array.from(this.data.values()).filter((row) => row[keyPath] === value);
+    return {
+      openCursor: async (range: { __only: unknown } | null) => {
+        const rows = matching(range ? range.__only : undefined).map(clone);
+        return makeCursor(rows);
+      }
+    };
+  }
+
+  async openCursor() {
+    const rows = Array.from(this.data.values()).map(clone);
+    let i = 0;
+    const next = (): StubCursor | null =>
+      i < rows.length
+        ? {
+            value: rows[i],
+            update: async (v: Record<string, unknown>) => {
+              this.data.set(rows[i].id as string, clone(v));
+            },
+            continue: async () => {
+              i++;
+              return next();
+            }
+          }
+        : null;
+    return next();
+  }
+}
+
+interface StubCursor {
+  value: Record<string, unknown>;
+  update: (v: Record<string, unknown>) => Promise<void>;
+  continue: () => Promise<StubCursor | null>;
+}
+
+function makeCursor(rows: Record<string, unknown>[]): StubCursor | null {
+  let i = 0;
+  const next = (): StubCursor | null =>
+    i < rows.length
+      ? {
+          value: rows[i],
+          update: async () => undefined,
+          continue: async () => {
+            i++;
+            return next();
+          }
+        }
+      : null;
+  return next();
+}
+
+class StubDb {
+  stores: Record<string, StubObjectStore>;
+  constructor(stores: Record<string, StubObjectStore>) {
+    this.stores = stores;
+  }
+  get objectStoreNames() {
+    const names = Object.keys(this.stores);
+    return {
+      contains: (n: string) => names.includes(n),
+      [Symbol.iterator]: () => names[Symbol.iterator]()
+    };
+  }
+  transaction(...args: unknown[]) {
+    void args;
+    return {
+      objectStore: (n: string) => this.stores[n],
+      done: Promise.resolve(),
+      db: this
+    };
+  }
+  async getAll(storeName: string) {
+    return this.stores[storeName].getAll();
+  }
+  async count(storeName: string) {
+    return this.stores[storeName].count();
+  }
+}
+
+let stubDb: StubDb;
+
+vi.mock('../core/database', () => ({
+  databaseManager: {
+    isInitialized: () => stubDb !== undefined,
+    getDatabase: () => stubDb,
+    reconnect: async () => stubDb
+  },
+  getDatabaseIfInitialized: () => stubDb ?? null,
+  requireDatabase: async () => stubDb
+}));
+
+// Simplified mirror of the real iv:ciphertext validation (see
+// encrypted-fields-guard.spec.ts) - enough to prove the store calls it on the
+// FULL record before splitting.
+vi.mock('@reborn/crypto', () => ({
+  validateEncryptedPayload: vi.fn((data: Record<string, unknown>) => {
+    for (const key of Object.keys(data)) {
+      if (!key.endsWith('_encrypted')) continue;
+      const value = data[key];
+      if (value === null || value === undefined) continue;
+      if (typeof value !== 'string' || value.split(':').length !== 2) {
+        throw new Error(`Encryption guard: invalid encrypted format (field: ${key}).`);
+      }
+    }
+  })
+}));
+
+// The store builds IDBKeyRange.only() ranges; jsdom has no IndexedDB.
+(globalThis as Record<string, unknown>).IDBKeyRange = {
+  only: (v: unknown) => ({ __only: v })
+};
+
+import { noteStore } from '../stores/note.store';
+import { getDatabaseConfig } from '../stores/base.store';
+
+const VALID_ENCRYPTED = 'dGVzdGl2MTIzNDU2:Y2lwaGVydGV4dGRhdGE=';
+
+function makeNote(id: string, overrides: Partial<NoteStoredLocal> = {}): NoteStoredLocal {
+  return {
+    id,
+    title_encrypted: VALID_ENCRYPTED,
+    content_encrypted: VALID_ENCRYPTED,
+    sync_status: 'pending',
+    sync_version: 0,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    ...overrides
+  } as NoteStoredLocal;
+}
+
+function freshDb() {
+  stubDb = new StubDb({
+    notes: new StubObjectStore({ folder_id: 'folder_id' }),
+    noteContents: new StubObjectStore()
+  });
+}
+
+beforeEach(() => {
+  freshDb();
+});
+
+describe('SplitNoteStore', () => {
+  it('save() writes the meta row without content and the content row separately', async () => {
+    await noteStore.save(makeNote('n1', { is_pinned: true }));
+
+    const metaRaw = stubDb.stores.notes.data.get('n1')!;
+    expect(metaRaw).not.toHaveProperty('content_encrypted');
+    expect(metaRaw.title_encrypted).toBe(VALID_ENCRYPTED);
+    // BooleanInt shadow index on the physical row
+    expect(metaRaw.is_pinned).toBe(1);
+
+    const contentRaw = stubDb.stores.noteContents.data.get('n1')!;
+    expect(contentRaw).toEqual({ id: 'n1', content_encrypted: VALID_ENCRYPTED });
+  });
+
+  it('get() joins both rows back into the full public record', async () => {
+    await noteStore.save(makeNote('n1', { is_pinned: true, is_starred: false }));
+
+    const note = await noteStore.get('n1');
+    expect(note).not.toBeNull();
+    expect(note!.content_encrypted).toBe(VALID_ENCRYPTED);
+    expect(note!.title_encrypted).toBe(VALID_ENCRYPTED);
+    // Booleans round-trip through the BooleanInt transformer
+    expect(note!.is_pinned).toBe(true);
+    expect(note!.is_starred).toBe(false);
+  });
+
+  it('get() returns null for a missing id', async () => {
+    expect(await noteStore.get('absent')).toBeNull();
+  });
+
+  it('getAll() joins every row; getMany() joins the requested ids only', async () => {
+    await noteStore.save(makeNote('n1'));
+    await noteStore.save(makeNote('n2'));
+
+    const all = await noteStore.getAll();
+    expect(all).toHaveLength(2);
+    for (const n of all) expect(n.content_encrypted).toBe(VALID_ENCRYPTED);
+
+    const many = await noteStore.getMany(['n2', 'absent']);
+    expect(many).toHaveLength(1);
+    expect(many[0].id).toBe('n2');
+    expect(many[0].content_encrypted).toBe(VALID_ENCRYPTED);
+  });
+
+  it('getAllMeta()/getManyMeta() never carry content_encrypted', async () => {
+    await noteStore.save(makeNote('n1', { is_archived: true }));
+    await noteStore.save(makeNote('n2'));
+
+    const metas = await noteStore.getAllMeta();
+    expect(metas).toHaveLength(2);
+    for (const m of metas) {
+      expect(m).not.toHaveProperty('content_encrypted');
+      expect(m.title_encrypted).toBe(VALID_ENCRYPTED);
+    }
+    // Booleans still round-trip on the meta projection
+    expect(metas.find((m) => m.id === 'n1')!.is_archived).toBe(true);
+
+    const some = await noteStore.getManyMeta(['n1', 'absent']);
+    expect(some).toHaveLength(1);
+    expect(some[0]).not.toHaveProperty('content_encrypted');
+  });
+
+  it('save() refuses a record without content_encrypted and writes nothing', async () => {
+    const partial = { ...makeNote('n1') } as Record<string, unknown>;
+    delete partial.content_encrypted;
+
+    await expect(noteStore.save(partial as unknown as NoteStoredLocal)).rejects.toThrow(
+      /missing content_encrypted/
+    );
+    expect(stubDb.stores.notes.data.size).toBe(0);
+    expect(stubDb.stores.noteContents.data.size).toBe(0);
+  });
+
+  it('save() runs the encryption guard on the FULL record before splitting', async () => {
+    await expect(
+      noteStore.save(makeNote('n1', { content_encrypted: 'plaintext, no colon' }))
+    ).rejects.toThrow(/Encryption guard/);
+    expect(stubDb.stores.notes.data.size).toBe(0);
+    expect(stubDb.stores.noteContents.data.size).toBe(0);
+  });
+
+  it('saveMany() keeps valid items and counts invalid ones as failed', async () => {
+    const bad = { ...makeNote('bad') } as Record<string, unknown>;
+    delete bad.content_encrypted;
+
+    const result = await noteStore.saveMany([
+      makeNote('ok1'),
+      bad as unknown as NoteStoredLocal,
+      makeNote('ok2')
+    ]);
+
+    expect(result.success).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(stubDb.stores.notes.data.has('ok1')).toBe(true);
+    expect(stubDb.stores.notes.data.has('ok2')).toBe(true);
+    expect(stubDb.stores.notes.data.has('bad')).toBe(false);
+    expect(stubDb.stores.noteContents.data.has('bad')).toBe(false);
+  });
+
+  it('delete()/deleteMany() cascade to the content store', async () => {
+    await noteStore.saveMany([makeNote('n1'), makeNote('n2'), makeNote('n3')]);
+
+    await noteStore.delete('n1');
+    expect(stubDb.stores.notes.data.has('n1')).toBe(false);
+    expect(stubDb.stores.noteContents.data.has('n1')).toBe(false);
+
+    await noteStore.deleteMany(['n2', 'n3']);
+    expect(stubDb.stores.notes.data.size).toBe(0);
+    expect(stubDb.stores.noteContents.data.size).toBe(0);
+  });
+
+  it('clear() wipes both stores', async () => {
+    await noteStore.saveMany([makeNote('n1'), makeNote('n2')]);
+    await noteStore.clear();
+    expect(stubDb.stores.notes.data.size).toBe(0);
+    expect(stubDb.stores.noteContents.data.size).toBe(0);
+  });
+
+  it('query() joins content for index-matched rows', async () => {
+    await noteStore.save(makeNote('n1', { folder_id: 'f1' }));
+    await noteStore.save(makeNote('n2', { folder_id: 'f2' }));
+
+    const inF1 = await noteStore.query('folder_id', 'f1');
+    expect(inF1).toHaveLength(1);
+    expect(inF1[0].id).toBe('n1');
+    expect(inF1[0].content_encrypted).toBe(VALID_ENCRYPTED);
+  });
+
+  it('count() counts metadata rows', async () => {
+    await noteStore.saveMany([makeNote('n1'), makeNote('n2')]);
+    expect(await noteStore.count()).toBe(2);
+  });
+
+  it('joins a (never-expected) missing content row as an empty ciphertext instead of dropping the note', async () => {
+    await noteStore.save(makeNote('n1'));
+    stubDb.stores.noteContents.data.delete('n1');
+
+    const note = await noteStore.get('n1');
+    expect(note).not.toBeNull();
+    expect(note!.content_encrypted).toBe('');
+  });
+});
+
+describe('legacy v13 rows (content still inline on the meta row)', () => {
+  function seedLegacyRow(id: string, extra: Record<string, unknown> = {}) {
+    stubDb.stores.notes.data.set(id, {
+      id,
+      title_encrypted: VALID_ENCRYPTED,
+      content_encrypted: `${id}-content:cipher`,
+      updated_at: '2026-07-01T00:00:00.000Z',
+      ...extra
+    });
+  }
+
+  it('joined reads prefer the inline legacy ciphertext over the empty-string fallback', async () => {
+    seedLegacyRow('legacy');
+
+    const viaGet = await noteStore.get('legacy');
+    expect(viaGet!.content_encrypted).toBe('legacy-content:cipher');
+
+    const viaGetAll = await noteStore.getAll();
+    expect(viaGetAll[0].content_encrypted).toBe('legacy-content:cipher');
+  });
+
+  it('save() of a legacy row self-heals it into the split shape', async () => {
+    seedLegacyRow('legacy');
+
+    const full = await noteStore.get('legacy');
+    await noteStore.save({ ...full!, content_encrypted: VALID_ENCRYPTED });
+
+    expect(stubDb.stores.notes.data.get('legacy')).not.toHaveProperty('content_encrypted');
+    expect(stubDb.stores.noteContents.data.get('legacy')).toEqual({
+      id: 'legacy',
+      content_encrypted: VALID_ENCRYPTED
+    });
+  });
+
+  describe('migrateLegacyContent sweep', () => {
+    it('moves inline content into noteContents and strips it from the meta row', async () => {
+      seedLegacyRow('a', { is_pinned: 1 });
+      seedLegacyRow('b');
+
+      const moved = await noteStore.migrateLegacyContent();
+
+      expect(moved).toBe(2);
+      for (const id of ['a', 'b']) {
+        const meta = stubDb.stores.notes.data.get(id)!;
+        expect(meta).not.toHaveProperty('content_encrypted');
+        expect(meta.title_encrypted).toBe(VALID_ENCRYPTED);
+        expect(stubDb.stores.noteContents.data.get(id)).toEqual({
+          id,
+          content_encrypted: `${id}-content:cipher`
+        });
+      }
+      // Shadow index untouched by the move
+      expect(stubDb.stores.notes.data.get('a')!.is_pinned).toBe(1);
+    });
+
+    it('works chunked and is idempotent (second run is a no-op)', async () => {
+      seedLegacyRow('a');
+      seedLegacyRow('b');
+      seedLegacyRow('c');
+
+      expect(await noteStore.migrateLegacyContent(1)).toBe(3);
+      expect(stubDb.stores.noteContents.data.size).toBe(3);
+      expect(await noteStore.migrateLegacyContent(1)).toBe(0);
+    });
+
+    it('skips rows already in the split shape', async () => {
+      await noteStore.save(makeNote('split'));
+      seedLegacyRow('legacy');
+
+      const moved = await noteStore.migrateLegacyContent();
+
+      expect(moved).toBe(1);
+      expect(stubDb.stores.noteContents.data.get('split')!.content_encrypted).toBe(
+        VALID_ENCRYPTED
+      );
+    });
+  });
+});
+
+describe('getDatabaseConfig noteContents wiring', () => {
+  it('notes config contains the noteContents store; task config does not', () => {
+    const notesStores = getDatabaseConfig('notes').stores.map((s) => s.name);
+    const taskStores = getDatabaseConfig('task').stores.map((s) => s.name);
+    expect(notesStores).toContain('noteContents');
+    expect(taskStores).not.toContain('noteContents');
+  });
+});

--- a/packages/storage/src/core/database.ts
+++ b/packages/storage/src/core/database.ts
@@ -149,13 +149,13 @@ class DatabaseManager {
         });
       },
       blocked: () => {
-        logger.warn('Database upgrade blocked by other tabs — waiting for them to close');
+        logger.warn('Database upgrade blocked by other tabs - waiting for them to close');
       },
       blocking: () => {
         // Another tab needs to upgrade the database. Close our connection
         // so the upgrade can proceed. The next operation that needs the DB
         // will re-initialize the connection at the new version.
-        logger.warn('Another tab requested DB upgrade — closing connection to unblock');
+        logger.warn('Another tab requested DB upgrade - closing connection to unblock');
         if (this.db) {
           this.db.close();
           this.db = null;
@@ -180,7 +180,7 @@ class DatabaseManager {
   getDatabase(): IDBPDatabase {
     if (!this.db) {
       if (this.config) {
-        // Connection was closed but config is still known — schedule reconnect.
+        // Connection was closed but config is still known - schedule reconnect.
         // For now throw so callers handle the "not initialized" case gracefully;
         // the reconnect will happen on the next initializeStorage() or initialize() call.
         logger.debug('Database connection lost, will reconnect on next initialize()');
@@ -254,3 +254,29 @@ export const initDatabase = (config: DatabaseConfig) => databaseManager.initiali
 export const closeDatabase = () => databaseManager.close();
 export const getDatabase = () => databaseManager.getDatabase();
 export const isDatabaseInitialized = () => databaseManager.isInitialized();
+
+/** Current connection for a read, or null when not initialized (callers soft-return empty). */
+export function getDatabaseIfInitialized(): IDBPDatabase | null {
+  return databaseManager.isInitialized() ? databaseManager.getDatabase() : null;
+}
+
+/**
+ * Live DB connection for a write, reconnecting once if it was dropped.
+ *
+ * `databaseManager` nulls its connection out from under us in two cases: a
+ * `blocking` upgrade requested by another tab, and `terminated` - which fires
+ * when the platform tears the IndexedDB connection down (a Capacitor WKWebView
+ * does this when the app is backgrounded / under memory pressure). After that
+ * `getDatabase()` throws until the next `initialize()`, so a write issued
+ * before any re-init would fail even though the database is perfectly healthy
+ * on disk (a fresh `indexedDB.open` still works - exactly the asymmetry that
+ * surfaced as folder-sync "Failed to save item" on iOS). Reconnect on the spot
+ * using the last known config rather than dropping the write. Shared by every
+ * store implementation (IndexedDBStore, SplitNoteStore).
+ */
+export async function requireDatabase(): Promise<IDBPDatabase> {
+  if (databaseManager.isInitialized()) return databaseManager.getDatabase();
+  await databaseManager.reconnect();
+  if (databaseManager.isInitialized()) return databaseManager.getDatabase();
+  throw new Error('Database not initialized (reconnect failed).');
+}

--- a/packages/storage/src/core/store.ts
+++ b/packages/storage/src/core/store.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@reborn/utils';
 import { validateEncryptedPayload } from '@reborn/crypto';
 import type { IDBPDatabase, IDBPTransaction } from 'idb';
-import { databaseManager } from './database';
+import { databaseManager, requireDatabase } from './database';
 import type { StoreConfig, QueryOptions, BatchResult, WithId } from './types';
 import { writable, type Writable } from 'svelte/store';
 
@@ -34,23 +34,12 @@ export class IndexedDBStore<TStored extends WithId, TPublic extends WithId = TSt
   }
 
   /**
-   * Live DB connection for a write, reconnecting once if it was dropped.
-   *
-   * `databaseManager` nulls its connection out from under us in two cases: a
-   * `blocking` upgrade requested by another tab, and `terminated` - which fires
-   * when the platform tears the IndexedDB connection down (a Capacitor WKWebView
-   * does this when the app is backgrounded / under memory pressure). After that
-   * `getDatabase()` throws until the next `initialize()`, so a write issued
-   * before any re-init would fail even though the database is perfectly healthy
-   * on disk (a fresh `indexedDB.open` still works - exactly the asymmetry that
-   * surfaced as folder-sync "Failed to save item" on iOS). Reconnect on the spot
-   * using the last known config rather than dropping the write.
+   * Live DB connection for a write, reconnecting once if it was dropped -
+   * see `requireDatabase()` in core/database.ts for the WKWebView-teardown
+   * rationale (shared with SplitNoteStore).
    */
   private async requireDb(): Promise<IDBPDatabase> {
-    if (databaseManager.isInitialized()) return databaseManager.getDatabase();
-    await databaseManager.reconnect();
-    if (databaseManager.isInitialized()) return databaseManager.getDatabase();
-    throw new Error('Database not initialized (reconnect failed).');
+    return requireDatabase();
   }
 
   /**

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -262,6 +262,9 @@ export async function clearAllUserData(): Promise<void> {
     if (existingStores.has('subtasks')) await subtaskStore.clear();
 
     // Notes stores
+    // noteStore.clear() wipes BOTH physical stores (notes + noteContents) in
+    // one transaction - the DB v14 content split must not leak the previous
+    // account's content ciphertext on logout / account switch.
     if (existingStores.has('notes')) await noteStore.clear();
     if (existingStores.has('folders')) await folderStore.clear();
     if (existingStores.has('tags')) await tagStore.clear();

--- a/packages/storage/src/stores/base.store.ts
+++ b/packages/storage/src/stores/base.store.ts
@@ -114,6 +114,18 @@ export const NOTES_STORE_DEFINITIONS: StoreDefinition[] = [
   {
     name: 'folderSyncConfigs',
     primaryKey: 'id'
+  },
+  {
+    // Content ciphertext split out of `notes` (DB v14): { id, content_encrypted }.
+    // Keeps metadata-only getAll() on `notes` from deserializing every content
+    // blob (note index build, sync reconcile, pending counts). Managed
+    // exclusively by the note store's joined reads / atomic dual-store writes.
+    // The v14 upgrade itself only CREATES this store (structure-only, cannot
+    // fail on data volume); legacy v13 rows still carrying content inline are
+    // moved lazily by `noteStore.migrateLegacyContent()` (chunked, resumable)
+    // and tolerated by the joined read path until swept.
+    name: 'noteContents',
+    primaryKey: 'id'
   }
 ];
 

--- a/packages/storage/src/stores/note.store.ts
+++ b/packages/storage/src/stores/note.store.ts
@@ -1,63 +1,535 @@
-import { IndexedDBStore } from '../core/store';
-import type { BooleanInt, NoteStoredLocal } from '@reborn/types';
+import { createLogger } from '@reborn/utils';
+import { validateEncryptedPayload } from '@reborn/crypto';
+import type { IDBPDatabase } from 'idb';
+import { getDatabaseIfInitialized, requireDatabase } from '../core/database';
+import type { BatchResult, QueryOptions } from '../core/types';
+import type {
+  BooleanInt,
+  NoteContentRow,
+  NoteMetaLocal,
+  NoteStoredLocal
+} from '@reborn/types';
 import { boolToInt, intToBool } from '../transformers/boolean';
 
+const logger = createLogger('storage:note-store');
+
+const NOTES_STORE = 'notes';
+const CONTENTS_STORE = 'noteContents';
+
 /**
- * Storage representation: shadow-index booleans (is_pinned / is_starred /
- * is_archived) stored as `BooleanInt` (0 | 1) so IndexedDB can index them
- * efficiently. Boolean keys are not reliably indexed across browsers.
+ * Storage representation of the metadata row: shadow-index booleans
+ * (is_pinned / is_starred / is_archived) stored as `BooleanInt` (0 | 1) so
+ * IndexedDB can index them efficiently. Boolean keys are not reliably indexed
+ * across browsers.
  *
- * The public type (`NoteStoredLocal`) keeps boolean fields — the transformer
- * round-trips them on save / load.
+ * The public types keep boolean fields - the transformer round-trips them on
+ * save / load.
  */
-type NoteStoredRaw = Omit<NoteStoredLocal, 'is_pinned' | 'is_starred' | 'is_archived'> & {
+type NoteMetaRaw = Omit<NoteMetaLocal, 'is_pinned' | 'is_starred' | 'is_archived'> & {
   is_pinned?: BooleanInt;
   is_starred?: BooleanInt;
   is_archived?: BooleanInt;
 };
 
-const noteTransformer = {
-  toStorage: (item: NoteStoredLocal): NoteStoredRaw => {
-    const result: Record<string, unknown> = { ...item };
-    if (typeof item.is_pinned === 'boolean') result.is_pinned = boolToInt(item.is_pinned);
-    if (typeof item.is_starred === 'boolean') result.is_starred = boolToInt(item.is_starred);
-    if (typeof item.is_archived === 'boolean') result.is_archived = boolToInt(item.is_archived);
-    return result as unknown as NoteStoredRaw;
-  },
-  fromStorage: (item: NoteStoredRaw): NoteStoredLocal => {
-    const result: Record<string, unknown> = { ...item };
-    // Tolerate legacy boolean values from records saved before this transformer
-    // existed — only convert when the stored value is the new BooleanInt form.
-    if (item.is_pinned === 0 || item.is_pinned === 1) {
-      result.is_pinned = intToBool(item.is_pinned);
-    }
-    if (item.is_starred === 0 || item.is_starred === 1) {
-      result.is_starred = intToBool(item.is_starred);
-    }
-    if (item.is_archived === 0 || item.is_archived === 1) {
-      result.is_archived = intToBool(item.is_archived);
-    }
-    return result as unknown as NoteStoredLocal;
+function metaToStorage(item: NoteMetaLocal): NoteMetaRaw {
+  const result: Record<string, unknown> = { ...item };
+  if (typeof item.is_pinned === 'boolean') result.is_pinned = boolToInt(item.is_pinned);
+  if (typeof item.is_starred === 'boolean') result.is_starred = boolToInt(item.is_starred);
+  if (typeof item.is_archived === 'boolean') result.is_archived = boolToInt(item.is_archived);
+  return result as unknown as NoteMetaRaw;
+}
+
+function metaFromStorage(item: NoteMetaRaw): NoteMetaLocal {
+  const result: Record<string, unknown> = { ...item };
+  // Tolerate legacy boolean values from records saved before this transformer
+  // existed - only convert when the stored value is the new BooleanInt form.
+  if (item.is_pinned === 0 || item.is_pinned === 1) {
+    result.is_pinned = intToBool(item.is_pinned);
   }
-};
+  if (item.is_starred === 0 || item.is_starred === 1) {
+    result.is_starred = intToBool(item.is_starred);
+  }
+  if (item.is_archived === 0 || item.is_archived === 1) {
+    result.is_archived = intToBool(item.is_archived);
+  }
+  return result as unknown as NoteMetaLocal;
+}
 
 /**
- * Note store for RebornNotes application.
- * Stores `NoteStoredRaw` (BooleanInt shadow indexes) and exposes
- * `NoteStoredLocal` (boolean shadow indexes) via the transformer.
+ * Join a metadata row with its content row into the full public record.
+ * Precedence: the `noteContents` row wins; a legacy v13 row not yet swept by
+ * `migrateLegacyContent()` still carries its ciphertext inline on the meta
+ * row and must never be masked. The empty-string fallback only applies when
+ * neither exists (cannot happen through this store's API - writes are atomic
+ * across both stores) - it fails ciphertext decoding downstream, so such a
+ * row surfaces as an explicit undecryptable placeholder instead of silently
+ * vanishing.
  */
-export const noteStore = new IndexedDBStore<NoteStoredRaw, NoteStoredLocal>({
-  storeName: 'notes',
-  indexes: [
-    { name: 'folder_id', keyPath: 'folder_id' },
-    { name: 'is_pinned', keyPath: 'is_pinned' },
-    { name: 'is_starred', keyPath: 'is_starred' },
-    { name: 'created_at', keyPath: 'created_at' },
-    { name: 'updated_at', keyPath: 'updated_at' },
-    { name: 'is_archived', keyPath: 'is_archived' }
-  ],
-  transform: noteTransformer
-});
+function joinNote(meta: NoteMetaRaw, content: NoteContentRow | undefined): NoteStoredLocal {
+  const joined = metaFromStorage(meta) as NoteStoredLocal;
+  joined.content_encrypted = content?.content_encrypted ?? joined.content_encrypted ?? '';
+  return joined;
+}
+
+/**
+ * Split a full public record into its two physical rows. The content row is
+ * keyed by the same id as the metadata row.
+ */
+function splitNote(item: NoteStoredLocal): { meta: NoteMetaRaw; content: NoteContentRow } {
+  const { content_encrypted, ...metaPublic } = item;
+  return {
+    meta: metaToStorage(metaPublic),
+    content: { id: item.id, content_encrypted }
+  };
+}
+
+/**
+ * Guard against the one content-loss hazard the split introduces: a caller
+ * bypassing the types (e.g. spreading a `NoteMetaLocal` and casting) would
+ * previously overwrite the full record minus content; now it would write an
+ * empty content row. Fail loudly instead - the pre-save Encryption Guard
+ * skips absent fields, so this is the only place that can catch it.
+ */
+function assertHasContent(item: NoteStoredLocal): void {
+  if (typeof item.content_encrypted !== 'string') {
+    throw new Error(
+      `Note ${item.id} is missing content_encrypted - refusing a partial save that would drop the note content`
+    );
+  }
+}
+
+/**
+ * Note store for RebornNotes.
+ *
+ * Since DB v14 a note is physically split across two object stores:
+ *   - `notes`        - metadata + `title_encrypted` (+ shadow indexes)
+ *   - `noteContents` - `{ id, content_encrypted }`
+ *
+ * The public API is unchanged for full-record readers and all writers:
+ * `get`/`getMany`/`getAll`/`query` join both stores in one transaction and
+ * return the complete `NoteStoredLocal`; `save`/`saveMany` validate the full
+ * record (Encryption Guard) and write both rows atomically in one
+ * `readwrite` transaction; `delete`/`deleteMany`/`clear` cascade to both
+ * stores. Metadata-only readers opt into `getAllMeta`/`getManyMeta`, which
+ * never deserialize the content blobs - that projection is the point of the
+ * split (cold-start note index build, sync reconcile snapshots, pending
+ * counts; see reapps-docs guideline 10).
+ *
+ * Legacy v13 rows (content still inline on the meta row) are tolerated by
+ * every joined read and migrated lazily - by `migrateLegacyContent()` and by
+ * any save() of the row - so the v14 upgrade itself stays structure-only.
+ *
+ * Unlike the generic `IndexedDBStore`, this class deliberately has NO
+ * `items` writable and NO post-write `refreshItems()`: nothing subscribed to
+ * `noteStore.items`, yet every save paid a full-table `getAll()` for it. The
+ * notes UI reads the in-memory `noteIndex` instead.
+ */
+class SplitNoteStore {
+  private getDb(): IDBPDatabase | null {
+    return getDatabaseIfInitialized();
+  }
+
+  /** Shared write-path connection helper - see core/database.ts. */
+  private async requireDb(): Promise<IDBPDatabase> {
+    return requireDatabase();
+  }
+
+  /** Both stores must exist (v14 schema); false during early boot / stale schema. */
+  private hasStores(db: IDBPDatabase): boolean {
+    return (
+      db.objectStoreNames.contains(NOTES_STORE) && db.objectStoreNames.contains(CONTENTS_STORE)
+    );
+  }
+
+  // ── Metadata-only reads (no content deserialization) ─────────────
+
+  /** All note metadata rows - never touches the `noteContents` blobs. */
+  async getAllMeta(): Promise<NoteMetaLocal[]> {
+    try {
+      const db = this.getDb();
+      if (!db || !db.objectStoreNames.contains(NOTES_STORE)) {
+        logger.debug('Database or notes store unavailable, returning empty array');
+        return [];
+      }
+      const stored = (await db.getAll(NOTES_STORE)) as NoteMetaRaw[];
+      return stored.map(metaFromStorage);
+    } catch (error) {
+      logger.error('Failed to get all note metadata', { error });
+      throw error;
+    }
+  }
+
+  /** Metadata rows for the given ids (missing ids are skipped). */
+  async getManyMeta(ids: string[]): Promise<NoteMetaLocal[]> {
+    try {
+      const db = this.getDb();
+      if (!db || !db.objectStoreNames.contains(NOTES_STORE)) {
+        logger.debug('Database or notes store unavailable, returning empty array');
+        return [];
+      }
+      const tx = db.transaction(NOTES_STORE, 'readonly');
+      const store = tx.objectStore(NOTES_STORE);
+      // Issue all point reads up front - IDB serves them within the one
+      // transaction without a per-request microtask round-trip.
+      const stored = (await Promise.all(ids.map((id) => store.get(id)))) as Array<
+        NoteMetaRaw | undefined
+      >;
+      await tx.done;
+      return stored.filter((s): s is NoteMetaRaw => s !== undefined).map(metaFromStorage);
+    } catch (error) {
+      logger.error('Failed to get note metadata by ids', { ids, error });
+      throw error;
+    }
+  }
+
+  // ── Full-record reads (join both stores in one transaction) ──────
+
+  async get(id: string): Promise<NoteStoredLocal | null> {
+    try {
+      const db = this.getDb();
+      if (!db || !this.hasStores(db)) {
+        logger.debug('Database or note stores unavailable, returning null', { id });
+        return null;
+      }
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readonly');
+      const meta = (await tx.objectStore(NOTES_STORE).get(id)) as NoteMetaRaw | undefined;
+      const content = meta
+        ? ((await tx.objectStore(CONTENTS_STORE).get(id)) as NoteContentRow | undefined)
+        : undefined;
+      await tx.done;
+      return meta ? joinNote(meta, content) : null;
+    } catch (error) {
+      logger.error('Failed to get note', { id, error });
+      throw error;
+    }
+  }
+
+  async getMany(ids: string[]): Promise<NoteStoredLocal[]> {
+    try {
+      const db = this.getDb();
+      if (!db || !this.hasStores(db)) {
+        logger.debug('Database or note stores unavailable, returning empty array');
+        return [];
+      }
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readonly');
+      const notes = tx.objectStore(NOTES_STORE);
+      const contents = tx.objectStore(CONTENTS_STORE);
+      // Both stores share the id keyspace - issue all reads concurrently.
+      const pairs = (await Promise.all(
+        ids.map((id) => Promise.all([notes.get(id), contents.get(id)]))
+      )) as Array<[NoteMetaRaw | undefined, NoteContentRow | undefined]>;
+      await tx.done;
+      return pairs
+        .filter((pair): pair is [NoteMetaRaw, NoteContentRow | undefined] => pair[0] !== undefined)
+        .map(([meta, content]) => joinNote(meta, content));
+    } catch (error) {
+      logger.error('Failed to get notes by ids', { ids, error });
+      throw error;
+    }
+  }
+
+  async getAll(): Promise<NoteStoredLocal[]> {
+    try {
+      const db = this.getDb();
+      if (!db || !this.hasStores(db)) {
+        logger.debug('Database or note stores unavailable, returning empty array');
+        return [];
+      }
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readonly');
+      const [metas, contents] = await Promise.all([
+        tx.objectStore(NOTES_STORE).getAll() as Promise<NoteMetaRaw[]>,
+        tx.objectStore(CONTENTS_STORE).getAll() as Promise<NoteContentRow[]>
+      ]);
+      await tx.done;
+      const contentById = new Map(contents.map((c) => [c.id, c]));
+      return metas.map((meta) => joinNote(meta, contentById.get(meta.id)));
+    } catch (error) {
+      logger.error('Failed to get all notes', { error });
+      throw error;
+    }
+  }
+
+  /**
+   * Query full records via a metadata index (same index set as before the
+   * split - indexes live on the `notes` store). Contents are joined per
+   * matched row inside the same transaction.
+   */
+  async query(index: string, value: unknown, options?: QueryOptions): Promise<NoteStoredLocal[]> {
+    try {
+      const db = this.getDb();
+      if (!db || !this.hasStores(db)) {
+        logger.debug('Database or note stores unavailable, returning empty array', {
+          index,
+          value
+        });
+        return [];
+      }
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readonly');
+      const idx = tx.objectStore(NOTES_STORE).index(index);
+      const contents = tx.objectStore(CONTENTS_STORE);
+
+      let cursor = await idx.openCursor(IDBKeyRange.only(value), options?.direction);
+      const metas: NoteMetaRaw[] = [];
+      let count = 0;
+      const offset = options?.offset || 0;
+      const limit = options?.limit || Infinity;
+
+      while (cursor) {
+        if (count >= offset && metas.length < limit) {
+          metas.push(cursor.value as NoteMetaRaw);
+        }
+        count++;
+        if (count >= offset + limit) {
+          break;
+        }
+        cursor = await cursor.continue();
+      }
+
+      // Join contents in one concurrent batch after the cursor walk.
+      const contentRows = (await Promise.all(metas.map((m) => contents.get(m.id)))) as Array<
+        NoteContentRow | undefined
+      >;
+      await tx.done;
+      const results = metas.map((meta, i) => joinNote(meta, contentRows[i]));
+      logger.debug('Note query completed', { index, value, count: results.length });
+      return results;
+    } catch (error) {
+      logger.error('Note query failed', { index, value, error });
+      throw error;
+    }
+  }
+
+  // ── Writes (atomic across both stores) ───────────────────────────
+
+  async save(item: NoteStoredLocal): Promise<void> {
+    try {
+      const db = await this.requireDb();
+      assertHasContent(item);
+      // Pre-save encryption guard: validate all *_encrypted fields on the FULL
+      // record (title + content + metadata) before it is split for storage.
+      validateEncryptedPayload(item as unknown as Record<string, unknown>);
+      const { meta, content } = splitNote(item);
+
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readwrite');
+      await Promise.all([
+        tx.objectStore(NOTES_STORE).put(meta),
+        tx.objectStore(CONTENTS_STORE).put(content)
+      ]);
+      await tx.done;
+      logger.debug('Note saved', { id: item.id });
+    } catch (error) {
+      logger.error('Failed to save note', {
+        id: item.id,
+        errorName: error instanceof Error ? error.name : typeof error,
+        errorMessage: error instanceof Error ? error.message : String(error)
+      });
+      throw error;
+    }
+  }
+
+  async saveMany(items: NoteStoredLocal[]): Promise<BatchResult> {
+    const result: BatchResult = {
+      success: 0,
+      failed: 0,
+      errors: []
+    };
+
+    try {
+      const db = await this.requireDb();
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readwrite');
+      const notes = tx.objectStore(NOTES_STORE);
+      const contents = tx.objectStore(CONTENTS_STORE);
+
+      for (const item of items) {
+        try {
+          assertHasContent(item);
+          validateEncryptedPayload(item as unknown as Record<string, unknown>);
+          const { meta, content } = splitNote(item);
+          await Promise.all([notes.put(meta), contents.put(content)]);
+          result.success++;
+        } catch (error) {
+          result.failed++;
+          result.errors.push(error as Error);
+          logger.error('Failed to save note in batch', { id: item.id, error });
+        }
+      }
+
+      await tx.done;
+      logger.info('Note batch save completed', {
+        success: result.success,
+        failed: result.failed
+      });
+      return result;
+    } catch (error) {
+      logger.error('Note batch save failed', { error });
+      throw error;
+    }
+  }
+
+  // ── Deletes (cascade to both stores) ─────────────────────────────
+
+  async delete(id: string): Promise<void> {
+    try {
+      const db = await this.requireDb();
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readwrite');
+      await Promise.all([
+        tx.objectStore(NOTES_STORE).delete(id),
+        tx.objectStore(CONTENTS_STORE).delete(id)
+      ]);
+      await tx.done;
+      logger.debug('Note deleted', { id });
+    } catch (error) {
+      logger.error('Failed to delete note', { id, error });
+      throw error;
+    }
+  }
+
+  async deleteMany(ids: string[]): Promise<void> {
+    const result: BatchResult = {
+      success: 0,
+      failed: 0,
+      errors: []
+    };
+
+    try {
+      const db = await this.requireDb();
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readwrite');
+      const notes = tx.objectStore(NOTES_STORE);
+      const contents = tx.objectStore(CONTENTS_STORE);
+
+      for (const id of ids) {
+        try {
+          await Promise.all([notes.delete(id), contents.delete(id)]);
+          result.success++;
+        } catch (error) {
+          result.failed++;
+          result.errors.push(error as Error);
+          logger.error('Failed to delete note in batch', { id, error });
+        }
+      }
+
+      await tx.done;
+      logger.info('Note batch delete completed', {
+        success: result.success,
+        failed: result.failed
+      });
+    } catch (error) {
+      logger.error('Note batch delete failed', { error });
+      throw error;
+    }
+  }
+
+  /** Wipe both stores (logout / account switch - see clearAllUserData). */
+  async clear(): Promise<void> {
+    try {
+      const db = await this.requireDb();
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readwrite');
+      await Promise.all([
+        tx.objectStore(NOTES_STORE).clear(),
+        tx.objectStore(CONTENTS_STORE).clear()
+      ]);
+      await tx.done;
+      logger.info('Note stores cleared');
+    } catch (error) {
+      logger.error('Failed to clear note stores', { error });
+      throw error;
+    }
+  }
+
+  // ── Legacy content sweep (post-v14 upgrade) ──────────────────────
+
+  /**
+   * Move `content_encrypted` ciphertext still stored inline on legacy (pre-v14)
+   * `notes` rows into `noteContents`. The v14 upgrade itself is structure-only
+   * (it just creates the store), so it can never fail on data volume; this
+   * sweep does the data move AFTER the database is open, in small independent
+   * readwrite transactions:
+   *
+   * - chunked: a quota or transient error aborts only the current chunk, the
+   *   app keeps working (joined reads prefer the inline legacy ciphertext, see
+   *   joinNote) and the next run resumes where it stopped;
+   * - idempotent: each row is re-checked inside its transaction, so a
+   *   concurrent save() that already split the row is skipped;
+   * - self-healing by construction: every save() writes the split shape, so
+   *   rows migrate organically even if the sweep never completes.
+   *
+   * Returns the number of rows moved this run. Callers gate it behind a
+   * once-per-profile flag (see reborn-notes hooks.client.ts).
+   */
+  async migrateLegacyContent(chunkSize = 50): Promise<number> {
+    const db = this.getDb();
+    if (!db || !this.hasStores(db)) return 0;
+
+    // Pass 1 (readonly): collect ids of rows still carrying inline content.
+    const legacyIds: string[] = [];
+    {
+      const tx = db.transaction(NOTES_STORE, 'readonly');
+      let cursor = await tx.objectStore(NOTES_STORE).openCursor();
+      while (cursor) {
+        const row = cursor.value as { id: string; content_encrypted?: unknown };
+        if (typeof row.content_encrypted === 'string') legacyIds.push(row.id);
+        cursor = await cursor.continue();
+      }
+      await tx.done;
+    }
+    if (legacyIds.length === 0) return 0;
+
+    // Pass 2: move in chunks, one readwrite transaction per chunk.
+    let moved = 0;
+    for (let i = 0; i < legacyIds.length; i += chunkSize) {
+      const chunk = legacyIds.slice(i, i + chunkSize);
+      const tx = db.transaction([NOTES_STORE, CONTENTS_STORE], 'readwrite');
+      const notes = tx.objectStore(NOTES_STORE);
+      const contents = tx.objectStore(CONTENTS_STORE);
+      for (const id of chunk) {
+        const row = (await notes.get(id)) as
+          | { id: string; content_encrypted?: unknown }
+          | undefined;
+        if (!row || typeof row.content_encrypted !== 'string') continue;
+        await contents.put({ id: row.id, content_encrypted: row.content_encrypted });
+        delete row.content_encrypted;
+        await notes.put(row);
+        moved++;
+      }
+      await tx.done;
+      // Yield between chunks - keep the boot-time main thread responsive.
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    logger.info('Moved legacy inline note content into noteContents', {
+      moved,
+      total: legacyIds.length
+    });
+    return moved;
+  }
+
+  // ── Counts ───────────────────────────────────────────────────────
+
+  async count(): Promise<number> {
+    try {
+      const db = this.getDb();
+      if (!db || !db.objectStoreNames.contains(NOTES_STORE)) {
+        logger.debug('Database or notes store unavailable, returning 0');
+        return 0;
+      }
+      try {
+        return await db.count(NOTES_STORE);
+      } catch (countError) {
+        logger.debug('Note count operation failed, returning 0', { error: countError });
+        return 0;
+      }
+    } catch (error) {
+      logger.error('Failed to count notes', { error });
+      // Don't throw for count operations - return 0 instead
+      return 0;
+    }
+  }
+}
+
+/**
+ * Note store for RebornNotes application. See `SplitNoteStore` for the
+ * physical two-store layout behind the unchanged public record shape.
+ */
+export const noteStore = new SplitNoteStore();
 
 /**
  * Helper queries for notes

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -97,6 +97,23 @@ export interface NoteStoredLocal extends NoteEncrypted {
   is_ephemeral?: boolean;
 }
 
+/**
+ * Metadata-only view of a locally stored note: everything except the (large)
+ * `content_encrypted` blob. Physically, notes are split across two IndexedDB
+ * stores since DB v14 - `notes` holds this shape, `noteContents` holds the
+ * content ciphertext - so metadata readers (note index build, sync reconcile,
+ * pending counts) can `getAll()` without deserializing every content blob.
+ * Read-only by design: it cannot be passed to `noteStore.save()`, which
+ * requires the full `NoteStoredLocal` (content included).
+ */
+export type NoteMetaLocal = Omit<NoteStoredLocal, 'content_encrypted'>;
+
+/** Row shape of the `noteContents` IndexedDB store (DB v14+). */
+export interface NoteContentRow {
+  id: string;
+  content_encrypted: string;
+}
+
 /** Maximum number of version snapshots kept per note (client and server). */
 export const MAX_NOTE_VERSIONS = 10;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -54,5 +54,5 @@ export * as schemas from './schemas';
  * `docs/architecture/zero-knowledge-architecture.md` for the rationale.
  */
 export const DB_CONFIG = {
-  version: 13 // Bump: folderSyncConfigs store (notes)
+  version: 14 // Bump: noteContents store (notes) - content_encrypted split out of `notes`
 };


### PR DESCRIPTION
## Summary

Cuts the dominant cold-start cost of the native shell: `noteIndex.build()` (and the per-boot sync reconcile, pending-count refresh, push sweep) deserialized **every** `content_encrypted` blob (~50 MB for 10K notes) just to read titles and shadow fields. IndexedDB has no column projection, so since **DB v14** a note is physically split across two stores: `notes` (metadata + `title_encrypted`) and `noteContents` (`{ id, content_encrypted }`).

- **Public record shape unchanged.** `noteStore` (new `SplitNoteStore`) joins both stores for full reads (`get/getMany/getAll/query`), writes both rows atomically in one transaction (`save/saveMany`, full-record Encryption Guard first), cascades deletes/`clear()` (incl. logout wipe). All ~25 get-spread-save call sites work unmodified.
- **Metadata-only projection** `getAllMeta()/getManyMeta()` (type `NoteMetaLocal`, cannot round-trip into `save()`; a save missing content throws loudly). Switched: noteIndex build/upsert, `prePullSyncedIds` + orphan sweep, `pushPendingItems` (full rows point-read only for rows actually pushed), `refreshPendingCount`, shadow-index reconciler scan, backup watermark, folder-sync `liveNoteIds`, `cleanEphemeralNotes`.
- **Upgrade v13→v14 is structure-only.** Content migrates lazily: joined reads prefer legacy inline ciphertext, every `save()` self-heals its row, and a chunked idempotent `migrateLegacyContent()` sweep (one-shot flag in `hooks.client.ts`) finishes the move. A quota/transient error only delays the sweep - it can never brick the DB open.
- Dead `items`/`refreshItems` not carried over (zero subscribers; every save paid a full-table `getAll()` for it).
- Content search / link graph / editor / export / push payloads: unchanged semantics via joined reads (verified by the full regression suite).

### Decisions for review
1. **Lazy sweep instead of a versionchange data migration** - adversarial review (19-agent workflow) showed the all-or-nothing upgrade transaction could hit `QuotaExceededError` on near-quota devices and leave the DB unable to open (retry loop), compounded by the fixed 8 s open timeout.
2. Import dedup probe uses throwing `getAllMeta()`, not error-swallowing `count()` (silent duplicate-import hazard).
3. Reconciler drift writes re-read the live row and re-derive pin/star from it (closes a mid-scan revert window).
4. Shared `requireDatabase()`/`getDatabaseIfInitialized()` extracted to `core/database.ts`.
5. Shared `DB_CONFIG` bump 13→14 also versions the task DB - structural no-op there (precedent: v12 savedSearches, v13 folderSyncConfigs).

## Test plan
- `nx affected -t lint typecheck test check` + builds: green (storage 67, types 80, notes app 1263 tests).
- New `packages/storage/src/__tests__/note-store-split.spec.ts`: join/split writes, partial-save guard, legacy-inline precedence, self-healing save, chunked idempotent sweep.
- Smoke (Michał): cold start on emulator - notes list + editor open + content search ("szukaj w treści") + tag/pin/star toggles + export/import round-trip; first boot after update should log `Moved legacy inline note content into noteContents` once; second boot skips the sweep (flag). Watch that trash/restore and manual sync behave as before.