### PR TITLE
feat(notes): account-scoped backup phrase + overdue-backup reminder

### DIFF
--- a/apps/reborn-notes/android/app/capacitor.build.gradle
+++ b/apps/reborn-notes/android/app/capacitor.build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-clipboard')
     implementation project(':capacitor-filesystem')
+    implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-network')
     implementation project(':capacitor-share')
     implementation project(':capacitor-splash-screen')

--- a/apps/reborn-notes/android/capacitor.settings.gradle
+++ b/apps/reborn-notes/android/capacitor.settings.gradle
@@ -17,6 +17,9 @@ project(':capacitor-clipboard').projectDir = new File('../../../node_modules/.pn
 include ':capacitor-filesystem'
 project(':capacitor-filesystem').projectDir = new File('../../../node_modules/.pnpm/@capacitor+filesystem@8.1.2_@capacitor+core@8.4.0/node_modules/@capacitor/filesystem/android')
 
+include ':capacitor-local-notifications'
+project(':capacitor-local-notifications').projectDir = new File('../../../node_modules/.pnpm/@capacitor+local-notifications@8.2.0_@capacitor+core@8.4.0/node_modules/@capacitor/local-notifications/android')
+
 include ':capacitor-network'
 project(':capacitor-network').projectDir = new File('../../../node_modules/.pnpm/@capacitor+network@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/network/android')
 

--- a/apps/reborn-notes/ios/App/CapApp-SPM/Package.swift
+++ b/apps/reborn-notes/ios/App/CapApp-SPM/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(name: "CapacitorApp", path: "../../../../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.4.0/node_modules/@capacitor/app"),
         .package(name: "CapacitorClipboard", path: "../../../../../node_modules/.pnpm/@capacitor+clipboard@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/clipboard"),
         .package(name: "CapacitorFilesystem", path: "../../../../../node_modules/.pnpm/@capacitor+filesystem@8.1.2_@capacitor+core@8.4.0/node_modules/@capacitor/filesystem"),
+        .package(name: "CapacitorLocalNotifications", path: "../../../../../node_modules/.pnpm/@capacitor+local-notifications@8.2.0_@capacitor+core@8.4.0/node_modules/@capacitor/local-notifications"),
         .package(name: "CapacitorNetwork", path: "../../../../../node_modules/.pnpm/@capacitor+network@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/network"),
         .package(name: "CapacitorShare", path: "../../../../../node_modules/.pnpm/@capacitor+share@8.0.1_@capacitor+core@8.4.0/node_modules/@capacitor/share")
     ],
@@ -31,6 +32,7 @@ let package = Package(
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorClipboard", package: "CapacitorClipboard"),
                 .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
+                .product(name: "CapacitorLocalNotifications", package: "CapacitorLocalNotifications"),
                 .product(name: "CapacitorNetwork", package: "CapacitorNetwork"),
                 .product(name: "CapacitorShare", package: "CapacitorShare")
             ]

--- a/apps/reborn-notes/package.json
+++ b/apps/reborn-notes/package.json
@@ -44,6 +44,7 @@
     "@capacitor/core": "8.4.0",
     "@capacitor/filesystem": "8.1.2",
     "@capacitor/ios": "8.4.0",
+    "@capacitor/local-notifications": "8.2.0",
     "@capacitor/network": "8.0.1",
     "@capacitor/share": "8.0.1",
     "@capacitor/splash-screen": "8.0.1",

--- a/apps/reborn-notes/src/lib/services/auto-backup/index.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/index.ts
@@ -55,14 +55,20 @@ export async function runNotesAutoBackupIfDue(
   }
 
   const config = loadAutoBackupConfig();
-  if (!config.enabled) return { status: 'skipped', reason: 'disabled' };
+  if (!config.enabled) {
+    // Backup was turned off outside the settings page's own reminder wiring
+    // (e.g. a config wipe) - make sure no stale "backup overdue" nudge fires.
+    const { cancelBackupReminders } = await import('./reminder');
+    void cancelBackupReminders();
+    return { status: 'skipped', reason: 'disabled' };
+  }
 
   // Import the native-only adapters lazily so the web bundle never pulls the
   // secure-storage / FolderFs bridges (they throw on web by construction).
   const { createNativeFolderDestination } = await import('./folder-destination');
   const { loadRecoveryPhrase } = await import('./recovery-phrase-vault');
 
-  return runAutoBackup({
+  const outcome = await runAutoBackup({
     app: 'reborn-notes',
     config,
     state: loadAutoBackupState(),
@@ -75,6 +81,14 @@ export async function runNotesAutoBackupIfDue(
     saveState: async (next) => saveAutoBackupState(next),
     verifyBackup
   });
+
+  // Re-plan the overdue reminders from the just-persisted state: a successful
+  // run pushes them ~a day out, so they only ever fire when the app stays
+  // closed past the cadence. Internally best-effort, never affects the outcome.
+  const { syncBackupReminders } = await import('./reminder');
+  void syncBackupReminders();
+
+  return outcome;
 }
 
 /**
@@ -113,6 +127,10 @@ export async function clearAutoBackupState(): Promise<void> {
     // Lazy import keeps the native secure-storage bridge out of the web bundle.
     const { clearRecoveryPhrase } = await import('./recovery-phrase-vault');
     await clearRecoveryPhrase();
+    // No backup will run for the next user until they set it up themselves -
+    // drop the pending "backup overdue" nudges (own try/catch inside).
+    const { cancelBackupReminders } = await import('./reminder');
+    await cancelBackupReminders();
   } catch (err) {
     logger.error('Failed to clear auto-backup state:', err);
   }

--- a/apps/reborn-notes/src/lib/services/auto-backup/index.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/index.ts
@@ -41,6 +41,19 @@ export async function runNotesAutoBackupIfDue(
   // The backup decrypts account data to re-wrap it portably; needs the key.
   if (!cryptoManager.isInitialized()) return { status: 'skipped', reason: 'locked' };
 
+  // Sync the vault with the account-scoped wrapped phrase BEFORE reading any
+  // config: this hydrates a fresh/wiped device after login (the settings pull
+  // at unlock runs earlier in the same runSync), picks up a rotation made on
+  // another device, and publishes the phrase of installs that predate account
+  // scoping. Runs even when auto-backup is disabled here, so the settings
+  // page later finds the phrase ready. Never throws.
+  try {
+    const { reconcileRecoveryPhrase } = await import('./phrase-sync');
+    await reconcileRecoveryPhrase();
+  } catch (err) {
+    logger.warn('Recovery phrase reconcile before backup failed:', err);
+  }
+
   const config = loadAutoBackupConfig();
   if (!config.enabled) return { status: 'skipped', reason: 'disabled' };
 
@@ -102,6 +115,34 @@ export async function clearAutoBackupState(): Promise<void> {
     await clearRecoveryPhrase();
   } catch (err) {
     logger.error('Failed to clear auto-backup state:', err);
+  }
+}
+
+/**
+ * Carry the auto-backup setup across the local→account upgrade: the upgrade
+ * swaps `autoBackupScopeId()` from the local pseudo id to the account id, so
+ * without this the config/state (localStorage) and phrase (OS vault) written
+ * under the local id would be orphaned and the upgraded account would start
+ * from a disabled, phraseless default - forcing a full re-setup on the very
+ * device that already has a valid folder grant and phrase. Same device, same
+ * human: carrying it over is safe. Call AFTER the account credentials are in
+ * localStorage (so pushes see the account) and BEFORE any backup run.
+ * Best-effort: a failure only costs the user a re-setup, like before.
+ */
+export async function migrateAutoBackupScope(
+  fromScopeId: string | null,
+  toScopeId: string
+): Promise<void> {
+  if (!fromScopeId || fromScopeId === toScopeId) return;
+  try {
+    const { migrateAutoBackupPrefsScope } = await import('./prefs');
+    migrateAutoBackupPrefsScope(fromScopeId, toScopeId);
+    if (__REBORN_NATIVE__) {
+      const { migrateRecoveryPhraseScope } = await import('./recovery-phrase-vault');
+      await migrateRecoveryPhraseScope(fromScopeId, toScopeId);
+    }
+  } catch (err) {
+    logger.error('Failed to migrate auto-backup scope on account upgrade:', err);
   }
 }
 

--- a/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.spec.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the account-scoped recovery-phrase reconcile
+ * (`reconcilePhraseCore`). The core takes injected I/O precisely so these
+ * rules stay testable: `__REBORN_NATIVE__` is compile-time false under vitest,
+ * which makes the real vault/native wrapper dead code here.
+ *
+ * The rule table under test (row = synced truth, vault = device copy):
+ *   row present & differs  → hydrate vault (fresh login / remote rotation)
+ *   row absent & vault set → publish wrapped copy (pre-scoping migration)
+ *   row corrupt & vault set→ republish (GCM auth failure can't be a rotation)
+ *   otherwise              → noop
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { reconcilePhraseCore, type PhraseSyncDeps } from './phrase-sync';
+
+const PHRASE = 'able baker charlie dog easy fox george how item jig king love';
+const OTHER = 'mike nan oboe peter queen roger sugar tare uncle victor will xray';
+
+/** Deps where wrap/unwrap are a trivial reversible encoding. */
+function makeDeps(overrides: Partial<PhraseSyncDeps> = {}): PhraseSyncDeps & {
+  saveVaultPhrase: ReturnType<typeof vi.fn>;
+  setWrappedInRow: ReturnType<typeof vi.fn>;
+} {
+  return {
+    loadVaultPhrase: vi.fn(async () => null),
+    saveVaultPhrase: vi.fn(async () => {}),
+    getWrappedFromRow: vi.fn(async () => null),
+    setWrappedInRow: vi.fn(async () => {}),
+    wrap: vi.fn(async (p: string) => `wrapped:${p}`),
+    unwrap: vi.fn(async (w: string) => {
+      if (!w.startsWith('wrapped:')) throw new Error('auth failure');
+      return w.slice('wrapped:'.length);
+    }),
+    ...overrides
+  } as PhraseSyncDeps & {
+    saveVaultPhrase: ReturnType<typeof vi.fn>;
+    setWrappedInRow: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('reconcilePhraseCore', () => {
+  it('hydrates an empty vault from the synced row (fresh device / after logout)', async () => {
+    const deps = makeDeps({ getWrappedFromRow: async () => `wrapped:${PHRASE}` });
+    await expect(reconcilePhraseCore(deps)).resolves.toBe('hydrated-vault');
+    expect(deps.saveVaultPhrase).toHaveBeenCalledWith(PHRASE);
+    expect(deps.setWrappedInRow).not.toHaveBeenCalled();
+  });
+
+  it('overwrites a stale vault copy when the row differs (rotation on another device)', async () => {
+    const deps = makeDeps({
+      loadVaultPhrase: async () => OTHER,
+      getWrappedFromRow: async () => `wrapped:${PHRASE}`
+    });
+    await expect(reconcilePhraseCore(deps)).resolves.toBe('hydrated-vault');
+    expect(deps.saveVaultPhrase).toHaveBeenCalledWith(PHRASE);
+  });
+
+  it('publishes the vault phrase when the row has none (pre-scoping install migration)', async () => {
+    const deps = makeDeps({ loadVaultPhrase: async () => PHRASE });
+    await expect(reconcilePhraseCore(deps)).resolves.toBe('published-row');
+    expect(deps.setWrappedInRow).toHaveBeenCalledWith(`wrapped:${PHRASE}`);
+    expect(deps.saveVaultPhrase).not.toHaveBeenCalled();
+  });
+
+  it('republishes over an undecryptable row value when the vault knows the phrase', async () => {
+    const deps = makeDeps({
+      loadVaultPhrase: async () => PHRASE,
+      getWrappedFromRow: async () => 'garbage-not-wrapped'
+    });
+    await expect(reconcilePhraseCore(deps)).resolves.toBe('republished-row');
+    expect(deps.setWrappedInRow).toHaveBeenCalledWith(`wrapped:${PHRASE}`);
+  });
+
+  it('leaves an undecryptable row alone when this device has no vault copy', async () => {
+    const deps = makeDeps({ getWrappedFromRow: async () => 'garbage-not-wrapped' });
+    await expect(reconcilePhraseCore(deps)).resolves.toBe('noop');
+    expect(deps.setWrappedInRow).not.toHaveBeenCalled();
+    expect(deps.saveVaultPhrase).not.toHaveBeenCalled();
+  });
+
+  it('noops when row and vault already agree', async () => {
+    const deps = makeDeps({
+      loadVaultPhrase: async () => PHRASE,
+      getWrappedFromRow: async () => `wrapped:${PHRASE}`
+    });
+    await expect(reconcilePhraseCore(deps)).resolves.toBe('noop');
+    expect(deps.saveVaultPhrase).not.toHaveBeenCalled();
+    expect(deps.setWrappedInRow).not.toHaveBeenCalled();
+  });
+
+  it('noops when neither side has a phrase', async () => {
+    const deps = makeDeps();
+    await expect(reconcilePhraseCore(deps)).resolves.toBe('noop');
+  });
+});

--- a/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.spec.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.spec.ts
@@ -4,11 +4,14 @@
  * rules stay testable: `__REBORN_NATIVE__` is compile-time false under vitest,
  * which makes the real vault/native wrapper dead code here.
  *
- * The rule table under test (row = synced truth, vault = device copy):
- *   row present & differs  → hydrate vault (fresh login / remote rotation)
- *   row absent & vault set → publish wrapped copy (pre-scoping migration)
- *   row corrupt & vault set→ republish (GCM auth failure can't be a rotation)
- *   otherwise              → noop
+ * The rule table under test (row = newest known after pull-merge):
+ *   row present, vault empty   → hydrate vault (fresh login / wiped device)
+ *   row present, vault differs → replace vault + raise the notice flag
+ *   row absent, vault present  → publish wrap(vault) ONLY when allowed
+ *     (definitive server view this session / local-only) - "absent locally"
+ *     is otherwise indistinguishable from "the pull failed"
+ *   row corrupt                → republish from vault (GCM auth failure can't
+ *     be a rotation), noop with no vault copy
  */
 import { describe, expect, it, vi } from 'vitest';
 import { reconcilePhraseCore, type PhraseSyncDeps } from './phrase-sync';
@@ -16,80 +19,102 @@ import { reconcilePhraseCore, type PhraseSyncDeps } from './phrase-sync';
 const PHRASE = 'able baker charlie dog easy fox george how item jig king love';
 const OTHER = 'mike nan oboe peter queen roger sugar tare uncle victor will xray';
 
+const row = (phrase: string, updatedAt = '2026-07-10T10:00:00.000Z') => ({
+  wrapped: `wrapped:${phrase}`,
+  updatedAt
+});
+
 /** Deps where wrap/unwrap are a trivial reversible encoding. */
 function makeDeps(overrides: Partial<PhraseSyncDeps> = {}): PhraseSyncDeps & {
   saveVaultPhrase: ReturnType<typeof vi.fn>;
-  setWrappedInRow: ReturnType<typeof vi.fn>;
+  setRowPhrase: ReturnType<typeof vi.fn>;
+  notePhraseReplaced: ReturnType<typeof vi.fn>;
 } {
   return {
     loadVaultPhrase: vi.fn(async () => null),
     saveVaultPhrase: vi.fn(async () => {}),
-    getWrappedFromRow: vi.fn(async () => null),
-    setWrappedInRow: vi.fn(async () => {}),
+    getRowPhrase: vi.fn(async () => null),
+    setRowPhrase: vi.fn(async () => {}),
     wrap: vi.fn(async (p: string) => `wrapped:${p}`),
     unwrap: vi.fn(async (w: string) => {
       if (!w.startsWith('wrapped:')) throw new Error('auth failure');
       return w.slice('wrapped:'.length);
     }),
+    notePhraseReplaced: vi.fn(),
     ...overrides
   } as PhraseSyncDeps & {
     saveVaultPhrase: ReturnType<typeof vi.fn>;
-    setWrappedInRow: ReturnType<typeof vi.fn>;
+    setRowPhrase: ReturnType<typeof vi.fn>;
+    notePhraseReplaced: ReturnType<typeof vi.fn>;
   };
 }
 
+const PUBLISH = { allowPublish: true };
+const NO_PUBLISH = { allowPublish: false };
+
 describe('reconcilePhraseCore', () => {
   it('hydrates an empty vault from the synced row (fresh device / after logout)', async () => {
-    const deps = makeDeps({ getWrappedFromRow: async () => `wrapped:${PHRASE}` });
-    await expect(reconcilePhraseCore(deps)).resolves.toBe('hydrated-vault');
+    const deps = makeDeps({ getRowPhrase: async () => row(PHRASE) });
+    await expect(reconcilePhraseCore(deps, NO_PUBLISH)).resolves.toBe('hydrated-vault');
     expect(deps.saveVaultPhrase).toHaveBeenCalledWith(PHRASE);
-    expect(deps.setWrappedInRow).not.toHaveBeenCalled();
+    expect(deps.setRowPhrase).not.toHaveBeenCalled();
+    expect(deps.notePhraseReplaced).not.toHaveBeenCalled();
   });
 
-  it('overwrites a stale vault copy when the row differs (rotation on another device)', async () => {
+  it('replaces a differing vault copy AND raises the notice flag (rotation elsewhere)', async () => {
     const deps = makeDeps({
       loadVaultPhrase: async () => OTHER,
-      getWrappedFromRow: async () => `wrapped:${PHRASE}`
+      getRowPhrase: async () => row(PHRASE)
     });
-    await expect(reconcilePhraseCore(deps)).resolves.toBe('hydrated-vault');
+    await expect(reconcilePhraseCore(deps, NO_PUBLISH)).resolves.toBe('replaced-vault');
     expect(deps.saveVaultPhrase).toHaveBeenCalledWith(PHRASE);
+    expect(deps.notePhraseReplaced).toHaveBeenCalledOnce();
   });
 
-  it('publishes the vault phrase when the row has none (pre-scoping install migration)', async () => {
+  it('publishes the vault phrase when the row has none and publishing is allowed', async () => {
     const deps = makeDeps({ loadVaultPhrase: async () => PHRASE });
-    await expect(reconcilePhraseCore(deps)).resolves.toBe('published-row');
-    expect(deps.setWrappedInRow).toHaveBeenCalledWith(`wrapped:${PHRASE}`);
+    await expect(reconcilePhraseCore(deps, PUBLISH)).resolves.toBe('published-row');
+    expect(deps.setRowPhrase).toHaveBeenCalledWith(`wrapped:${PHRASE}`);
     expect(deps.saveVaultPhrase).not.toHaveBeenCalled();
+  });
+
+  it('does NOT publish without a definitive server view (failed pull must not clobber the account)', async () => {
+    const deps = makeDeps({ loadVaultPhrase: async () => PHRASE });
+    await expect(reconcilePhraseCore(deps, NO_PUBLISH)).resolves.toBe('noop');
+    expect(deps.setRowPhrase).not.toHaveBeenCalled();
   });
 
   it('republishes over an undecryptable row value when the vault knows the phrase', async () => {
     const deps = makeDeps({
       loadVaultPhrase: async () => PHRASE,
-      getWrappedFromRow: async () => 'garbage-not-wrapped'
+      getRowPhrase: async () => ({ wrapped: 'garbage-not-wrapped', updatedAt: '2026-07-10T10:00:00.000Z' })
     });
-    await expect(reconcilePhraseCore(deps)).resolves.toBe('republished-row');
-    expect(deps.setWrappedInRow).toHaveBeenCalledWith(`wrapped:${PHRASE}`);
+    await expect(reconcilePhraseCore(deps, NO_PUBLISH)).resolves.toBe('republished-row');
+    expect(deps.setRowPhrase).toHaveBeenCalledWith(`wrapped:${PHRASE}`);
   });
 
   it('leaves an undecryptable row alone when this device has no vault copy', async () => {
-    const deps = makeDeps({ getWrappedFromRow: async () => 'garbage-not-wrapped' });
-    await expect(reconcilePhraseCore(deps)).resolves.toBe('noop');
-    expect(deps.setWrappedInRow).not.toHaveBeenCalled();
+    const deps = makeDeps({
+      getRowPhrase: async () => ({ wrapped: 'garbage-not-wrapped', updatedAt: '2026-07-10T10:00:00.000Z' })
+    });
+    await expect(reconcilePhraseCore(deps, PUBLISH)).resolves.toBe('noop');
+    expect(deps.setRowPhrase).not.toHaveBeenCalled();
     expect(deps.saveVaultPhrase).not.toHaveBeenCalled();
   });
 
   it('noops when row and vault already agree', async () => {
     const deps = makeDeps({
       loadVaultPhrase: async () => PHRASE,
-      getWrappedFromRow: async () => `wrapped:${PHRASE}`
+      getRowPhrase: async () => row(PHRASE)
     });
-    await expect(reconcilePhraseCore(deps)).resolves.toBe('noop');
+    await expect(reconcilePhraseCore(deps, PUBLISH)).resolves.toBe('noop');
     expect(deps.saveVaultPhrase).not.toHaveBeenCalled();
-    expect(deps.setWrappedInRow).not.toHaveBeenCalled();
+    expect(deps.setRowPhrase).not.toHaveBeenCalled();
+    expect(deps.notePhraseReplaced).not.toHaveBeenCalled();
   });
 
   it('noops when neither side has a phrase', async () => {
     const deps = makeDeps();
-    await expect(reconcilePhraseCore(deps)).resolves.toBe('noop');
+    await expect(reconcilePhraseCore(deps, PUBLISH)).resolves.toBe('noop');
   });
 });

--- a/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.ts
@@ -1,0 +1,149 @@
+/**
+ * Account-scoped recovery phrase: keeps the OS-vault copy (the runtime source
+ * the backup runner reads) in sync with a WRAPPED copy in the AppSettings row
+ * (`autoBackupPhraseWrapped` - the phrase encrypted under the master key).
+ *
+ * Why: the row rides the E2E synced settings bundle, so the wrapped copy
+ * reaches the server (as ciphertext it cannot read) and from there the user's
+ * other devices - and it survives logout, because logout only wipes this
+ * device. That makes the phrase ONE durable secret per account (the
+ * wrapped-recovery-secret pattern used by Ente/Bitwarden), instead of a new
+ * phrase per device per enable. The paper copy remains the only
+ * disaster-recovery path - this sync is a convenience for logged-in installs,
+ * never a substitute for the recovery kit.
+ *
+ * Zero-Knowledge: the phrase is NEVER stored plaintext outside the OS vault.
+ * In the row it is its own AES-GCM ciphertext; in transport it is additionally
+ * inside the encrypted settings bundle. No new server exposure: decrypting it
+ * requires the master key, which already decrypts everything.
+ *
+ * Reconcile rules (row = synced truth, vault = device runtime copy):
+ *   - row present, vault differs → vault := row (hydration after login on a
+ *     fresh/wiped device; also propagates a rotation done on another device)
+ *   - row absent, vault present → row := wrap(vault) (migration: publishes the
+ *     phrase of installs that predate account scoping; also self-heals after a
+ *     settings reset dropped the field)
+ *   - row undecryptable, vault present → row := wrap(vault) (a corrupt value
+ *     cannot be someone's good rotation - AES-GCM authenticates)
+ *
+ * Local-only mode has no server sync, but the row copy still matters: the
+ * local→account upgrade adopts the local master key, so after upgrading the
+ * wrapped copy bootstrap-pushes as-is and the phrase becomes account-scoped.
+ */
+
+import { cryptoManager } from '@reborn/crypto';
+import { createLogger } from '@reborn/utils';
+
+const logger = createLogger('Notes-AutoBackup-PhraseSync');
+
+/** What a reconcile pass did - returned for tests and debug logging. */
+export type PhraseReconcileAction =
+  | 'hydrated-vault'
+  | 'published-row'
+  | 'republished-row'
+  | 'noop';
+
+/**
+ * Injected I/O so the decision logic is testable under vitest, where
+ * `__REBORN_NATIVE__` is compile-time false and the real vault is dead code.
+ */
+export interface PhraseSyncDeps {
+  loadVaultPhrase(): Promise<string | null>;
+  saveVaultPhrase(phrase: string): Promise<void>;
+  /** Current `autoBackupPhraseWrapped` from the AppSettings row (null = absent/no row). */
+  getWrappedFromRow(): Promise<string | null>;
+  /** Write `autoBackupPhraseWrapped` to the row AND schedule the synced-settings push. */
+  setWrappedInRow(wrapped: string): Promise<void>;
+  wrap(phrase: string): Promise<string>;
+  /** Must reject on tamper/garbage (AES-GCM auth failure). */
+  unwrap(wrapped: string): Promise<string>;
+}
+
+/** Pure reconcile core - see the module doc for the rule table. */
+export async function reconcilePhraseCore(deps: PhraseSyncDeps): Promise<PhraseReconcileAction> {
+  const [wrapped, vaultPhrase] = await Promise.all([
+    deps.getWrappedFromRow(),
+    deps.loadVaultPhrase()
+  ]);
+
+  if (wrapped) {
+    let rowPhrase: string;
+    try {
+      rowPhrase = await deps.unwrap(wrapped);
+    } catch {
+      // Authenticated decryption failed - the row value is garbage, not a
+      // rotation we could be clobbering. Re-publish the vault copy if we have
+      // one; otherwise leave the corrupt value for a device that does.
+      if (!vaultPhrase) return 'noop';
+      await deps.setWrappedInRow(await deps.wrap(vaultPhrase));
+      return 'republished-row';
+    }
+    if (!rowPhrase || rowPhrase === vaultPhrase) return 'noop';
+    await deps.saveVaultPhrase(rowPhrase);
+    return 'hydrated-vault';
+  }
+
+  if (vaultPhrase) {
+    await deps.setWrappedInRow(await deps.wrap(vaultPhrase));
+    return 'published-row';
+  }
+
+  return 'noop';
+}
+
+/**
+ * Reconcile the vault with the synced row on this device. Native-only (web has
+ * no vault and no auto-backup) and requires the master key for wrap/unwrap.
+ * Never throws - a failed reconcile must not break the backup run or the
+ * settings page; the next trigger retries.
+ */
+export async function reconcileRecoveryPhrase(): Promise<PhraseReconcileAction> {
+  if (!__REBORN_NATIVE__) return 'noop';
+  if (!cryptoManager.isInitialized()) return 'noop';
+  try {
+    const action = await reconcilePhraseCore(await nativeDeps());
+    if (action !== 'noop') logger.info('Recovery phrase reconciled:', action);
+    return action;
+  } catch (err) {
+    logger.warn('Recovery phrase reconcile failed:', err);
+    return 'noop';
+  }
+}
+
+/**
+ * Store a NEWLY confirmed phrase everywhere at once: OS vault (runtime copy)
+ * plus the wrapped row copy (account scope). Used by the settings page after
+ * the user confirms they wrote the phrase down. Vault write errors propagate
+ * (the enable flow must warn the user - see saveRecoveryPhrase); a failed row
+ * publish is only logged, because the next reconcile pass republishes it.
+ */
+export async function storeRecoveryPhrase(phrase: string): Promise<void> {
+  if (!__REBORN_NATIVE__) return;
+  const { saveRecoveryPhrase } = await import('./recovery-phrase-vault');
+  await saveRecoveryPhrase(phrase);
+  try {
+    const deps = await nativeDeps();
+    await deps.setWrappedInRow(await deps.wrap(phrase));
+  } catch (err) {
+    logger.warn('Publishing the wrapped phrase to synced settings failed:', err);
+  }
+}
+
+/** Real I/O wiring. Lazy store imports keep this module cheap to load on web. */
+async function nativeDeps(): Promise<PhraseSyncDeps> {
+  const [{ loadRecoveryPhrase, saveRecoveryPhrase }, { appSettings }] = await Promise.all([
+    import('./recovery-phrase-vault'),
+    import('$lib/stores/app-settings.store')
+  ]);
+  const { getSettings } = await import('$lib/utils/app-settings');
+  return {
+    loadVaultPhrase: loadRecoveryPhrase,
+    saveVaultPhrase: saveRecoveryPhrase,
+    getWrappedFromRow: async () => (await getSettings())?.autoBackupPhraseWrapped ?? null,
+    // appSettings.update writes IDB, refreshes the store and schedules the
+    // debounced synced-settings push - the same path every other setting uses.
+    setWrappedInRow: (wrapped) => appSettings.update('autoBackupPhraseWrapped', wrapped),
+    wrap: (phrase) => cryptoManager.encryptText(phrase),
+    unwrap: (wrapped) => cryptoManager.decryptText(wrapped)
+  };
+}

--- a/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/phrase-sync.ts
@@ -1,7 +1,8 @@
 /**
  * Account-scoped recovery phrase: keeps the OS-vault copy (the runtime source
  * the backup runner reads) in sync with a WRAPPED copy in the AppSettings row
- * (`autoBackupPhraseWrapped` - the phrase encrypted under the master key).
+ * (`autoBackupPhrase` - the phrase encrypted under the master key, plus its
+ * own freshness stamp).
  *
  * Why: the row rides the E2E synced settings bundle, so the wrapped copy
  * reaches the server (as ciphertext it cannot read) and from there the user's
@@ -17,14 +18,27 @@
  * inside the encrypted settings bundle. No new server exposure: decrypting it
  * requires the master key, which already decrypts everything.
  *
- * Reconcile rules (row = synced truth, vault = device runtime copy):
- *   - row present, vault differs → vault := row (hydration after login on a
- *     fresh/wiped device; also propagates a rotation done on another device)
- *   - row absent, vault present → row := wrap(vault) (migration: publishes the
- *     phrase of installs that predate account scoping; also self-heals after a
- *     settings reset dropped the field)
- *   - row undecryptable, vault present → row := wrap(vault) (a corrupt value
- *     cannot be someone's good rotation - AES-GCM authenticates)
+ * Conflict safety (settings sync is whole-row last-write-wins, which the
+ * phrase must not inherit - a stale device pushing an unrelated setting would
+ * otherwise revert the account's newest phrase and silently make every backup
+ * taken since undecryptable with the phrase the user wrote down):
+ *   - the row copy carries its own `updatedAt`; bundle merge and pull-repair
+ *     are newest-wins on that stamp (settings-bundle / synced-settings),
+ *   - publishing a vault-only phrase to the row is gated on a DEFINITIVE
+ *     server view this session (`markSettingsPullSucceeded`, or local-only
+ *     mode where no server exists) - never on "the field is absent locally",
+ *     which is indistinguishable from "the pull failed",
+ *   - when hydration REPLACES a non-empty vault phrase, a notice flag is set
+ *     for the backup settings page: the user must re-view and re-record the
+ *     now-current phrase instead of trusting a stale written kit.
+ *
+ * Reconcile rules (row = newest known after pull-merge, vault = device copy):
+ *   - row present, vault empty   → hydrate vault (fresh login / wiped device)
+ *   - row present, vault differs → replace vault + set the notice flag
+ *   - row absent, vault present  → publish wrap(vault) IF publishing allowed
+ *     (migration of pre-scoping installs; self-heal after a settings reset)
+ *   - row undecryptable          → republish from vault (GCM auth failure
+ *     cannot be someone's good rotation), or noop with no vault copy
  *
  * Local-only mode has no server sync, but the row copy still matters: the
  * local→account upgrade adopts the local master key, so after upgrading the
@@ -39,9 +53,22 @@ const logger = createLogger('Notes-AutoBackup-PhraseSync');
 /** What a reconcile pass did - returned for tests and debug logging. */
 export type PhraseReconcileAction =
   | 'hydrated-vault'
+  | 'replaced-vault'
   | 'published-row'
   | 'republished-row'
   | 'noop';
+
+/**
+ * One-shot per JS context: flips true once a settings pull obtained a
+ * definitive server view (see `fetched` in SyncedSettingsService.pullAndMerge).
+ * Gates the publish branch - see the module doc's conflict-safety notes.
+ */
+let settingsPullSucceeded = false;
+
+/** Called from the root layout after a pull that definitively saw the server. */
+export function markSettingsPullSucceeded(): void {
+  settingsPullSucceeded = true;
+}
 
 /**
  * Injected I/O so the decision logic is testable under vitest, where
@@ -50,41 +77,56 @@ export type PhraseReconcileAction =
 export interface PhraseSyncDeps {
   loadVaultPhrase(): Promise<string | null>;
   saveVaultPhrase(phrase: string): Promise<void>;
-  /** Current `autoBackupPhraseWrapped` from the AppSettings row (null = absent/no row). */
-  getWrappedFromRow(): Promise<string | null>;
-  /** Write `autoBackupPhraseWrapped` to the row AND schedule the synced-settings push. */
-  setWrappedInRow(wrapped: string): Promise<void>;
+  /** Current `autoBackupPhrase` from the AppSettings row (null = absent/no row). */
+  getRowPhrase(): Promise<{ wrapped: string; updatedAt: string } | null>;
+  /**
+   * Write `autoBackupPhrase` to the row (stamping a fresh `updatedAt`) AND
+   * schedule the synced-settings push.
+   */
+  setRowPhrase(wrapped: string): Promise<void>;
   wrap(phrase: string): Promise<string>;
   /** Must reject on tamper/garbage (AES-GCM auth failure). */
   unwrap(wrapped: string): Promise<string>;
+  /** Flag the settings page: the vault phrase was replaced from the account. */
+  notePhraseReplaced(): void;
 }
 
 /** Pure reconcile core - see the module doc for the rule table. */
-export async function reconcilePhraseCore(deps: PhraseSyncDeps): Promise<PhraseReconcileAction> {
-  const [wrapped, vaultPhrase] = await Promise.all([
-    deps.getWrappedFromRow(),
+export async function reconcilePhraseCore(
+  deps: PhraseSyncDeps,
+  opts: { allowPublish: boolean }
+): Promise<PhraseReconcileAction> {
+  const [rowPhrase, vaultPhrase] = await Promise.all([
+    deps.getRowPhrase(),
     deps.loadVaultPhrase()
   ]);
 
-  if (wrapped) {
-    let rowPhrase: string;
+  if (rowPhrase) {
+    let phrase: string;
     try {
-      rowPhrase = await deps.unwrap(wrapped);
+      phrase = await deps.unwrap(rowPhrase.wrapped);
     } catch {
       // Authenticated decryption failed - the row value is garbage, not a
       // rotation we could be clobbering. Re-publish the vault copy if we have
       // one; otherwise leave the corrupt value for a device that does.
       if (!vaultPhrase) return 'noop';
-      await deps.setWrappedInRow(await deps.wrap(vaultPhrase));
+      await deps.setRowPhrase(await deps.wrap(vaultPhrase));
       return 'republished-row';
     }
-    if (!rowPhrase || rowPhrase === vaultPhrase) return 'noop';
-    await deps.saveVaultPhrase(rowPhrase);
+    if (!phrase || phrase === vaultPhrase) return 'noop';
+    await deps.saveVaultPhrase(phrase);
+    if (vaultPhrase) {
+      // The device held a DIFFERENT phrase: backups already in its folder
+      // stay decryptable with the old one, but everything from now on uses
+      // the account phrase - the user must re-view and re-record it.
+      deps.notePhraseReplaced();
+      return 'replaced-vault';
+    }
     return 'hydrated-vault';
   }
 
-  if (vaultPhrase) {
-    await deps.setWrappedInRow(await deps.wrap(vaultPhrase));
+  if (vaultPhrase && opts.allowPublish) {
+    await deps.setRowPhrase(await deps.wrap(vaultPhrase));
     return 'published-row';
   }
 
@@ -101,7 +143,12 @@ export async function reconcileRecoveryPhrase(): Promise<PhraseReconcileAction> 
   if (!__REBORN_NATIVE__) return 'noop';
   if (!cryptoManager.isInitialized()) return 'noop';
   try {
-    const action = await reconcilePhraseCore(await nativeDeps());
+    // Publishing is safe when this session definitively saw the server state,
+    // or in local-only mode where the row never leaves the device.
+    const { localOnly } = await import('$lib/stores/sync-status.store');
+    const { get } = await import('svelte/store');
+    const allowPublish = get(localOnly) || settingsPullSucceeded;
+    const action = await reconcilePhraseCore(await nativeDeps(), { allowPublish });
     if (action !== 'noop') logger.info('Recovery phrase reconciled:', action);
     return action;
   } catch (err) {
@@ -113,9 +160,11 @@ export async function reconcileRecoveryPhrase(): Promise<PhraseReconcileAction> 
 /**
  * Store a NEWLY confirmed phrase everywhere at once: OS vault (runtime copy)
  * plus the wrapped row copy (account scope). Used by the settings page after
- * the user confirms they wrote the phrase down. Vault write errors propagate
- * (the enable flow must warn the user - see saveRecoveryPhrase); a failed row
- * publish is only logged, because the next reconcile pass republishes it.
+ * the user confirms they wrote the phrase down - an explicit user action, so
+ * it publishes unconditionally (this IS the newest phrase by definition).
+ * Vault write errors propagate (the enable flow must warn the user - see
+ * saveRecoveryPhrase); a failed row publish is only logged, because the next
+ * reconcile pass republishes it.
  */
 export async function storeRecoveryPhrase(phrase: string): Promise<void> {
   if (!__REBORN_NATIVE__) return;
@@ -123,7 +172,7 @@ export async function storeRecoveryPhrase(phrase: string): Promise<void> {
   await saveRecoveryPhrase(phrase);
   try {
     const deps = await nativeDeps();
-    await deps.setWrappedInRow(await deps.wrap(phrase));
+    await deps.setRowPhrase(await deps.wrap(phrase));
   } catch (err) {
     logger.warn('Publishing the wrapped phrase to synced settings failed:', err);
   }
@@ -136,14 +185,20 @@ async function nativeDeps(): Promise<PhraseSyncDeps> {
     import('$lib/stores/app-settings.store')
   ]);
   const { getSettings } = await import('$lib/utils/app-settings');
+  const { setPhraseChangedNotice } = await import('./prefs');
   return {
     loadVaultPhrase: loadRecoveryPhrase,
     saveVaultPhrase: saveRecoveryPhrase,
-    getWrappedFromRow: async () => (await getSettings())?.autoBackupPhraseWrapped ?? null,
+    getRowPhrase: async () => (await getSettings())?.autoBackupPhrase ?? null,
     // appSettings.update writes IDB, refreshes the store and schedules the
     // debounced synced-settings push - the same path every other setting uses.
-    setWrappedInRow: (wrapped) => appSettings.update('autoBackupPhraseWrapped', wrapped),
+    setRowPhrase: (wrapped) =>
+      appSettings.update('autoBackupPhrase', {
+        wrapped,
+        updatedAt: new Date().toISOString()
+      }),
     wrap: (phrase) => cryptoManager.encryptText(phrase),
-    unwrap: (wrapped) => cryptoManager.decryptText(wrapped)
+    unwrap: (wrapped) => cryptoManager.decryptText(wrapped),
+    notePhraseReplaced: () => setPhraseChangedNotice()
   };
 }

--- a/apps/reborn-notes/src/lib/services/auto-backup/prefs.spec.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/prefs.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the scope-migration helper used by the local→account upgrade:
+ * config/state entries must move from the local pseudo user id to the account
+ * id (so the upgraded account keeps its backup setup), never overwrite an
+ * existing target entry, and always vacate the dead source scope.
+ */
+import { describe, expect, it } from 'vitest';
+import { migrateAutoBackupPrefsScope, type KeyValueStore } from './prefs';
+
+const LOCAL_ID = 'local-uuid';
+const ACCOUNT_ID = 'account-uuid';
+const configKey = (scope: string) => `reborn-notes:autoBackup:config:${scope}`;
+const stateKey = (scope: string) => `reborn-notes:autoBackup:state:${scope}`;
+
+function memoryStore(seed: Record<string, string> = {}): KeyValueStore & {
+  dump(): Record<string, string>;
+} {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+    dump: () => Object.fromEntries(map)
+  };
+}
+
+describe('migrateAutoBackupPrefsScope', () => {
+  it('moves config and state from the local scope to the account scope', () => {
+    const store = memoryStore({
+      [configKey(LOCAL_ID)]: '{"enabled":true,"folderBookmark":"tree-uri"}',
+      [stateKey(LOCAL_ID)]: '{"lastBackupAt":123,"lastError":null}'
+    });
+    migrateAutoBackupPrefsScope(LOCAL_ID, ACCOUNT_ID, store);
+    expect(store.dump()).toEqual({
+      [configKey(ACCOUNT_ID)]: '{"enabled":true,"folderBookmark":"tree-uri"}',
+      [stateKey(ACCOUNT_ID)]: '{"lastBackupAt":123,"lastError":null}'
+    });
+  });
+
+  it('never overwrites an existing target entry, but still vacates the source', () => {
+    const store = memoryStore({
+      [configKey(LOCAL_ID)]: '{"enabled":true}',
+      [configKey(ACCOUNT_ID)]: '{"enabled":false}'
+    });
+    migrateAutoBackupPrefsScope(LOCAL_ID, ACCOUNT_ID, store);
+    expect(store.dump()).toEqual({ [configKey(ACCOUNT_ID)]: '{"enabled":false}' });
+  });
+
+  it('noops when the source scope has no entries', () => {
+    const store = memoryStore({ 'unrelated-key': 'x' });
+    migrateAutoBackupPrefsScope(LOCAL_ID, ACCOUNT_ID, store);
+    expect(store.dump()).toEqual({ 'unrelated-key': 'x' });
+  });
+
+  it('noops when source and target scope are identical', () => {
+    const store = memoryStore({ [configKey(LOCAL_ID)]: '{"enabled":true}' });
+    migrateAutoBackupPrefsScope(LOCAL_ID, LOCAL_ID, store);
+    expect(store.dump()).toEqual({ [configKey(LOCAL_ID)]: '{"enabled":true}' });
+  });
+});

--- a/apps/reborn-notes/src/lib/services/auto-backup/prefs.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/prefs.ts
@@ -33,6 +33,7 @@ import {
 
 const CONFIG_KEY_PREFIX = 'reborn-notes:autoBackup:config';
 const STATE_KEY_PREFIX = 'reborn-notes:autoBackup:state';
+const PHRASE_NOTICE_KEY_PREFIX = 'reborn-notes:autoBackup:phraseChanged';
 
 // The shared cross-app session keys (duplicated string literals from
 // auth.store on purpose: they are a frozen cross-app storage contract, and
@@ -112,6 +113,34 @@ export function autoBackupScopeId(store = safeLocalStorage()): string | null {
 
 const configKey = (scopeId: string): string => `${CONFIG_KEY_PREFIX}:${scopeId}`;
 const stateKey = (scopeId: string): string => `${STATE_KEY_PREFIX}:${scopeId}`;
+const phraseNoticeKey = (scopeId: string): string => `${PHRASE_NOTICE_KEY_PREFIX}:${scopeId}`;
+
+/**
+ * Flag: phrase-sync replaced this device's vault phrase with a different one
+ * from the account (a rotation elsewhere, or the two-installs migration
+ * collision). The backup settings page shows a notice until the user re-views
+ * the current phrase - a silently swapped phrase must never go unnoticed,
+ * because a stale written kit stops matching every backup taken from now on.
+ */
+export function setPhraseChangedNotice(store = safeLocalStorage()): void {
+  const scopeId = autoBackupScopeId(store);
+  if (!scopeId) return;
+  store?.setItem(phraseNoticeKey(scopeId), '1');
+}
+
+/** Is the "phrase changed from the account" notice pending for this user? */
+export function hasPhraseChangedNotice(store = safeLocalStorage()): boolean {
+  const scopeId = autoBackupScopeId(store);
+  if (!scopeId) return false;
+  return store?.getItem(phraseNoticeKey(scopeId)) === '1';
+}
+
+/** Clear the notice - the user has re-viewed the current phrase. */
+export function clearPhraseChangedNotice(store = safeLocalStorage()): void {
+  const scopeId = autoBackupScopeId(store);
+  if (!scopeId) return;
+  store?.removeItem(phraseNoticeKey(scopeId));
+}
 
 /** Load the persisted config, merged over defaults. `store` is injectable for tests. */
 export function loadAutoBackupConfig(store = safeLocalStorage()): NotesAutoBackupConfig {
@@ -178,7 +207,7 @@ export function migrateAutoBackupPrefsScope(
   store = safeLocalStorage()
 ): void {
   if (!store || fromScopeId === toScopeId) return;
-  for (const keyFor of [configKey, stateKey]) {
+  for (const keyFor of [configKey, stateKey, phraseNoticeKey]) {
     const value = store.getItem(keyFor(fromScopeId));
     if (value !== null && store.getItem(keyFor(toScopeId)) === null) {
       store.setItem(keyFor(toScopeId), value);
@@ -200,6 +229,7 @@ export function clearAutoBackupPrefs(store = safeLocalStorage()): void {
   if (scopeId) {
     store.removeItem(configKey(scopeId));
     store.removeItem(stateKey(scopeId));
+    store.removeItem(phraseNoticeKey(scopeId));
   }
   // Legacy unscoped keys from builds before per-user scoping.
   store.removeItem(CONFIG_KEY_PREFIX);

--- a/apps/reborn-notes/src/lib/services/auto-backup/prefs.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/prefs.ts
@@ -162,6 +162,32 @@ export function saveAutoBackupState(state: AutoBackupState, store = safeLocalSto
 }
 
 /**
+ * Copy the config and state entries from one scope id to another. Used by the
+ * local→account upgrade: the upgrade flips `autoBackupScopeId()` from the
+ * local pseudo user id to the account id, which would orphan the local-only
+ * user's backup setup (folder bookmark, enabled flag, cadence state) under
+ * keys nothing reads any more. Same device, same human, same folder grant -
+ * carrying the setup over is safe and spares a full re-setup. The target
+ * scope is only written where it has no entry of its own (it never does in
+ * practice: logout wipes account-scoped entries), and the source entries are
+ * removed so nothing lingers under the dead scope.
+ */
+export function migrateAutoBackupPrefsScope(
+  fromScopeId: string,
+  toScopeId: string,
+  store = safeLocalStorage()
+): void {
+  if (!store || fromScopeId === toScopeId) return;
+  for (const keyFor of [configKey, stateKey]) {
+    const value = store.getItem(keyFor(fromScopeId));
+    if (value !== null && store.getItem(keyFor(toScopeId)) === null) {
+      store.setItem(keyFor(toScopeId), value);
+    }
+    store.removeItem(keyFor(fromScopeId));
+  }
+}
+
+/**
  * Remove the persisted config and state of the CURRENT user. Called on logout
  * and on the local-only wipe, while the session keys are still readable - the
  * next account on this device must not inherit this user's backup target.

--- a/apps/reborn-notes/src/lib/services/auto-backup/recovery-phrase-vault.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/recovery-phrase-vault.ts
@@ -60,6 +60,30 @@ export async function loadRecoveryPhrase(): Promise<string | null> {
 }
 
 /**
+ * Re-key the stored phrase from one scope id to another (local→account
+ * upgrade - see migrateAutoBackupPrefsScope for why). The target entry is
+ * never overwritten if it somehow exists; the source entry is removed either
+ * way. Best-effort: the phrase is also recoverable from the synced wrapped
+ * copy (phrase-sync), so a failed vault migration self-heals on reconcile.
+ */
+export async function migrateRecoveryPhraseScope(
+  fromScopeId: string,
+  toScopeId: string
+): Promise<void> {
+  if (!__REBORN_NATIVE__ || fromScopeId === toScopeId) return;
+  try {
+    const storage = await getSecureStorage();
+    const phrase = await storage.getItem(phraseKey(fromScopeId));
+    if (phrase !== null && (await storage.getItem(phraseKey(toScopeId))) === null) {
+      await storage.setItem(phraseKey(toScopeId), phrase);
+    }
+    await storage.removeItem(phraseKey(fromScopeId));
+  } catch {
+    // Best-effort - reconcile republishes/hydrates from the synced copy.
+  }
+}
+
+/**
  * Remove the current user's stored phrase (disabling backups / logout), plus
  * the legacy unscoped entry from builds before per-user scoping. Best-effort.
  */

--- a/apps/reborn-notes/src/lib/services/auto-backup/reminder.spec.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/reminder.spec.ts
@@ -2,6 +2,11 @@
  * Tests for the pure overdue-reminder planner. The native executor
  * (syncBackupReminders) is dead code under vitest (`__REBORN_NATIVE__` false),
  * so the decision logic lives in `planBackupReminders` and is pinned here.
+ *
+ * Invariant under test: a reminder exists ONLY while something is actually
+ * unbacked. `lastBackupAt` freezes when the data is unchanged (the runner's
+ * skip-if-unchanged gate), so planning from it alone would nag a read-only
+ * user one hour after every single open.
  */
 import { describe, expect, it } from 'vitest';
 import { BACKUP_REMINDER_IDS, planBackupReminders } from './reminder';
@@ -10,15 +15,15 @@ const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
 const NOW = 1_800_000_000_000;
 
+const base = { enabled: true, configured: true, intervalHours: 24, now: NOW };
+
 describe('planBackupReminders', () => {
   it('plans a nudge 2h past the cadence point and a follow-up ~a week later', () => {
     const lastBackupAt = NOW - 3 * HOUR;
     const plan = planBackupReminders({
-      enabled: true,
-      configured: true,
+      ...base,
       lastBackupAt,
-      intervalHours: 24,
-      now: NOW
+      lastDataChangeAt: NOW - HOUR
     });
     expect(plan).toEqual([
       { id: BACKUP_REMINDER_IDS[0], at: lastBackupAt + 26 * HOUR },
@@ -28,11 +33,9 @@ describe('planBackupReminders', () => {
 
   it('clamps to a 1h minimum lead when the backup is already overdue', () => {
     const plan = planBackupReminders({
-      enabled: true,
-      configured: true,
+      ...base,
       lastBackupAt: NOW - 10 * DAY,
-      intervalHours: 24,
-      now: NOW
+      lastDataChangeAt: NOW - 5 * DAY
     });
     expect(plan[0].at).toBe(NOW + HOUR);
     expect(plan[1].at).toBe(NOW + HOUR + 6 * DAY);
@@ -40,18 +43,38 @@ describe('planBackupReminders', () => {
 
   it('measures from now when no backup has run yet', () => {
     const plan = planBackupReminders({
-      enabled: true,
-      configured: true,
+      ...base,
       lastBackupAt: null,
-      intervalHours: 24,
-      now: NOW
+      lastDataChangeAt: NOW - HOUR
     });
     expect(plan[0].at).toBe(NOW + 26 * HOUR);
   });
 
+  it('plans nothing while the data is fully backed up (read-only usage must not nag)', () => {
+    // lastBackupAt frozen for days because nothing changed - the exact state
+    // a read-only user is in on every open.
+    expect(
+      planBackupReminders({
+        ...base,
+        lastBackupAt: NOW - 10 * DAY,
+        lastDataChangeAt: NOW - 12 * DAY
+      })
+    ).toEqual([]);
+    // Equal timestamps count as covered too.
+    expect(
+      planBackupReminders({ ...base, lastBackupAt: NOW - DAY, lastDataChangeAt: NOW - DAY })
+    ).toEqual([]);
+  });
+
+  it('plans nothing when there is no data at all', () => {
+    expect(planBackupReminders({ ...base, lastBackupAt: null, lastDataChangeAt: null })).toEqual(
+      []
+    );
+  });
+
   it('plans nothing when disabled or not configured', () => {
-    const base = { lastBackupAt: NOW, intervalHours: 24, now: NOW };
-    expect(planBackupReminders({ enabled: false, configured: true, ...base })).toEqual([]);
-    expect(planBackupReminders({ enabled: true, configured: false, ...base })).toEqual([]);
+    const args = { lastBackupAt: NOW - 2 * DAY, lastDataChangeAt: NOW, intervalHours: 24, now: NOW };
+    expect(planBackupReminders({ enabled: false, configured: true, ...args })).toEqual([]);
+    expect(planBackupReminders({ enabled: true, configured: false, ...args })).toEqual([]);
   });
 });

--- a/apps/reborn-notes/src/lib/services/auto-backup/reminder.spec.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/reminder.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the pure overdue-reminder planner. The native executor
+ * (syncBackupReminders) is dead code under vitest (`__REBORN_NATIVE__` false),
+ * so the decision logic lives in `planBackupReminders` and is pinned here.
+ */
+import { describe, expect, it } from 'vitest';
+import { BACKUP_REMINDER_IDS, planBackupReminders } from './reminder';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const NOW = 1_800_000_000_000;
+
+describe('planBackupReminders', () => {
+  it('plans a nudge 2h past the cadence point and a follow-up ~a week later', () => {
+    const lastBackupAt = NOW - 3 * HOUR;
+    const plan = planBackupReminders({
+      enabled: true,
+      configured: true,
+      lastBackupAt,
+      intervalHours: 24,
+      now: NOW
+    });
+    expect(plan).toEqual([
+      { id: BACKUP_REMINDER_IDS[0], at: lastBackupAt + 26 * HOUR },
+      { id: BACKUP_REMINDER_IDS[1], at: lastBackupAt + 26 * HOUR + 6 * DAY }
+    ]);
+  });
+
+  it('clamps to a 1h minimum lead when the backup is already overdue', () => {
+    const plan = planBackupReminders({
+      enabled: true,
+      configured: true,
+      lastBackupAt: NOW - 10 * DAY,
+      intervalHours: 24,
+      now: NOW
+    });
+    expect(plan[0].at).toBe(NOW + HOUR);
+    expect(plan[1].at).toBe(NOW + HOUR + 6 * DAY);
+  });
+
+  it('measures from now when no backup has run yet', () => {
+    const plan = planBackupReminders({
+      enabled: true,
+      configured: true,
+      lastBackupAt: null,
+      intervalHours: 24,
+      now: NOW
+    });
+    expect(plan[0].at).toBe(NOW + 26 * HOUR);
+  });
+
+  it('plans nothing when disabled or not configured', () => {
+    const base = { lastBackupAt: NOW, intervalHours: 24, now: NOW };
+    expect(planBackupReminders({ enabled: false, configured: true, ...base })).toEqual([]);
+    expect(planBackupReminders({ enabled: true, configured: false, ...base })).toEqual([]);
+  });
+});

--- a/apps/reborn-notes/src/lib/services/auto-backup/reminder.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/reminder.ts
@@ -7,10 +7,14 @@
  * uses on iOS (a scheduled "open the app" notification, not background work).
  *
  * Mechanics: after every backup run (and every toggle change) the pending
- * reminders are re-planned from `lastBackupAt` - one nudge ~2h past the due
- * point and a second one ~a week later for long absences. Opening the app
- * reruns the backup, which reschedules both into the future, so as long as
- * the user opens the app roughly daily no notification ever fires.
+ * reminders are re-planned - one nudge ~2h past the due point and a second
+ * one ~a week later for long absences. A reminder is only planned while
+ * there is actually something unbacked (`lastDataChangeAt` newer than
+ * `lastBackupAt`): the skip-if-unchanged gate freezes `lastBackupAt` for a
+ * user who merely READS notes, and nagging them to open an app that would
+ * then do nothing is noise. Any future data change necessarily happens with
+ * the app open, which reruns the backup and re-plans - so no reminder is
+ * ever missed by cancelling here.
  *
  * Zero-Knowledge: the notification carries only static localized copy -
  * never note data, filenames or timestamps derived from content.
@@ -54,10 +58,19 @@ export function planBackupReminders(args: {
   /** A write destination exists (folder picked). */
   configured: boolean;
   lastBackupAt: number | null;
+  /** Newest data change (the backup watermark); null = no data at all. */
+  lastDataChangeAt: number | null;
   intervalHours: number;
   now: number;
 }): BackupReminderPlan[] {
   if (!args.enabled || !args.configured) return [];
+  // Remind only while something is actually unbacked. With no data there is
+  // nothing to back up; with lastBackupAt covering the newest change, the
+  // next change happens in-app and re-plans - see the module doc.
+  const unbacked =
+    args.lastDataChangeAt !== null &&
+    (args.lastBackupAt === null || args.lastDataChangeAt > args.lastBackupAt);
+  if (!unbacked) return [];
   // No backup yet: measure from now - the first run happens on this very
   // open, and if it fails the next successful run resets the clock anyway.
   const base = args.lastBackupAt ?? args.now;
@@ -79,11 +92,14 @@ export async function syncBackupReminders(): Promise<void> {
   try {
     const config = loadAutoBackupConfig();
     const state = loadAutoBackupState();
+    const { getLastDataChangeAt } = await import('./watermark');
+    const lastDataChangeAt = await getLastDataChangeAt();
     const plan = planBackupReminders({
       enabled: config.enabled,
       configured: Boolean(config.folderBookmark),
-      // AutoBackupState keeps an ISO string; the planner works in epoch ms.
+      // State/watermark keep ISO strings; the planner works in epoch ms.
       lastBackupAt: state.lastBackupAt ? Date.parse(state.lastBackupAt) : null,
+      lastDataChangeAt: lastDataChangeAt ? Date.parse(lastDataChangeAt) : null,
       intervalHours: config.intervalHours,
       now: Date.now()
     });

--- a/apps/reborn-notes/src/lib/services/auto-backup/reminder.ts
+++ b/apps/reborn-notes/src/lib/services/auto-backup/reminder.ts
@@ -1,0 +1,152 @@
+/**
+ * Overdue-backup reminder: a local notification nudging the user to open the
+ * app when an automatic backup could not run for too long. Backups execute
+ * only on app open/resume (guideline 71 - true background execution is not
+ * viable in a Capacitor WebView), so a user who stops opening the app silently
+ * stops getting backups; this is the mitigation, same pattern Proton Drive
+ * uses on iOS (a scheduled "open the app" notification, not background work).
+ *
+ * Mechanics: after every backup run (and every toggle change) the pending
+ * reminders are re-planned from `lastBackupAt` - one nudge ~2h past the due
+ * point and a second one ~a week later for long absences. Opening the app
+ * reruns the backup, which reschedules both into the future, so as long as
+ * the user opens the app roughly daily no notification ever fires.
+ *
+ * Zero-Knowledge: the notification carries only static localized copy -
+ * never note data, filenames or timestamps derived from content.
+ *
+ * Best-effort by design: requires OS notification permission (requested from
+ * the settings page when enabling); on Android 12+ exact alarms are NOT
+ * requested - the plugin transparently falls back to inexact scheduling,
+ * which is plenty for a "sometime after it became overdue" nudge.
+ */
+
+import { createLogger } from '@reborn/utils';
+import { loadAutoBackupConfig, loadAutoBackupState } from './prefs';
+
+const logger = createLogger('Notes-AutoBackup-Reminder');
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Fixed notification ids so re-planning replaces instead of accumulating. */
+export const BACKUP_REMINDER_IDS = [841_001, 841_002] as const;
+
+/** How long past the cadence point a backup counts as overdue. */
+const OVERDUE_GRACE_MS = 2 * HOUR_MS;
+/** Minimum lead so a reminder never fires right under the user's fingers. */
+const MIN_LEAD_MS = 1 * HOUR_MS;
+/** Gap between the first nudge and the long-absence follow-up. */
+const FOLLOW_UP_GAP_MS = 6 * DAY_MS;
+
+export interface BackupReminderPlan {
+  id: number;
+  /** Epoch ms to fire at. */
+  at: number;
+}
+
+/**
+ * Pure scheduling decision (testable under vitest, where the native executor
+ * below is dead code): [] = nothing to remind about, cancel any pending.
+ */
+export function planBackupReminders(args: {
+  enabled: boolean;
+  /** A write destination exists (folder picked). */
+  configured: boolean;
+  lastBackupAt: number | null;
+  intervalHours: number;
+  now: number;
+}): BackupReminderPlan[] {
+  if (!args.enabled || !args.configured) return [];
+  // No backup yet: measure from now - the first run happens on this very
+  // open, and if it fails the next successful run resets the clock anyway.
+  const base = args.lastBackupAt ?? args.now;
+  const overdueAt = base + args.intervalHours * HOUR_MS + OVERDUE_GRACE_MS;
+  const first = Math.max(overdueAt, args.now + MIN_LEAD_MS);
+  return [
+    { id: BACKUP_REMINDER_IDS[0], at: first },
+    { id: BACKUP_REMINDER_IDS[1], at: first + FOLLOW_UP_GAP_MS }
+  ];
+}
+
+/**
+ * Re-plan the pending reminders from the current config/state. Cancel-then-
+ * schedule with fixed ids keeps this idempotent - safe to fire after every
+ * backup run. Never throws; missing permission just means no reminders.
+ */
+export async function syncBackupReminders(): Promise<void> {
+  if (!__REBORN_NATIVE__) return;
+  try {
+    const config = loadAutoBackupConfig();
+    const state = loadAutoBackupState();
+    const plan = planBackupReminders({
+      enabled: config.enabled,
+      configured: Boolean(config.folderBookmark),
+      // AutoBackupState keeps an ISO string; the planner works in epoch ms.
+      lastBackupAt: state.lastBackupAt ? Date.parse(state.lastBackupAt) : null,
+      intervalHours: config.intervalHours,
+      now: Date.now()
+    });
+
+    const { LocalNotifications } = await import('@capacitor/local-notifications');
+    await LocalNotifications.cancel({
+      notifications: BACKUP_REMINDER_IDS.map((id) => ({ id }))
+    });
+    if (plan.length === 0) return;
+
+    const { display } = await LocalNotifications.checkPermissions();
+    if (display !== 'granted') return;
+
+    // Static localized copy resolved at schedule time (post-unlock, locale
+    // loaded) - the export-import.service pattern for i18n outside components.
+    const [{ t }, { get }] = await Promise.all([
+      import('$lib/stores/i18n.store'),
+      import('svelte/store')
+    ]);
+    const tFn = get(t);
+    await LocalNotifications.schedule({
+      notifications: plan.map((p) => ({
+        id: p.id,
+        title: tFn('settings_page.backup.reminder_title'),
+        body: tFn('settings_page.backup.reminder_body'),
+        schedule: { at: new Date(p.at), allowWhileIdle: true }
+      }))
+    });
+  } catch (err) {
+    logger.warn('Failed to (re)schedule backup reminders:', err);
+  }
+}
+
+/** Drop any pending reminders (backup disabled here / logout wipe). */
+export async function cancelBackupReminders(): Promise<void> {
+  if (!__REBORN_NATIVE__) return;
+  try {
+    const { LocalNotifications } = await import('@capacitor/local-notifications');
+    await LocalNotifications.cancel({
+      notifications: BACKUP_REMINDER_IDS.map((id) => ({ id }))
+    });
+  } catch (err) {
+    logger.warn('Failed to cancel backup reminders:', err);
+  }
+}
+
+/**
+ * Ensure the OS notification permission, prompting if still undecided.
+ * Called from the settings page when the user enables auto-backup - the one
+ * moment the prompt has obvious context. Returns whether reminders can fire;
+ * a denial is fine (backups themselves are unaffected).
+ */
+export async function ensureReminderPermission(): Promise<boolean> {
+  if (!__REBORN_NATIVE__) return false;
+  try {
+    const { LocalNotifications } = await import('@capacitor/local-notifications');
+    const current = await LocalNotifications.checkPermissions();
+    if (current.display === 'granted') return true;
+    if (current.display === 'denied') return false;
+    const requested = await LocalNotifications.requestPermissions();
+    return requested.display === 'granted';
+  } catch (err) {
+    logger.warn('Notification permission check failed:', err);
+    return false;
+  }
+}

--- a/apps/reborn-notes/src/routes/+layout.svelte
+++ b/apps/reborn-notes/src/routes/+layout.svelte
@@ -194,8 +194,17 @@
       // just fail auth and log a warning). Local IDB stays the source of truth.
       if (!get(authStore).isLocalOnly) {
         try {
-          const { applied } = await syncedSettings.pullAndMerge();
+          const { applied, fetched } = await syncedSettings.pullAndMerge();
           if (applied) await appSettings.refresh();
+          if (fetched) {
+            // Definitive server view obtained - unlock the phrase-publish
+            // branch of the auto-backup reconcile (it must never publish on
+            // "field absent locally", which a failed pull also looks like).
+            const { markSettingsPullSucceeded } = await import(
+              '$lib/services/auto-backup/phrase-sync'
+            );
+            markSettingsPullSucceeded();
+          }
         } catch (err: unknown) {
           logger.warn('Synced settings pull on E2E unlock failed', err);
         }
@@ -397,7 +406,15 @@
       // device sees the user's preferences instead of IDB defaults.
       if (cryptoManager.isInitialized() && !$authStore.isLocalOnly) {
         try {
-          await syncedSettings.pullAndMerge();
+          const { fetched } = await syncedSettings.pullAndMerge();
+          if (fetched) {
+            // Same unlock-path signal as in runSync: a definitive server view
+            // permits the phrase-publish branch of the auto-backup reconcile.
+            const { markSettingsPullSucceeded } = await import(
+              '$lib/services/auto-backup/phrase-sync'
+            );
+            markSettingsPullSucceeded();
+          }
         } catch (err: unknown) {
           logger.warn('Synced settings pull failed - falling back to local IDB', err);
         }

--- a/apps/reborn-notes/src/routes/auth/register/+page.svelte
+++ b/apps/reborn-notes/src/routes/auth/register/+page.svelte
@@ -176,8 +176,18 @@
       master_key_salt: data.masterKeySalt ?? masterKeySalt,
       user_profile: data.user
     };
+    // Capture the local pseudo user id BEFORE the account credentials land:
+    // auto-backup artifacts (config/state/phrase) are keyed by it, and setting
+    // the credentials flips autoBackupScopeId() to the account id.
+    const localUserId = localStorage.getItem(LOCAL_USER_ID_KEY);
     localStorage.setItem(CREDENTIALS_KEY, JSON.stringify(credentials));
     localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
+    // Re-key the auto-backup setup (folder grant, enabled flag, phrase) from
+    // the local scope to the account scope - same device, same owner, so the
+    // upgraded account keeps its working backup instead of a silent reset.
+    // Best-effort inside; must not block the upgrade.
+    const { migrateAutoBackupScope } = await import('$lib/services/auto-backup');
+    await migrateAutoBackupScope(localUserId, data.user.id);
     // Native: persist the body-delivered refresh token to secure storage. The
     // local->account upgrade deliberately does NOT call loginInNotes (that would
     // clear the IndexedDB notes we are adopting), so it must replicate the token

--- a/apps/reborn-notes/src/routes/settings/backup/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/backup/+page.svelte
@@ -10,6 +10,7 @@
   } from '@reborn/ui';
   import { KeyRound, FolderOpen, AlertTriangle, Copy, Check, ShieldCheck } from '@lucide/svelte';
   import { t } from '$lib/stores/i18n.store';
+  import { localOnly } from '$lib/stores/sync-status.store';
   import { IS_NATIVE } from '$lib/utils/native-client';
   import { copyText } from '$lib/utils/clipboard';
   import { generateRecoveryPhrase } from '@reborn/crypto';
@@ -48,6 +49,11 @@
     if (!supported) return;
     cfg = loadAutoBackupConfig();
     bstate = loadAutoBackupState();
+    // Hydrate the vault from the account-scoped wrapped copy first, so a
+    // phrase enabled on another device (or before a logout) shows up as set
+    // here instead of prompting for a brand-new one. Never throws.
+    const { reconcileRecoveryPhrase } = await import('$lib/services/auto-backup/phrase-sync');
+    await reconcileRecoveryPhrase();
     const { loadRecoveryPhrase } = await import('$lib/services/auto-backup/recovery-phrase-vault');
     phraseSet = Boolean(await loadRecoveryPhrase());
   });
@@ -73,8 +79,10 @@
 
   async function confirmSaved() {
     if (!shownPhrase || !confirmChecked) return;
-    const { saveRecoveryPhrase } = await import('$lib/services/auto-backup/recovery-phrase-vault');
-    await saveRecoveryPhrase(shownPhrase);
+    // Writes the OS vault AND publishes the wrapped copy to synced settings,
+    // making the phrase account-scoped (survives logout, reaches other devices).
+    const { storeRecoveryPhrase } = await import('$lib/services/auto-backup/phrase-sync');
+    await storeRecoveryPhrase(shownPhrase);
     phraseSet = true;
     shownPhrase = null;
     phraseIsNew = false;
@@ -224,6 +232,11 @@
                   {$t('settings_page.backup.phrase_view_btn')}
                 </button>
               </div>
+              {#if !$localOnly}
+                <p class="text-xs text-muted-foreground/80">
+                  {$t('settings_page.backup.phrase_synced_hint')}
+                </p>
+              {/if}
             {:else}
               <button
                 type="button"

--- a/apps/reborn-notes/src/routes/settings/backup/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/backup/+page.svelte
@@ -23,12 +23,19 @@
     DEFAULT_NOTES_AUTO_BACKUP_CONFIG,
     type NotesAutoBackupConfig
   } from '$lib/services/auto-backup';
+  import {
+    hasPhraseChangedNotice,
+    clearPhraseChangedNotice
+  } from '$lib/services/auto-backup/prefs';
 
   const supported = IS_NATIVE;
 
   let cfg = $state<NotesAutoBackupConfig>({ ...DEFAULT_NOTES_AUTO_BACKUP_CONFIG });
   let bstate = $state<AutoBackupState>({ lastBackupAt: null, lastError: null });
   let phraseSet = $state(false);
+  // The vault phrase was replaced from the account (rotation on another
+  // device) - the user must re-view it so their written kit stays current.
+  let phraseChanged = $state(false);
 
   // The 12 words currently on screen (after generate, or while viewing). null = hidden.
   let shownPhrase = $state<string | null>(null);
@@ -56,6 +63,7 @@
     await reconcileRecoveryPhrase();
     const { loadRecoveryPhrase } = await import('$lib/services/auto-backup/recovery-phrase-vault');
     phraseSet = Boolean(await loadRecoveryPhrase());
+    phraseChanged = hasPhraseChangedNotice();
   });
 
   function generate() {
@@ -93,6 +101,12 @@
     const { loadRecoveryPhrase } = await import('$lib/services/auto-backup/recovery-phrase-vault');
     shownPhrase = await loadRecoveryPhrase();
     phraseIsNew = false;
+    // Viewing the current phrase resolves the "changed on another device"
+    // notice - the user can now bring their written kit up to date.
+    if (phraseChanged) {
+      clearPhraseChangedNotice();
+      phraseChanged = false;
+    }
   }
 
   function hidePhrase() {
@@ -164,6 +178,15 @@
               <h3 class="text-sm font-medium">{$t('settings_page.backup.phrase_heading')}</h3>
             </div>
             <p class="text-xs text-muted-foreground">{$t('settings_page.backup.phrase_intro')}</p>
+
+            {#if phraseChanged}
+              <div class="flex items-start gap-2 rounded-md border border-amber-400/50 bg-amber-500/10 px-3 py-2.5">
+                <AlertTriangle class="h-4 w-4 shrink-0 mt-0.5 text-amber-600 dark:text-amber-400" />
+                <p class="text-xs text-amber-700 dark:text-amber-400">
+                  {$t('settings_page.backup.phrase_updated_notice')}
+                </p>
+              </div>
+            {/if}
 
             {#if shownPhrase}
               <div class="space-y-3 rounded-lg border border-primary/40 bg-muted/30 p-4">

--- a/apps/reborn-notes/src/routes/settings/backup/+page.svelte
+++ b/apps/reborn-notes/src/routes/settings/backup/+page.svelte
@@ -109,10 +109,18 @@
     saveAutoBackupConfig(cfg);
   }
 
-  function toggleEnabled() {
+  async function toggleEnabled() {
     if (!cfg.enabled && !canEnable) return;
     cfg.enabled = !cfg.enabled;
     saveAutoBackupConfig(cfg);
+    // Overdue reminders follow the toggle. Enabling is the one moment the OS
+    // notification prompt has obvious context; a denial only mutes reminders,
+    // the backups themselves are unaffected.
+    const { ensureReminderPermission, syncBackupReminders } = await import(
+      '$lib/services/auto-backup/reminder'
+    );
+    if (cfg.enabled) await ensureReminderPermission();
+    await syncBackupReminders();
   }
 
   async function backupNow() {
@@ -301,6 +309,11 @@
             {#if !canEnable}
               <p class="text-xs text-muted-foreground/80 pl-6">
                 {$t('settings_page.backup.enable_requires')}
+              </p>
+            {/if}
+            {#if cfg.enabled}
+              <p class="text-xs text-muted-foreground/80 pl-6">
+                {$t('settings_page.backup.reminder_hint')}
               </p>
             {/if}
           </section>

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -931,6 +931,7 @@
       "phrase_view_btn": "Phrase erneut anzeigen",
       "phrase_hide_btn": "Ausblenden",
       "phrase_synced_hint": "Die Phrase wird verschlüsselt in Ihrem Konto gespeichert - sie synchronisiert sich mit Ihren anderen Geräten und bleibt nach dem Abmelden erhalten. Ihre schriftliche Kopie bleibt die einzige Rettung, wenn Sie den Zugriff auf Ihr Konto verlieren.",
+      "phrase_updated_notice": "Die Wiederherstellungsphrase wurde aus Ihrem Konto aktualisiert (auf einem anderen Gerät geändert). Sehen Sie sich die aktuelle Phrase an und aktualisieren Sie Ihre schriftliche Kopie - Sicherungen verwenden ab jetzt die neue Phrase.",
       "folder_heading": "Sicherungsordner",
       "folder_intro": "Wählen Sie, wo die verschlüsselten Sicherungsdateien gespeichert werden.",
       "folder_pick_btn": "Ordner wählen",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -930,6 +930,7 @@
       "phrase_set": "Wiederherstellungsphrase ist gesetzt.",
       "phrase_view_btn": "Phrase erneut anzeigen",
       "phrase_hide_btn": "Ausblenden",
+      "phrase_synced_hint": "Die Phrase wird verschlüsselt in Ihrem Konto gespeichert - sie synchronisiert sich mit Ihren anderen Geräten und bleibt nach dem Abmelden erhalten. Ihre schriftliche Kopie bleibt die einzige Rettung, wenn Sie den Zugriff auf Ihr Konto verlieren.",
       "folder_heading": "Sicherungsordner",
       "folder_intro": "Wählen Sie, wo die verschlüsselten Sicherungsdateien gespeichert werden.",
       "folder_pick_btn": "Ordner wählen",

--- a/packages/i18n/src/translations/notes/de.json
+++ b/packages/i18n/src/translations/notes/de.json
@@ -948,7 +948,10 @@
       "now_done": "Sicherung gespeichert.",
       "now_nothing": "Derzeit nichts zu sichern.",
       "now_failed": "Sicherung fehlgeschlagen: {error}",
-      "cadence_note": "Sicherungen laufen automatisch beim Öffnen der App, höchstens einmal täglich."
+      "cadence_note": "Sicherungen laufen automatisch beim Öffnen der App, höchstens einmal täglich.",
+      "reminder_title": "Automatische Sicherung fällig",
+      "reminder_body": "Öffnen Sie die App, um eine frische verschlüsselte Kopie Ihrer Notizen zu erstellen.",
+      "reminder_hint": "Wenn eine Sicherung überfällig ist, erinnert Sie eine Benachrichtigung daran, die App zu öffnen."
     },
     "export_import": {
       "title": "Export & Import",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -931,6 +931,7 @@
       "phrase_view_btn": "Show phrase again",
       "phrase_hide_btn": "Hide",
       "phrase_synced_hint": "The phrase is kept in your account in encrypted form - it syncs to your other devices and survives logging out. Your written copy remains the only recovery if you lose access to your account.",
+      "phrase_updated_notice": "The recovery phrase was updated from your account (changed on another device). View the current phrase and update your written copy - backups from now on use the new phrase.",
       "folder_heading": "Backup folder",
       "folder_intro": "Choose where the encrypted backup files are saved.",
       "folder_pick_btn": "Choose folder",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -930,6 +930,7 @@
       "phrase_set": "Recovery phrase is set.",
       "phrase_view_btn": "Show phrase again",
       "phrase_hide_btn": "Hide",
+      "phrase_synced_hint": "The phrase is kept in your account in encrypted form - it syncs to your other devices and survives logging out. Your written copy remains the only recovery if you lose access to your account.",
       "folder_heading": "Backup folder",
       "folder_intro": "Choose where the encrypted backup files are saved.",
       "folder_pick_btn": "Choose folder",

--- a/packages/i18n/src/translations/notes/en.json
+++ b/packages/i18n/src/translations/notes/en.json
@@ -948,7 +948,10 @@
       "now_done": "Backup saved.",
       "now_nothing": "Nothing to back up right now.",
       "now_failed": "Backup failed: {error}",
-      "cadence_note": "Backups run automatically when you open the app, at most once a day."
+      "cadence_note": "Backups run automatically when you open the app, at most once a day.",
+      "reminder_title": "Automatic backup is due",
+      "reminder_body": "Open the app to create a fresh encrypted copy of your notes.",
+      "reminder_hint": "If a backup becomes overdue, a notification will remind you to open the app."
     },
     "export_import": {
       "title": "Export & Import",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -931,6 +931,7 @@
       "phrase_view_btn": "Mostrar la frase de nuevo",
       "phrase_hide_btn": "Ocultar",
       "phrase_synced_hint": "La frase se guarda cifrada en su cuenta - se sincroniza con sus otros dispositivos y se conserva al cerrar sesión. Su copia escrita sigue siendo el único recurso si pierde el acceso a su cuenta.",
+      "phrase_updated_notice": "La frase de recuperación se actualizó desde su cuenta (se cambió en otro dispositivo). Vea la frase actual y actualice su copia escrita - las copias de seguridad usan a partir de ahora la nueva frase.",
       "folder_heading": "Carpeta de copias",
       "folder_intro": "Elija dónde se guardan los archivos de copia cifrados.",
       "folder_pick_btn": "Elegir carpeta",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -948,7 +948,10 @@
       "now_done": "Copia guardada.",
       "now_nothing": "No hay nada que copiar en este momento.",
       "now_failed": "Error al crear la copia: {error}",
-      "cadence_note": "Las copias se crean automáticamente al abrir la aplicación, como máximo una vez al día."
+      "cadence_note": "Las copias se crean automáticamente al abrir la aplicación, como máximo una vez al día.",
+      "reminder_title": "Copia de seguridad automática pendiente",
+      "reminder_body": "Abra la aplicación para crear una copia cifrada reciente de sus notas.",
+      "reminder_hint": "Si una copia queda pendiente, una notificación le recordará abrir la aplicación."
     },
     "export_import": {
       "title": "Exportar e importar",

--- a/packages/i18n/src/translations/notes/es.json
+++ b/packages/i18n/src/translations/notes/es.json
@@ -930,6 +930,7 @@
       "phrase_set": "La frase de recuperación está configurada.",
       "phrase_view_btn": "Mostrar la frase de nuevo",
       "phrase_hide_btn": "Ocultar",
+      "phrase_synced_hint": "La frase se guarda cifrada en su cuenta - se sincroniza con sus otros dispositivos y se conserva al cerrar sesión. Su copia escrita sigue siendo el único recurso si pierde el acceso a su cuenta.",
       "folder_heading": "Carpeta de copias",
       "folder_intro": "Elija dónde se guardan los archivos de copia cifrados.",
       "folder_pick_btn": "Elegir carpeta",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -930,6 +930,7 @@
       "phrase_set": "La phrase de récupération est définie.",
       "phrase_view_btn": "Afficher à nouveau la phrase",
       "phrase_hide_btn": "Masquer",
+      "phrase_synced_hint": "La phrase est conservée chiffrée dans votre compte - elle se synchronise avec vos autres appareils et survit à la déconnexion. Votre copie écrite reste le seul recours si vous perdez l'accès à votre compte.",
       "folder_heading": "Dossier de sauvegarde",
       "folder_intro": "Choisissez où les fichiers de sauvegarde chiffrés sont enregistrés.",
       "folder_pick_btn": "Choisir un dossier",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -931,6 +931,7 @@
       "phrase_view_btn": "Afficher à nouveau la phrase",
       "phrase_hide_btn": "Masquer",
       "phrase_synced_hint": "La phrase est conservée chiffrée dans votre compte - elle se synchronise avec vos autres appareils et survit à la déconnexion. Votre copie écrite reste le seul recours si vous perdez l'accès à votre compte.",
+      "phrase_updated_notice": "La phrase de récupération a été mise à jour depuis votre compte (modifiée sur un autre appareil). Affichez la phrase actuelle et mettez à jour votre copie écrite - les sauvegardes utilisent désormais la nouvelle phrase.",
       "folder_heading": "Dossier de sauvegarde",
       "folder_intro": "Choisissez où les fichiers de sauvegarde chiffrés sont enregistrés.",
       "folder_pick_btn": "Choisir un dossier",

--- a/packages/i18n/src/translations/notes/fr.json
+++ b/packages/i18n/src/translations/notes/fr.json
@@ -948,7 +948,10 @@
       "now_done": "Sauvegarde enregistrée.",
       "now_nothing": "Rien à sauvegarder pour le moment.",
       "now_failed": "Échec de la sauvegarde : {error}",
-      "cadence_note": "Les sauvegardes se font automatiquement à l'ouverture de l'application, au maximum une fois par jour."
+      "cadence_note": "Les sauvegardes se font automatiquement à l'ouverture de l'application, au maximum une fois par jour.",
+      "reminder_title": "Sauvegarde automatique à faire",
+      "reminder_body": "Ouvrez l'application pour créer une nouvelle copie chiffrée de vos notes.",
+      "reminder_hint": "Si une sauvegarde est en retard, une notification vous rappellera d'ouvrir l'application."
     },
     "export_import": {
       "title": "Export et import",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -930,6 +930,7 @@
       "phrase_set": "Fraza odzyskiwania jest ustawiona.",
       "phrase_view_btn": "Pokaż frazę ponownie",
       "phrase_hide_btn": "Ukryj",
+      "phrase_synced_hint": "Fraza jest przechowywana w koncie w postaci zaszyfrowanej - synchronizuje się między Twoimi urządzeniami i przetrwa wylogowanie. Zapisana kopia pozostaje jedynym ratunkiem, gdy stracisz dostęp do konta.",
       "folder_heading": "Folder kopii",
       "folder_intro": "Wybierz, gdzie zapisywane są pliki zaszyfrowanej kopii.",
       "folder_pick_btn": "Wybierz folder",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -931,6 +931,7 @@
       "phrase_view_btn": "Pokaż frazę ponownie",
       "phrase_hide_btn": "Ukryj",
       "phrase_synced_hint": "Fraza jest przechowywana w koncie w postaci zaszyfrowanej - synchronizuje się między Twoimi urządzeniami i przetrwa wylogowanie. Zapisana kopia pozostaje jedynym ratunkiem, gdy stracisz dostęp do konta.",
+      "phrase_updated_notice": "Fraza odzyskiwania została zaktualizowana z konta (zmieniona na innym urządzeniu). Podejrzyj aktualną frazę i uaktualnij zapisaną kopię - kopie zapasowe od teraz używają nowej frazy.",
       "folder_heading": "Folder kopii",
       "folder_intro": "Wybierz, gdzie zapisywane są pliki zaszyfrowanej kopii.",
       "folder_pick_btn": "Wybierz folder",

--- a/packages/i18n/src/translations/notes/pl.json
+++ b/packages/i18n/src/translations/notes/pl.json
@@ -948,7 +948,10 @@
       "now_done": "Kopia zapisana.",
       "now_nothing": "Brak danych do skopiowania w tej chwili.",
       "now_failed": "Tworzenie kopii nie powiodło się: {error}",
-      "cadence_note": "Kopie tworzą się automatycznie przy otwarciu aplikacji, najwyżej raz dziennie."
+      "cadence_note": "Kopie tworzą się automatycznie przy otwarciu aplikacji, najwyżej raz dziennie.",
+      "reminder_title": "Czas na automatyczną kopię notatek",
+      "reminder_body": "Otwórz aplikację, aby utworzyć świeżą zaszyfrowaną kopię notatek.",
+      "reminder_hint": "Gdy kopia będzie zaległa, powiadomienie przypomni o otwarciu aplikacji."
     },
     "export_import": {
       "title": "Eksport i import",

--- a/packages/storage/src/__tests__/settings-bundle.spec.ts
+++ b/packages/storage/src/__tests__/settings-bundle.spec.ts
@@ -85,16 +85,19 @@ describe('settings-bundle: extract', () => {
     const app = extractAppBundle(taskFixture);
     expect('periodicNotes' in app).toBe(false);
     expect('folderSortMode' in app).toBe(false);
-    expect('autoBackupPhraseWrapped' in app).toBe(false);
+    expect('autoBackupPhrase' in app).toBe(false);
   });
 
   it('extractAppBundle carries the wrapped auto-backup phrase when present', () => {
     const withPhrase: AppSettings = {
       ...NOTES_FIXTURE,
-      autoBackupPhraseWrapped: 'aXY=:Y2lwaGVydGV4dA=='
+      autoBackupPhrase: { wrapped: 'aXY=:Y2lwaGVydGV4dA==', updatedAt: '2026-07-10T10:00:00.000Z' }
     };
     const app = extractAppBundle(withPhrase);
-    expect(app.autoBackupPhraseWrapped).toBe('aXY=:Y2lwaGVydGV4dA==');
+    expect(app.autoBackupPhrase).toEqual({
+      wrapped: 'aXY=:Y2lwaGVydGV4dA==',
+      updatedAt: '2026-07-10T10:00:00.000Z'
+    });
   });
 });
 
@@ -164,18 +167,46 @@ describe('settings-bundle: applyBundlesToSettings', () => {
   });
 
   it('round-trip preserves the wrapped auto-backup phrase; absent key leaves local intact', () => {
-    const withPhrase: AppSettings = {
-      ...NOTES_FIXTURE,
-      autoBackupPhraseWrapped: 'aXY=:Y2lwaGVydGV4dA=='
-    };
+    const phrase = { wrapped: 'aXY=:Y2lwaGVydGV4dA==', updatedAt: '2026-07-10T10:00:00.000Z' };
+    const withPhrase: AppSettings = { ...NOTES_FIXTURE, autoBackupPhrase: phrase };
     const app = extractAppBundle(withPhrase);
     const merged = applyBundlesToSettings(NOTES_FIXTURE, null, app);
-    expect(merged.autoBackupPhraseWrapped).toBe('aXY=:Y2lwaGVydGV4dA==');
+    expect(merged.autoBackupPhrase).toEqual(phrase);
 
     // A bundle WITHOUT the key (older client / settings reset elsewhere) must
     // not clear a locally-known phrase - that device re-publishes from its vault.
     const withoutKey = applyBundlesToSettings(withPhrase, null, { schema_version: 1 });
-    expect(withoutKey.autoBackupPhraseWrapped).toBe('aXY=:Y2lwaGVydGV4dA==');
+    expect(withoutKey.autoBackupPhrase).toEqual(phrase);
+  });
+
+  it('merges the phrase newest-updatedAt-wins, independent of row-level LWW', () => {
+    const older = { wrapped: 'old', updatedAt: '2026-07-01T00:00:00.000Z' };
+    const newer = { wrapped: 'new', updatedAt: '2026-07-09T00:00:00.000Z' };
+
+    // Incoming NEWER phrase wins over a local older one...
+    const upgraded = applyBundlesToSettings({ ...NOTES_FIXTURE, autoBackupPhrase: older }, null, {
+      schema_version: 1,
+      autoBackupPhrase: newer
+    });
+    expect(upgraded.autoBackupPhrase).toEqual(newer);
+
+    // ...but an incoming STALE phrase must never revert a newer local one,
+    // even though the surrounding bundle would win row-level LWW - a stale
+    // device pushing an unrelated setting must not break recoverability.
+    const defended = applyBundlesToSettings({ ...NOTES_FIXTURE, autoBackupPhrase: newer }, null, {
+      schema_version: 1,
+      theme: 'light',
+      autoBackupPhrase: older
+    });
+    expect(defended.autoBackupPhrase).toEqual(newer);
+    expect(defended.theme).toBe('light');
+
+    // A present phrase beats an absent local one regardless of stamps.
+    const adopted = applyBundlesToSettings(NOTES_FIXTURE, null, {
+      schema_version: 1,
+      autoBackupPhrase: older
+    });
+    expect(adopted.autoBackupPhrase).toEqual(older);
   });
 });
 
@@ -234,13 +265,17 @@ describe('settings-bundle: migrate (decrypt → unknown JSON → typed bundle)',
     expect(out.folderSortMode).toBeUndefined();
   });
 
-  it('migrateAppBundle reads autoBackupPhraseWrapped only when it is a string', () => {
+  it('migrateAppBundle reads autoBackupPhrase only with a valid {wrapped, updatedAt} shape', () => {
+    const valid = { wrapped: 'aXY=:Y2lwaGVydGV4dA==', updatedAt: '2026-07-10T10:00:00.000Z' };
+    expect(migrateAppBundle({ autoBackupPhrase: valid }).autoBackupPhrase).toEqual(valid);
+    // Legacy/garbage shapes are dropped: bare string, missing stamp, unparseable stamp.
+    expect(migrateAppBundle({ autoBackupPhrase: 'bare-string' }).autoBackupPhrase).toBeUndefined();
     expect(
-      migrateAppBundle({ autoBackupPhraseWrapped: 'aXY=:Y2lwaGVydGV4dA==' }).autoBackupPhraseWrapped
-    ).toBe('aXY=:Y2lwaGVydGV4dA==');
-    expect(migrateAppBundle({ autoBackupPhraseWrapped: 42 }).autoBackupPhraseWrapped).toBeUndefined();
+      migrateAppBundle({ autoBackupPhrase: { wrapped: 'x' } }).autoBackupPhrase
+    ).toBeUndefined();
     expect(
-      migrateAppBundle({ autoBackupPhraseWrapped: { iv: 'x' } }).autoBackupPhraseWrapped
+      migrateAppBundle({ autoBackupPhrase: { wrapped: 'x', updatedAt: 'not-a-date' } })
+        .autoBackupPhrase
     ).toBeUndefined();
   });
 });

--- a/packages/storage/src/__tests__/settings-bundle.spec.ts
+++ b/packages/storage/src/__tests__/settings-bundle.spec.ts
@@ -85,6 +85,16 @@ describe('settings-bundle: extract', () => {
     const app = extractAppBundle(taskFixture);
     expect('periodicNotes' in app).toBe(false);
     expect('folderSortMode' in app).toBe(false);
+    expect('autoBackupPhraseWrapped' in app).toBe(false);
+  });
+
+  it('extractAppBundle carries the wrapped auto-backup phrase when present', () => {
+    const withPhrase: AppSettings = {
+      ...NOTES_FIXTURE,
+      autoBackupPhraseWrapped: 'aXY=:Y2lwaGVydGV4dA=='
+    };
+    const app = extractAppBundle(withPhrase);
+    expect(app.autoBackupPhraseWrapped).toBe('aXY=:Y2lwaGVydGV4dA==');
   });
 });
 
@@ -152,6 +162,21 @@ describe('settings-bundle: applyBundlesToSettings', () => {
     expect(merged.theme).toBe(baseline.theme);
     expect(merged.editorMode).toBe(baseline.editorMode);
   });
+
+  it('round-trip preserves the wrapped auto-backup phrase; absent key leaves local intact', () => {
+    const withPhrase: AppSettings = {
+      ...NOTES_FIXTURE,
+      autoBackupPhraseWrapped: 'aXY=:Y2lwaGVydGV4dA=='
+    };
+    const app = extractAppBundle(withPhrase);
+    const merged = applyBundlesToSettings(NOTES_FIXTURE, null, app);
+    expect(merged.autoBackupPhraseWrapped).toBe('aXY=:Y2lwaGVydGV4dA==');
+
+    // A bundle WITHOUT the key (older client / settings reset elsewhere) must
+    // not clear a locally-known phrase - that device re-publishes from its vault.
+    const withoutKey = applyBundlesToSettings(withPhrase, null, { schema_version: 1 });
+    expect(withoutKey.autoBackupPhraseWrapped).toBe('aXY=:Y2lwaGVydGV4dA==');
+  });
 });
 
 describe('settings-bundle: migrate (decrypt → unknown JSON → typed bundle)', () => {
@@ -207,5 +232,15 @@ describe('settings-bundle: migrate (decrypt → unknown JSON → typed bundle)',
   it('migrateAppBundle drops unknown folderSortMode values', () => {
     const out = migrateAppBundle({ folderSortMode: 'by-size' });
     expect(out.folderSortMode).toBeUndefined();
+  });
+
+  it('migrateAppBundle reads autoBackupPhraseWrapped only when it is a string', () => {
+    expect(
+      migrateAppBundle({ autoBackupPhraseWrapped: 'aXY=:Y2lwaGVydGV4dA==' }).autoBackupPhraseWrapped
+    ).toBe('aXY=:Y2lwaGVydGV4dA==');
+    expect(migrateAppBundle({ autoBackupPhraseWrapped: 42 }).autoBackupPhraseWrapped).toBeUndefined();
+    expect(
+      migrateAppBundle({ autoBackupPhraseWrapped: { iv: 'x' } }).autoBackupPhraseWrapped
+    ).toBeUndefined();
   });
 });

--- a/packages/storage/src/services/synced-settings.service.ts
+++ b/packages/storage/src/services/synced-settings.service.ts
@@ -98,12 +98,24 @@ export class SyncedSettingsService {
    *   - Server has a newer bundle than local → server wins (overwrite local
    *     with merged bundle, local `updated_at` advances to server's).
    *   - Local is newer → push up (handled implicitly by the next push).
+   *   - `autoBackupPhrase` is exempt from row-level LWW in BOTH directions:
+   *     it merges newest-`updatedAt`-wins even when the row comparison would
+   *     skip the apply, and when the local copy is the newer one a push is
+   *     scheduled to repair the server. The server stores bundles as opaque
+   *     whole-blob replacements, so without this a stale device pushing an
+   *     unrelated setting would revert the account's recovery phrase.
+   *
+   * `fetched` reports whether this call obtained a DEFINITIVE view of the
+   * server state (bundles decoded, or confirmed absent) - as opposed to a
+   * swallowed network/decrypt failure. Callers use it to gate actions that
+   * must not run on the assumption "server has nothing" (e.g. publishing a
+   * device-local recovery phrase to the account).
    */
-  async pullAndMerge(): Promise<{ applied: boolean }> {
-    if (this.syncDisabled()) return { applied: false };
+  async pullAndMerge(): Promise<{ applied: boolean; fetched: boolean }> {
+    if (this.syncDisabled()) return { applied: false, fetched: false };
     if (!cryptoManager.isInitialized()) {
       logger.debug('Master key not initialized - skipping pull');
-      return { applied: false };
+      return { applied: false, fetched: false };
     }
 
     let body: GetSettingsResponse;
@@ -111,17 +123,17 @@ export class SyncedSettingsService {
       const res = await this.adapter.authFetch(`${this.adapter.basePath}/api/settings`);
       if (!res.ok) {
         logger.warn('Settings pull returned non-OK', { status: res.status });
-        return { applied: false };
+        return { applied: false, fetched: false };
       }
       body = (await res.json()) as GetSettingsResponse;
     } catch (err) {
       logger.warn('Settings pull failed (network)', err);
-      return { applied: false };
+      return { applied: false, fetched: false };
     }
 
     if (!body.success || !body.data) {
       logger.warn('Settings pull returned error body', { error: body.error });
-      return { applied: false };
+      return { applied: false, fetched: false };
     }
 
     const { shared, app } = body.data;
@@ -134,7 +146,7 @@ export class SyncedSettingsService {
       if (app) appBundle = migrateAppBundle(JSON.parse(await cryptoManager.decryptText(app.settings_encrypted)));
     } catch (err) {
       logger.error('Failed to decrypt server bundle - local IDB stays authoritative', err);
-      return { applied: false };
+      return { applied: false, fetched: false };
     }
 
     // Bootstrap path: server empty for a scope, but local row exists → push it.
@@ -156,8 +168,9 @@ export class SyncedSettingsService {
     if (!sharedBundle && !appBundle) {
       // Nothing on the server. Either we just bootstrapped above, or this is
       // a brand-new account with no IDB row yet - caller's `init()` will run
-      // `initializeDefaults()` next and we'll push on first mutation.
-      return { applied: false };
+      // `initializeDefaults()` next and we'll push on first mutation. The
+      // server state is nonetheless definitively known - `fetched` is true.
+      return { applied: false, fetched: true };
     }
 
     // Compute the server's most recent updated_at across the two scopes.
@@ -195,7 +208,7 @@ export class SyncedSettingsService {
       merged.updated_at = new Date(serverUpdated).toISOString();
       await settingsStore.save(merged);
       logger.info('Adopted server settings (no local row)');
-      return { applied: true };
+      return { applied: true, fetched: true };
     }
 
     if (serverUpdated > localUpdated) {
@@ -206,11 +219,38 @@ export class SyncedSettingsService {
         serverUpdated: new Date(serverUpdated).toISOString(),
         localUpdated: new Date(localUpdated).toISOString()
       });
-      return { applied: true };
+      // applyBundlesToSettings kept the LOCAL phrase where it is the newer one
+      // (field-level newest-wins) - which means the server currently holds a
+      // stale phrase inside an opaque blob it cannot merge. Repair it.
+      if (phraseNewer(localSettings.autoBackupPhrase, appBundle?.autoBackupPhrase)) {
+        logger.info('Local recovery phrase is newer than the pulled bundle - scheduling repair push');
+        this.schedulePush();
+      }
+      return { applied: true, fetched: true };
     }
 
-    // localUpdated >= serverUpdated → local wins; defer to push flow.
-    return { applied: false };
+    // localUpdated >= serverUpdated → local wins; defer to push flow. The
+    // phrase is exempt from that row-level verdict: adopt a NEWER server
+    // phrase into the (otherwise winning) local row, and repair the server
+    // when the local phrase is the newer one - a stale device's unrelated
+    // settings push must never revert the account's recovery phrase.
+    if (appBundle) {
+      if (phraseNewer(appBundle.autoBackupPhrase, localSettings.autoBackupPhrase)) {
+        await settingsStore.save({
+          ...localSettings,
+          // Keep the row's updated_at: this is a field-level repair, not a
+          // row-level win - the rest of the LWW semantics must not shift.
+          autoBackupPhrase: appBundle.autoBackupPhrase
+        });
+        logger.info('Adopted newer recovery phrase from server (local row otherwise newer)');
+        return { applied: true, fetched: true };
+      }
+      if (phraseNewer(localSettings.autoBackupPhrase, appBundle.autoBackupPhrase)) {
+        logger.info('Local recovery phrase is newer than the pulled bundle - scheduling repair push');
+        this.schedulePush();
+      }
+    }
+    return { applied: false, fetched: true };
   }
 
   /**
@@ -299,6 +339,20 @@ export class SyncedSettingsService {
     // 4xx/5xx → log and drop. The next push or pull will reconcile.
     logger.warn('Settings push returned non-OK', { scope, status: res.status });
   }
+}
+
+/**
+ * Is phrase stamp `a` strictly newer than `b`? Absent/`undefined` never wins;
+ * a present phrase beats an absent one. Field-level freshness for
+ * `autoBackupPhrase` (see the AppSettings field doc).
+ */
+function phraseNewer(
+  a: AppSettings['autoBackupPhrase'],
+  b: AppSettings['autoBackupPhrase']
+): boolean {
+  if (!a) return false;
+  if (!b) return true;
+  return Date.parse(a.updatedAt) > Date.parse(b.updatedAt);
 }
 
 /**

--- a/packages/storage/src/stores/settings.store.ts
+++ b/packages/storage/src/stores/settings.store.ts
@@ -95,6 +95,18 @@ export interface AppSettings {
    * don't carry the field. Defaults are written by `initializeDefaults` for the notes app.
    */
   periodicNotes?: PeriodicNotesSettings;
+  /**
+   * Notes-only: the auto-backup recovery phrase, wrapped as its OWN AES-GCM
+   * ciphertext under the master key (`cryptoManager.encryptText` output,
+   * `iv:ciphertext`). NEVER plaintext: this row is stored unencrypted in
+   * IndexedDB, so the phrase gets the same at-rest protection as note content
+   * only through this inner envelope. Syncing it in the app bundle makes the
+   * phrase ACCOUNT-scoped - it survives logout and reaches the user's other
+   * devices as ciphertext the server cannot read (the wrapped-recovery-secret
+   * pattern; see reborn-notes' auto-backup phrase-sync module). Absent until
+   * the user enables auto-backup somewhere.
+   */
+  autoBackupPhraseWrapped?: string;
   created_at: string;
   updated_at: string;
 }

--- a/packages/storage/src/stores/settings.store.ts
+++ b/packages/storage/src/stores/settings.store.ts
@@ -105,8 +105,14 @@ export interface AppSettings {
    * devices as ciphertext the server cannot read (the wrapped-recovery-secret
    * pattern; see reborn-notes' auto-backup phrase-sync module). Absent until
    * the user enables auto-backup somewhere.
+   *
+   * `updatedAt` is the phrase's OWN freshness stamp: the settings bundle syncs
+   * whole-row last-write-wins, so without it a device pushing an unrelated
+   * setting from a stale row would silently revert the account's newest phrase
+   * (breaking recoverability of every backup made since). Merge for this field
+   * is newest-`updatedAt`-wins, independent of the row's `updated_at`.
    */
-  autoBackupPhraseWrapped?: string;
+  autoBackupPhrase?: { wrapped: string; updatedAt: string };
   created_at: string;
   updated_at: string;
 }

--- a/packages/storage/src/utils/settings-bundle.ts
+++ b/packages/storage/src/utils/settings-bundle.ts
@@ -60,6 +60,13 @@ export interface AppSettingsBundle {
   confirmBeforeDelete?: AppSettings['confirmBeforeDelete'];
   folderSortMode?: AppSettings['folderSortMode'];
   periodicNotes?: AppSettings['periodicNotes'];
+  /**
+   * Notes-only: recovery phrase wrapped as its own ciphertext under the master
+   * key (never plaintext - see the AppSettings field doc). Riding the app
+   * bundle makes it account-scoped without any server-side change: the server
+   * stores it doubly encrypted inside `settings_encrypted`.
+   */
+  autoBackupPhraseWrapped?: AppSettings['autoBackupPhraseWrapped'];
 }
 
 /** Extract the shared subset of an AppSettings row. */
@@ -95,6 +102,9 @@ export function extractAppBundle(s: AppSettings): AppSettingsBundle {
   if (s.periodicNotes !== undefined) {
     bundle.periodicNotes = s.periodicNotes;
   }
+  if (s.autoBackupPhraseWrapped !== undefined) {
+    bundle.autoBackupPhraseWrapped = s.autoBackupPhraseWrapped;
+  }
   return bundle;
 }
 
@@ -129,6 +139,9 @@ export function applyBundlesToSettings(
     if (app.confirmBeforeDelete !== undefined) merged.confirmBeforeDelete = app.confirmBeforeDelete;
     if (app.folderSortMode !== undefined) merged.folderSortMode = app.folderSortMode;
     if (app.periodicNotes !== undefined) merged.periodicNotes = app.periodicNotes;
+    if (app.autoBackupPhraseWrapped !== undefined) {
+      merged.autoBackupPhraseWrapped = app.autoBackupPhraseWrapped;
+    }
   }
   return merged;
 }
@@ -177,6 +190,9 @@ export function migrateAppBundle(raw: unknown): AppSettingsBundle {
   }
   if (typeof obj.periodicNotes === 'object' && obj.periodicNotes !== null) {
     out.periodicNotes = obj.periodicNotes as AppSettings['periodicNotes'];
+  }
+  if (typeof obj.autoBackupPhraseWrapped === 'string') {
+    out.autoBackupPhraseWrapped = obj.autoBackupPhraseWrapped;
   }
   return out;
 }

--- a/packages/storage/src/utils/settings-bundle.ts
+++ b/packages/storage/src/utils/settings-bundle.ts
@@ -64,9 +64,10 @@ export interface AppSettingsBundle {
    * Notes-only: recovery phrase wrapped as its own ciphertext under the master
    * key (never plaintext - see the AppSettings field doc). Riding the app
    * bundle makes it account-scoped without any server-side change: the server
-   * stores it doubly encrypted inside `settings_encrypted`.
+   * stores it doubly encrypted inside `settings_encrypted`. Merged
+   * newest-`updatedAt`-wins (see applyBundlesToSettings), NOT row-level LWW.
    */
-  autoBackupPhraseWrapped?: AppSettings['autoBackupPhraseWrapped'];
+  autoBackupPhrase?: AppSettings['autoBackupPhrase'];
 }
 
 /** Extract the shared subset of an AppSettings row. */
@@ -102,8 +103,8 @@ export function extractAppBundle(s: AppSettings): AppSettingsBundle {
   if (s.periodicNotes !== undefined) {
     bundle.periodicNotes = s.periodicNotes;
   }
-  if (s.autoBackupPhraseWrapped !== undefined) {
-    bundle.autoBackupPhraseWrapped = s.autoBackupPhraseWrapped;
+  if (s.autoBackupPhrase !== undefined) {
+    bundle.autoBackupPhrase = s.autoBackupPhrase;
   }
   return bundle;
 }
@@ -139,8 +140,16 @@ export function applyBundlesToSettings(
     if (app.confirmBeforeDelete !== undefined) merged.confirmBeforeDelete = app.confirmBeforeDelete;
     if (app.folderSortMode !== undefined) merged.folderSortMode = app.folderSortMode;
     if (app.periodicNotes !== undefined) merged.periodicNotes = app.periodicNotes;
-    if (app.autoBackupPhraseWrapped !== undefined) {
-      merged.autoBackupPhraseWrapped = app.autoBackupPhraseWrapped;
+    if (app.autoBackupPhrase !== undefined) {
+      // Newest-wins on the field's OWN stamp, independent of the row's
+      // updated_at: whole-row LWW must never let a stale device's unrelated
+      // settings push revert the account's newest recovery phrase - that
+      // would silently make every backup taken since undecryptable with the
+      // phrase the user actually wrote down.
+      const local = merged.autoBackupPhrase;
+      if (!local || Date.parse(app.autoBackupPhrase.updatedAt) > Date.parse(local.updatedAt)) {
+        merged.autoBackupPhrase = app.autoBackupPhrase;
+      }
     }
   }
   return merged;
@@ -191,8 +200,15 @@ export function migrateAppBundle(raw: unknown): AppSettingsBundle {
   if (typeof obj.periodicNotes === 'object' && obj.periodicNotes !== null) {
     out.periodicNotes = obj.periodicNotes as AppSettings['periodicNotes'];
   }
-  if (typeof obj.autoBackupPhraseWrapped === 'string') {
-    out.autoBackupPhraseWrapped = obj.autoBackupPhraseWrapped;
+  if (typeof obj.autoBackupPhrase === 'object' && obj.autoBackupPhrase !== null) {
+    const phrase = obj.autoBackupPhrase as Record<string, unknown>;
+    if (
+      typeof phrase.wrapped === 'string' &&
+      typeof phrase.updatedAt === 'string' &&
+      !Number.isNaN(Date.parse(phrase.updatedAt))
+    ) {
+      out.autoBackupPhrase = { wrapped: phrase.wrapped, updatedAt: phrase.updatedAt };
+    }
   }
   return out;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@capacitor/ios':
         specifier: 8.4.0
         version: 8.4.0(@capacitor/core@8.4.0)
+      '@capacitor/local-notifications':
+        specifier: 8.2.0
+        version: 8.2.0(@capacitor/core@8.4.0)
       '@capacitor/network':
         specifier: 8.0.1
         version: 8.0.1(@capacitor/core@8.4.0)
@@ -1542,6 +1545,11 @@ packages:
 
   '@capacitor/keyboard@8.0.3':
     resolution: {integrity: sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/local-notifications@8.2.0':
+    resolution: {integrity: sha512-fvLY0w2w4MiX+DD4+Wv4DOwOLdzKZsMDwAcRv/Juudd+QbKbn69s6cM3xVqPwAiDqfnqsY4/S8xtQD6M73wY2A==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
@@ -7794,6 +7802,10 @@ snapshots:
       '@capacitor/core': 8.4.0
 
   '@capacitor/keyboard@8.0.3(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
+
+  '@capacitor/local-notifications@8.2.0(@capacitor/core@8.4.0)':
     dependencies:
       '@capacitor/core': 8.4.0
 


### PR DESCRIPTION
## Summary

Two changes to the automatic-backup feature (guideline 71), following the 2026-07-10 research into E2EE industry practice (Signal/WhatsApp/1Password/Ente all use ONE durable backup secret per account) - direction approved by Michal:

**1. The recovery phrase is now account-scoped (wrapped-recovery-secret pattern).**
- A copy of the phrase, encrypted under the master key (`cryptoManager.encryptText`), rides the existing E2E synced settings bundle as `AppSettings.autoBackupPhrase` - the server stores it doubly encrypted, zero server-side changes. At rest in IndexedDB it has the same protection as note content; plaintext exists only in the OS vault, as before.
- A reconcile module (`phrase-sync.ts`) syncs vault <-> row before every backup run and on the settings page: it hydrates a fresh/post-logout device after login, propagates the phrase to other devices, and publishes the phrase of pre-existing installs (migration). Logout still wipes the device; the account copy is what survives - after re-login the user only re-picks the folder, no new phrase to write down.
- The local->account upgrade now migrates the whole auto-backup setup (config, folder grant, vault phrase) to the account scope instead of orphaning it.
- Conflict safety (from the adversarial review): the phrase carries its own `updatedAt` and merges newest-wins independent of the bundle's row-level LWW; `pullAndMerge` repairs the server when the local phrase is newer; publishing is gated on a definitive server view (`fetched`); a hydration that REPLACES a differing vault phrase shows a persistent notice on the backup page until the user re-views the current phrase.

**2. Overdue-backup reminder via local notification** (the Proton-Drive-iOS pattern - backups still run only on app open; true background execution is not viable in a Capacitor WebView).
- New dependency `@capacitor/local-notifications` 8.2.0 (official, MIT). No exact-alarm permission: the plugin falls back to inexact scheduling on Android 12+.
- Pure planner: first nudge ~2h past the cadence point, follow-up ~a week later; planned ONLY while data is actually unbacked (watermark-aware, so read-only usage never nags); re-planned after every run, cancelled on disable/logout. Notification carries static localized copy only (5 locales, ZK-clean).
- OS permission requested when enabling auto-backup; denial only mutes reminders.

**Decisions (auto mode / for review):** field rides the synced settings bundle (no new server surface) - the `prefs.ts` "keep auto-backup out of synced settings" rule was about the device-local folder bookmark, the phrase is account-scoped by nature; new dependency @capacitor/local-notifications (needed for the approved reminder); generated Capacitor lists hand-edited (verify with cap sync post-merge).

Quality: vitest 1281 (notes) + 71 (storage) green; svelte-check notes 0/0 @ 5721 and task 0/0 @ 5483; i18n parity 5/5; eslint clean; adversarial review workflow (4 lenses, 9 agents) - all 3 confirmed findings fixed in the third commit.

## Test plan

Post-merge (Michal): `pnpm install`, `npx cap sync` in apps/reborn-notes (should reproduce the hand-edited native lists; also backfills the iOS splash-screen entry pending from #437), native build.

Smoke:
1. Phrase sync: enable auto-backup on device A (new phrase) -> log the same account in on device B -> Settings > Backup should show "Recovery phrase is set" with the SAME phrase (View) without generating; pick folder + enable on B.
2. Logout survival: log out on A (vault/config wiped) -> log back in -> phrase is back (from account); only folder re-pick + toggle needed.
3. Reminder: enable backup, accept the notification permission prompt, edit a note, force-close the app for >26h (or shorten interval in code for testing) -> one "backup due" notification; opening the app and backing up cancels/re-plans. Read-only usage (no edits) must produce NO notifications.
4. Local->account upgrade: local-only user with backup enabled -> create account (upgrade) -> backup stays enabled with the same folder and phrase.
5. Web regression: web build unaffected (backup page still shows the native-only note; no plugin code in the web bundle).