### PR TITLE
chore(android): bump notes versionCode to 4 for internal testing

### DIFF
--- a/apps/reborn-notes/android/app/build.gradle
+++ b/apps/reborn-notes/android/app/build.gradle
@@ -33,7 +33,7 @@ android {
         // Store versioning (Faza 5, plan D5): versionName = public semver of the
         // native shell (independent of the monorepo's nx-release version);
         // versionCode = monotonic int, bumped on every store submission.
-        versionCode 3
+        versionCode 4
         versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {


### PR DESCRIPTION
## Summary

versionCode 3 is already on the Play internal track (#435); every upload needs a unique code. Bump to 4 for the next internal-testing AAB, which carries the account-scoped backup recovery phrase + overdue-backup reminder (#440). versionName stays 1.0.0 (same public release, new build).

## Test plan

None beyond CI - single-line gradle version bump. The AAB build itself (after merge): pnpm install, npx cap sync android, then the bundle build with the upload keystore.